### PR TITLE
add option to also print warning message to screen

### DIFF
--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -83,15 +83,6 @@ class EasyBuildLog(fancylogger.FancyLogger):
                 break
         return "(at %s:%s in %s)" % (os.path.join(*filepath_dirs), line, function_name)
 
-    def experimental(self, msg, *args, **kwargs):
-        """Handle experimental functionality if EXPERIMENTAL is True, otherwise log error"""
-        if EXPERIMENTAL:
-            msg = 'Experimental functionality. Behaviour might change/be removed later. ' + msg
-            self.warning(msg, *args, **kwargs)
-        else:
-            msg = 'Experimental functionality. Behaviour might change/be removed later (use --experimental option to enable). ' + msg
-            self.error(msg, *args)
-
     def deprecated(self, msg, max_ver):
         """Print deprecation warning or raise an EasyBuildError, depending on max version allowed."""
         fancylogger.FancyLogger.deprecated(self, msg, str(CURRENT_VERSION), max_ver, exception=EasyBuildError)
@@ -113,6 +104,22 @@ class EasyBuildLog(fancylogger.FancyLogger):
         self.raiseError = True
 
         raise EasyBuildError(newMsg)
+
+    def experimental(self, msg, *args, **kwargs):
+        """Handle experimental functionality if EXPERIMENTAL is True, otherwise log error"""
+        if EXPERIMENTAL:
+            msg = 'Experimental functionality. Behaviour might change/be removed later. ' + msg
+            self.warning(msg, *args, **kwargs)
+        else:
+            msg = 'Experimental functionality. Behaviour might change/be removed later (use --experimental option to enable). ' + msg
+            self.error(msg, *args)
+
+    def warning(self, msg, *args, **kwargs):
+        """Print warning message, and continue."""
+        print_to_screen = kwargs.pop('print_to_screen', False)
+        if print_to_screen:
+            print("WARNING: %s" % msg)
+        fancylogger.FancyLogger.warning(self, msg, *args, **kwargs)
 
 
 # set format for logger


### PR DESCRIPTION
warnings are now 'silent' in the sense that they only appear in log files, not in the terminal output, which is wrong

switching to verbose warnings directly would be too painful for now, given all the deprecated stuff that is still being triggered and should be fleshed out first

for now, we can provide the possibility for verbose warnings using a `print_to_screen` named argument, which can later be switched to default `True`
