### PR TITLE
hotfixes for bugs in develop

### DIFF
--- a/easybuild/easyblocks/i/ifort.py
+++ b/easybuild/easyblocks/i/ifort.py
@@ -28,10 +28,10 @@ EasyBuild support for installing the Intel Fortran compiler suite, implemented a
 
 from distutils.version import LooseVersion
 
-from easybuild.easyblocks.icc import EB_Icc, EB_IntelBase
+from easybuild.easyblocks.icc import EB_icc, EB_IntelBase
 
 
-class EB_ifort(Icc):
+class EB_ifort(EB_icc):
     """
     Class that can be used to install ifort
     - tested with 11.1.046

--- a/easybuild/framework/application.py
+++ b/easybuild/framework/application.py
@@ -1589,7 +1589,7 @@ def get_class(easyblock, log, name=None):
             except ImportError, err:
                 # No easyblock could be found, so fall back to default class.
 
-                log.error("Failed to import easyblock for %s, falling back to default %s class: erro: %s" % \
+                log.debug("Failed to import easyblock for %s, falling back to default %s class: erro: %s" % \
                           (class_name, app_mod_class, err))
                 (modulepath, class_name) = app_mod_class
         # If Application was specified, use the framework namespace


### PR DESCRIPTION
Fix bugs introduced in #106 and #87.

EB_ifort was using incorrect class for icc;
EasyBuild was exiting when no easyblock was found instead of falling back to Application class as a default
