### PR TITLE
extend module classes for helping with some default module categories

### DIFF
--- a/easybuild/easybuild_config.py
+++ b/easybuild/easybuild_config.py
@@ -31,6 +31,7 @@ EasyBuild configuration file.
 @author: Pieter De Baets (Ghent University)
 @author: Jens Timmerman (Ghent University)
 @author: Toon Willems (Ghent University)
+@author: Fotis Georgatos (University of Luxembourg)
 """
 
 import os
@@ -78,7 +79,8 @@ log_format = ("easybuild", "easybuild-%(name)s-%(version)s-%(date)s.%(time)s.log
 log_dir = tempfile.gettempdir()
 
 # define set of supported module classes
-module_classes = ['base', 'bio', 'chem', 'compiler', 'lib', 'phys', 'tools']
+module_classes = ['base', 'bio', 'chem', 'compiler', 'lib', 'phys', 'tools',
+  'cae', 'data', 'debugger', 'devel', 'ide', 'math', 'mpi', 'numlib', 'perf', 'system', 'vis']
 
 # general cleanliness
 del os, get_log, config, log, prefix


### PR DESCRIPTION
I'd like to start getting all of us the habit of using categories (does not matter much which!) so that we can cope with the many automated builds (esp. in light of upcoming toolchains).

If someone doesn't like this style it can be easily over-riden with --amend=moduleclass=foo

Signed-off-by: Fotis Georgatos fotis.georgatos@uni.lu
