### PR TITLE
CGAL complains about missing QGLWidget

### DIFF
--- a/easybuild/easyconfigs/c/CGAL/CGAL-4.0-goalf-1.1.0-no-OFED-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/c/CGAL/CGAL-4.0-goalf-1.1.0-no-OFED-Python-2.7.3.eb
@@ -19,3 +19,6 @@ dependencies = [
                 ('Boost','1.49.0', versionsuffix),
                 ('MPFR','3.1.0'),
                 ]
+
+osdependencies = ['qt4-devel']
+

--- a/easybuild/easyconfigs/c/CGAL/CGAL-4.0-ictce-4.0.6-Python-2.7.3.eb
+++ b/easybuild/easyconfigs/c/CGAL/CGAL-4.0-ictce-4.0.6-Python-2.7.3.eb
@@ -20,3 +20,5 @@ dependencies = [
                 ('MPFR','3.1.0'),
                 ]
                 
+osdependencies = ['qt4-devel']
+


### PR DESCRIPTION
Hi there,

while building target CGAL-4.0-goalf-1.1.0-no-OFED-Python-2.7.3.eb
I came across an error mentioning missing "QGLWidget", as per
http://www.cgal.org/Manual/latest/doc_html/installation_manual/Chapter_installation_manual.html#Subsection_4.13

On debian squeeze I resolved it by bringing `libqglviewer-qt4-2`, `libqglviewer-qt4-dev` and their deps;
for RedHat and its offsprings you might wish to call your "dag" neighbour for more info:
http://rpmfind.net//linux/RPM/dag/redhat/el5/i386/libqglviewer-2.2.3-1.el5.rf.i386.html
(a quick search in an SL5 with default repos did not reveal the answer to this)

cheers,
Fotis

```
Scanning dependencies of target CGAL
[  5%] Building CXX object src/CGAL/CMakeFiles/CGAL.dir/all_files.cpp.o
Linking CXX shared library ../../lib/libCGAL.so
[  5%] Built target CGAL
[ 10%] [ 15%] [ 20%] [ 25%] [ 30%] [ 35%] [ 40%] [ 45%] Generating qrc_Triangulation_2.cxx
Generating __/__/include/CGAL/Qt/moc_GraphicsViewNavigation.cxx
Generating __/__/include/CGAL/Qt/moc_DemosMainWindow.cxx
Generating __/__/include/CGAL/Qt/moc_GraphicsItem.cxx
Generating __/__/include/CGAL/Qt/moc_GraphicsViewInput.cxx
Generating qrc_CGAL.cxx
Generating qrc_Input.cxx
Generating qrc_File.cxx
Scanning dependencies of target CGAL_Core
[ 50%] Building CXX object src/Core/CMakeFiles/CGAL_Core.dir/all_files.cpp.o
Scanning dependencies of target CGAL_ImageIO
[ 55%] Building CXX object src/ImageIO/CMakeFiles/CGAL_ImageIO.dir/all_files.cpp.o
Scanning dependencies of target CGAL_Qt4
[ 60%] [ 65%] [ 70%] [ 75%] [ 80%] Building CXX object src/Qt4/CMakeFiles/CGAL_Qt4.dir/all_files.cpp.o
[ 85%] Building CXX object src/Qt4/CMakeFiles/CGAL_Qt4.dir/__/__/include/CGAL/Qt/moc_GraphicsViewNavigation.cxx.o
[ 90%] Building CXX object src/Qt4/CMakeFiles/CGAL_Qt4.dir/__/__/include/CGAL/Qt/moc_DemosMainWindow.cxx.o
[ 95%] [100%] Building CXX object src/Qt4/CMakeFiles/CGAL_Qt4.dir/__/__/include/CGAL/Qt/moc_GraphicsItem.cxx.o
Building CXX object src/Qt4/CMakeFiles/CGAL_Qt4.dir/__/__/include/CGAL/Qt/moc_GraphicsViewInput.cxx.o
Building CXX object src/Qt4/CMakeFiles/CGAL_Qt4.dir/qrc_CGAL.cxx.o
Building CXX object src/Qt4/CMakeFiles/CGAL_Qt4.dir/qrc_Input.cxx.o
Building CXX object src/Qt4/CMakeFiles/CGAL_Qt4.dir/qrc_Triangulation_2.cxx.o
Building CXX object src/Qt4/CMakeFiles/CGAL_Qt4.dir/qrc_File.cxx.o
In file included from /tmp/CGAL/4.0/goalf-1.1.0-no-OFED-Python-2.7.3/CGAL-4.0/src/Qt4/all_files.cpp:1:0:
/tmp/CGAL/4.0/goalf-1.1.0-no-OFED-Python-2.7.3/CGAL-4.0/src/CGALQt4/DemosMainWindow.cpp:33:21: fatal error: QGLWidget: No such file or directory
compilation terminated.
make[2]: *** [src/Qt4/CMakeFiles/CGAL_Qt4.dir/all_files.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [src/Qt4/CMakeFiles/CGAL_Qt4.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
Linking CXX shared library ../../lib/libCGAL_Core.so
[100%] Built target CGAL_Core
Linking CXX shared library ../../lib/libCGAL_ImageIO.so
[100%] Built target CGAL_ImageIO
make: *** [all] Error 2

```
