### PR TITLE
fix copyright header in prep_for_release.py

### DIFF
--- a/easybuild/scripts/prep_for_release.py
+++ b/easybuild/scripts/prep_for_release.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 ##
-# Copyright 2009-2012 Stijn De Weirdt, Dries Verdegem, Kenneth Hoste, Pieter De Baets, Jens Timmerman
+# Copyright 2009-2012 Stijn De Weirdt
+# Copyright 2010 Dries Verdegem
+# Copyright 2010-2012 Kenneth Hoste
+# Copyright 2011 Pieter De Baets
+# Copyright 2011-2012 Jens Timmerman
 # Copyright 2012 Toon Willems
 #
 # This file is part of EasyBuild,


### PR DESCRIPTION
This, together with https://github.com/nudded/easybuild/pull/2 fixes the automagic merge of this branch into develop.
