### PR TITLE
add quotes around setenv definitions in modulefiles & define authors as per issue easyblocks/#99

### DIFF
--- a/easybuild/framework/easyconfig.py
+++ b/easybuild/framework/easyconfig.py
@@ -39,10 +39,11 @@ import tempfile
 from distutils.version import LooseVersion
 
 from easybuild.tools.build_log import EasyBuildError, get_log
-from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.filetools import run_cmd
 from easybuild.tools.ordereddict import OrderedDict
+from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.toolchain.utilities import search_toolchain
+from easybuild.tools.utilities import quote_str
 
 # we use a tuple here so we can sort them based on the numbers
 MANDATORY = (0, 'mandatory')
@@ -954,25 +955,6 @@ def tweak(src_fn, target_fn, tweaks, log):
 
             tweaks.pop(key)
 
-    def quoted(x):
-        """Obtain a new value to be used in string replacement context.
-
-        For non-string values, it just returns the exact same value.
-
-        For string values, it tries to escape the string in quotes, e.g.,
-        foo becomes 'foo', foo'bar becomes "foo'bar",
-        foo'bar"baz becomes \"\"\"foo'bar"baz\"\"\", etc.
-        """
-        if type(x) == str:
-            if "'" in x and '"' in x:
-                return '"""%s"""' % x
-            elif "'" in x:
-                return '"%s"' % x
-            else:
-                return "'%s'" % x
-        else:
-            return x
-
     # add parameters or replace existing ones
     for (key,val) in tweaks.items():
 
@@ -992,10 +974,10 @@ def tweak(src_fn, target_fn, tweaks, log):
                 diff = not res.group(1) == val
 
             if diff:
-                ectxt = regexp.sub("%s = %s # tweaked by EasyBuild (was: %s)" % (key, quoted(val), res.group(1)), ectxt)
-                log.info("Tweaked '%s' to '%s'" % (key, quoted(val)))
+                ectxt = regexp.sub("%s = %s # tweaked by EasyBuild (was: %s)" % (key, quote_str(val), res.group(1)), ectxt)
+                log.info("Tweaked '%s' to '%s'" % (key, quote_str(val)))
         else:
-            additions.append("%s = %s" % (key, quoted(val)))
+            additions.append("%s = %s" % (key, quote_str(val)))
 
 
     if additions:

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -87,6 +87,7 @@ from easybuild.tools.modules import Modules, search_module
 from easybuild.tools.modules import curr_module_paths, mk_module_path
 from easybuild.tools.toolchain.utilities import search_toolchain
 from easybuild.tools.ordereddict import OrderedDict
+from easybuild.tools.utilities import any
 from easybuild.tools.version import VERBOSE_VERSION as FRAMEWORK_VERSION
 EASYBLOCKS_VERSION = 'UNKNOWN'
 try:
@@ -1539,12 +1540,6 @@ def list_toolchains():
         tc_elems = set([y for x in dir(tc) if x.endswith('_MODULE_NAME') for y in eval("tc.%s" % x)])
 
         print "\t%s: %s" % (tcname, ', '.join(sorted(tc_elems)))
-
-# FIXME: remove when Python version on which we rely provides any by itself
-def any(ls):
-    """Reimplementation of 'any' function, which is not available in Python 2.4 yet."""
-
-    return sum([bool(x) for x in ls]) != 0
 
 if __name__ == "__main__":
     try:

--- a/easybuild/test/easyconfig.py
+++ b/easybuild/test/easyconfig.py
@@ -478,7 +478,7 @@ class TestObtainEasyconfig(EasyConfigTest):
         self.assertEqual(ec['toolchain'], {'name': tcname, 'version': tcver})
         # can't check for key 'foo', because EasyConfig ignores parameter names it doesn't know about
         txt = open(res[1], "r").read()
-        self.assertTrue(re.search("foo = '%s'" % specs['foo'], txt))
+        self.assertTrue(re.search('foo = "%s"' % specs['foo'], txt))
         os.remove(res[1])
 
         # should pick correct version, i.e. not newer than what's specified, if a choice needs to be made

--- a/easybuild/test/modulegenerator.py
+++ b/easybuild/test/modulegenerator.py
@@ -77,7 +77,7 @@ conflict    gzip
         desc = self.modgen.get_description()
         self.assertEqual(desc, expected)
 
