### PR TITLE
improve error message generated for a missing easyconfig file

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1032,7 +1032,8 @@ class ActiveMNS(object):
                     self.log.debug("Full list of parsed easyconfigs: %s" % parsed_ec)
                 ec = parsed_ec[0]['ec']
             else:
-                self.log.error("Failed to find an easyconfig file when determining module name for: %s" % ec)
+                tup = (ec['name'], det_full_ec_version(ec), ec)
+                self.log.error("Failed to find easyconfig file '%s-%s.eb' when determining module name for: %s" % tup)
 
         return ec
 


### PR DESCRIPTION
easyconfig filename being looked for is now included in error message:

```
Failed to find easyconfig file 'imkl-10.3.12.361.eb' when determining module name for: {'dummy': True, 'versionsuffix': '', 'version': '10.3.12.361', 'toolchain': {'version': 'dummy', 'name': 'dummy'}, 'name': 'imkl', 'full_mod_name': None, 'hidden': False, 'short_mod_name': None}
```

suggestion by @treydock
