### PR TITLE
add toy build unit test with easyconfig in format v2 and version section markers, including nesting

### DIFF
--- a/test/framework/easyconfigs/v2.0/toy-with-sections.eb
+++ b/test/framework/easyconfigs/v2.0/toy-with-sections.eb
@@ -1,0 +1,36 @@
+# EASYCONFIGFORMAT 2.0
+# this is a version test
+"""
+docstring test
+@author: Stijn De Weirdt (UGent)
+@maintainer: Kenneth Hoste (UGent)
+"""
+name = "toy"
+
+homepage = 'http://hpcugent.github.com/easybuild'
+description = "Toy C program."
+
+sources = ['%(name)s-0.0.tar.gz']  # purposely fixed to 0.0
+checksums = ['f09dca47638869866e28c9f44aadc111']  # (MD5) source checksum
+
+sanity_check_paths = {
+    'files': [('bin/yot', 'bin/toy')],
+    'dirs': ['bin'],
+}
+
+moduleclass = 'tools'
+
+[SUPPORTED]
+versions = 1.0, 0.0, 1.5, 2.0, 3.0
+toolchains = goolf == 1.4.10, dummy == dummy
+
+[> 1.0]
+# all 1.x versions and more recent are 'stable'
+versionprefix = 'stable-'
+[[<= 1.5]]
+# custom suffix for 'early' 1.x releases
+versionsuffix = '-early'
+
+[> 2.0]
+# v2.x and up is considered stable mature
+versionsuffix = '-mature'

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -171,6 +171,42 @@ class ToyBuildTest(TestCase):
 
         self.check_toy(self.installpath, outtxt)
 
+    def test_toy_build_formatv2_sections(self):
+        """Perform a toy build (format v2, using sections)."""
+        versions = {
+            '0.0': {'version': '', 'versionprefix': '', 'versionsuffix': ''},
+            '1.0': {'version': '', 'versionprefix': '', 'versionsuffix': ''},
+            '1.1': {'version': '', 'versionprefix': '', 'versionsuffix': ''},
+            '1.5': {'version': '', 'versionprefix': '', 'versionsuffix': ''},
+            '1.6': {'version': '', 'versionprefix': '', 'versionsuffix': ''},
+            '2.0': {'version': '', 'versionprefix': '', 'versionsuffix': ''},
+            '3.0': {'version': '', 'versionprefix': '', 'versionsuffix': ''},
+        }
+
+        for version, specs in versions.items():
+            args = [
+                os.path.join(os.path.dirname(__file__), 'easyconfigs', 'v2.0', 'toy-with-sections.eb'),
+                '--sourcepath=%s' % self.sourcepath,
+                '--buildpath=%s' % self.buildpath,
+                '--installpath=%s' % self.installpath,
+                '--debug',
+                '--unittest-file=%s' % self.logfile,
+                '--force',
+                '--robot=%s' % os.pathsep.join([self.buildpath, os.path.dirname(__file__)]),
+                '--software-version=%s' % version,
+                '--toolchain=dummy,dummy',
+                '--experimental',
+            ]
+            try:
+                main((args, self.dummylogfn, True))
+            except SystemExit:
+                pass
+            except Exception, err:
+                print "err: %s" % err
+            outtxt = read_file(self.logfile)
+
+            self.check_toy(self.installpath, outtxt, **specs)
+
     def test_toy_build_with_blocks(self):
         """Test a toy build with multiple blocks."""
         orig_sys_path = sys.path[:]


### PR DESCRIPTION
@stdweird: This only adds a unit test for an easyconfig in format v2 that includes version section markers and nesting. The unit test itself is also incomplete, but trying to parse this example now leads to the below (which doesn't make sense to me), which will have to be fixed first:

```
$ eb test/framework/easyconfigs/v2.0/toy-with-sections.eb --experimental
== temporary log file in case of crash /var/folders/6y/x4gmwgjn5qz63b7ftg4j_40m0000gn/T/easybuild-okoKcx/easybuild-i5A_DI.log
Traceback (most recent call last):
  File "/Users/kehoste/work/easybuild-framework/easybuild/main.py", line 360, in <module>
    main()
  File "/Users/kehoste/work/easybuild-framework/easybuild/main.py", line 265, in main
    ecs = process_easyconfig(ec_file, build_options=build_options, build_specs=build_specs)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/tools.py", line 257, in process_easyconfig
    ec = EasyConfig(spec, build_options=build_options, build_specs=build_specs)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 135, in __init__
    self.parse()
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 212, in parse
    local_vars = parser.get_config_dict()
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/parser.py", line 146, in get_config_dict
    return self._formatter.get_config_dict()
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/format/two.py", line 106, in get_config_dict
    co = EBConfigObj(self.configobj)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/format/format.py", line 117, in __init__
    self.parse(configobj)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/format/format.py", line 290, in parse
    self.sections = self.parse_sections(self.configobj)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/format/format.py", line 185, in parse_sections
    new_value = self.parse_sections(configobj, toparse=value, parent=value.parent, depth=value.depth)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyconfig/format/format.py", line 188, in parse_sections
    parsed[new_key] = new_value
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/configobj.py", line 600, in __setitem__
    raise ValueError('The key "%s" is not a string.' % key)
ValueError: The key "<= 1.5" is not a string.
```
