### PR TITLE
also make search do something usefull when easybuild-easyconfigs are not installed

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -147,6 +147,7 @@ def main(testing_data=(None, None)):
     easyconfigs_paths = get_paths_for("easyconfigs", robot_path=options.robot)
     easyconfigs_pkg_full_path = None
 
+    search_path = os.getcwd()
     if easyconfigs_paths:
         easyconfigs_pkg_full_path = easyconfigs_paths[0]
         if not options.robot:


### PR DESCRIPTION
Search will now look in the cwd by default if it can not find an easyconfigs installation.
- `search <string>` will recursively look into the current directory and subdirectories
- `-r <path>` will keep working as it does 
- `-r` will exit with the message that it cannot locate easyconfigs
