### PR TITLE
add guard around checking first entry in LDFLAGS list to fix unit test

### DIFF
--- a/easybuild/test/toolchain.py
+++ b/easybuild/test/toolchain.py
@@ -79,9 +79,9 @@ class ToolchainTest(TestCase):
         tc.prepare()
 
         ldflags = tc.get_variable('LDFLAGS', typ=list)
-        self.assertTrue(type(ldflags) == list)
+        self.assertTrue(isinstance(ldflags, list))
         if len(ldflags) > 0:
-            self.assertTrue(type(ldflags[0]) == basestring)
+            self.assertTrue(isinstance(ldflags[0], basestring))
 
     def tearDown(self):
         """Cleanup."""


### PR DESCRIPTION
Test is failing because lib directories pointed from in the module files are not there.

Test now also works if list is empty.
