### PR TITLE
fix logger in build.py

### DIFF
--- a/easybuild/build.py
+++ b/easybuild/build.py
@@ -149,7 +149,7 @@ def main():
         blocks = None
 
     ## Initialize logger
-    logFile, log, hn = initLogger(filename=logFile, debug=options.debug, typ=None)
+    logFile, log, hn = initLogger(filename=logFile, debug=options.debug, typ="build")
 
     ## Show version
     if options.version:

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -117,6 +117,8 @@ def initLogger(name=None, version=None, debug=False, filename=None, typ='UNKNOWN
     - does not append
     - sets log handlers
     """
+
+    # obtain root logger
     log = logging.getLogger()
 
     # set log level
@@ -135,6 +137,7 @@ def initLogger(name=None, version=None, debug=False, filename=None, typ='UNKNOWN
     hand.setFormatter(formatter)
     log.addHandler(hand)
 
+    # initialize our logger
     log = logging.getLogger(typ)
     log.setLevel(defaultLogLevel)
 


### PR DESCRIPTION
avoid using root logger, but instance of EasyBuildLog, which raises EasyBuildError on log.error, instead
