### PR TITLE
make locate part in osdependency check a lot stricter

### DIFF
--- a/easybuild/framework/easyconfig.py
+++ b/easybuild/framework/easyconfig.py
@@ -409,7 +409,7 @@ class EasyConfig(object):
 
         if not found:
             # fallback for when os-dependency is a binary/library
-            cmd = 'which %(dep)s || locate --regexp "%(dep)s$"' % {'dep': dep}
+            cmd = 'which %(dep)s || locate --regexp "/%(dep)s$"' % {'dep': dep}
 
             found = run_cmd(cmd, simple=True, log_all=False, log_ok=False)
             


### PR DESCRIPTION
When falling back to the locate check for e.g. `blcr-libs`, it was finding stuff like `/path/to//blcr-libs-0.8.4-1.x86_64.rpm`, which is not the intention.

This is because `locate` by default translates `locate xxx` into `locate *xxx*`.

Making this a lot stricter by using `locate --regexp "/xxx$"`.
