### PR TITLE
Fix bug while detecting dependencies on Debian/Ubuntu systems, iff rpm is installed

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -459,17 +459,14 @@ class EasyConfig(object):
         # - uses rpm -q and dpkg -s --> can be run as non-root!!
         # - fallback on which
         # - should be extended to files later?
+        cmd = "exit 1"
         if get_os_name() in ['debian', 'ubuntu']:
             if run_cmd('which dpkg', simple=True, log_ok=False):
                 cmd = "dpkg -s %s" % dep
-            else:
-                cmd = "exit 1"
         else:
             # OK for get_os_name() == redhat, fedora, RHEL, SL, centos
             if run_cmd('which rpm', simple=True, log_ok=False):
                 cmd = "rpm -q %s" % dep
-            else:
-                cmd = "exit 1"
 
         found = run_cmd(cmd, simple=True, log_all=False, log_ok=False)
 


### PR DESCRIPTION
This fix a corner case with
https://github.com/ajdecon/easybuild-easyconfigs/commit/d143572f181957cb0db21fb2af817721058ce7fc
