### PR TITLE
include 'hidden' in key for easyconfigs cache

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -886,7 +886,7 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
     # only cache when no build specifications are involved (since those can't be part of a dict key)
     cache_key = None
     if build_specs is None:
-        cache_key = (path, validate, parse_only)
+        cache_key = (path, validate, hidden, parse_only)
         if cache_key in _easyconfigs_cache:
             return copy.deepcopy(_easyconfigs_cache[cache_key])
 


### PR DESCRIPTION
bug introduced via #1009, which manifest itself via the easybuild-easyconfigs unit tests (see e.g. https://jenkins1.ugent.be/view/pull-request-builder/job/easybuild-easyconfigs-pr-builder/1297/console)
