### PR TITLE
set OMPI_* environment variables for OpenMPI

### DIFF
--- a/easybuild/toolchains/mpi/openmpi.py
+++ b/easybuild/toolchains/mpi/openmpi.py
@@ -30,6 +30,8 @@ Support for OpenMPI as toolchain MPI library.
 """
 
 from easybuild.tools.toolchain.mpi import Mpi
+from easybuild.tools.toolchain.variables import CommandFlagList
+
 
 TC_CONSTANT_OPENMPI = "OpenMPI"
 TC_CONSTANT_MPI_TYPE_OPENMPI = "MPI_TYPE_OPENMPI"
@@ -52,3 +54,18 @@ class OpenMPI(Mpi):
                              }
 
     MPI_LINK_INFO_OPTION = '-showme:link'
+
+    def _set_mpi_compiler_variables(self):
+        """Add OMPI_XXX variables to set."""
+
+        # this needs to be done first, otherwise e.g., CC is set to MPICC if the usempi toolchain option is enabled
+        for var in ["CC", "CXX", "F77", ("F90", "FC")]:
+            if isinstance(var, basestring):
+                source_var = var
+                target_var = var
+            else:
+                source_var = var[0]
+                target_var = var[1]
+            self.variables.nappend("OMPI_%s" % target_var, str(self.variables[source_var].get_first()), var_class=CommandFlagList)
+
+        super(OpenMPI, self)._set_mpi_compiler_variables()

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -96,6 +96,15 @@ class ToolchainTest(TestCase):
         mpif90 = tc.get_variable('MPIF90')
         self.assertEqual(mpif90, "mpif90")
 
+        ompi_cc = tc.get_variable('OMPI_CC')
+        self.assertEqual(ompi_cc, "gcc")
+        ompi_cxx = tc.get_variable('OMPI_CXX')
+        self.assertEqual(ompi_cxx, "g++")
+        ompi_f77 = tc.get_variable('OMPI_F77')
+        self.assertEqual(ompi_f77, "gfortran")
+        ompi_fc = tc.get_variable('OMPI_FC')
+        self.assertEqual(ompi_fc, "gfortran")
+
     def test_get_variable_mpi_compilers(self):
         """Test get_variable function to obtain compiler variables."""
         tc_class, _ = search_toolchain("goalf")
@@ -111,6 +120,7 @@ class ToolchainTest(TestCase):
         self.assertEqual(f77, "mpif77")
         f90 = tc.get_variable('F90')
         self.assertEqual(f90, "mpif90")
+
         mpicc = tc.get_variable('MPICC')
         self.assertEqual(mpicc, "mpicc")
         mpicxx = tc.get_variable('MPICXX')
@@ -119,6 +129,15 @@ class ToolchainTest(TestCase):
         self.assertEqual(mpif77, "mpif77")
         mpif90 = tc.get_variable('MPIF90')
         self.assertEqual(mpif90, "mpif90")
+
+        ompi_cc = tc.get_variable('OMPI_CC')
+        self.assertEqual(ompi_cc, "gcc")
+        ompi_cxx = tc.get_variable('OMPI_CXX')
+        self.assertEqual(ompi_cxx, "g++")
+        ompi_f77 = tc.get_variable('OMPI_F77')
+        self.assertEqual(ompi_f77, "gfortran")
+        ompi_fc = tc.get_variable('OMPI_FC')
+        self.assertEqual(ompi_fc, "gfortran")
 
     def test_get_variable_seq_compilers(self):
         """Test get_variable function to obtain compiler variables."""


### PR DESCRIPTION
set OMPI_\* environment variables, to avoid that others (unwillingly) take control of the build process via the environment (cfr. https://github.com/hpcugent/easybuild-easyblocks/issues/188)
