### PR TITLE
Update error RegExp to decrease false positives

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -765,7 +765,7 @@ def parse_log_for_error(txt, regExp=None, stdout=True, msg=None):
     global errorsFoundInLog
 
     if regExp and type(regExp) == bool:
-        regExp = r"(?<![(,]|\w)(?:error|segmentation fault|failed)(?![(,]|\.?\w)"
+        regExp = r"(?<![(,-]|\w)(?:error|segmentation fault|failed)(?![(,-]|\.?\w)"
         _log.debug('Using default regular expression: %s' % regExp)
     elif type(regExp) == str:
         pass


### PR DESCRIPTION
Currently, things like "-Wno-error" give a false positive on possible
errors in the compilation process. This commit fixes this.
