### PR TITLE
get rid of references to hpcugent after move to github.com/easybuilders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20170705.01 25fcfc58064367d496797ae8d563544dc9ffb284ef19ace20882aff63aa406c3"
+    - EB_BOOTSTRAP_EXPECTED="20170706.01 484b3ae32ca7057de2ccc83820927bdaf0f4e3d3be6cda1747ec80449509a0e9"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ under different terms from the Initial License or this Contributor Agreement.
 
 ### Fork easybuild-framework
 
-First, you'll need to fork [easybuild-framework on GitHub](http://github.com/hpcugent/easybuild-framework).
+First, you'll need to fork [easybuild-framework on GitHub](https://github.com/easybuilders/easybuild-framework).
 
 If you do not have a (free) GitHub account yet, you'll need to get one.
 
@@ -43,10 +43,10 @@ Pull the _develop_ branch from the main easybuild-framework repository:
 
 ```bash
 cd easybuild
-git remote add github_hpcugent git@github.com:hpcugent/easybuild-framework.git
+git remote add github_easybuilders git@github.com/easybuilders/easybuild-framework.git
 git branch develop
 git checkout develop
-git pull github_hpcugent develop
+git pull github_easybuilders develop
 ```
 
 ### Keep develop up-to-date
@@ -57,7 +57,7 @@ Make sure you update it every time you create a feature branch (see below):
 
 ```bash
 git checkout develop
-git pull github_hpcugent develop
+git pull github_easybuilders develop
 ```
 
 
@@ -67,7 +67,7 @@ git pull github_hpcugent develop
 ### Pick a branch name
 
 Please try and follow these guidelines when picking a branch name:
