### PR TITLE
allow more liberal version regexp in EnvironmentModulesC

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -565,7 +565,7 @@ class ModulesTool(object):
 class EnvironmentModulesC(ModulesTool):
     """Interface to (C) environment modules (modulecmd)."""
     COMMAND = "modulecmd"
-    VERSION_REGEXP = r'^\s*VERSION\s*=\s*(?P<version>\d\S*)\s*^'
+    VERSION_REGEXP = r'^\s*(VERSION\s*=\s*)?(?P<version>\d\S*)\s*^'
 
     def module_software_name(self, mod_name):
         """Get the software name for a given module name."""


### PR DESCRIPTION
Older versions of environment modules (C) simply output version strings like `3.1.6`.  Make the VERSION_REGEXP accept this.
