### PR TITLE
fix generate_software_list.py script w.r.t. deprecated fallback to ConfigureMake

### DIFF
--- a/easybuild/scripts/generate_software_list.py
+++ b/easybuild/scripts/generate_software_list.py
@@ -126,12 +126,13 @@ for root, subfolders, files in walk(options.path):
             log.info("found valid easyconfig %s" % ec)
             if not ec.name in names:
                 log.info("found new software package %s" % ec)
+                ec.easyblock = None
                 # check if an easyblock exists
-                module = get_easyblock_class(None, name=ec.name).__module__.split('.')[-1]
-                if module != "configuremake":
-                    ec.easyblock = module
-                else:
-                    ec.easyblock = None
+                ebclass = get_easyblock_class(None, name=ec.name, default_fallback=False)
+                if ebclass is not None:
+                    module = ebclass.__module__.split('.')[-1]
+                    if module != "configuremake":
+                        ec.easyblock = module
                 configs.append(ec)
                 names.append(ec.name)
         except Exception, err:


### PR DESCRIPTION
replaces #1125, for inclusion in v1.16.1
