### PR TITLE
fix unit tests

### DIFF
--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -74,7 +74,6 @@ for test_fn in [fn, os.path.join(testdir, 'test')]:
         sys.exit(1)
 os.remove(fn)
 shutil.rmtree(testdir)
-sys.exit(0)
 
 # initialize logger for all the unit tests
 fd, log_fn = tempfile.mkstemp(prefix='easybuild-tests-', suffix='.log')


### PR DESCRIPTION
get rid of sys.exit(0) that slipped in with #752
