### PR TITLE
fix github tests

### DIFF
--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -72,7 +72,7 @@ class GithubTest(EnhancedTestCase):
     def test_read_api(self):
         """Test the githubfs read function"""
         try:
-            self.assertEquals(self.ghfs.read("a_directory/a_file.txt"), "this is a line of text\n")
+            self.assertEquals(self.ghfs.read("a_directory/a_file.txt").strip(), "this is a line of text")
         except IOError:
             pass
 
@@ -80,7 +80,7 @@ class GithubTest(EnhancedTestCase):
         """Test the githubfs read function without using the api"""
         try:
             fp = self.ghfs.read("a_directory/a_file.txt", api=False)
-            self.assertEquals(open(fp, 'r').read(), "this is a line of text\n")
+            self.assertEquals(open(fp, 'r').read().strip(), "this is a line of text")
             os.remove(fp)
         except (IOError, OSError):
             pass


### PR DESCRIPTION
seems like something changed in the GitHub API, tests occasionally fail with:

```
======================================================================
FAIL [0.774s]: Test the githubfs read function without using the api
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/var/lib/jenkins/workspace/easybuild-framework_unit-test_boegel_test-python24/test/framework/github.py", line 83, in test_read
    self.assertEquals(open(fp, 'r').read(), "this is a line of text\n")
AssertionError: 'this is a line of text\n\n' != 'this is a line of text\n'

----------------------------------------------------------------------
```

This patch should fix that.
