### PR TITLE
add zip_safe flag to setup, to silence multitude of warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,4 +93,5 @@ implement support for installing particular (groups of) software packages.""",
                 "easybuild.toolchains.mpi", "easybuild.toolchains.fft", "easybuild.toolchains.linalg",
                 "easybuild.tools", "easybuild.tools.toolchain", "easybuild.test", "vsc"],
     test_suite = "easybuild.test.suite",
+    zip_safe = False,
 )


### PR DESCRIPTION
without the `zip_safe` flag set to `False`, a whole bunch of warnings are spit out when installing easybuild-framework

```
zip_safe flag not set; analyzing archive contents...
easybuild.__init__: module references __path__
easybuild.test.modules: module references __file__
easybuild.test.options: module references __file__
easybuild.toolchains.__init__: module references __path__
easybuild.toolchains.compiler.__init__: module references __path__
easybuild.toolchains.fft.__init__: module references __path__
easybuild.toolchains.linalg.__init__: module references __path__
easybuild.toolchains.mpi.__init__: module references __path__
easybuild.tools.config: module references __file__
easybuild.tools.options: module references __path__
easybuild.tools.version: module references __file__
easybuild.tools.toolchain.utilities: module references __file__
vsc.utils.fancylogger: module MAY be using inspect.stack
vsc.utils.generaloption: module MAY be using inspect.stack
```

see also http://stackoverflow.com/questions/8362510/getting-rid-of-the-easy-install-message-module-references-file
