### PR TITLE
Ignore some error codes that can be given by modulecmd, these can happen...

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -57,10 +57,10 @@ outputMatchers = {
     # matches whitespace and module-listing headers
     'whitespace': re.compile(r"^\s*$|^(-+).*(-+)$"),
     # matches errors such as "cmdTrace.c(713):ERROR:104: 'asdfasdf' is an unrecognized subcommand"
-    ## following erros should not be matches, they are considered warnings
-    # ModuleCmd_Avail.c(804):ERROR:64: Directory '/usr/local/modulefiles/SCIENTIFIC/tremolo' not found
+    ## following errors should not be matches, they are considered warnings
     # ModuleCmd_Avail.c(529):ERROR:57: Error while reading directory '/usr/local/modulefiles/SCIENTIFIC'
-    'error': re.compile(r"^\S+:(?P<level>\w+):(?P<code>(?!64|57)\d+):\s+(?P<msg>.*)$"),
+    # ModuleCmd_Avail.c(804):ERROR:64: Directory '/usr/local/modulefiles/SCIENTIFIC/tremolo' not found
+    'error': re.compile(r"^\S+:(?P<level>\w+):(?P<code>(?!57|64)\d+):\s+(?P<msg>.*)$"),
     # available with --terse has one module per line
     # matches modules such as "ictce/3.2.1.015.u4(default)"
     # line ending with : is ignored (the modulepath in --terse)


### PR DESCRIPTION
... withsymlinks with which point to a directory where we have no read persmissions

This should be allowed, since this system of pointing to unreadable directories allows us to hide modules where a user has no acces to anyway
 but they will automatically show up for users who have the right permissions.
