### PR TITLE
Remove temp git directory

### DIFF
--- a/easybuild/tools/repository.py
+++ b/easybuild/tools/repository.py
@@ -317,6 +317,7 @@ class GitRepository(FileRepository):
         Clean up git working copy.
         """
         try:
+            self.wc = os.path.dirname(self.wc)
             rmtree2(self.wc)
         except IOError, err:
             self.log.exception("Can't remove working copy %s: %s" % (self.wc, err))


### PR DESCRIPTION
Currently, /tmp fills up with empty /tmp/git-wc-\* directories. This
commit makes sure that this directory is also removed.
