### PR TITLE
fix tests that break when installed easyconfigs pkg is present

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -89,9 +89,9 @@ def find_easyconfigs_by_specs(build_specs, robot_path, try_to_generate, testing=
                 _log.warning("Failed to remove generated easyconfig file %s: %s" % (ec_file, err))
 
             # don't use a generated easyconfig unless generation was requested (using a --try-X option)
-            print_error(("Unable to find an easyconfig for the given specifications: %s; "
-                         "to make EasyBuild try to generate a matching easyconfig, "
-                         "use the --try-X options ") % build_specs, log=_log)
+            _log.error(("Unable to find an easyconfig for the given specifications: %s; "
+                        "to make EasyBuild try to generate a matching easyconfig, "
+                        "use the --try-X options ") % build_specs)
 
     return [(ec_file, generated)]
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -578,7 +578,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         os.close(fd)
 
         # copy test easyconfigs to easybuild/easyconfigs subdirectory of temp directory
-        # to check with easyconfigs install path is auto-included in robot path
+        # to check whether easyconfigs install path is auto-included in robot path
         tmpdir = tempfile.mkdtemp(prefix='easybuild-easyconfigs-pkg-install-path')
         mkdir(os.path.join(tmpdir, 'easybuild'), parents=True)
 
@@ -586,7 +586,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         shutil.copytree(test_ecs_dir, os.path.join(tmpdir, 'easybuild', 'easyconfigs'))
 
         orig_sys_path = sys.path[:]
-        sys.path.append(tmpdir)
+        sys.path.insert(0, tmpdir)  # prepend to give it preference over possible other installed easyconfigs pkgs
 
         for dry_run_arg in ['-D', '--dry-run-short']:
             open(self.logfile, 'w').write('')


### PR DESCRIPTION
missed these when handling #1059, these tests only fail when an installed easyconfigs package is present in `$PYTHONPATH`, which is not the case on Jenkins
