### PR TITLE
escape modloadmsg

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -214,7 +214,8 @@ class ModuleGenerator(object):
         """
         Add a message that should be printed when loading the module.
         """
-        msg = re.sub(r'((?<!\\)[%s])'% ''.join(self.CHARS_TO_ESCAPE),r'\\\1',msg)
+        # escape any (non-escaped) characters with special meaning by prefixing them with a backslash
+        msg = re.sub(r'((?<!\\)[%s])'% ''.join(self.CHARS_TO_ESCAPE), r'\\\1', msg)
         return '\n'.join([
             "",
             "if [ module-info mode load ] {",

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -171,8 +171,15 @@ class ModuleGeneratorTest(EnhancedTestCase):
 
     def test_load_msg(self):
         """Test including a load message in the module file."""
-        tcl_load_msg = '\nif [ module-info mode load ] {\n        puts stderr     "test"\n}\n'
-        self.assertEqual(tcl_load_msg, self.modgen.msg_on_load('test'))
+        tcl_load_msg = '\n'.join([
+            '',
+            "if [ module-info mode load ] {",
+            "        puts stderr     \"test \\$test \\$test",
+            "test \\$foo \\$bar\"",
+            "}",
+            '',
+        ])
+        self.assertEqual(tcl_load_msg, self.modgen.msg_on_load('test $test \\$test\ntest $foo \\$bar'))
 
     def test_tcl_footer(self):
         """Test including a Tcl footer."""


### PR DESCRIPTION
when you use something like this in a easyconfig, you need to scape $

```
modloadmsg = """To list all the available utilities execute ls \\$EBROOTPICARD"""
```

With this fix easybuild will take care of scaping 