-        # test loadModule
+        # test load_module
         expected = """
 if { ![is-loaded name/version] } {
     module load name/version
@@ -85,7 +85,7 @@ if { ![is-loaded name/version] } {
 """
         self.assertEqual(expected, self.modgen.load_module("name", "version"))
 
-        # test unloadModule
+        # test unload_module
         expected = """
 if { ![is-loaded name/version] } {
     if { [is-loaded name] } {
@@ -95,7 +95,7 @@ if { ![is-loaded name/version] } {
 """
         self.assertEqual(expected, self.modgen.unload_module("name", "version"))
 
-        # test prependPaths
+        # test prepend_paths
         expected = """prepend-path	key		$root/path1
 prepend-path	key		$root/path2
 """
@@ -110,8 +110,11 @@ prepend-path	key		$root/path2
                               self.modgen.prepend_paths, "key2", ["bar", "/tmp/foo"])
 
 
-        # test setEnvironment
-        self.assertEqual("setenv\tkey\t\tvalue\n", self.modgen.set_environment("key", "value"))
+        # test set_environment
+        self.assertEqual('setenv\tkey\t\t"value"\n', self.modgen.set_environment("key", "value"))
+        self.assertEqual("setenv\tkey\t\t'va\"lue'\n", self.modgen.set_environment("key", 'va"lue'))
+        self.assertEqual('setenv\tkey\t\t"va\'lue"\n', self.modgen.set_environment("key", "va'lue"))
+        self.assertEqual('setenv\tkey\t\t"""va"l\'ue"""\n', self.modgen.set_environment("key", """va"l'ue"""))
 
     def tearDown(self):
         """cleanup"""

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -40,6 +40,7 @@ from easybuild.tools.build_log import get_log
 from easybuild.tools.config import install_path
 from easybuild.tools.filetools import rmtree2
 from easybuild.tools.modules import Modules
+from easybuild.tools.utilities import quote_str
 
 
 log = get_log('moduleGenerator')
@@ -177,8 +178,8 @@ if { ![is-loaded %(name)s/%(version)s] } {
         """
         Generate setenv statement for the given key/value pair.
         """
-        # Double quotes are needed, to ensure smooth working of EBDEVEL* modulefiles
-        return 'setenv\t%s\t\t"%s"\n' % (key, value)
+        # quotes are needed, to ensure smooth working of EBDEVEL* modulefiles
+        return 'setenv\t%s\t\t%s\n' % (key, quote_str(value))
 
     def __del__(self):
         """

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -230,7 +230,7 @@ class Modules(object):
             try:
                 exec stdout
             except Exception, err:
-                raise EasyBuildError("Changing environment as dictated by module failed: %s" % err)
+                raise EasyBuildError("Changing environment as dictated by module failed: %s (%s)" % (err, stdout))
 
             # Process stderr
             result = []

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -1,0 +1,57 @@
+##
+# Copyright 2012-2013 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# the Hercules foundation (http://www.herculesstichting.be/in_English)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+Module with various utility functions
+
+@authors: Kenneth Hoste (UGent)
+"""
+
+# FIXME: remove when Python version on which we rely provides any by itself
+def any(ls):
+    """Reimplementation of 'any' function, which is not available in Python 2.4 yet."""
+
+    return sum([bool(x) for x in ls]) != 0
+
+def quote_str(x):
+    """
+    Obtain a new value to be used in string replacement context.
+    
+    For non-string values, it just returns the exact same value.
+    
+    For string values, it tries to escape the string in quotes, e.g.,
+    foo becomes 'foo', foo'bar becomes "foo'bar",
+    foo'bar"baz becomes \"\"\"foo'bar"baz\"\"\", etc.
+    """
+
+    if isinstance(x, basestring):
+        if "'" in x and '"' in x:
+            return '"""%s"""' % x
+        elif '"' in x:
+            return "'%s'" % x
+        else:
+            return '"%s"' % x
+    else:
+        return x
+


### PR DESCRIPTION
So,

hopefully this is a fix for the bug affecting EBDEVEL\* modulefiles, described in issue #457;
i have done a couple of tests -went fine- with the original cases that manifested the error, but nothing too extreme, so better play cautious. Consider a full regression test necessary before merging to master or such, but my guess is that it is good enough for develop.

Signed-off-by: Fotis Georgatos fotis.georgatos@uni.lu
