### PR TITLE
make sure $SCALAPACK_INC_DIR (and $SCALAPACK_LIB_DIR) are defined when using imkl

### DIFF
--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -153,5 +153,8 @@ class IntelMKL(LinAlg):
             # ilp64/i8
             self.SCALAPACK_LIB_MAP.update({"lp64_sc":'_ilp64'})
 
+        self.SCALAPACK_LIB_DIR = self.BLAS_LIB_DIR
+        self.SCALAPACK_INCLUDE_DIR = self.BLAS_INCLUDE_DIR
+
         super(IntelMKL, self)._set_scalapack_variables()
 


### PR DESCRIPTION
fix for issue https://github.com/hpcugent/easybuild-easyconfigs/issues/981 reported by @hajgato
