### PR TITLE
add support for reporting regtest leaf jobs

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -1379,7 +1379,7 @@ def regtest(options, log, easyconfig_paths):
         resolved = resolve_dependencies(easyconfigs, options.robot, log)
 
         # use %%s so we can replace it later
-        cmd = "eb %%s --regtest --sequential -ld"
+        cmd = "eb %%(spec)s --regtest --sequential -ld"
         command = "cd %s && %s; " % (cur_dir, cmd)
         # retry twice in case of failure, to avoid fluke errors
         command += "if [ $? -ne 0 ]; then %(cmd)s && %(cmd)s; fi" % {'cmd': cmd}

--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -81,7 +81,7 @@ def create_job(build_command, easyconfig, log, output_dir=""):
     returns the job
     """
     # create command based on build_command template
-    command = build_command % easyconfig['spec']
+    command = build_command % {'spec': easyconfig['spec']}
 
     # capture PYTHONPATH, MODULEPATH and all variables starting with EASYBUILD
     easybuild_vars = {}


### PR DESCRIPTION
This can then be used by a script submitting the regtest, to also submit a follow-up job to trigger Jenkins to pull in the regtest result.
