### PR TITLE
fix unit test for --skip

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -242,11 +242,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--try-amend=sources=toy-0.0.tar.gz,toy-0.0.tar.gz',  # hackish, but fine
             '--force',
             '--debug',
+            '--skip',
         ]
-        self.eb_main(args, do_build=True)
-        modules_tool().purge()
-
-        args.append('--skip')
         outtxt = self.eb_main(args, do_build=True, verbose=True)
 
         found_msg = "Module toy/1.2.3.4.5.6.7.8.9 found."


### PR DESCRIPTION
I have no idea how the sanity check part of the skipped build ever worked, since the installation was never actually there (only the module was/is)...
