### PR TITLE
Repository get buildstats

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -38,7 +38,6 @@ import time
 import easybuild.tools.environment as env
 from easybuild.tools.asyncprocess import Popen, PIPE, STDOUT, send_all, recv_some
 from easybuild.tools.build_log import getLog
-from easybuild.tools.config import logPath
 
 
 log = getLog('fileTools')
@@ -93,7 +92,7 @@ def findBaseDir():
     """
     def getLocalDirsPurged():
         ## e.g. always purge the log directory
-        ignoreDirs = [logPath()]
+        ignoreDirs = ["easybuild"]
 
         lst = os.listdir(os.getcwd())
         for ignDir in ignoreDirs:

--- a/easybuild/tools/repository.py
+++ b/easybuild/tools/repository.py
@@ -160,7 +160,7 @@ class FileRepository(Repository):
 
             # append a line to the eb file so we don't have git merge conflicts
             if not previous:
-                statstemplate = "\n#Build statistics\nbuildstats=[%s]t\n"
+                statstemplate = "\n#Build statistics\nbuildstats=[%s]\n"
             else:
                 statstemplate = "\nbuildstats.append(%s)\n"
 


### PR DESCRIPTION
add a get buildstats method.

Unfortunately, A little bug seems to have slipped into the buildstats, so every eb file in the repo will have a syntax error (if built with develop branch) :(.
