### PR TITLE
fix --job cmd args, print what's being built

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1455,6 +1455,8 @@ class EasyBlock(object):
         steps = self.get_steps(run_test_cases)
 
         try:
+            full_name = "%s-%s" % (self.name, self.get_installversion())
+            print_msg("building and installing %s..." % full_name, self.log)
             for (stop_name, descr, step_methods, skippable) in steps:
                 print_msg("%s..." % descr, self.log)
                 self.run_step(stop_name, step_methods, skippable=skippable)

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -466,9 +466,17 @@ def main(options, orig_paths, log, logfile, hn, parser):
         # the options to ignore
         ignore = map(parser.get_option, ['--robot', '--help', '--job'])
 
+        def flatten(lst):
+            """Flatten a list of lists."""
+            res = []
+            for x in lst:
+                res.extend(x)
+            return res
+
         # loop over all the different options.
         result_opts = []
-        relevant_opts = [o for o in parser.option_list if o not in ignore]
+        all_options = parser.option_list + flatten([g.option_list for g in parser.option_groups])
+        relevant_opts = [o for o in all_options if o not in ignore]
         for opt in relevant_opts:
             value = getattr(options, opt.dest)
             # explicit check for None (some option are store_false)
@@ -482,7 +490,8 @@ def main(options, orig_paths, log, logfile, hn, parser):
 
         opts = ' '.join(result_opts)
 
-        command = "cd %s && eb %%s %s" % (curdir, opts)
+        command = "cd %s && eb %%(spec)s %s" % (curdir, opts)
+        log.debug("Command template for jobs: %s" % command)
         jobs = parbuild.build_easyconfigs_in_parallel(command, orderedSpecs, "easybuild-build", log)
         print "List of submitted jobs:"
         for job in jobs:


### PR DESCRIPTION
fix passing of command line parameter to job, add printing of what's being built (useful without -ld and with -r)
