### PR TITLE
Make use of LMOD_CMD if it is set

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -568,7 +568,7 @@ class Lmod(ModulesTool):
     def __init__(self, *args, **kwargs):
         """Constructor, set lmod-specific class variable values."""
         super(Lmod, self).__init__(*args, **kwargs)
-        self.cmd = "lmod"
+        self.cmd = os.getenv("LMOD_CMD", "lmod")
         self.check_cmd_avail()
 
         # $LMOD_EXPERT needs to be set to avoid EasyBuild tripping over fiddly bits in output


### PR DESCRIPTION
The Lmod init scripts set LMOD_CMD to the absolute path of the lmod executable.  Respecting LMOD_CMD makes it unnecessary to have lmod findable in PATH and also makes it easier to test new versions of lmod.
