### PR TITLE
Adding ClustalW2-2.1-goalf-1.1.0-no-OFED.eb

### DIFF
--- a/easybuild/easyconfigs/c/ClustalW2/ClustalW2-2.1-goalf-1.1.0-no-OFED.eb
+++ b/easybuild/easyconfigs/c/ClustalW2/ClustalW2-2.1-goalf-1.1.0-no-OFED.eb
@@ -36,3 +36,4 @@ buildstats=[
                   'install_size': 845303,
                   'core_count': 12
                  }
+           ]


### PR DESCRIPTION
Taken working example from ebfiles_repo and cleaned up as per style instructions.

fyi. while doing so, realized that generated "buildstats=" needs to have spaces before/after equal mark.

Signed-off-by: fgeorgatos fotis.georgatos@uni.lu
