### PR TITLE
Easyconfig: allow configs to be overridden with env vars

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -260,7 +260,7 @@ class EasyConfig(object):
                         self[new_config] = os.environ[env_var].split(os.pathsep)
                     elif isinstance(self[new_config], dict):
                         try:
-                            self[new_config] = {x.split('=')[0] : x.split('=')[1] for x in os.environ[env_var].split(os.pathsep)}
+                            self[new_config] = dict([(x.split('=')[0], x.split('=')[1]) for x in os.environ[env_var].split(os.pathsep)])
                         except IndexError, err:
                             self.log.error("Environment variable %s has an invalid syntax for a dict: %s" % (env_var,err))
 


### PR DESCRIPTION
Based on the discussion in #700

It's possible to override an Easyconfig option with an environment
variable. The name should follow EB_EC_PARAM_<eb name>_<config>, for
example: EB_EC_PARAM_ZLIB_HOMEPAGE. Options can be strings, list and
dicts. Specify like:
EB_EC_PARAM_ZLIB_PATCHES="file1:file2"
EB_EC_PARAM_ZLIB_TOOLCHAINOPTS="pic=False:optarch=True"
EB_EC_PARAM_ZLIB_HOMEPAGE="www.somesite.com"

@boegel, @fgeorgatos please have a look. 

Currently, only EB specific overrides are possible. Something like EB_EC_PARAM_MAXPARALLEL would make sense but EB_EC_PARAM_NAME doesn't. Do we allow a limited set of general options? In principle, all options can be general, only name would give problems (I think).
