### PR TITLE
Improve intel compiler arch optimization when compiling in amd cpus

### DIFF
--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -70,7 +70,7 @@ class IntelIccIfort(Compiler):
 
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {
         systemtools.INTEL : 'xHOST',
-        systemtools.AMD : 'mavx',
+        systemtools.AMD : 'xHost',
     }
 
     COMPILER_CC = 'icc'


### PR DESCRIPTION
this requires more testing. 

only tested in AMD bulldozer cpus and toolchain ictce-6.2.5

mavx option help
`-mavx     May generate Intel(R) AVX, SSE4.2, SSE4.1, SSSE3, SSE3, SSE2, and SSE`
