### PR TITLE
fetch extension sources in fetch_step, enhances --stop=fetch

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1287,7 +1287,7 @@ class EasyBlock(object):
         """Install built software (abstract method)."""
         raise NotImplementedError
 
-    def extensions_step(self):
+    def extensions_step(self, fetch=False):
         """
         After make install, run this.
         - only if variable len(exts_list) > 0
@@ -1304,10 +1304,10 @@ class EasyBlock(object):
 
         self.prepare_for_extensions()
 
-        if self.exts:
-            self.exts_all = self.exts[:]  # retain a copy of all extensions, regardless of filtering/skipping
-        else:
-            self.exts = []
+        if fetch:
+            self.exts = self.fetch_extension_sources()
+            
+        self.exts_all = self.exts[:]  # retain a copy of all extensions, regardless of filtering/skipping
 
         if self.skip:
             self.skip_extensions()

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -212,8 +212,8 @@ class EasyBlockTest(EnhancedTestCase):
         # test for proper error message without the exts_defaultclass set
         eb = EasyBlock(EasyConfig(self.eb_file))
         eb.installdir = config.install_path()
-        self.assertRaises(EasyBuildError, eb.extensions_step)
-        self.assertErrorRegex(EasyBuildError, "No default extension class set", eb.extensions_step)
+        self.assertRaises(EasyBuildError, eb.extensions_step, fetch=True)
+        self.assertErrorRegex(EasyBuildError, "No default extension class set", eb.extensions_step, fetch=True)
 
         # test if everything works fine if set
         self.contents += "\nexts_defaultclass = ['easybuild.framework.extension', 'Extension']"
@@ -221,7 +221,7 @@ class EasyBlockTest(EnhancedTestCase):
         eb = EasyBlock(EasyConfig(self.eb_file))
         eb.builddir = config.build_path()
         eb.installdir = config.install_path()
-        eb.extensions_step()
+        eb.extensions_step(fetch=True)
 
         # test for proper error message when skip is set, but no exts_filter is set
         self.assertRaises(EasyBuildError, eb.skip_extensions)
@@ -250,7 +250,7 @@ class EasyBlockTest(EnhancedTestCase):
         eb.builddir = config.build_path()
         eb.installdir = config.install_path()
         eb.skip = True
-        eb.extensions_step()
+        eb.extensions_step(fetch=True)
         # 'ext1' should be in eb.exts
         self.assertTrue('ext1' in [y for x in eb.exts for y in x.values()])
         # 'ext2' should not


### PR DESCRIPTION
Add download-only basic option to permit download without building software.

It can be useful for packages with tons of extensions like R which fails to build because an extension version is not online anymore, it happen frequently.

Example (output was truncated by removing dependencies lines) :
eb --download-only R-3.0.2-goolf-1.4.10.eb -r
== temporary log file in case of crash /tmp/easybuild-DilvLk/easybuild-1iRUpm.log
== Download sources and extensions with dependencies
[*] processing /Softs/easybuild/easybuild/easyconfigs/r/R/R-3.0.2-goolf-1.4.10.eb
ERROR: EasyBuild crashed with an error (at easybuild/python/lib/python2.6/site-packages/easybuild_framework-1.15.0dev-py2.6.egg/easybuild/framework/easyblock.py:562 in obtain_file): Couldn't find file mzR_1.10.0.tar.gz anywhere, and downloading it didn't work either...

By preparing download before building, less time is lost by rebuilding because of stupid wrong url.
