### PR TITLE
Fix bad architecture detection on Raspbian Wheezy

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -100,13 +100,17 @@ def get_cpu_vendor():
     # Linux
     txt = read_file("/proc/cpuinfo", log_error=False)
     if txt is not None:
-        result = regexp.search(txt).groupdict()
-        arch = result.get('vendorid', UNKNOWN)
+        # vendor_id might not be in the /proc/cpuinfo, so this might fail 
+        try:
+            result = regexp.search(txt).groupdict()
+            arch = result.get('vendorid', UNKNOWN)
+        except AttributeError:
+            arch=UNKNOWN	
         if arch in VENDORS:
             return VENDORS[arch]
 
         # some embeded linux on arm behaves differently (e.g. raspbian)
-        regexp = re.compile(r"^Processor\s+:\s*(?P<vendorid>ARM\S+)\s*$", re.M)
+        regexp = re.compile(r"^Processor\s+:\s*(?P<vendorid>ARM\S+)\s*", re.M)
         result = regexp.search(txt).groupdict()
         arch = result.get('vendorid', UNKNOWN)
         if ARM in arch:


### PR DESCRIPTION
Ref: Issue #652 (but not sure how to re-open the issue).

On Raspbian Wheezy (on my system), there is no "vendor_id" in the /proc/cpuinfo
so the regex on line 94:

```
regexp = re.compile(r"^vendor_id\s+:\s*(?P<vendorid>\S+)\s*$", re.M)
```

will fail, and there will be no groupdict() returned from the immediately
following line:

```
result = regexp.search(txt).groupdict()
```

So I wrapped this in a "try/except AttributeError" and so that this could proceed to the ARM detection.

With these edits, EasyBuild proceeds smoothly to compile GCC on my Raspberry Pi.
