### PR TITLE
filter out /dev/null entries in list of patch files for PR

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -608,7 +608,11 @@ def det_patched_files(path=None, txt=None, omit_ab_prefix=False):
         patched_file = match.group('file')
         if not omit_ab_prefix and match.group('ab_prefix') is not None:
             patched_file = match.group('ab_prefix') + patched_file
-        patched_files.append(patched_file)
+
+        if patched_file in ['/dev/null']:
+            _log.debug("Ignoring patched file %s" % patched_file)
+        else:
+            patched_files.append(patched_file)
 
     return patched_files
 

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -251,10 +251,7 @@ def fetch_easyconfigs_from_pr(pr, path=None, github_user=None):
     diff_txt = download(pr_data['diff_url'])
 
     patched_files = det_patched_files(txt=diff_txt, omit_ab_prefix=True)
-    _log.debug("List of patched files (before filtering): %s" % patched_files)
-    # filter out '/dev/null' entries (removed files)
-    patched_files = [pf for pf in patched_files if pf != '/dev/null']
-    _log.debug("List of patched files (after filtering): %s" % patched_files)
+    _log.debug("List of patched files: %s" % patched_files)
 
     # obtain last commit
     # get all commits, increase to (max of) 100 per page


### PR DESCRIPTION
Ran into this issue when testing https://github.com/hpcugent/easybuild-easyconfigs/pull/1217, see https://github.com/hpcugent/easybuild-easyconfigs/pull/1217.diff