- * use the number of the issue as a prefix for your branch name, e.g. `86_` for issue [#86](https://github.com/hpcugent/easybuild-framework/issues/86)
+ * use the number of the issue as a prefix for your branch name, e.g. `86_` for issue [#86](https://github.com/easybuilders/easybuild-framework/issues/86)
  * append a short but descriptive branch name, in which words are joined by underscores, e.g. `86_encoding_scheme`
 
 ### Create branch
@@ -131,7 +131,7 @@ If you're contributing code to an existing issue you can also convert the issue 
 GITHUBUSER=your_username && PASSWD=your_password && BRANCH=branch_name && ISSUE=issue_number && \
 curl --user "$GITHUBUSER:$PASSWD" --request POST \
 --data "{\"issue\": \"$ISSUE\", \"head\": \"$GITHUBUSER:$BRANCH\", \"base\": \"develop\"}" \
-https://api.github.com/repos/hpcugent/easybuild-framework/pulls
+https://api.github.com/repos/easybuilders/easybuild-framework/pulls
 ```
 This is currently only supported by github from the command line and not via the web interface.
 You might also want to look into [hub](https://github.com/defunkt/hub) for more command line features.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
-.. image:: http://hpcugent.github.io/easybuild/images/easybuild_logo_small.png
+.. image:: https://easybuilders.github.io/easybuild/images/easybuild_logo_small.png
    :align: center
 
-`EasyBuild <https://hpcugent.github.io/easybuild>`_ is a software build
+`EasyBuild <https://easybuilders.github.io/easybuild>`_ is a software build
 and installation framework that allows you to manage (scientific) software
 on High Performance Computing (HPC) systems in an efficient way.
 
@@ -14,14 +14,14 @@ The EasyBuild documentation is available at http://easybuild.readthedocs.org/.
 
 The EasyBuild framework source code is hosted on GitHub, along
 with an issue tracker for bug reports and feature requests, see
-http://github.com/hpcugent/easybuild-framework.
+https://github.com/easybuilders/easybuild-framework.
 
 Related Python packages:
 
 * **easybuild-easyblocks**
 
   * a collection of easyblocks that implement support for building and installing (groups of) software packages
-  * GitHub repository: http://github.com/hpcugent/easybuild-easyblocks
+  * GitHub repository: https://github.com/easybuilders/easybuild-easyblocks
   * package on PyPi: https://pypi.python.org/pypi/easybuild-easyblocks
 
 * **easybuild-easyconfigs**
@@ -29,21 +29,21 @@ Related Python packages:
   * a collection of example easyconfig files that specify which software to build,
     and using which build options; these easyconfigs will be well tested
     with the latest compatible versions of the easybuild-framework and easybuild-easyblocks packages
-  * GitHub repository: http://github.com/hpcugent/easybuild-easyconfigs
+  * GitHub repository: https://github.com/easybuilders/easybuild-easyconfigs
   * PyPi: https://pypi.python.org/pypi/easybuild-easyconfigs
 
 The code in the ``vsc`` directory originally comes from the *vsc-base* package
-(https://github.com/hpcugent/vsc-base).
+(https://github.com/easybuilders/vsc-base).
 
 
 *Build status overview:*
 
 * **master** branch:
 
-  .. image:: https://travis-ci.org/hpcugent/easybuild-framework.svg?branch=master
-      :target: https://travis-ci.org/hpcugent/easybuild-framework/branches
+  .. image:: https://travis-ci.org/easybuilders/easybuild-framework.svg?branch=master
+      :target: https://travis-ci.org/easybuilders/easybuild-framework/branches
 
 * **develop** branch:
 
-  .. image:: https://travis-ci.org/hpcugent/easybuild-framework.svg?branch=develop
-      :target: https://travis-ci.org/hpcugent/easybuild-framework/branches
+  .. image:: https://travis-ci.org/easybuilders/easybuild-framework.svg?branch=develop
+      :target: https://travis-ci.org/easybuilders/easybuild-framework/branches

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,13 @@ https://github.com/easybuilders/easybuild-framework.
 
 Related Python packages:
 
+* **vsc-base**
+
+  * dependency for EasyBuild framework
+  * provides ``generaloption`` (support for command line interface) & ``fancylogger`` (logging support)
+  * GitHub repository: https://github.com/hpcugent/vsc-base
+  * package on PyPi: https://pypi.python.org/pypi/vsc-base
+
 * **easybuild-easyblocks**
 
   * a collection of easyblocks that implement support for building and installing (groups of) software packages
@@ -31,9 +38,6 @@ Related Python packages:
     with the latest compatible versions of the easybuild-framework and easybuild-easyblocks packages
   * GitHub repository: https://github.com/easybuilders/easybuild-easyconfigs
   * PyPi: https://pypi.python.org/pypi/easybuild-easyconfigs
-
-The code in the ``vsc`` directory originally comes from the *vsc-base* package
-(https://github.com/easybuilders/vsc-base).
 
 
 *Build status overview:*

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,7 +1,7 @@
 This file contains a description of the major changes to the easybuild-framework EasyBuild package.
 For more detailed information, please see the git log.
 
-These release notes can also be consulted at http://easybuild.readthedocs.org/en/latest/Release_notes.html.
+These release notes can also be consulted at https://easybuild.readthedocs.io/en/latest/Release_notes.html.
 
 v3.3.0 (June 26th 2017)
 -----------------------
@@ -15,9 +15,9 @@ feature release
   - add support for SHA256 checksums (#2215)
     - also auto-detect whether provided checksum is MD5 or SHA256 based on length (if not checksum type is specified)
     - add support for --enforce-checksums, to require availability of checksums for sources/patches
-    - see http://easybuild.readthedocs.io/en/latest/Writing_easyconfig_files.html#source-files-patches-and-checksums
+    - see https://easybuild.readthedocs.io/en/latest/Writing_easyconfig_files.html#source-files-patches-and-checksums
   - add support for renaming sources on download (#2223)
-    - also involves deprecating use of 2-tuple elements in list of sources, see http://easybuild.readthedocs.io/en/latest/Deprecated-functionality.html#depr-sources-2-element-tuple
+    - also involves deprecating use of 2-tuple elements in list of sources, see https://easybuild.readthedocs.io/en/latest/Deprecated-functionality.html#depr-sources-2-element-tuple
   - add support for --detect-loaded-modules (#2228)
   - give extensions access to module_generator of parent (#2229)
   - pass down additional arguments to copy_dir down to shutil.copytree (#2230)
@@ -188,11 +188,11 @@ feature release
   - the minimal required version of Lmod was bumped to 5.8 (#1985)
 - major new features:
   - (experimental) support for RPATH linking via --rpath (#1942)
-    - see http://easybuild.readthedocs.org/en/latest/RPATH-support.html
+    - see https://easybuild.readthedocs.io/en/latest/RPATH-support.html
   - add support for --consider-archived-easyconfigs (#1972)
-    - see http://easybuild.readthedocs.org/en/latest/Archived-easyconfigs.html
+    - see https://easybuild.readthedocs.io/en/latest/Archived-easyconfigs.html
   - stabilize --new-pr and --update-pr (#1979)
-    - see http://easybuild.readthedocs.org/en/latest/Integration_with_GitHub.html
+    - see https://easybuild.readthedocs.io/en/latest/Integration_with_GitHub.html
 - various other small enhancements, including:
   - add support for 'devel' log level (#1815)
   - make remove_file aware of --extended-dry-run + add dedicated unit test (#1932)
@@ -413,7 +413,7 @@ feature + bugfix release
         - using custom easyblocks by adding them in the Python search path ($PYTHONPATH) may require adjustments,
           i.e. also using pkg_resources.declare_namespace in the __init__.py files;
           we highly recommend to use --include-easyblocks instead,
-          see http://easybuild.readthedocs.org/en/latest/Including_additional_Python_modules.html
+          see https://easybuild.readthedocs.io/en/latest/Including_additional_Python_modules.html
         - note: this has the side-effect of not being able anymore to reliably use 'eb' in the parent directory of
           the easybuild-framework repository (#1667)
     - fix template for savannah.gnu.org source URL (#1601)
@@ -471,7 +471,7 @@ v2.5.0 (December 17th 2015)
 feature + bugfix release
 - add support for IBM XL compilers on Power7 and PowerPC (BlueGene) (#1470)
 - add support fo generic compilation using --optarch=GENERIC (#1471)
-    - see also http://easybuild.readthedocs.org/en/latest/Controlling_compiler_optimization_flags.html
+    - see also https://easybuild.readthedocs.io/en/latest/Controlling_compiler_optimization_flags.html
 - update experimental support for .yeb easyconfigs (#1515)
     - support clean way to specify toolchain + dependencies in .yeb easyconfigs
 - various other enhancements, including:
@@ -510,9 +510,9 @@ feature + bugfix release
     - this impacts several easyconfig files where sanity_check_paths was not 100% correct
 - make 'eb' script aware of Python v3.x, fall back to using python2 if required (#1411)
 - add experimental support for parsing .yeb easyconfig files in YAML syntax (#1447, #1448, #1449)
-    - see also http://easybuild.readthedocs.org/en/latest/Writing_yeb_easyconfig_files.html
+    - see also https://easybuild.readthedocs.io/en/latest/Writing_yeb_easyconfig_files.html
 - add experimental support for resolving dependencies with minimal toolchains (#1306)
-    - see also http://easybuild.readthedocs.org/en/latest/Manipulating_dependencies.html#using-minimal-toolchains-for-dependencies
+    - see also https://easybuild.readthedocs.io/en/latest/Manipulating_dependencies.html#using-minimal-toolchains-for-dependencies
 - various other enhancements, including:
     - refactor extract_cmd function to get rid of if/elif/else spaghetti blob (#1382)
     - add support for --review-pr (#1383)
@@ -576,11 +576,11 @@ v2.2.0 (July 15th 2015)
 
 feature + bugfix release
 - add support for using GC3Pie as a backend for --job (#1008)
-    - see also http://easybuild.readthedocs.org/en/latest/Submitting_jobs.html
+    - see also https://easybuild.readthedocs.io/en/latest/Submitting_jobs.html
 - add support for --include-* configuration options to include additional easyblocks, toolchains, etc. (#1301)
-    - see http://easybuild.readthedocs.org/en/latest/Including_additional_Python_modules.html
+    - see https://easybuild.readthedocs.io/en/latest/Including_additional_Python_modules.html
 - add (experimental) support for packaging installed software using FPM (#1224)
-    - see http://easybuild.readthedocs.org/en/latest/Packaging_support.html
+    - see https://easybuild.readthedocs.io/en/latest/Packaging_support.html
 - various other enhancements, including:
     - use https for PyPI URL templates (#1286)
     - add GNU toolchain definition (#1287)
@@ -627,15 +627,15 @@ feature + bugfix release
     - added support to GeneralOption to act on unknown configuration environment variables
 - add support for only (re)generating module files: --module-only (#1018)
     - module naming scheme API is enhanced to include det_install_subdir method
-    - see http://easybuild.readthedocs.org/en/latest/Partial_installations.html#module-only
+    - see https://easybuild.readthedocs.io/en/latest/Partial_installations.html#module-only
 - add support for generating module files in Lua syntax (note: requires Lmod as modules tool) (#1060, #1255, #1256, #1270)
-    - see --module-syntax configuration option and http://easybuild.readthedocs.org/en/latest/Configuration.html#module-syntax
+    - see --module-syntax configuration option and https://easybuild.readthedocs.io/en/latest/Configuration.html#module-syntax
 - deprecate log.error method in favor of raising EasyBuildError exception (#1218)
-    - see http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html#depr-error-reporting
+    - see https://easybuild.readthedocs.io/en/latest/Deprecated-functionality.html#depr-error-reporting
 - add support for using external modules as dependencies, and to provide metadata for external modules (#1230, #1265, #1267)
-    - see http://easybuild.readthedocs.org/en/latest/Using_external_modules.html
+    - see https://easybuild.readthedocs.io/en/latest/Using_external_modules.html
 - add experimental support for Cray toolchains on top of PrgEnv modules: CrayGNU, CrayIntel, CrayCCE (#1234, #1268)
-    - see http://easybuild.readthedocs.io/en/latest/Cray-support.html for more information
+    - see https://easybuild.readthedocs.io/en/latest/Cray-support.html for more information
 - various other enhancements, including:
     - clear list of checksums when using --try-software-version (#1169)
     - sort the results of searching for files (e.g., --search output) (#1214)
@@ -644,17 +644,17 @@ feature + bugfix release
     - also reset $LD_PRELOAD when running module commands, in case module defined $LD_PRELOAD (#1222)
     - move location of 'module use' statements in generated module file (*after* 'module load' statements) (#1232)
     - add support for --show-default-configfiles (#1240)
-      - see http://easybuild.readthedocs.org/en/latest/Configuration.html#default-configuration-files
+      - see https://easybuild.readthedocs.io/en/latest/Configuration.html#default-configuration-files
     - report error on missing configuration files, rather than ignoring them (#1240)
-      - see http://easybuild.readthedocs.org/en/latest/Configuration.html#configuration-env-vars
+      - see https://easybuild.readthedocs.io/en/latest/Configuration.html#configuration-env-vars
     - clean up commit message used in easyconfig git repository (#1248)
     - add --hide-deps configuration option to specify names of software that must be installed as hidden modules (#1250)
-        - see http://easybuild.readthedocs.org/en/latest/Manipulating_dependencies.html#hide-deps
+        - see https://easybuild.readthedocs.io/en/latest/Manipulating_dependencies.html#hide-deps
     - add support for appending/prepending to --robot-paths to avoid overwriting default robot search path (#1252)
-        - see also http://easybuild.readthedocs.org/en/latest/Using_the_EasyBuild_command_line.html#robot-search-path-prepend-append
+        - see also https://easybuild.readthedocs.io/en/latest/Using_the_EasyBuild_command_line.html#robot-search-path-prepend-append
     - enable detection of use of unknown $EASYBUILD-prefixed environment variables (#1253)
     - add --installpath-modules and --installpath-software configuration options (#1258)
-      - see http://easybuild.readthedocs.org/en/latest/Configuration.html#installpath
+      - see https://easybuild.readthedocs.io/en/latest/Configuration.html#installpath
     - use dedicated subdirectory in temporary directory for each test to ensure better cleanup (#1260)
     - get rid of $PROFILEREAD hack when running commands, not needed anymore (#1264)
 - various bug fixes, including:
@@ -674,36 +674,36 @@ feature + bugfix release
     - avoid deprecation warnings w.r.t. use of 'message' attribute (hpcugent/vsc-base#155)
     - fix typo in log message rendering --ignoreconfigfiles unusable (hpcugent/vsc-base#158)
 - removed functionality that was deprecated for EasyBuild version 2.0 (#1143)
-    - see http://easybuild.readthedocs.org/en/latest/Removed-functionality.html
+    - see https://easybuild.readthedocs.io/en/latest/Removed-functionality.html
     - the fix_broken_easyconfigs.py script can be used to update easyconfig files suffering from this (#1151, #1206, #1207)
-    - for more information about this script, see http://easybuild.readthedocs.org/en/latest/Useful-scripts.html#fix-broken-easyconfigs-py
+    - for more information about this script, see https://easybuild.readthedocs.io/en/latest/Useful-scripts.html#fix-broken-easyconfigs-py
 - stop including a crippled copy of vsc-base, include vsc-base as a proper dependency instead (#1160, #1194)
     - vsc-base is automatically installed as a dependency for easybuild-framework, if a Python installation tool is used
-    - see http://easybuild.readthedocs.org/en/latest/Installation.html#required-python-packages
+    - see https://easybuild.readthedocs.io/en/latest/Installation.html#required-python-packages
 - various other enhancements, including:
     - add support for Linux/POWER systems (#1044)
     - major cleanup in tools/systemtools.py + significantly enhanced tests (#1044)
     - add support for 'eb -a rst', list available easyconfig parameters in ReST format (#1131)
     - add support for specifying one or more easyconfigs in combination with --from-pr (#1132)
-        - see http://easybuild.readthedocs.org/en/latest/Integration_with_GitHub.html#using-easyconfigs-from-pull-requests-via-from-pr
+        - see https://easybuild.readthedocs.io/en/latest/Integration_with_GitHub.html#using-easyconfigs-from-pull-requests-via-from-pr
     - define __contains__ in EasyConfig class (#1155)
     - restore support for downloading over a proxy (#1158)
         - i.e., use urllib2 rather than urllib
         - this involved sacrificing the download progress report (which was only visible in the log file)
     - let mpi_family return None if MPI is not supported by a toolchain (#1164)
     - include support for specifying system-level configuration files for EasyBuild via $XDG_CONFIG_DIRS (#1166)
-        - see http://easybuild.readthedocs.org/en/latest/Configuration.html#default-configuration-files
+        - see https://easybuild.readthedocs.io/en/latest/Configuration.html#default-configuration-files
     - make unit tests more robust (#1167, #1196)
-        - see http://easybuild.readthedocs.org/en/latest/Unit-tests.html
+        - see https://easybuild.readthedocs.io/en/latest/Unit-tests.html
     - add hierarchical module naming scheme categorizing modules by 'moduleclass' (#1176)
     - enhance bootstrap script to allow bootstrapping using supplied tarballs (#1184)
-        - see http://easybuild.readthedocs.org/en/latest/Installation.html#advanced-bootstrapping-options
+        - see https://easybuild.readthedocs.io/en/latest/Installation.html#advanced-bootstrapping-options
     - disable updating of Lmod user cache by default, add configuration option --update-modules-tool-cache (#1185)
         - for now, only the Lmod user cache can be updated using --update-modules-tool-cache
     - use available which() function, rather than running 'which' via run_cmd (#1192)
     - fix install-EasyBuild-develop.sh script w.r.t. vsc-base dependency (#1193)
     - also consider robot search path when looking for specified easyconfigs (#1201)
-        - see http://easybuild.readthedocs.org/en/latest/Using_the_EasyBuild_command_line.html#specifying-easyconfigs
+        - see https://easybuild.readthedocs.io/en/latest/Using_the_EasyBuild_command_line.html#specifying-easyconfigs
 - various bug fixes, including:
     - stop triggering deprecated/no longer support functionality in unit tests (#1126)
     - fix from_pr test by including dummy easyblocks for HPL and ScaLAPACK (#1133)
@@ -745,9 +745,9 @@ feature + bugfix release
 - deprecate automagic fallback to ConfigureMake easyblock (#1113)
     - easyconfigs should specify easyblock = 'ConfigureMake' instead of relying on the fallback mechanism
     - note: automagic fallback to ConfigureMake easyblock will be dropped in EasyBuild v2.0
-    - see also http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html#configuremake-fallback
+    - see also https://easybuild.readthedocs.io/en/latest/Deprecated-functionality.html#configuremake-fallback
 - stop triggering deprecated functionality, to enable use of --deprecated=2.0 (#1107, #1115, #1119)
-    - see http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html#configuremake-fallback for more information
+    - see https://easybuild.readthedocs.io/en/latest/Deprecated-functionality.html#configuremake-fallback for more information
 - various other enhancements, including:
     - add script to clean up gists created via --upload-test-report (#958)
     - also use -xHost when using Intel compilers on AMD systems (as opposed to -msse3) (#960)
@@ -763,12 +763,12 @@ feature + bugfix release
     - enable use of --show_hidden for avail subcommand with recent Lmod versions (#1081)
     - add --robot-paths configure option (#1080, #1093, #1095, #1114)
     - support use of %(DEFAULT_ROBOT_PATHS)s template in EasyBuild configuration files (#1100)
-        - see also http://easybuild.readthedocs.org/en/latest/Using_the_EasyBuild_command_line.html#controlling-the-robot-search-path
+        - see also https://easybuild.readthedocs.io/en/latest/Using_the_EasyBuild_command_line.html#controlling-the-robot-search-path
     - use -xHost rather than -xHOST, to match Intel documentation (#1084)
     - update and cleanup README file (#1085)
     - deprecate self.moduleGenerator in favor of self.module_generator in EasyBlock (#1088)
     - also support MPICH MPI family in mpi_cmd_for function (#1098)
-    - update documentation references to point to http://easybuild.readthedocs.org (#1102)
+    - update documentation references to point to https://easybuild.readthedocs.io (#1102)
     - check for OS dependencies with both rpm and dpkg (if available) (#1111)
 - various bug fixes, including:
     - fix picking required software version specified by --software-version and clean up tweak.py (#1062, #1063)
@@ -905,7 +905,7 @@ feature + bugfix release
     - add --upload-test-report command line option for uploading a detailed test report to GitHub as a gist
         - this requires specifying a GitHub username for which a GitHub token is available, using --github-user
         - with --dump-test-report, the test report can simply be dumped to file rather than being uploaded to GitHub
-        - see also http://easybuild.readthedocs.io/en/latest/Integration_with_GitHub.html#uploading-test-reports-upload-test-report
+        - see also https://easybuild.readthedocs.io/en/latest/Integration_with_GitHub.html#uploading-test-reports-upload-test-report
 - the 'makeopts' and 'premakeopts' easyconfig parameter are deprecated, and replaced by 'buildopts' and 'prebuildopts' (#918)
     - both 'makeopts' and 'premakeopts' will still be honored in future EasyBuild v1.x versions, but should no longer be used
 - various other enhancements, including:
@@ -1200,7 +1200,7 @@ v1.3.0 (April 1st 2013)
 -----------------------
 
 feature + bugfix release
-- added script to bootstrap EasyBuild with EasyBuild, see http://easybuild.readthedocs.io/en/latest/Installation.html#bootstrapping-easybuild (#531)
+- added script to bootstrap EasyBuild with EasyBuild, see https://easybuild.readthedocs.io/en/latest/Installation.html#bootstrapping-easybuild (#531)
 - reorganize framework/easyconfig.py module into framework/easyconfig package with modules (#574, #580)
 - support EasyBuild configuration via command line, environment variables and configuration files (#529, #552, #556, #558, #559)
 - various other enhancements, including:

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -635,7 +635,7 @@ feature + bugfix release
 - add support for using external modules as dependencies, and to provide metadata for external modules (#1230, #1265, #1267)
     - see http://easybuild.readthedocs.org/en/latest/Using_external_modules.html
 - add experimental support for Cray toolchains on top of PrgEnv modules: CrayGNU, CrayIntel, CrayCCE (#1234, #1268)
-    - see https://github.com/hpcugent/easybuild/wiki/EasyBuild-on-Cray for more information
+    - see http://easybuild.readthedocs.io/en/latest/Cray-support.html for more information
 - various other enhancements, including:
     - clear list of checksums when using --try-software-version (#1169)
     - sort the results of searching for files (e.g., --search output) (#1214)
@@ -905,7 +905,7 @@ feature + bugfix release
     - add --upload-test-report command line option for uploading a detailed test report to GitHub as a gist
         - this requires specifying a GitHub username for which a GitHub token is available, using --github-user
         - with --dump-test-report, the test report can simply be dumped to file rather than being uploaded to GitHub
-        - see also https://github.com/hpcugent/easybuild/wiki/Review-process-for-contributions#testing-result
+        - see also http://easybuild.readthedocs.io/en/latest/Integration_with_GitHub.html#uploading-test-reports-upload-test-report
 - the 'makeopts' and 'premakeopts' easyconfig parameter are deprecated, and replaced by 'buildopts' and 'prebuildopts' (#918)
     - both 'makeopts' and 'premakeopts' will still be honored in future EasyBuild v1.x versions, but should no longer be used
 - various other enhancements, including:
@@ -1015,7 +1015,7 @@ feature + bugfix release
         - cfr. 'checksums' easyconfig parameter
     - add support for `eb --confighelp`, which prints out an example configuration file (#775)
     - add initial support for `eb` tab completion in bash shells (#775, #797, #798)
-        - see also https://github.com/hpcugent/easybuild/wiki/Setting-up-tab-completion-for-bash
+        - see also https://github.com/easybuilders/easybuild/wiki/Setting-up-tab-completion-for-bash
         - note: may be quite slow for now
     - enhancements for using Lmod as modules tool (#780, #795, #796):
         - ignore Lmod spider cache by setting $LMOD_IGNORE_CACHE (requires Lmod 5.2)
@@ -1047,7 +1047,7 @@ feature + bugfix release
     - this prepares the codebase for supporting easyconfig format v2.0
     - some initial work on adding support for the new easyconfig format is included, but it's by no means complete yet
     - the current easyconfig format (now dubbed v1.0) is still the default and only supported format, for now
-    - for more details, see https://github.com/hpcugent/easybuild/wiki/Easyconfig-format-two
+    - for more details, see https://github.com/easybuilders/easybuild/wiki/Easyconfig-format-two
 - various other enhancements, including:
     - include a full version of vsc-base (see the 'vsc' subdirectory) (#740)
         - this is a first step towards switching to using vsc-base as a proper dependency
@@ -1091,7 +1091,7 @@ v1.8.0 (October 4th 2013)
 
 feature + bugfix release
 - add support for using alternative module naming schemes (#679, #696, #705, #706, #707)
-    - see https://github.com/hpcugent/easybuild/wiki/Using-a-custom-module-naming-scheme for documentation
+    - see https://github.com/easybuilders/easybuild/wiki/Using-a-custom-module-naming-scheme for documentation
     - module naming scheme classes that derive from the 'abstract' ModuleNamingScheme class can be provided to EasyBuild
         - the Python module providing the class must be available in the easybuild.tools.module_naming_scheme namespace
         - a function named 'det_full_module_name' must be implemented, that determines the module name
@@ -1107,7 +1107,7 @@ feature + bugfix release
         - the format for specifying dependencies was extended, to allow for specifying a custom toolchain
             - this allows to fix inaccurate dependency specifications,
               like "('OpenMPI', '1.6.4-GCC-4.7.2')" to "('OpenMPI', '1.6.4', '', ('GCC', '4.7.2'))"
-            - see also https://github.com/hpcugent/easybuild-easyconfigs/pull/431
+            - see also https://github.com/easybuilders/easybuild-easyconfigs/pull/431
         - the recommended version for Lmod was bumped to v5.1.5
             - using earlier 5.x version still works, but may be very slow when 'available' is used,
               due to bugs and a missing feature in Lmod versions prior to v5.1.5 on which we rely
@@ -1122,7 +1122,7 @@ feature + bugfix release
     - restore original environment after running 'module purge' (#698)
         - important sidenote: this results in resetting the entire environment, and has impact on the sanity check step;
           any environment variables that are set before the EasyBlock.sanity_check_step method fires, are no longer there
-          when the sanity check commands are run (cfr. https://github.com/hpcugent/easybuild-easyblocks/pull/268)
+          when the sanity check commands are run (cfr. https://github.com/easybuilders/easybuild-easyblocks/pull/268)
 
 v1.7.0 (September 2nd 2013)
 ---------------------------
@@ -1200,7 +1200,7 @@ v1.3.0 (April 1st 2013)
 -----------------------
 
 feature + bugfix release
-- added script to bootstrap EasyBuild with EasyBuild, see https://github.com/hpcugent/easybuild/wiki/Bootstrapping-EasyBuild (#531)
+- added script to bootstrap EasyBuild with EasyBuild, see http://easybuild.readthedocs.io/en/latest/Installation.html#bootstrapping-easybuild (#531)
 - reorganize framework/easyconfig.py module into framework/easyconfig package with modules (#574, #580)
 - support EasyBuild configuration via command line, environment variables and configuration files (#529, #552, #556, #558, #559)
 - various other enhancements, including:

--- a/easybuild/__init__.py
+++ b/easybuild/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/__init__.py
+++ b/easybuild/framework/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/__init__.py
+++ b/easybuild/framework/easyconfig/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/constants.py
+++ b/easybuild/framework/easyconfig/constants.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/format/__init__.py
+++ b/easybuild/framework/easyconfig/format/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/format/convert.py
+++ b/easybuild/framework/easyconfig/format/convert.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/format/format.py
+++ b/easybuild/framework/easyconfig/format/format.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/format/two.py
+++ b/easybuild/framework/easyconfig/format/two.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/format/version.py
+++ b/easybuild/framework/easyconfig/format/version.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/format/yeb.py
+++ b/easybuild/framework/easyconfig/format/yeb.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/licenses.py
+++ b/easybuild/framework/easyconfig/licenses.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/style.py
+++ b/easybuild/framework/easyconfig/style.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -4,7 +4,7 @@
 # This file is part of EasyBuild,
 # originally created by the HPC team of the University of Ghent (http://ugent.be/hpc).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/scripts/EasyBuild-reinstall-dev.sh
+++ b/easybuild/scripts/EasyBuild-reinstall-dev.sh
@@ -22,7 +22,7 @@ else
     do
         logfile=$PREFIX/EasyBuild-dev-install-${pkg}.log
         echo "installing easybuild-$pkg (output goes to $logfile)..."
-        easy_install --prefix=$PREFIX http://github.com/hpcugent/easybuild-${pkg}/archive/develop.tar.gz > $logfile 2>&1
+        easy_install --prefix=$PREFIX https://github.com/easybuilders/easybuild-${pkg}/archive/develop.tar.gz > $logfile 2>&1
         exit_code=$?
         if [ $exit_code -ne 0 ]
         then

--- a/easybuild/scripts/add_header.py
+++ b/easybuild/scripts/add_header.py
@@ -5,7 +5,7 @@
 # This file is part of EasyBuild,
 # originally created by the HPC-UGent team.
 #
-# http://github.com/easybuild/easybuild
+# https://github.com/easybuild/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/easybuilders/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -53,7 +53,7 @@ from distutils.version import LooseVersion
 from hashlib import md5
 
 
-EB_BOOTSTRAP_VERSION = '20170705.01'
+EB_BOOTSTRAP_VERSION = '20170706.01'
 
 # argparse preferrred, optparse deprecated >=2.7
 HAVE_ARGPARSE = False
@@ -419,7 +419,7 @@ def stage0(tmpdir):
     # We download a custom version of distribute: it uses a newer version of markerlib to avoid a bug (#1099)
     # It's is the source of distribute 0.6.49 with the file _markerlib/markers.py replaced by the 0.6 version of
     # markerlib which can be found at https://pypi.python.org/pypi/markerlib/0.6.0
-    sys.argv.append('--download-base=http://easybuilders.github.io/easybuild/files/')
+    sys.argv.append('--download-base=https://easybuilders.github.io/easybuild/files/')
     distribute_setup_main(version="0.6.49-patched1")
     sys.argv = orig_sys_argv
 

--- a/easybuild/scripts/clean_gists.py
+++ b/easybuild/scripts/clean_gists.py
@@ -2,7 +2,7 @@
 ##
 # Copyright 2014 Ward Poelmans
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/scripts/fix_broken_easyconfigs.py
+++ b/easybuild/scripts/fix_broken_easyconfigs.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/scripts/fix_docs.py
+++ b/easybuild/scripts/fix_docs.py
@@ -8,7 +8,7 @@
 # the Hercules foundation (http://www.herculesstichting.be/in_English)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/scripts/generate_software_list.py
+++ b/easybuild/scripts/generate_software_list.py
@@ -5,7 +5,7 @@
 # This file is part of EasyBuild,
 # originally created by the HPC team of the University of Ghent (http://ugent.be/hpc).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -49,7 +49,7 @@ parser.add_option("-q", "--quiet", action="store_true", dest="quiet",
 parser.add_option("-b", "--branch", action="store", dest="branch",
      help="Choose the branch to link to (default develop).")
 parser.add_option("-u", "--username", action="store", dest="username",
-     help="Choose the user to link to (default hpcugent).")
+     help="Choose the user to link to (default easybuilders).")
 parser.add_option("-r", "--repo", action="store", dest="repo",
      help="Choose the branch to link to (default easybuild-easyconfigs).")
 parser.add_option("-p", "--path", action="store", dest="path",
@@ -77,7 +77,7 @@ else:
 if not options.branch:
     options.branch = "develop"
 if not options.username:
-    options.username = "hpcugent"
+    options.username = "easybuilders"
 if not options.repo:
     options.repo = "easybuild-easyconfigs"
 if not options.path:
@@ -163,11 +163,11 @@ for config in configs:
                 'count': len([x for x in configs if x.name[0].lower() == firstl]),
             }
     print "* [![EasyConfigs](http://hpc.ugent.be/easybuild/images/easyblocks_configs_logo_16x16.png)] "
-    print "(https://github.com/hpcugent/easybuild-easyconfigs/tree/%s/easybuild/easyconfigs/%s/%s)" % \
+    print "(https://github.com/easybuilders/easybuild-easyconfigs/tree/%s/easybuild/easyconfigs/%s/%s)" % \
             (options.branch, firstl, config.name)
     if config.easyblock:
         print "[![EasyBlocks](http://hpc.ugent.be/easybuild/images/easyblocks_easyblocks_logo_16x16.png)] "
-        print " (https://github.com/hpcugent/easybuild-easyblocks/tree/%s/easybuild/easyblocks/%s/%s.py)" % \
+        print " (https://github.com/easybuilders/easybuild-easyblocks/tree/%s/easybuild/easyblocks/%s/%s.py)" % \
             (options.branch, firstl, config.easyblock)
     else:
         print "&nbsp;&nbsp;&nbsp;&nbsp;"

--- a/easybuild/scripts/install-EasyBuild-develop.sh
+++ b/easybuild/scripts/install-EasyBuild-develop.sh
@@ -28,11 +28,11 @@ github_clone_branch()
     echo "=== Cloning ${GITHUB_USERNAME}/${REPO} ..."
     git clone --branch "${BRANCH}" "git@github.com:${GITHUB_USERNAME}/${REPO}.git"
 
-    echo "=== Adding and fetching HPC-UGent GitHub repository @ hpcugent/${REPO} ..."
+    echo "=== Adding and fetching HPC-UGent GitHub repository @ easybuilders/${REPO} ..."
     cd "${REPO}"
-    git remote add "github_hpcugent" "git@github.com:hpcugent/${REPO}.git"
-    git fetch github_hpcugent
-    git branch --set-upstream "${BRANCH}" "github_hpcugent/${BRANCH}"
+    git remote add "github_easybuilders" "git@github.com/easybuilders/${REPO}.git"
+    git fetch github_easybuilders
+    git branch --set-upstream "${BRANCH}" "github_easybuilders/${BRANCH}"
 }
 
 # Print the content of the module
@@ -44,7 +44,7 @@ cat <<EOF
 proc ModulesHelp { } {
     puts stderr {   EasyBuild is a software build and installation framework
 written in Python that allows you to install software in a structured,
-repeatable and robust way. - Homepage: http://hpcugent.github.com/easybuild/
+repeatable and robust way. - Homepage: https://easybuilders.github.io/easybuild/
 
 This module provides the development version of EasyBuild.
 }
@@ -52,7 +52,7 @@ This module provides the development version of EasyBuild.
 
 module-whatis {EasyBuild is a software build and installation framework
 written in Python that allows you to install software in a structured,
-repeatable and robust way. - Homepage: http://hpcugent.github.com/easybuild/
+repeatable and robust way. - Homepage: https://easybuilders.github.io/easybuild/
 
 This module provides the development version of EasyBuild.
 }

--- a/easybuild/scripts/install_eb_dep.sh
+++ b/easybuild/scripts/install_eb_dep.sh
@@ -17,13 +17,13 @@ PRECONFIG_CMD=
 
 if [ x$PKG_NAME == 'xmodules' ]; then
     PKG_URL="http://prdownloads.sourceforge.net/modules/${PKG}.tar.gz"
-    BACKUP_PKG_URL="http://easybuilders.github.io/easybuild/files/${PKG}.tar.gz"
+    BACKUP_PKG_URL="https://easybuilders.github.io/easybuild/files/${PKG}.tar.gz"
     export PATH=$PREFIX/Modules/$PKG_VERSION/bin:$PATH
     export MOD_INIT=$HOME/Modules/$PKG_VERSION/init/bash
 
 elif [ x$PKG_NAME == 'xlua' ]; then
     PKG_URL="http://downloads.sourceforge.net/project/lmod/${PKG}.tar.gz"
-    BACKUP_PKG_URL="http://easybuilders.github.io/easybuild/files/${PKG}.tar.gz"
+    BACKUP_PKG_URL="https://easybuilders.github.io/easybuild/files/${PKG}.tar.gz"
     PRECONFIG_CMD="make clean"
     CONFIG_OPTIONS='--with-static=yes'
     export PATH=$PWD/$PKG:$PREFIX/bin:$PATH
@@ -35,7 +35,7 @@ elif [ x$PKG_NAME == 'xLmod' ]; then
 
 elif [ x$PKG_NAME == 'xmodules-tcl' ]; then
     # obtain tarball from upstream via http://modules.cvs.sourceforge.net/viewvc/modules/modules/?view=tar&revision=1.147
-    PKG_URL="http://easybuilders.github.io/easybuild/files/modules-tcl-${PKG_VERSION}.tar.gz"
+    PKG_URL="https://easybuilders.github.io/easybuild/files/modules-tcl-${PKG_VERSION}.tar.gz"
     export MODULESHOME=$PREFIX/$PKG/tcl  # required by init/bash source script
     export PATH=$MODULESHOME:$PATH
     export MOD_INIT=$MODULESHOME/init/bash.in

--- a/easybuild/scripts/mk_tmpl_easyblock_for.py
+++ b/easybuild/scripts/mk_tmpl_easyblock_for.py
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -98,7 +98,7 @@ tmpl = """##
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/scripts/port_easyblock.py
+++ b/easybuild/scripts/port_easyblock.py
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/scripts/prep_for_release.py
+++ b/easybuild/scripts/prep_for_release.py
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/scripts/repo_setup.py
+++ b/easybuild/scripts/repo_setup.py
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/scripts/rpath_wrapper_template.sh.in
+++ b/easybuild/scripts/rpath_wrapper_template.sh.in
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/scripts/run_easybuild_regtest.sh
+++ b/easybuild/scripts/run_easybuild_regtest.sh
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -70,7 +70,7 @@ echo "Installing EasyBuild in $EBHOME from GitHub ($branch branch)..."
 for package in easybuild-framework easybuild-easyblocks easybuild-easyconfigs
 do
     echo "+++ installing $package (output, see install_${package}.out)..."
-    easy_install --prefix=$EBHOME http://github.com/hpcugent/${package}/archive/${branch}.tar.gz &> install_${package}.out
+    easy_install --prefix=$EBHOME https://github.com/easybuilders/${package}/archive/${branch}.tar.gz &> install_${package}.out
     if [ $? -ne 0 ]
     then
         echo "Installation of $package failed?"

--- a/easybuild/toolchains/__init__.py
+++ b/easybuild/toolchains/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/cgmpich.py
+++ b/easybuild/toolchains/cgmpich.py
@@ -11,7 +11,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/cgmpolf.py
+++ b/easybuild/toolchains/cgmpolf.py
@@ -11,7 +11,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/cgmvapich2.py
+++ b/easybuild/toolchains/cgmvapich2.py
@@ -11,7 +11,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/cgmvolf.py
+++ b/easybuild/toolchains/cgmvolf.py
@@ -11,7 +11,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/cgompi.py
+++ b/easybuild/toolchains/cgompi.py
@@ -11,7 +11,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/cgoolf.py
+++ b/easybuild/toolchains/cgoolf.py
@@ -11,7 +11,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/clanggcc.py
+++ b/easybuild/toolchains/clanggcc.py
@@ -11,7 +11,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/compiler/__init__.py
+++ b/easybuild/toolchains/compiler/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/compiler/clang.py
+++ b/easybuild/toolchains/compiler/clang.py
@@ -11,7 +11,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/compiler/craype.py
+++ b/easybuild/toolchains/compiler/craype.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/compiler/cuda.py
+++ b/easybuild/toolchains/compiler/cuda.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/compiler/dummycompiler.py
+++ b/easybuild/toolchains/compiler/dummycompiler.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/compiler/pgi.py
+++ b/easybuild/toolchains/compiler/pgi.py
@@ -11,7 +11,7 @@
 # the Hercules foundation (http://www.herculesstichting.be/in_English)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/craycce.py
+++ b/easybuild/toolchains/craycce.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/craygnu.py
+++ b/easybuild/toolchains/craygnu.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/crayintel.py
+++ b/easybuild/toolchains/crayintel.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/craypgi.py
+++ b/easybuild/toolchains/craypgi.py
@@ -8,7 +8,7 @@
 # the Hercules foundation (http://www.herculesstichting.be/in_English)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/dummy.py
+++ b/easybuild/toolchains/dummy.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/fft/__init__.py
+++ b/easybuild/toolchains/fft/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/fft/fftw.py
+++ b/easybuild/toolchains/fft/fftw.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/foss.py
+++ b/easybuild/toolchains/foss.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gcc.py
+++ b/easybuild/toolchains/gcc.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gcccore.py
+++ b/easybuild/toolchains/gcccore.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gcccuda.py
+++ b/easybuild/toolchains/gcccuda.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gimkl.py
+++ b/easybuild/toolchains/gimkl.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gimpi.py
+++ b/easybuild/toolchains/gimpi.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gmacml.py
+++ b/easybuild/toolchains/gmacml.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gmpich.py
+++ b/easybuild/toolchains/gmpich.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gmpich2.py
+++ b/easybuild/toolchains/gmpich2.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gmpolf.py
+++ b/easybuild/toolchains/gmpolf.py
@@ -11,7 +11,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gmvapich2.py
+++ b/easybuild/toolchains/gmvapich2.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gmvolf.py
+++ b/easybuild/toolchains/gmvolf.py
@@ -11,7 +11,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gnu.py
+++ b/easybuild/toolchains/gnu.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/goalf.py
+++ b/easybuild/toolchains/goalf.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gompi.py
+++ b/easybuild/toolchains/gompi.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gompic.py
+++ b/easybuild/toolchains/gompic.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/goolf.py
+++ b/easybuild/toolchains/goolf.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/goolfc.py
+++ b/easybuild/toolchains/goolfc.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gpsmpi.py
+++ b/easybuild/toolchains/gpsmpi.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gpsolf.py
+++ b/easybuild/toolchains/gpsolf.py
@@ -11,7 +11,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/gqacml.py
+++ b/easybuild/toolchains/gqacml.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/iccifort.py
+++ b/easybuild/toolchains/iccifort.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/iccifortcuda.py
+++ b/easybuild/toolchains/iccifortcuda.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/ictce.py
+++ b/easybuild/toolchains/ictce.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/iimkl.py
+++ b/easybuild/toolchains/iimkl.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/iimpi.py
+++ b/easybuild/toolchains/iimpi.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/iimpic.py
+++ b/easybuild/toolchains/iimpic.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/iiqmpi.py
+++ b/easybuild/toolchains/iiqmpi.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/impich.py
+++ b/easybuild/toolchains/impich.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/impmkl.py
+++ b/easybuild/toolchains/impmkl.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/intel-para.py
+++ b/easybuild/toolchains/intel-para.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/intel.py
+++ b/easybuild/toolchains/intel.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/intelcuda.py
+++ b/easybuild/toolchains/intelcuda.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/iomkl.py
+++ b/easybuild/toolchains/iomkl.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/iompi.py
+++ b/easybuild/toolchains/iompi.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/ipsmpi.py
+++ b/easybuild/toolchains/ipsmpi.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/iqacml.py
+++ b/easybuild/toolchains/iqacml.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/ismkl.py
+++ b/easybuild/toolchains/ismkl.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/linalg/__init__.py
+++ b/easybuild/toolchains/linalg/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/linalg/acml.py
+++ b/easybuild/toolchains/linalg/acml.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/linalg/atlas.py
+++ b/easybuild/toolchains/linalg/atlas.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/linalg/blacs.py
+++ b/easybuild/toolchains/linalg/blacs.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/linalg/flame.py
+++ b/easybuild/toolchains/linalg/flame.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/linalg/gotoblas.py
+++ b/easybuild/toolchains/linalg/gotoblas.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/linalg/lapack.py
+++ b/easybuild/toolchains/linalg/lapack.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/linalg/libsci.py
+++ b/easybuild/toolchains/linalg/libsci.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/linalg/openblas.py
+++ b/easybuild/toolchains/linalg/openblas.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/linalg/scalapack.py
+++ b/easybuild/toolchains/linalg/scalapack.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/mpi/__init__.py
+++ b/easybuild/toolchains/mpi/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/mpi/craympich.py
+++ b/easybuild/toolchains/mpi/craympich.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/mpi/intelmpi.py
+++ b/easybuild/toolchains/mpi/intelmpi.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/mpi/mpich.py
+++ b/easybuild/toolchains/mpi/mpich.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/mpi/mpich2.py
+++ b/easybuild/toolchains/mpi/mpich2.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/mpi/mvapich2.py
+++ b/easybuild/toolchains/mpi/mvapich2.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/mpi/openmpi.py
+++ b/easybuild/toolchains/mpi/openmpi.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/mpi/psmpi.py
+++ b/easybuild/toolchains/mpi/psmpi.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/mpi/qlogicmpi.py
+++ b/easybuild/toolchains/mpi/qlogicmpi.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/pgi.py
+++ b/easybuild/toolchains/pgi.py
@@ -11,7 +11,7 @@
 # the Hercules foundation (http://www.herculesstichting.be/in_English)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/pomkl.py
+++ b/easybuild/toolchains/pomkl.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/toolchains/pompi.py
+++ b/easybuild/toolchains/pompi.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/__init__.py
+++ b/easybuild/tools/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/asyncprocess.py
+++ b/easybuild/tools/asyncprocess.py
@@ -14,7 +14,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/build_details.py
+++ b/easybuild/tools/build_details.py
@@ -7,7 +7,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/convert.py
+++ b/easybuild/tools/convert.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/deprecated/__init__.py
+++ b/easybuild/tools/deprecated/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/environment.py
+++ b/easybuild/tools/environment.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -195,7 +195,7 @@ class Githubfs(object):
         """Read the contents of a file and return it
         Or, if api=False it will download the file and return the location of the downloaded file"""
         # we don't need use the api for this, but can also use raw.github.com
-        # https://raw.github.com/hpcugent/easybuild/master/README.rst
+        # https://raw.github.com/easybuilders/easybuild/master/README.rst
         if not api:
             outfile = tempfile.mkstemp()[1]
             url = '/'.join([GITHUB_RAW, self.githubuser, self.reponame, self.branchname, path])
@@ -1252,7 +1252,7 @@ def validate_github_token(token, github_user):
     else:
         _log.warning("Sanity check on token failed; token doesn't match pattern '%s'", sha_regex.pattern)
 
-    # try and determine sha of latest commit in hpcugent/easybuild-easyconfigs repo through authenticated access
+    # try and determine sha of latest commit in easybuilders/easybuild-easyconfigs repo through authenticated access
     sha = None
     try:
         sha = fetch_latest_commit_sha(GITHUB_EASYCONFIGS_REPO, GITHUB_EB_MAIN, github_user=github_user, token=token)

--- a/easybuild/tools/include.py
+++ b/easybuild/tools/include.py
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/jenkins.py
+++ b/easybuild/tools/jenkins.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/job/__init__.py
+++ b/easybuild/tools/job/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/job/backend.py
+++ b/easybuild/tools/job/backend.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/job/gc3pie.py
+++ b/easybuild/tools/job/gc3pie.py
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/job/pbs_python.py
+++ b/easybuild/tools/job/pbs_python.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/module_naming_scheme/__init__.py
+++ b/easybuild/tools/module_naming_scheme/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/module_naming_scheme/categorized_mns.py
+++ b/easybuild/tools/module_naming_scheme/categorized_mns.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/module_naming_scheme/easybuild_mns.py
+++ b/easybuild/tools/module_naming_scheme/easybuild_mns.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/module_naming_scheme/hierarchical_mns.py
+++ b/easybuild/tools/module_naming_scheme/hierarchical_mns.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/module_naming_scheme/migrate_from_eb_to_hmns.py
+++ b/easybuild/tools/module_naming_scheme/migrate_from_eb_to_hmns.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/module_naming_scheme/mns.py
+++ b/easybuild/tools/module_naming_scheme/mns.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/module_naming_scheme/toolchain.py
+++ b/easybuild/tools/module_naming_scheme/toolchain.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/module_naming_scheme/utilities.py
+++ b/easybuild/tools/module_naming_scheme/utilities.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/multidiff.py
+++ b/easybuild/tools/multidiff.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -100,9 +100,9 @@ except ImportError:
             return False
 
 # monkey patch shell_quote in vsc.utils.generaloption, used by generate_cmd_line,
-# to fix known issue, cfr. https://github.com/hpcugent/vsc-base/issues/152;
-# inspired by https://github.com/hpcugent/vsc-base/pull/151
-# this fixes https://github.com/hpcugent/easybuild-framework/issues/1438
+# to fix known issue, cfr. https://github.com/easybuilders/vsc-base/issues/152;
+# inspired by https://github.com/easybuilders/vsc-base/pull/151
+# this fixes https://github.com/easybuilders/easybuild-framework/issues/1438
 # proper fix would be to implement a serialiser for command line options
 def eb_shell_quote(token):
     """

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -100,8 +100,8 @@ except ImportError:
             return False
 
 # monkey patch shell_quote in vsc.utils.generaloption, used by generate_cmd_line,
-# to fix known issue, cfr. https://github.com/easybuilders/vsc-base/issues/152;
-# inspired by https://github.com/easybuilders/vsc-base/pull/151
+# to fix known issue, cfr. https://github.com/hpcugent/vsc-base/issues/152;
+# inspired by https://github.com/hpcugent/vsc-base/pull/151
 # this fixes https://github.com/easybuilders/easybuild-framework/issues/1438
 # proper fix would be to implement a serialiser for command line options
 def eb_shell_quote(token):

--- a/easybuild/tools/package/__init__.py
+++ b/easybuild/tools/package/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/package/package_naming_scheme/__init__.py
+++ b/easybuild/tools/package/package_naming_scheme/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/package/package_naming_scheme/easybuild_pns.py
+++ b/easybuild/tools/package/package_naming_scheme/easybuild_pns.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/package/package_naming_scheme/pns.py
+++ b/easybuild/tools/package/package_naming_scheme/pns.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/package/utilities.py
+++ b/easybuild/tools/package/utilities.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/repository/__init__.py
+++ b/easybuild/tools/repository/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/repository/filerepo.py
+++ b/easybuild/tools/repository/filerepo.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/repository/gitrepo.py
+++ b/easybuild/tools/repository/gitrepo.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/repository/hgrepo.py
+++ b/easybuild/tools/repository/hgrepo.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/repository/repository.py
+++ b/easybuild/tools/repository/repository.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/repository/svnrepo.py
+++ b/easybuild/tools/repository/svnrepo.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/testing.py
+++ b/easybuild/tools/testing.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -148,7 +148,7 @@ def create_test_report(msg, ecs_with_res, init_session_state, pr_nr=None, gist_l
     test_report = []
     if pr_nr is not None:
         test_report.extend([
-            "Test report for https://github.com/hpcugent/easybuild-easyconfigs/pull/%s" % pr_nr,
+            "Test report for https://github.com/easybuilders/easybuild-easyconfigs/pull/%s" % pr_nr,
             "",
         ])
     test_report.extend([

--- a/easybuild/tools/toolchain/__init__.py
+++ b/easybuild/tools/toolchain/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/toolchain/constants.py
+++ b/easybuild/tools/toolchain/constants.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/toolchain/fft.py
+++ b/easybuild/tools/toolchain/fft.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/toolchain/linalg.py
+++ b/easybuild/tools/toolchain/linalg.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/toolchain/mpi.py
+++ b/easybuild/tools/toolchain/mpi.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/toolchain/options.py
+++ b/easybuild/tools/toolchain/options.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/toolchain/toolchainvariables.py
+++ b/easybuild/tools/toolchain/toolchainvariables.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/toolchain/utilities.py
+++ b/easybuild/tools/toolchain/utilities.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/toolchain/variables.py
+++ b/easybuild/tools/toolchain/variables.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/variables.py
+++ b/easybuild/tools/variables.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/easybuild/tools/version.py
+++ b/easybuild/tools/version.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/eb
+++ b/eb
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/etc/cray_external_modules_metadata.cfg
+++ b/etc/cray_external_modules_metadata.cfg
@@ -1,4 +1,4 @@
-# metadata useful to EasyBuild (hpcugent.github.io/easybuild) for modules provided by Cray on Cray systems
+# metadata useful to EasyBuild (easybuilders.github.io/easybuild) for modules provided by Cray on Cray systems
 # authors: Guilherme Peretti-Pezzi (CSCS), Petar Forai (IMP/IMBA), Kenneth Hoste (HPC-UGent)
 
 [cray-hdf5/1.8.13]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -87,7 +87,7 @@ setup(
 implement support for installing particular (groups of) software packages.""",
     license="GPLv2",
     keywords="software build building installation installing compilation HPC scientific",
-    url="http://hpcugent.github.com/easybuild",
+    url="https://easybuilders.github.io/easybuild",
     packages=easybuild_packages,
     package_dir={'test.framework': 'test/framework'},
     package_data={'test.framework': find_rel_test(),},

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/__init__.py
+++ b/test/framework/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/asyncprocess.py
+++ b/test/framework/asyncprocess.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -239,7 +239,7 @@ class DocsTest(EnhancedTestCase):
             '',
             'Toy C program, 100% toy.',
             '',
-            'homepage: http://hpcugent.github.com/easybuild',
+            'homepage: https://easybuilders.github.io/easybuild',
             '',
             "  * toy v0.0: dummy",
             "  * toy v0.0 (versionsuffix: '-deps'): dummy",
@@ -258,7 +258,7 @@ class DocsTest(EnhancedTestCase):
             '',
             'Toy C program, 100% toy.',
             '',
-            '*homepage*: http://hpcugent.github.com/easybuild',
+            '*homepage*: https://easybuilders.github.io/easybuild',
             '',
             '=======    =============    ================',
             'version    versionsuffix    toolchain       ',

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -895,7 +895,7 @@ class EasyBlockTest(EnhancedTestCase):
         # file specifications via URL also work, are downloaded to (first) sourcepath
         init_config(args=["--sourcepath=%s:/no/such/dir:%s" % (tmpdir, sandbox_sources)])
         urls = [
-            "http://easybuilders.github.io/easybuild/index.html",
+            "https://easybuilders.github.io/easybuild/index.html",
             "https://easybuilders.github.io/easybuild/index.html",
         ]
         for file_url in urls:

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -781,8 +781,9 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertTrue(os.path.samefile(eb.src[0]['path'], toy_source))
         self.assertEqual(eb.src[0]['name'], 'toy-0.0.tar.gz')
         self.assertEqual(eb.src[0]['cmd'], None)
-        self.assertEqual(len(eb.src[0]['checksum']), 6)
+        self.assertEqual(len(eb.src[0]['checksum']), 7)
         self.assertEqual(eb.src[0]['checksum'][0], 'be662daa971a640e40be5c804d9d7d10')
+        self.assertEqual(eb.src[0]['checksum'][1], '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc')
 
         # reconfigure EasyBuild so we can check 'downloaded' sources
         os.environ['EASYBUILD_SOURCEPATH'] = self.test_prefix

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -313,8 +313,10 @@ class EasyConfigTest(EnhancedTestCase):
             '       "source_urls": [("http://example.com", "suffix")],'
             '       "patches": ["toy-0.0.eb"],',  # dummy patch to avoid downloading fail
             '       "checksums": [',
-            '           "2dc55aee0346ad5e4f0c2e46d554a92e",',  # MD5 checksum for source (gzip-1.4.eb)
-            '           "c8308888dca8bc2ea62efb22be445414",',  # MD5 checksum for patch (toy-0.0.eb)
+                        # SHA256 checksum for source (gzip-1.4.eb)
+            '           "6f281b6d7a3965476324a23b9d80232bd4ffe3967da85e4b7c01d9d81d649a09",',
+                        # SHA256 checksum for 'patch' (toy-0.0.eb)
+            '           "b1875ce33955bc6f15dc44de28f3bdf2658323e8321ed20bf6b88a33836feb6c",',
             '       ],',
             '   }),',
             ']',

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -786,7 +786,7 @@ class EasyConfigTest(EnhancedTestCase):
                 'R: %%(rver)s, %%(rshortver)s',
             ]),
             'license_file = HOME + "/licenses/PI/license.txt"',
-            "github_account = 'hpcugent'",
+            "github_account = 'easybuilders'",
         ]) % inp
         self.prep()
         eb = EasyConfig(self.eb_file, validate=False)
@@ -804,7 +804,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(eb['sources'][0], 'PI-3.04.tar.gz')
         self.assertEqual(eb['sources'][1], ('pi-3.04.tar.bz2', "tar xfvz %s"))
         self.assertEqual(eb['source_urls'][0], 'http://pi.googlecode.com/files')
-        self.assertEqual(eb['source_urls'][1], 'https://github.com/hpcugent/PI/archive')
+        self.assertEqual(eb['source_urls'][1], 'https://github.com/easybuilders/PI/archive')
         self.assertEqual(eb['versionsuffix'], '-Python-2.7.10')
         self.assertEqual(eb['sanity_check_paths']['files'][0], 'bin/pi_3_04')
         self.assertEqual(eb['sanity_check_paths']['files'][1], 'lib/python2.7/site-packages')

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -316,7 +316,7 @@ class EasyConfigTest(EnhancedTestCase):
                         # SHA256 checksum for source (gzip-1.4.eb)
             '           "6f281b6d7a3965476324a23b9d80232bd4ffe3967da85e4b7c01d9d81d649a09",',
                         # SHA256 checksum for 'patch' (toy-0.0.eb)
-            '           "b1875ce33955bc6f15dc44de28f3bdf2658323e8321ed20bf6b88a33836feb6c",',
+            '           "044e300a051120defb01c14c7c06e9aa4bca40c5d589828df360e2684dcc9074",',
             '       ],',
             '   }),',
             ']',

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -313,8 +313,8 @@ class EasyConfigTest(EnhancedTestCase):
             '       "source_urls": [("http://example.com", "suffix")],'
             '       "patches": ["toy-0.0.eb"],',  # dummy patch to avoid downloading fail
             '       "checksums": [',
-            '           "9e9485921c6afe15f62aedfead2c8f6e",',  # MD5 checksum for source (gzip-1.4.eb)
-            '           "8ebc2c32692be9ee61eadc5d650cd288",',  # MD5 checksum for patch (toy-0.0.eb)
+            '           "2dc55aee0346ad5e4f0c2e46d554a92e",',  # MD5 checksum for source (gzip-1.4.eb)
+            '           "c8308888dca8bc2ea62efb22be445414",',  # MD5 checksum for patch (toy-0.0.eb)
             '       ],',
             '   }),',
             ']',

--- a/test/framework/easyconfigformat.py
+++ b/test/framework/easyconfigformat.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/easyconfigs/test_ecs/c/CUDA/CUDA-5.5.22-GCC-4.8.2.eb
+++ b/test/framework/easyconfigs/test_ecs/c/CUDA/CUDA-5.5.22-GCC-4.8.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA, Ghent University
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/test/framework/easyconfigs/test_ecs/c/CUDA/CUDA-5.5.22-iccifort-2013.5.192-GCC-4.8.3.eb
+++ b/test/framework/easyconfigs/test_ecs/c/CUDA/CUDA-5.5.22-iccifort-2013.5.192-GCC-4.8.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA, Ghent University
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/test/framework/easyconfigs/test_ecs/c/CUDA/CUDA-5.5.22.eb
+++ b/test/framework/easyconfigs/test_ecs/c/CUDA/CUDA-5.5.22.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Cyprus Institute / CaSToRC, Uni.Lu/LCSB, NTUA, Ghent University
 # Authors::   George Tsouloupas <g.tsouloupas@cyi.ac.cy>, Fotis Georgatos <fotis@cern.ch>, Kenneth Hoste

--- a/test/framework/easyconfigs/test_ecs/g/gzip/gzip-1.4-GCC-4.6.3.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gzip/gzip-1.4-GCC-4.6.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/test/framework/easyconfigs/test_ecs/g/gzip/gzip-1.4-broken.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gzip/gzip-1.4-broken.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/test/framework/easyconfigs/test_ecs/g/gzip/gzip-1.4.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gzip/gzip-1.4.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/test/framework/easyconfigs/test_ecs/g/gzip/gzip-1.5-goolf-1.4.10.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gzip/gzip-1.5-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/test/framework/easyconfigs/test_ecs/g/gzip/gzip-1.5-ictce-4.1.13.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gzip/gzip-1.5-ictce-4.1.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/test/framework/easyconfigs/test_ecs/g/gzip/gzip-1.6-GCC-4.9.2.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gzip/gzip-1.6-GCC-4.9.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/test/framework/easyconfigs/test_ecs/i/iccifort/iccifort-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/test/framework/easyconfigs/test_ecs/i/iccifort/iccifort-2016.1.150-GCC-4.9.3-2.25.eb
@@ -1,4 +1,4 @@
-# This is an easyconfig file for EasyBuild, see http://hpcugent.github.io/easybuild
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild
 easyblock = "Toolchain"
 
 name = 'iccifort'

--- a/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-GCC-4.7.2.eb
+++ b/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-GCC-4.7.2.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-gompi-1.4.10.eb
+++ b/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-gompi-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-goolf-1.4.10.eb
+++ b/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright 2012-2014 Uni.Lu/LCSB, NTUA
 # Authors::   Fotis Georgatos <fotis@cern.ch>

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-deps.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-deps.eb
@@ -2,7 +2,7 @@ name = 'toy'
 version = '0.0'
 versionsuffix = '-deps'
 
-homepage = 'http://hpcugent.github.com/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = "Toy C program, 100% toy."
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-deps.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-deps.eb
@@ -10,6 +10,7 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 sources = [SOURCE_TAR_GZ]
 checksums = [[
     'be662daa971a640e40be5c804d9d7d10',  # default (MD5)
+    '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # default (SHA256)
     ('adler32', '0x998410035'),
     ('crc32', '0x1553842328'),
     ('md5', 'be662daa971a640e40be5c804d9d7d10'),

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
@@ -11,6 +11,7 @@ toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
 sources = [SOURCE_TAR_GZ]
 checksums = [[
     'be662daa971a640e40be5c804d9d7d10',  # default (MD5)
+    '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # default (SHA256)
     ('adler32', '0x998410035'),
     ('crc32', '0x1553842328'),
     ('md5', 'be662daa971a640e40be5c804d9d7d10'),

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
@@ -2,7 +2,7 @@ name = 'toy'
 version = '0.0'
 versionsuffix = '-test'
 
-homepage = 'http://hpcugent.github.com/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = "Toy C program, 100% toy."
 
 toolchain = {'name': 'gompi', 'version': '1.3.12'}

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-iter.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-iter.eb
@@ -2,7 +2,7 @@ name = 'toy'
 version = '0.0'
 versionsuffix = '-iter'
 
-homepage = 'http://hpcugent.github.com/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = "Toy C program, 100% toy."
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-multiple.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-multiple.eb
@@ -3,7 +3,7 @@ version = '0.0'
 # required to fool test in modulegenerator, but will never be used (overwritten later)
 versionsuffix = '-multiple'
 
-homepage = 'http://hpcugent.github.com/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = "Toy C program, 100% toy."
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0.eb
@@ -9,6 +9,7 @@ toolchain = {'name': 'dummy', 'version': 'dummy'}
 sources = [SOURCE_TAR_GZ]
 checksums = [[
     'be662daa971a640e40be5c804d9d7d10',  # default (MD5)
+    '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # default (SHA256)
     ('adler32', '0x998410035'),
     ('crc32', '0x1553842328'),
     ('md5', 'be662daa971a640e40be5c804d9d7d10'),

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0.eb
@@ -1,7 +1,7 @@
 name = 'toy'
 version = '0.0'
 
-homepage = 'http://hpcugent.github.com/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = "Toy C program, 100% toy."
 
 toolchain = {'name': 'dummy', 'version': 'dummy'}

--- a/test/framework/easyconfigs/v1.0/g/gzip/gzip-1.4-GCC-4.6.3.eb
+++ b/test/framework/easyconfigs/v1.0/g/gzip/gzip-1.4-GCC-4.6.3.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/test/framework/easyconfigs/v1.0/g/gzip/gzip-1.4.eb
+++ b/test/framework/easyconfigs/v1.0/g/gzip/gzip-1.4.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/test/framework/easyconfigs/v1.0/g/gzip/gzip-1.5-goolf-1.4.10.eb
+++ b/test/framework/easyconfigs/v1.0/g/gzip/gzip-1.5-goolf-1.4.10.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/test/framework/easyconfigs/v1.0/g/gzip/gzip-1.5-ictce-4.1.13.eb
+++ b/test/framework/easyconfigs/v1.0/g/gzip/gzip-1.5-ictce-4.1.13.eb
@@ -1,5 +1,5 @@
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/test/framework/easyconfigs/v2.0/goolf.eb
+++ b/test/framework/easyconfigs/v2.0/goolf.eb
@@ -9,8 +9,8 @@ homepage = '(none)'
 description = 'GCC based compiler toolchain, including OpenMPI, OpenBLAS, FFTW and ScaLAPACK.'
 
 software_license = GPLv2
-software_license_urls = ['https://github.com/hpcugent/easybuild-framework/blob/master/easybuild/toolchains/goolf.py'] 
-docurls = ["https://github.com/hpcugent/easybuild/wiki/Compiler-toolchains"]
+software_license_urls = ['https://github.com/easybuilders/easybuild-framework/blob/master/easybuild/toolchains/goolf.py'] 
+docurls = ["https://github.com/easybuilders/easybuild/wiki/Compiler-toolchains"]
 
 [DEFAULT]
 easyblock = Toolchain

--- a/test/framework/easyconfigs/v2.0/gzip.eb
+++ b/test/framework/easyconfigs/v2.0/gzip.eb
@@ -1,7 +1,7 @@
 # EASYCONFIGFORMAT 2.0
 # this is a version test
 ##
-# This file is an EasyBuild reciPY as per https://github.com/hpcugent/easybuild
+# This file is an EasyBuild reciPY as per https://github.com/easybuilders/easybuild
 #
 # Copyright:: Copyright (c) 2012-2013 Cyprus Institute / CaSToRC
 # Authors::   Thekla Loizou <t.loizou@cyi.ac.cy>

--- a/test/framework/easyconfigs/v2.0/toy-with-sections.eb
+++ b/test/framework/easyconfigs/v2.0/toy-with-sections.eb
@@ -15,7 +15,10 @@ software_license = GPLv2
 software_license_urls = ['https://github.com/easybuilders/easybuild/wiki/License']
 
 sources = ['%(name)s-0.0.tar.gz']  # purposely fixed to 0.0
-checksums = ['be662daa971a640e40be5c804d9d7d10']  # (MD5) source checksum
+checksums = [
+    'be662daa971a640e40be5c804d9d7d10',  # MD5
+    '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # SHA256
+]
 
 sanity_check_paths = {
     'files': [('bin/yot', 'bin/toy')],

--- a/test/framework/easyconfigs/v2.0/toy-with-sections.eb
+++ b/test/framework/easyconfigs/v2.0/toy-with-sections.eb
@@ -7,12 +7,12 @@ docstring test
 """
 name = "toy"
 
-homepage = 'http://hpcugent.github.com/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = "Toy C program, 100% toy."
-docurls = ["https://github.com/hpcugent/easybuild/wiki"]
+docurls = ["https://github.com/easybuilders/easybuild/wiki"]
 
 software_license = GPLv2
-software_license_urls = ['https://github.com/hpcugent/easybuild/wiki/License']
+software_license_urls = ['https://github.com/easybuilders/easybuild/wiki/License']
 
 sources = ['%(name)s-0.0.tar.gz']  # purposely fixed to 0.0
 checksums = ['be662daa971a640e40be5c804d9d7d10']  # (MD5) source checksum

--- a/test/framework/easyconfigs/v2.0/toy.eb
+++ b/test/framework/easyconfigs/v2.0/toy.eb
@@ -15,7 +15,10 @@ software_license = GPLv2
 software_license_urls = ['https://github.com/easybuilders/easybuild/wiki/License']
 
 sources = ['%(name)s-0.0.tar.gz']  # purposely fixed to 0.0
-checksums = ['be662daa971a640e40be5c804d9d7d10']  # (MD5) source checksum
+checksums = [
+    'be662daa971a640e40be5c804d9d7d10',  # MD5
+    '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # SHA256
+]
 
 sanity_check_paths = {
     'files': [('bin/yot', 'bin/toy')],

--- a/test/framework/easyconfigs/v2.0/toy.eb
+++ b/test/framework/easyconfigs/v2.0/toy.eb
@@ -7,12 +7,12 @@ docstring test
 """
 name = "toy"
 
-homepage = 'http://hpcugent.github.com/easybuild'
+homepage = 'https://easybuilders.github.io/easybuild'
 description = "Toy C program, 100% toy."
-docurls = ["https://github.com/hpcugent/easybuild/wiki"]
+docurls = ["https://github.com/easybuilders/easybuild/wiki"]
 
 software_license = GPLv2
-software_license_urls = ['https://github.com/hpcugent/easybuild/wiki/License']
+software_license_urls = ['https://github.com/easybuilders/easybuild/wiki/License']
 
 sources = ['%(name)s-0.0.tar.gz']  # purposely fixed to 0.0
 checksums = ['be662daa971a640e40be5c804d9d7d10']  # (MD5) source checksum

--- a/test/framework/easyconfigs/yeb/toy-0.0.yeb
+++ b/test/framework/easyconfigs/yeb/toy-0.0.yeb
@@ -4,7 +4,7 @@
 name: toy
 version: 0.0
 
-homepage: 'http://hpcugent.github.com/easybuild'
+homepage: 'https://easybuilders.github.io/easybuild'
 description: "Toy C program, 100% toy."
 
 toolchain: dummy, dummy

--- a/test/framework/easyconfigs/yeb/toy-0.0.yeb
+++ b/test/framework/easyconfigs/yeb/toy-0.0.yeb
@@ -14,6 +14,7 @@ sources:
 
 checksums: [[
     'be662daa971a640e40be5c804d9d7d10',  # default [MD5]
+    '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # default (SHA256)
     ['adler32', '0x998410035'],
     ['crc32', '0x1553842328'],
     ['md5', 'be662daa971a640e40be5c804d9d7d10'],

--- a/test/framework/easyconfigversion.py
+++ b/test/framework/easyconfigversion.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/ebconfigobj.py
+++ b/test/framework/ebconfigobj.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/environment.py
+++ b/test/framework/environment.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -559,9 +559,9 @@ class FileToolsTest(EnhancedTestCase):
         self.assertTrue(lines[8].startswith(expected))
 
         # no postinstallcmds in toy-0.0-deps.eb
-        expected = "28 %s+ postinstallcmds = " % green
+        expected = "29 %s+ postinstallcmds = " % green
         self.assertTrue(any([line.startswith(expected) for line in lines]))
-        expected = "29 %s+%s (1/2) toy-0.0" % (green, endcol)
+        expected = "30 %s+%s (1/2) toy-0.0" % (green, endcol)
         self.assertTrue(any(l.startswith(expected) for l in lines), "Found '%s' in: %s" % (expected, lines))
         self.assertEqual(lines[-1], "=====")
 
@@ -585,9 +585,9 @@ class FileToolsTest(EnhancedTestCase):
         self.assertTrue(lines[10].startswith(expected))
 
         # no postinstallcmds in toy-0.0-deps.eb
-        expected = "28 + postinstallcmds = "
+        expected = "29 + postinstallcmds = "
         self.assertTrue(any(l.startswith(expected) for l in lines), "Found '%s' in: %s" % (expected, lines))
-        expected = "29 + (1/2) toy-0.0-"
+        expected = "30 + (1/2) toy-0.0-"
         self.assertTrue(any(l.startswith(expected) for l in lines), "Found '%s' in: %s" % (expected, lines))
 
         self.assertEqual(lines[-1], "=====")

--- a/test/framework/format_convert.py
+++ b/test/framework/format_convert.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/general.py
+++ b/test/framework/general.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -46,7 +46,7 @@ class GeneralTest(EnhancedTestCase):
 
     def test_vsc_location(self):
         """Make sure location of imported vsc module is not the framework itself."""
-        # cfr. https://github.com/hpcugent/easybuild-framework/pull/1160
+        # cfr. https://github.com/easybuilders/easybuild-framework/pull/1160
         # easybuild.framework.__file__ provides location to <prefix>/easybuild/framework/__init__.py
         framework_loc = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(easybuild.framework.__file__))))
         # vsc.utils.generaloption.__file__ provides location to <prefix>/vsc/utils/generaloption/__init__.py

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -56,7 +56,7 @@ except ImportError, err:
 # test account, for which a token may be available
 GITHUB_TEST_ACCOUNT = 'easybuild_test'
 # the user who's repo to test
-GITHUB_USER = "hpcugent"
+GITHUB_USER = "easybuilders"
 # the repo of this user to use in this test
 GITHUB_REPO = "testrepository"
 # branch to test
@@ -122,7 +122,7 @@ class GithubTest(EnhancedTestCase):
             return
 
         tmpdir = tempfile.mkdtemp()
-        # PR for rename of ffmpeg to FFmpeg, see https://github.com/hpcugent/easybuild-easyconfigs/pull/2481/files
+        # PR for rename of ffmpeg to FFmpeg, see https://github.com/easybuilders/easybuild-easyconfigs/pull/2481/files
         all_ecs = [
             'FFmpeg-2.4-intel-2014.06.eb',
             'FFmpeg-2.4-intel-2014b.eb',
@@ -151,9 +151,9 @@ class GithubTest(EnhancedTestCase):
             print "Skipping test_fetch_latest_commit_sha, no GitHub token available?"
             return
 
-        sha = gh.fetch_latest_commit_sha('easybuild-framework', 'hpcugent', github_user=GITHUB_TEST_ACCOUNT)
+        sha = gh.fetch_latest_commit_sha('easybuild-framework', 'easybuilders', github_user=GITHUB_TEST_ACCOUNT)
         self.assertTrue(re.match('^[0-9a-f]{40}$', sha))
-        sha = gh.fetch_latest_commit_sha('easybuild-easyblocks', 'hpcugent', github_user=GITHUB_TEST_ACCOUNT,
+        sha = gh.fetch_latest_commit_sha('easybuild-easyblocks', 'easybuilders', github_user=GITHUB_TEST_ACCOUNT,
                                          branch='develop')
         self.assertTrue(re.match('^[0-9a-f]{40}$', sha))
 

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -55,9 +55,8 @@ except ImportError, err:
 
 # test account, for which a token may be available
 GITHUB_TEST_ACCOUNT = 'easybuild_test'
-# the user who's repo to test
-GITHUB_USER = "easybuilders"
-# the repo of this user to use in this test
+# the user & repo to use in this test (https://github.com/hpcugent/testrepository)
+GITHUB_USER = "hpcugent"
 GITHUB_REPO = "testrepository"
 # branch to test
 GITHUB_BRANCH = 'master'

--- a/test/framework/include.py
+++ b/test/framework/include.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/license.py
+++ b/test/framework/license.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -717,7 +717,7 @@ class ModulesTest(EnhancedTestCase):
     def test_module_use_bash(self):
         """Test whether effect of 'module use' is preserved when a new bash session is started."""
         # this test is here as check for a nasty bug in how the modules tool is deployed
-        # cfr. https://github.com/hpcugent/easybuild-framework/issues/1756,
+        # cfr. https://github.com/easybuilders/easybuild-framework/issues/1756,
         # https://bugzilla.redhat.com/show_bug.cgi?id=1326075
         modules_dir = os.path.abspath(os.path.join(self.test_prefix, 'modules'))
         self.assertFalse(modules_dir in os.environ['MODULEPATH'])
@@ -763,7 +763,7 @@ class ModulesTest(EnhancedTestCase):
 
         # ensure that correct module is loaded when hierarchy is defined by loading the GCC module
         # (side-effect is that ModulesTool instance doesn't track the change being made to $MODULEPATH)
-        # verifies bug fixed in https://github.com/hpcugent/easybuild-framework/pull/1795
+        # verifies bug fixed in https://github.com/easybuilders/easybuild-framework/pull/1795
         self.modtool.purge()
         self.modtool.unuse(gcc_mod_dir)
         self.modtool.load(['GCC/4.7.2'])

--- a/test/framework/modules/toy/.0.0-deps
+++ b/test/framework/modules/toy/.0.0-deps
@@ -1,11 +1,11 @@
 #%Module
 
 proc ModulesHelp { } {
-    puts stderr {   Toy C program. - Homepage: http://hpcugent.github.com/easybuild
+    puts stderr {   Toy C program. - Homepage: https://easybuilders.github.io/easybuild
     }
 }
 
-module-whatis {Toy C program. - Homepage: http://hpcugent.github.com/easybuild}
+module-whatis {Toy C program. - Homepage: https://easybuilders.github.io/easybuild}
 
 set root    /var/folders/6y/x4gmwgjn5qz63b7ftg4j_40m0000gn/T/tmpviG1OT/software/toy/0.0-deps
 

--- a/test/framework/modules/toy/0.0
+++ b/test/framework/modules/toy/0.0
@@ -1,11 +1,11 @@
 #%Module
 
 proc ModulesHelp { } {
-    puts stderr {   Toy C program. - Homepage: http://hpcugent.github.com/easybuild
+    puts stderr {   Toy C program. - Homepage: https://easybuilders.github.io/easybuild
     }
 }
 
-module-whatis {Toy C program. - Homepage: http://hpcugent.github.com/easybuild}
+module-whatis {Toy C program. - Homepage: https://easybuilders.github.io/easybuild}
 
 set root    /var/folders/6y/x4gmwgjn5qz63b7ftg4j_40m0000gn/T/tmpviG1OT/software/toy/0.0
 

--- a/test/framework/modulestool.py
+++ b/test/framework/modulestool.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/package.py
+++ b/test/framework/package.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/parallelbuild.py
+++ b/test/framework/parallelbuild.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/repository.py
+++ b/test/framework/repository.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -79,7 +79,7 @@ class RepositoryTest(EnhancedTestCase):
             print "(skipping GitRepository test)"
             return
 
-        test_repo_url = 'https://github.com/hpcugent/testrepository'
+        test_repo_url = 'https://github.com/easybuilders/testrepository'
 
         # URL
         repo = GitRepository(test_repo_url)
@@ -122,7 +122,7 @@ class RepositoryTest(EnhancedTestCase):
             return
 
         # GitHub also supports SVN
-        test_repo_url = 'https://github.com/hpcugent/testrepository'
+        test_repo_url = 'https://github.com/easybuilders/testrepository'
 
         repo = SvnRepository(test_repo_url)
         repo.init()

--- a/test/framework/repository.py
+++ b/test/framework/repository.py
@@ -79,7 +79,7 @@ class RepositoryTest(EnhancedTestCase):
             print "(skipping GitRepository test)"
             return
 
-        test_repo_url = 'https://github.com/easybuilders/testrepository'
+        test_repo_url = 'https://github.com/hpcugent/testrepository'
 
         # URL
         repo = GitRepository(test_repo_url)
@@ -122,7 +122,7 @@ class RepositoryTest(EnhancedTestCase):
             return
 
         # GitHub also supports SVN
-        test_repo_url = 'https://github.com/easybuilders/testrepository'
+        test_repo_url = 'https://github.com/hpcugent/testrepository'
 
         repo = SvnRepository(test_repo_url)
         repo.init()

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -625,7 +625,7 @@ class RobotTest(EnhancedTestCase):
         args = [
             os.path.join(test_ecs_path, 't', 'toy', 'toy-0.0.eb'),
             test_ec,  # relative path, should be resolved via robot search path
-            # PR for foss/2015a, see https://github.com/hpcugent/easybuild-easyconfigs/pull/1239/files
+            # PR for foss/2015a, see https://github.com/easybuilders/easybuild-easyconfigs/pull/1239/files
             '--from-pr=1239',
             'FFTW-3.3.4-gompi-2015a.eb',
             'gompi-2015a-test.eb',  # relative path, available in robot search path

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/easyblocks/f/foo.py
+++ b/test/framework/sandbox/easybuild/easyblocks/f/foo.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/easyblocks/f/foofoo.py
+++ b/test/framework/sandbox/easybuild/easyblocks/f/foofoo.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/easyblocks/g/gcc.py
+++ b/test/framework/sandbox/easybuild/easyblocks/g/gcc.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/easyblocks/generic/bar.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/bar.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/easyblocks/generic/configuremake.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/configuremake.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/easyblocks/generic/dummyextension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/dummyextension.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/easyblocks/generic/toolchain.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toolchain.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/easyblocks/h/hpl.py
+++ b/test/framework/sandbox/easybuild/easyblocks/h/hpl.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/easyblocks/s/scalapack.py
+++ b/test/framework/sandbox/easybuild/easyblocks/s/scalapack.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy_buggy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy_buggy.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/tools/__init__.py
+++ b/test/framework/sandbox/easybuild/tools/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/tools/module_naming_scheme/__init__.py
+++ b/test/framework/sandbox/easybuild/tools/module_naming_scheme/__init__.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/tools/module_naming_scheme/broken_module_naming_scheme.py
+++ b/test/framework/sandbox/easybuild/tools/module_naming_scheme/broken_module_naming_scheme.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/tools/module_naming_scheme/test_module_naming_scheme.py
+++ b/test/framework/sandbox/easybuild/tools/module_naming_scheme/test_module_naming_scheme.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/sandbox/easybuild/tools/module_naming_scheme/test_module_naming_scheme_more.py
+++ b/test/framework/sandbox/easybuild/tools/module_naming_scheme/test_module_naming_scheme_more.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/scripts.py
+++ b/test/framework/scripts.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/style.py
+++ b/test/framework/style.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -9,7 +9,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/toolchainvariables.py
+++ b/test/framework/toolchainvariables.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -225,7 +225,7 @@ class ToyBuildTest(EnhancedTestCase):
             "usage = 'This toy is easy to use, 100%!'",
             "examples = 'No example available, 0% complete'",
             "docpaths = ['share/doc/toy/readme.txt', 'share/doc/toy/html/index.html']",
-            "docurls = ['http://hpcugent.github.com/easybuild/toy/docs.html']",
+            "docurls = ['https://easybuilders.github.io/easybuild/toy/docs.html']",
             "upstream_contacts = 'support@toy.org'",
             "site_contacts = ['Jim Admin', 'Jane Admin']",
         ])
@@ -1000,11 +1000,11 @@ class ToyBuildTest(EnhancedTestCase):
             r'',
             r'More information',
             r'================',
-            r' - Homepage: http://hpcugent.github.com/easybuild',
+            r' - Homepage: https://easybuilders.github.io/easybuild',
             r' - Documentation:',
             r'    - \$EBROOTTOY/share/doc/toy/readme.txt',
             r'    - \$EBROOTTOY/share/doc/toy/html/index.html',
-            r'    - http://hpcugent.github.com/easybuild/toy/docs.html',
+            r'    - https://easybuilders.github.io/easybuild/toy/docs.html',
             r' - Upstream contact: support@toy.org',
             r' - Site contacts:',
             r'    - Jim Admin',
@@ -1018,7 +1018,7 @@ class ToyBuildTest(EnhancedTestCase):
                 r'\]\]\)',
                 r'',
                 r'whatis\(\[\[Description: Toy C program, 100% toy.\]\]\)',
-                r'whatis\(\[\[Homepage: http://hpcugent.github.com/easybuild\]\]\)',
+                r'whatis\(\[\[Homepage: https://easybuilders.github.io/easybuild\]\]\)',
                 r'',
                 r'local root = "%s/software/toy/0.0-tweaked"' % self.test_installpath,
                 r'',
@@ -1054,7 +1054,7 @@ class ToyBuildTest(EnhancedTestCase):
                 r'}',
                 r'',
                 r'module-whatis {Description: Toy C program, 100% toy.}',
-                r'module-whatis {Homepage: http://hpcugent.github.com/easybuild}',
+                r'module-whatis {Homepage: https://easybuilders.github.io/easybuild}',
                 r'',
                 r'set root %s/software/toy/0.0-tweaked' % self.test_installpath,
                 r'',
@@ -1323,7 +1323,7 @@ class ToyBuildTest(EnhancedTestCase):
             "toolchain = {'name': 'goolf', 'version': '1.4.10'}",
             # specially construct (sort of senseless) sanity check commands,
             # that will fail if the corresponding modules are not loaded
-            # cfr. https://github.com/hpcugent/easybuild-framework/pull/1754
+            # cfr. https://github.com/easybuilders/easybuild-framework/pull/1754
             "sanity_check_commands = [",
             "   'env | grep EBROOTFFTW',",
             "   'env | grep EBROOTGCC',",

--- a/test/framework/tweak.py
+++ b/test/framework/tweak.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/type_checking.py
+++ b/test/framework/type_checking.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -180,7 +180,7 @@ class EnhancedTestCase(_EnhancedTestCase):
         # save values of $PATH & $PYTHONPATH, so they can be restored later
         # this is important in case EasyBuild was installed as a module, since that module may be unloaded,
         # for example due to changes to $MODULEPATH in case EasyBuild was installed in a module hierarchy
-        # cfr. https://github.com/hpcugent/easybuild-framework/issues/1685
+        # cfr. https://github.com/easybuilders/easybuild-framework/issues/1685
         self.env_path = os.environ.get('PATH')
         self.env_pythonpath = os.environ.get('PYTHONPATH')
 

--- a/test/framework/variables.py
+++ b/test/framework/variables.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/test/framework/yeb.py
+++ b/test/framework/yeb.py
@@ -8,7 +8,7 @@
 # Flemish Research Foundation (FWO) (http://www.fwo.be/en)
 # and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
 #
-# http://github.com/hpcugent/easybuild
+# https://github.com/easybuilders/easybuild
 #
 # EasyBuild is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
last changes (hopefully) related to the migration to github.com/easybuilders