### PR TITLE
update EasyBuild bootstrap script to download distribute tarball from http://easybuilders.github.io/easybuild/files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,10 +84,10 @@ script:
     # run test suite
     - python -O -m test.framework.suite
     # check bootstrap script version
-    # version and MD5 are hardcoded below to avoid forgetting to update the version in the script along with contents
+    # version and SHA256 checksum are hardcoded below to avoid forgetting to update the version in the script along with contents
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
-    - EB_BOOTSTRAP_MD5SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
-    - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_MD5SUM"
+    - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
+    - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
     - EB_BOOTSTRAP_EXPECTED="20170705.01 25fcfc58064367d496797ae8d563544dc9ffb284ef19ace20882aff63aa406c3"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_MD5SUM=$(md5sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_MD5SUM"
-    - EB_BOOTSTRAP_EXPECTED="20170503.01 fdf8ca02b6600c4ce0b6a02b88f1f40a"
+    - EB_BOOTSTRAP_EXPECTED="20170705.01 90d2dd008be027c35c1d194cbf5b1d44"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,9 +86,9 @@ script:
     # check bootstrap script version
     # version and MD5 are hardcoded below to avoid forgetting to update the version in the script along with contents
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
-    - EB_BOOTSTRAP_MD5SUM=$(md5sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
+    - EB_BOOTSTRAP_MD5SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_MD5SUM"
-    - EB_BOOTSTRAP_EXPECTED="20170705.01 90d2dd008be027c35c1d194cbf5b1d44"
+    - EB_BOOTSTRAP_EXPECTED="20170705.01 25fcfc58064367d496797ae8d563544dc9ffb284ef19ace20882aff63aa406c3"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# http://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -419,7 +419,7 @@ def stage0(tmpdir):
     # We download a custom version of distribute: it uses a newer version of markerlib to avoid a bug (#1099)
     # It's is the source of distribute 0.6.49 with the file _markerlib/markers.py replaced by the 0.6 version of
     # markerlib which can be found at https://pypi.python.org/pypi/markerlib/0.6.0
-    sys.argv.append('--download-base=http://hpcugent.github.io/easybuild/files/')
+    sys.argv.append('--download-base=http://easybuilders.github.io/easybuild/files/')
     distribute_setup_main(version="0.6.49-patched1")
     sys.argv = orig_sys_argv
 
@@ -846,7 +846,7 @@ easyblock = 'EB_EasyBuildMeta'
 name = 'EasyBuild'
 version = '%(version)s'
 
-homepage = 'http://hpcugent.github.com/easybuild/'
+homepage = 'http://easybuilders.github.com/easybuild/'
 description = \"\"\"EasyBuild is a software build and installation framework
 written in Python that allows you to install software in a structured,
 repeatable and robust way.\"\"\"

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -53,7 +53,7 @@ from distutils.version import LooseVersion
 from hashlib import md5
 
 
-EB_BOOTSTRAP_VERSION = '20170503.01'
+EB_BOOTSTRAP_VERSION = '20170705.01'
 
 # argparse preferrred, optparse deprecated >=2.7
 HAVE_ARGPARSE = False


### PR DESCRIPTION
The download of the `distribute` tarball is going to break when https://github.com/hpcugent/easybuild is transferred to https://github.com/easybuilders/easybuild later today.

This can be fixed by including `distribute-0.6.49-patched1.tar.gz` in https://github.com/hpcugent/hpcugent.github.com/pull/3 (which I'll probably do), but the bootstrap script should be updated accordingly.