### PR TITLE
include info log msg with name/location of used easyblock

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -186,7 +186,6 @@ class EasyBlock(object):
 
         # initialize logger
         self._init_log()
-        self.log.info("This is easyblock %s at %s" % (self.__class__.__name__, inspect.getmodule(self)))
 
         # should we keep quiet?
         self.silent = build_option('silent')
@@ -221,6 +220,10 @@ class EasyBlock(object):
         self.log = fancylogger.getLogger(name=self.__class__.__name__, fname=False)
 
         self.log.info(this_is_easybuild())
+
+        this_module = inspect.getmodule(self)
+        tup = (self.__class__.__name__, this_module.__name__, this_module.__file__)
+        self.log.info("This is easyblock %s from module %s (%s)" % tup)
 
     def close_log(self):
         """

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -116,8 +116,8 @@ class EasyBlockTest(EnhancedTestCase):
         sys.stdout = stdoutorig
 
         # check whether 'This is easyblock' log message is there
-        tup = ('EasyBlock', 'easybuild.framework.easyblock', 'easybuild/framework/easyblock.pyc*')
-        eb_log_msg_re = re.compile(r"INFO This is easyblock %s at <module '%s' from '%s'>" % tup, re.M)
+        tup = ('EasyBlock', 'easybuild.framework.easyblock', '.*easybuild/framework/easyblock.pyc*')
+        eb_log_msg_re = re.compile(r"INFO This is easyblock %s from module %s (%s)" % tup, re.M)
         logtxt = read_file(eb.logfile)
         self.assertTrue(eb_log_msg_re.search(logtxt), "Pattern '%s' found in: %s" % (eb_log_msg_re.pattern, logtxt))
 
@@ -391,7 +391,7 @@ class EasyBlockTest(EnhancedTestCase):
 
         # check whether 'This is easyblock' log message is there
         tup = ('EB_toy', 'easybuild.easyblocks.toy', '.*test/framework/sandbox/easybuild/easyblocks/toy.pyc*')
-        eb_log_msg_re = re.compile(r"INFO This is easyblock %s at <module '%s' from '%s'>" % tup, re.M)
+        eb_log_msg_re = re.compile(r"INFO This is easyblock %s from module %s (%s)" % tup, re.M)
         logtxt = read_file(eb.logfile)
         self.assertTrue(eb_log_msg_re.search(logtxt), "Pattern '%s' found in: %s" % (eb_log_msg_re.pattern, logtxt))
 


### PR DESCRIPTION
This makes a log message like the one below to be included in the application log:

```
== 2014-10-23 19:52:16,785 main.EB_bzip2 INFO This is easyblock EB_bzip2 at <module 'easybuild.easyblocks.bzip2' from '/Users/kehoste/work/easybuild-easyblocks/easybuild/easyblocks/b/bzip2.pyc'>
```

Although the class name is mentioned twice, I feel it's important to make the log message "complete" by including it in the actual message itself.
