### PR TITLE
Add gmvolf toolchain

### DIFF
--- a/easybuild/toolchains/gmvolf.py
+++ b/easybuild/toolchains/gmvolf.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013 Dmitri Gribenko
+# Copyright 2013 Ghent University
 #
 # This file is triple-licensed under GPLv2 (see below), MIT, and
 # BSD three-clause licenses.


### PR DESCRIPTION
'gmvolf' toolchain is 'goolf' with OpenMPI replaced by MVAPICH2.
