### PR TITLE
allow 'which eb' to fail if PATH is not correct, does little harm in general

### DIFF
--- a/easybuild/framework/easyconfig.py
+++ b/easybuild/framework/easyconfig.py
@@ -1041,7 +1041,7 @@ def get_paths_for(log, subdir="easyconfigs", robot_path=None):
     path_list.extend(sys.path)
 
     # figure out installation prefix, e.g. distutils install path for easyconfigs
-    (out, ec) = run_cmd("which eb", simple=False)
+    (out, ec) = run_cmd("which eb", simple=False, log_all=False, log_ok=False)
     if ec:
         log.warning("eb not found (%s), failed to determine installation prefix" % out)
     else:


### PR DESCRIPTION
If this fails, the distutils installation prefix won't be figured out, and thus finding easyconfigs _may_ fail.
Not having in `eb` in `$PATH` should be considered as a broken setup anyway imho.

This should fix the unit tests currently failing.
