### PR TITLE
generate 'module use' statements rather than 'prepend-path MODULEPATH' for module path extensions

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -863,9 +863,10 @@ class EasyBlock(object):
         txt = ''
         if modpath_exts:
             full_path_modpath_extensions = [os.path.join(top_modpath, GENERAL_CLASS, ext) for ext in modpath_exts]
-            # collapse to a single module path extension statement (requires a non-empty list of extension paths)
-            all_full_path_modpath_extensions = os.pathsep.join(full_path_modpath_extensions)
-            txt = self.moduleGenerator.prepend_paths('MODULEPATH', all_full_path_modpath_extensions, allow_abs=True)
+            # module path extensions must exist, otherwise loading this module file will fail
+            for modpath_extension in full_path_modpath_extensions:
+                mkdir(modpath_extension, parents=True)
+            txt = self.moduleGenerator.use(full_path_modpath_extensions)
         return txt
 
     def make_module_req(self):

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -179,6 +179,15 @@ class ModuleGenerator(object):
         statements = [template % (key, p) for p in paths]
         return ''.join(statements)
 
+    def use(self, paths):
+        """
+        Generate module use statements for given list of module paths.
+        """
+        use_statements = []
+        for path in paths:
+            use_statements.append("module use %s" % path)
+        return '\n'.join(use_statements)
+
     def set_environment(self, key, value):
         """
         Generate setenv statement for the given key/value pair.

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -144,6 +144,13 @@ class ModuleGeneratorTest(EnhancedTestCase):
                                               "which only expects relative paths." % self.modgen.app.installdir,
                               self.modgen.prepend_paths, "key2", ["bar", "%s/foo" % self.modgen.app.installdir])
 
+    def test_use(self):
+        """Test generating module use statements."""
+        expected = '\n'.join([
+            "module use /some/path",
+            "module use /foo/bar/baz",
+        ])
+        self.assertEqual(self.modgen.use(["/some/path", "/foo/bar/baz"]), expected)
 
     def test_env(self):
         """Test setting of environment variables."""

--- a/test/framework/modules/Compiler/GCC/4.7.2/OpenMPI/1.6.4
+++ b/test/framework/modules/Compiler/GCC/4.7.2/OpenMPI/1.6.4
@@ -10,7 +10,7 @@ module-whatis {Description: The Open MPI Project is an open source MPI-2 impleme
 set root    /tmp/software/Compiler/GCC/4.8.2/OpenMPI/1.6.5-no-OFED
 
 conflict    OpenMPI
-prepend-path	MODULEPATH		/tmp/modules/all/MPI/GCC/4.7.2/OpenMPI/1.6.4
+module use /tmp/modules/all/MPI/GCC/4.7.2/OpenMPI/1.6.4
 
 if { ![is-loaded hwloc/1.6.2] } {
     module load hwloc/1.6.2

--- a/test/framework/modules/Core/GCC/4.7.2
+++ b/test/framework/modules/Core/GCC/4.7.2
@@ -12,7 +12,7 @@ module-whatis {Description: The GNU Compiler Collection includes front ends for 
 set root    /tmp/software/Core/GCC/4.7.2
 
 conflict    GCC
-prepend-path	MODULEPATH		/tmp/modules/all/Compiler/GCC/4.7.2
+module use /tmp/modules/all/Compiler/GCC/4.7.2
 
 prepend-path	CPATH		$root/include
 prepend-path	LD_LIBRARY_PATH		$root/lib

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -508,7 +508,7 @@ class ToyBuildTest(EnhancedTestCase):
             os.path.join(install_mod_path, 'Compiler', 'GCC', '4.7.2', 'OpenMPI', '1.6.4'),
         ]:
             for line in fileinput.input(modfile, inplace=1):
-                line = re.sub(r"(prepend-path\s*MODULEPATH\s*)/tmp/modules/all",
+                line = re.sub(r"(module\s*use\s*)/tmp/modules/all",
                               r"\1%s/modules/all" % self.test_installpath,
                               line)
                 sys.stdout.write(line)
@@ -569,7 +569,7 @@ class ToyBuildTest(EnhancedTestCase):
         # no dependencies or toolchain => no module load statements in module file
         modtxt = open(toy_module_path, 'r').read()
         modpath_extension = os.path.join(mod_prefix, 'MPI', 'GCC', '4.7.2', 'toy', '0.0')
-        self.assertTrue(re.search("^prepend-path\s*MODULEPATH\s*%s" % modpath_extension, modtxt, re.M))
+        self.assertTrue(re.search("^module\s*use\s*%s" % modpath_extension, modtxt, re.M))
 
         # test module path with dummy/dummy build
         extra_args = [
@@ -599,7 +599,7 @@ class ToyBuildTest(EnhancedTestCase):
         # no dependencies or toolchain => no module load statements in module file
         modtxt = open(toy_module_path, 'r').read()
         modpath_extension = os.path.join(mod_prefix, 'Compiler', 'toy', '0.0')
-        self.assertTrue(re.search("^prepend-path\s*MODULEPATH\s*%s" % modpath_extension, modtxt, re.M))
+        self.assertTrue(re.search("^module\s*use\s*%s" % modpath_extension, modtxt, re.M))
 
     def test_toy_advanced(self):
         """Test toy build with extensions and non-dummy toolchain."""


### PR DESCRIPTION
this is a hard requirement for modulecmd.tcl (the DEISA variant), and it makes sense to differentiate `prepend-path X` from `module use` explicitely

@stdweird: please review
