### PR TITLE
extend packaging support for Docker/Singularity definition files & images (WIP)

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -58,9 +58,12 @@ UNLOAD = 'unload'
 UNSET = 'unset'
 WARN = 'warn'
 
+PKG_TOOL_DOCKER = 'docker'
 PKG_TOOL_FPM = 'fpm'
+PKG_TOOL_SINGULARITY = 'singularity'
+PKG_TYPE_DEF = 'def'
+PKG_TYPE_IMG = 'img'
 PKG_TYPE_RPM = 'rpm'
-
 
 DEFAULT_JOB_BACKEND = 'GC3Pie'
 DEFAULT_LOGFILE_FORMAT = ("easybuild", "easybuild-%(name)s-%(version)s-%(date)s.%(time)s.log")

--- a/easybuild/tools/package/utilities.py
+++ b/easybuild/tools/package/utilities.py
@@ -40,7 +40,9 @@ from vsc.utils import fancylogger
 from vsc.utils.missing import get_subclasses
 from vsc.utils.patterns import Singleton
 
-from easybuild.tools.config import PKG_TOOL_FPM, PKG_TYPE_RPM, build_option, get_package_naming_scheme, log_path
+from easybuild.tools.config import PKG_TOOL_DOCKER, PKG_TOOL_FPM, PKG_TOOL_SINGULARITY
+from easybuild.tools.config import PKG_TYPE_DEF, PKG_TYPE_IMG, PKG_TYPE_RPM
+from easybuild.tools.config import build_option, get_package_naming_scheme, log_path
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import change_dir, which
 from easybuild.tools.package.package_naming_scheme.pns import PackageNamingScheme
@@ -66,12 +68,35 @@ def package(easyblock):
     Package installed software, according to active packaging configuration settings."""
     pkgtool = build_option('package_tool')
 
-    if pkgtool == PKG_TOOL_FPM:
+    if pkgtool == PKG_TOOL_DOCKER:
+        pkgdir = package_with_docker(easyblock)
+    elif pkgtool == PKG_TOOL_FPM:
         pkgdir = package_with_fpm(easyblock)
+    elif pkgtool == PKG_TOOL_SINGULARITY:
+        pkgdir = package_with_singularity(easyblock)
     else:
         raise EasyBuildError("Unknown packaging tool specified: %s", pkgtool)
 
     return pkgdir
+
+
+def package_with_docker(easyblock):
+    """
+    Package software with Docker,
+    i.e. either generate a container definition file, or build an actual Docker container image
+    (depending on the value for --package-type, 'def' or 'img')
+    """
+    workdir = tempfile.mkdtemp(prefix='eb-pkgs-')
+    pkgtype = build_option('package_type')
+
+    if pkgtype == PKG_TYPE_DEF:
+        raise NotImplementedError
+    elif pkgtype == PKG_TYPE_IMG:
+        raise NotImplementedError
+    else:
+        raise EasyBuildError("Unknown package type '%s' for Docker", pkgtype)
+
+    return workdir
 
 
 def package_with_fpm(easyblock):
@@ -149,6 +174,25 @@ def package_with_fpm(easyblock):
     _log.info("Created %s package(s) in %s", pkgtype, workdir)
 
     change_dir(origdir)
+
+    return workdir
+
+
+def package_with_singularity(easyblock):
+    """
+    Package software with Singularity,
+    i.e. either generate a container definition file, or build an actual Singularity container image
+    (depending on the value for --package-type, 'def' or 'img')
+    """
+    workdir = tempfile.mkdtemp(prefix='eb-pkgs-')
+    pkgtype = build_option('package_type')
+
+    if pkgtype == PKG_TYPE_DEF:
+        raise NotImplementedError
+    elif pkgtype == PKG_TYPE_IMG:
+        raise NotImplementedError
+    else:
+        raise EasyBuildError("Unknown package type '%s' for Singularity", pkgtype)
 
     return workdir
 


### PR DESCRIPTION
After a nice discussion with a couple of the Singularity developers (@gmkurtzer, @GodloveD, @bauerm97) and some EasyBuilders who have been playing around with the combo of EasyBuild & Singularity (@pescobar, @shahzebsiddiqui), we came up with some ideas to extend the existing packaging support in EasyBuild (cfr. easybuild.readthedocs.io/en/latest/Packaging_support.html) to (Docker &) Singularity containers.

The idea is to add support for both generating container definition files (which can then be fed into `docker` or `singularity` the create the actual container image or uploaded to https://singularityhub.github.io/) and building actual container images by letting EasyBuild call out to the tools itself. Both use cases make sense.

Additional things to figure out:

* allowing to pick between different procedures to build the container image, e.g. letting `eb` build the software and then just shove than in a container image, letting `eb` generate RPMs which can then be used to populate the container image, etc.
* a flexible way to steer specifics, e.g. which bootstrap mechanism to use, which OS to use in the container image, whether an existing (Docker) image should be used as a base, etc.

Inspiration can be taken from earlier experiments:

* https://github.com/pescobar/singularity-easybuild (@pescobar & @shahzebsiddiqui)
* https://github.com/GodloveD/EasyBuild (@GodloveD)

In parallel, the Singularity developers plan to look into supporting EasyBuild as a bootstrap agent in Singularity, which we could then leverage here.

**Current status**: very much work-in-progress; only the rough structure is in place, actual packaging support (i.e. fleshing out the `package_with_docker` & `package_with_singularity` functions) is still TODO.