### PR TITLE
Remove useless (or undocumented) sleep() calls that were slowing down Python scipy build

### DIFF
--- a/easybuild/test/filetools.py
+++ b/easybuild/test/filetools.py
@@ -89,8 +89,14 @@ class FileToolsTest(TestCase):
         # no reason echo hello could fail
         self.assertEqual(ec, 0)
 
-        (out, ec) = ft.run_cmd_qa("echo question", {"question":"answer"})
-        self.assertEqual(out, "question\n")
+        # a more 'complex' command to run, make sure all required output is there
+        (out, ec) = ft.run_cmd("for j in `seq 1 3`; do for i in `seq 1 100`; do echo hello; done; sleep 1.4; done")
+        self.assertTrue(out.startswith('hello\nhello\n'))
+        self.assertEqual(len(out), len("hello\n"*300))
+        self.assertEqual(ec, 0)
+
+        (out, ec) = ft.run_cmd_qa("echo question; read x; echo $x", {"question": "answer"})
+        self.assertEqual(out, "question\nanswer\n")
         # no reason echo hello could fail
         self.assertEqual(ec, 0)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -560,7 +560,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
                                                                                     stdoutErr[-500:]
                                                                                     ))
 
-        # This sleep should not be needed.
+        # the sleep below is required to avoid exiting on unknown 'questions' too early (see above)
         time.sleep(1)
         ec = p.poll()
 


### PR DESCRIPTION
This removes useless (or undocumented) sleep() calls.  Calling read() on a pipe will block until data is available, so there is no reason to sleep().

There is one more sleep() that I marked with a comment in `run_cmd_qa`.  But because the function tries to emulate human input, the sleep() might be needed there if the program we interact with expects a delay (quite unlikely).
