### PR TITLE
fix linking with -lcudart, should also include -lrt

### DIFF
--- a/easybuild/toolchains/compiler/cuda.py
+++ b/easybuild/toolchains/compiler/cuda.py
@@ -65,7 +65,7 @@ class Cuda(Compiler):
 
     COMPILER_CUDA_CC = 'nvcc'
     COMPILER_CUDA_CXX = 'nvcc'
-    LIB_CUDA_RUNTIME = 'cudart'
+    LIB_CUDA_RUNTIME = ['rt', 'cudart']
 
     def __init__(self, *args, **kwargs):
         """Constructor, with settings custom to CUDA."""

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -373,7 +373,7 @@ class ToolchainTest(EnhancedTestCase):
         nvcc_flags = r' '.join([
             r'-Xcompiler="-O2 -march=native"',
             # the use of -lcudart in -Xlinker is a bit silly but hard to avoid
-            r'-Xlinker=".* -lm -lcudart -lpthread"',
+            r'-Xlinker=".* -lm -lrt -lcudart -lpthread"',
             r' '.join(["-gencode %s" % x for x in opts['cuda_gencode']]),
         ])
 
@@ -389,7 +389,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(tc.comp_family(prefix='CUDA'), "CUDA")
 
         # check CUDA runtime lib
-        self.assertTrue("-lcudart" in tc.get_variable('LIBS'))
+        self.assertTrue("-lrt -lcudart" in tc.get_variable('LIBS'))
 
     def test_ictce_toolchain(self):
         """Test for ictce toolchain."""


### PR DESCRIPTION
@pescobar: this should fix the problem of building `gzip` with a `goolfc` toolchain

@ajdecon: does this make sense to you, i.e. is `-lrt` requires when linking with `-lcudart`, even for non-CUDA apps like `gzip`?
