### PR TITLE
add support for --merge-pr

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1326,7 +1326,7 @@ class EasyBlock(object):
             try:
                 cmd = cmdtmpl % tmpldict
             except KeyError, err:
-                msg = "KeyError occured on completing extension filter template: %s; "
+                msg = "KeyError occurred on completing extension filter template: %s; "
                 msg += "'name'/'version' keys are no longer supported, should use 'ext_name'/'ext_version' instead"
                 self.log.nosupport(msg, '2.0')
 

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -273,7 +273,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
         install_github_token(options.github_user, silent=build_option('silent'))
 
     elif options.merge_pr:
-        print merge_pr(options.merge_pr)
+        merge_pr(options.merge_pr)
 
     elif options.review_pr:
         print review_pr(options.review_pr, colored=use_color(options.color))

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -59,7 +59,8 @@ from easybuild.framework.easyconfig.tweak import obtain_ec_for, tweak
 from easybuild.tools.config import find_last_log, get_repository, get_repositorypath, build_option
 from easybuild.tools.docs import list_software
 from easybuild.tools.filetools import adjust_permissions, cleanup, write_file
-from easybuild.tools.github import check_github, find_easybuild_easyconfig, install_github_token, new_pr, update_pr
+from easybuild.tools.github import check_github, find_easybuild_easyconfig, install_github_token
+from easybuild.tools.github import new_pr, merge_pr, update_pr
 from easybuild.tools.modules import modules_tool
 from easybuild.tools.options import parse_external_modules_metadata, process_software_build_specs, use_color
 from easybuild.tools.robot import check_conflicts, det_robot_path, dry_run, resolve_dependencies, search_easyconfigs
@@ -271,6 +272,9 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     elif options.install_github_token:
         install_github_token(options.github_user, silent=build_option('silent'))
 
+    elif options.merge_pr:
+        print merge_pr(options.merge_pr)
+
     elif options.review_pr:
         print review_pr(options.review_pr, colored=use_color(options.color))
 
@@ -287,6 +291,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
         options.install_github_token,
         options.list_installed_software,
         options.list_software,
+        options.merge_pr,
         options.review_pr,
         options.terse,
         search_query,

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -225,7 +225,7 @@ def print_msg(msg, log=None, silent=False, prefix=True, newline=True, stderr=Fal
     :param silent: be silent (only log, don't print)
     :param prefix: include message prefix characters ('== ')
     :param newline: end message with newline
-    :param stderr: print to stderr rather than stderr
+    :param stderr: print to stderr rather than stdout
     """
     if log:
         log.info(msg)

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -217,9 +217,15 @@ def get_log(name=None):
     log.nosupport("Use of get_log function", '2.0')
 
 
-def print_msg(msg, log=None, silent=False, prefix=True, newline=True):
+def print_msg(msg, log=None, silent=False, prefix=True, newline=True, stderr=False):
     """
-    Print a message to stdout.
+    Print a message.
+
+    :param log: logger instance to also message to
+    :param silent: be silent (only log, don't print)
+    :param prefix: include message prefix characters ('== ')
+    :param newline: end message with newline
+    :param stderr: print to stderr rather than stderr
     """
     if log:
         log.info(msg)
@@ -228,9 +234,12 @@ def print_msg(msg, log=None, silent=False, prefix=True, newline=True):
             msg = ' '.join([EB_MSG_PREFIX, msg])
 
         if newline:
-            print msg
+            msg += '\n'
+
+        if stderr:
+            sys.stderr.write(msg)
         else:
-            print msg,
+            sys.stdout.write(msg)
 
 
 def dry_run_set_dirs(prefix, builddir, software_installdir, module_installdir):

--- a/easybuild/tools/configobj.py
+++ b/easybuild/tools/configobj.py
@@ -263,7 +263,7 @@ class DuplicateError(ConfigObjError):
 
 class ConfigspecError(ConfigObjError):
     """
-    An error occured whilst parsing a configspec.
+    An error occurred whilst parsing a configspec.
     """
 
 
@@ -1725,7 +1725,7 @@ class ConfigObj(Section):
         Handle an error according to the error settings.
 
         Either raise the error or store it.
-        The error will have occured at ``cur_index``
+        The error will have occurred at ``cur_index``
         """
         line = infile[cur_index]
         cur_index += 1

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -418,7 +418,7 @@ def download_file(filename, url, path, forced=False):
                 _log.warning("URL %s was not found (HTTP response code %s), not trying again" % (url, err.code))
                 break
             else:
-                _log.warning("HTTPError occured while trying to download %s to %s: %s" % (url, path, err))
+                _log.warning("HTTPError occurred while trying to download %s to %s: %s" % (url, path, err))
                 attempt_cnt += 1
         except IOError as err:
             _log.warning("IOError occurred while trying to download %s to %s: %s" % (url, path, err))
@@ -577,7 +577,7 @@ def compute_checksum(path, checksum_type=DEFAULT_CHECKSUM):
     except IOError, err:
         raise EasyBuildError("Failed to read %s: %s", path, err)
     except MemoryError, err:
-        _log.warning("A memory error occured when computing the checksum for %s: %s" % (path, err))
+        _log.warning("A memory error occurred when computing the checksum for %s: %s" % (path, err))
         checksum = 'dummy_checksum_due_to_memory_error'
 
     return checksum

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -233,7 +233,7 @@ def github_api_get_request(request_f, github_user=None, token=None, **kwargs):
     try:
         status, data = url.get(**kwargs)
     except socket.gaierror, err:
-        _log.warning("Error occured while performing get request: %s", err)
+        _log.warning("Error occurred while performing get request: %s", err)
         status, data = 0, None
 
     _log.debug("get request result for %s: status: %d, data: %s", url, status, data)
@@ -259,7 +259,7 @@ def github_api_put_request(request_f, github_user=None, token=None, **kwargs):
     try:
         status, data = url.put(**kwargs)
     except socket.gaierror, err:
-        _log.warning("Error occured while performing put request: %s", err)
+        _log.warning("Error occurred while performing put request: %s", err)
         status, data = 0, {'message': err}
 
     if status == 200:
@@ -1260,8 +1260,8 @@ def check_github():
 
     if res:
         if res[0].flags & res[0].ERROR:
-            _log.warning("Error occured when pushing test branch to GitHub: %s", res[0].summary)
-            check_res = "FAIL (error occured)"
+            _log.warning("Error occurred when pushing test branch to GitHub: %s", res[0].summary)
+            check_res = "FAIL (error occurred)"
         else:
             check_res = "OK"
     elif github_user:
@@ -1295,7 +1295,7 @@ def check_github():
     try:
         res = create_gist("This is just a test", 'test.txt', descr='test123', github_user=github_user)
     except Exception as err:
-        _log.warning("Exception occured when trying to create gist: %s", err)
+        _log.warning("Exception occurred when trying to create gist: %s", err)
 
     if res and re.match('https://gist.github.com/[0-9a-f]+$', res):
         check_res = "OK"

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -915,25 +915,26 @@ def check_pr_eligible_to_merge(pr_data):
     else:
         res = not_eligible(msg_tmpl % "(result unknown)")
 
-    # check for successful test report (checked in reverse order)
-    msg_tmpl = "* last test report is successful: %s"
-    test_report_regex = re.compile(r"^Test report by @\S+")
-    test_report_found = False
-    for comment in pr_data['issue_comments'][::-1]:
-        comment = comment['body']
-        if test_report_regex.search(comment):
-            if 'SUCCESS' in comment:
-                print_msg(msg_tmpl % 'OK', prefix=False)
-                test_report_found = True
-                break
-            elif 'FAILED' in comment:
-                res = not_eligible(msg_tmpl % 'FAILED')
-                test_report_found = True
-            else:
-                print_warning("Failed to determine outcome of test report for comment:\n%s" % comment)
+    if pr_data['base']['repo']['name'] == GITHUB_EASYCONFIGS_REPO:
+        # check for successful test report (checked in reverse order)
+        msg_tmpl = "* last test report is successful: %s"
+        test_report_regex = re.compile(r"^Test report by @\S+")
+        test_report_found = False
+        for comment in pr_data['issue_comments'][::-1]:
+            comment = comment['body']
+            if test_report_regex.search(comment):
+                if 'SUCCESS' in comment:
+                    print_msg(msg_tmpl % 'OK', prefix=False)
+                    test_report_found = True
+                    break
+                elif 'FAILED' in comment:
+                    res = not_eligible(msg_tmpl % 'FAILED')
+                    test_report_found = True
+                else:
+                    print_warning("Failed to determine outcome of test report for comment:\n%s" % comment)
 
-    if not test_report_found:
-        res = not_eligible(msg_tmpl % "(no test reports found)")
+        if not test_report_found:
+            res = not_eligible(msg_tmpl % "(no test reports found)")
 
     # check for approved review
     approved_review_by = []

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -835,6 +835,13 @@ def find_software_name_for_patch(patch_name):
     return soft_name
 
 
+def merge_pr(pr):
+    """
+    Merge specified pull request
+    """
+    raise NotImplementedError
+
+
 @only_if_module_is_available('git', pkgname='GitPython')
 def new_pr(paths, ecs, title=None, descr=None, commit_msg=None):
     """

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1163,7 +1163,7 @@ class Lmod(ModulesTool):
             (stdout, stderr) = proc.communicate()
 
             if stderr:
-                raise EasyBuildError("An error occured when running '%s': %s", ' '.join(cmd), stderr)
+                raise EasyBuildError("An error occurred when running '%s': %s", ' '.join(cmd), stderr)
 
             if self.testing:
                 # don't actually update local cache when testing, just return the cache contents

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -550,6 +550,7 @@ class EasyBuildOptions(GeneralOption):
             'github-user': ("GitHub username", str, 'store', None),
             'github-org': ("GitHub organization", str, 'store', None),
             'install-github-token': ("Install GitHub token (requires --github-user)", None, 'store_true', False),
+            'merge-pr': ("Merge pull request", int, 'store', None, {'metavar': 'PR#'}),
             'new-pr': ("Open a new pull request", None, 'store_true', False),
             'pr-branch-name': ("Branch name to use for new PRs; '<timestamp>_new_pr_<name><version>' if unspecified",
                                str, 'store', None),

--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -213,4 +213,4 @@ def prepare_easyconfig(ec):
         easyblock_instance.close_log()
         os.remove(easyblock_instance.logfile)
     except (OSError, EasyBuildError), err:
-        raise EasyBuildError("An error occured while preparing %s: %s", ec, err)
+        raise EasyBuildError("An error occurred while preparing %s: %s", ec, err)

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -36,7 +36,7 @@ from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_
 from unittest import TextTestRunner
 from vsc.utils.fancylogger import getLogger, getRootLoggerName, logToFile, setLogFormat
 
-from easybuild.tools.build_log import LOGGING_FORMAT, EasyBuildError, print_warning
+from easybuild.tools.build_log import LOGGING_FORMAT, EasyBuildError, print_msg, print_warning
 from easybuild.tools.filetools import read_file, write_file
 
 
@@ -228,6 +228,31 @@ class BuildLogTest(EnhancedTestCase):
 
         self.assertEqual(stderr, "\nWARNING: You have been warned.\n\n")
         self.assertEqual(stdout, '')
+
+    def test_print_msg(self):
+        """Test print_msg"""
+        def run_check(msg, expected_stdout='', expected_stderr='', **kwargs):
+            """Helper function to check stdout/stderr produced via print_msg"""
+            self.mock_stdout(True)
+            self.mock_stderr(True)
+            print_msg(msg, **kwargs)
+            stdout = self.get_stdout()
+            stderr = self.get_stderr()
+            self.mock_stdout(False)
+            self.mock_stderr(False)
+            self.assertEqual(stdout, expected_stdout)
+            self.assertEqual(stderr, expected_stderr)
+
+        run_check("testing, 1, 2, 3", expected_stdout="== testing, 1, 2, 3\n")
+        run_check("testing, 1, 2, 3", expected_stdout="== testing, 1, 2, 3", newline=False)
+        run_check("testing, 1, 2, 3", expected_stdout="testing, 1, 2, 3\n", prefix=False)
+        run_check("testing, 1, 2, 3", expected_stdout="testing, 1, 2, 3", prefix=False, newline=False)
+        run_check("testing, 1, 2, 3", expected_stderr="== testing, 1, 2, 3\n", stderr=True)
+        run_check("testing, 1, 2, 3", expected_stderr="== testing, 1, 2, 3", stderr=True, newline=False)
+        run_check("testing, 1, 2, 3", expected_stderr="testing, 1, 2, 3\n", stderr=True, prefix=False)
+        run_check("testing, 1, 2, 3", expected_stderr="testing, 1, 2, 3", stderr=True, prefix=False, newline=False)
+        run_check("testing, 1, 2, 3", silent=True)
+        run_check("testing, 1, 2, 3", silent=True, stderr=True)
 
 
 def suite():

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -284,7 +284,7 @@ class GithubTest(EnhancedTestCase):
             """Helper function to check result of check_pr_eligible_to_merge"""
             self.mock_stdout(True)
             self.mock_stderr(True)
-            res = gh.check_pr_eligible_to_merge(pr_data, 'easybuilders', 'easybuild-easyconfigs')
+            res = gh.check_pr_eligible_to_merge(pr_data)
             stdout = self.get_stdout()
             stderr = self.get_stderr()
             self.mock_stdout(False)
@@ -297,13 +297,13 @@ class GithubTest(EnhancedTestCase):
         pr_data = {
             'base': {
                 'ref': 'master',
+                'repo': {
+                    'name': 'easybuild-easyconfigs',
+                    'owner': {'login': 'easybuilders'},
+                },
             },
-            'combined_status': {
-            },
-            'issue_comments': {
-                'bodies': [
-                ],
-            },
+            'status_last_commit': None,
+            'issue_comments': {'bodies': []},
             'milestone': None,
             'number': '1234',
         }
@@ -328,11 +328,11 @@ class GithubTest(EnhancedTestCase):
             ('failure', 'FAILED'),
         ]
         for status, test_result in tests:
-            pr_data['combined_status'] = status
+            pr_data['status_last_commit'] = status
             expected_warning = test_result_warning_template % test_result
             run_check()
 
-        pr_data['combined_status'] = 'success'
+        pr_data['status_last_commit'] = 'success'
         expected_stdout += "* test suite passes: OK\n"
         expected_warning = ''
         run_check()

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2747,6 +2747,33 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertEqual(stderr.strip(), expected_stderr)
         self.assertTrue(stdout.strip().endswith(expected_stdout), "'%s' ends with '%s'" % (stdout, expected_stdout))
 
+        # --merge-pr also works on easyblocks (& framework) PRs
+        args = [
+            '--merge-pr',
+            '1206',
+            '--pr-target-repo=easybuild-easyblocks',
+            '-D',
+            '--github-user=%s' % GITHUB_TEST_ACCOUNT,
+        ]
+        self.mock_stdout(True)
+        self.mock_stderr(True)
+        self.eb_main(args, do_build=True, raise_error=True, testing=False)
+        stdout = self.get_stdout()
+        stderr = self.get_stderr()
+        self.mock_stdout(False)
+        self.mock_stderr(False)
+        self.assertEqual(stderr.strip(), '')
+        expected_stdout = '\n'.join([
+            "Checking eligibility of easybuilders/easybuild-easyblocks PR #1206 for merging...",
+            "* targets develop branch: OK",
+            "* test suite passes: OK",
+            "* approved review: OK (by migueldiascosta)",
+            "* milestone is set: OK (3.3.1)",
+            '',
+            "Review OK, merging pull request!",
+        ])
+        self.assertTrue(expected_stdout in stdout)
+
     def test_empty_pr(self):
         """Test use of --new-pr (dry run only) with no changes"""
         if self.github_token is None:

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3024,7 +3024,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         txt = self.get_stdout()
         self.mock_stdout(False)
         expected = '\n'.join([
-            "== Processed 5/5 easyconfigs... ",
+            "== Processed 5/5 easyconfigs...",
             "== Found 2 different software packages",
             '',
             "* GCC",

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2681,6 +2681,43 @@ class CommandLineOptionsTest(EnhancedTestCase):
             regex = re.compile(regex, re.M)
             self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
 
+    def test_merge_pr(self):
+        """
+        Test use of --merge-pr (dry run)"""
+        if self.github_token is None:
+            print "Skipping test_merge_pr, no GitHub token available?"
+            return
+
+        args = [
+            '--merge-pr',
+            '4781',  # PR for easyconfig for EasyBuild-3.3.0.eb
+            '-D',
+            '--github-user=%s' % GITHUB_TEST_ACCOUNT,
+        ]
+
+        self.mock_stdout(True)
+        self.mock_stderr(True)
+        self.eb_main(args, do_build=True, raise_error=True, testing=False)
+        stdout = self.get_stdout()
+        stderr = self.get_stderr()
+        self.mock_stdout(False)
+        self.mock_stderr(False)
+
+        expected_stdout = '\n'.join([
+            "Checking eligibility of easybuilders/easybuild-easyconfigs PR #4781 for merging...",
+            "* targets develop branch: OK",
+            "* test suite passes: OK",
+            "* last test report is successful: OK",
+            "* approved style review by a human ('lgtm'): OK",
+            "* milestone is set: OK (3.3.1)",
+            '',
+            "Review OK, merging pull request!",
+            '',
+            "[DRY RUN] Adding comment to easybuild-easyconfigs issue #4781: 'Going in, thanks @boegel!'",
+            "[DRY RUN] Merged easybuilders/easybuild-easyconfigs pull request #4781",
+        ])
+        self.assertTrue(stdout.strip().endswith(expected_stdout))
+        self.assertEqual(stderr, '')
 
     def test_empty_pr(self):
         """Test use of --new-pr (dry run only) with no changes"""

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2695,6 +2695,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--github-user=%s' % GITHUB_TEST_ACCOUNT,
         ]
 
+        # merged PR for EasyBuild-3.3.0.eb, is missing approved review
         self.mock_stdout(True)
         self.mock_stderr(True)
         self.eb_main(args, do_build=True, raise_error=True, testing=False)
@@ -2708,16 +2709,43 @@ class CommandLineOptionsTest(EnhancedTestCase):
             "* targets develop branch: OK",
             "* test suite passes: OK",
             "* last test report is successful: OK",
-            "* approved style review by a human ('lgtm'): OK",
+            "* milestone is set: OK (3.3.1)",
+        ])
+        expected_stderr = '\n'.join([
+            "* approved review: MISSING => not eligible for merging!",
+            '',
+            "WARNING: Review indicates this PR should not be merged (use -f/--force to do so anyway)",
+        ])
+        self.assertEqual(stderr.strip(), expected_stderr)
+        self.assertTrue(stdout.strip().endswith(expected_stdout), "'%s' ends with '%s'" % (stdout, expected_stdout))
+
+        # full eligible merged PR
+        args[1] = '4832'
+
+        self.mock_stdout(True)
+        self.mock_stderr(True)
+        self.eb_main(args, do_build=True, raise_error=True, testing=False)
+        stdout = self.get_stdout()
+        stderr = self.get_stderr()
+        self.mock_stdout(False)
+        self.mock_stderr(False)
+
+        expected_stdout = '\n'.join([
+            "Checking eligibility of easybuilders/easybuild-easyconfigs PR #4832 for merging...",
+            "* targets develop branch: OK",
+            "* test suite passes: OK",
+            "* last test report is successful: OK",
+            "* approved review: OK (by wpoely86)",
             "* milestone is set: OK (3.3.1)",
             '',
             "Review OK, merging pull request!",
             '',
-            "[DRY RUN] Adding comment to easybuild-easyconfigs issue #4781: 'Going in, thanks @boegel!'",
-            "[DRY RUN] Merged easybuilders/easybuild-easyconfigs pull request #4781",
+            "[DRY RUN] Adding comment to easybuild-easyconfigs issue #4832: 'Going in, thanks @boegel!'",
+            "[DRY RUN] Merged easybuilders/easybuild-easyconfigs pull request #4832",
         ])
-        self.assertTrue(stdout.strip().endswith(expected_stdout))
-        self.assertEqual(stderr, '')
+        expected_stderr = ''
+        self.assertEqual(stderr.strip(), expected_stderr)
+        self.assertTrue(stdout.strip().endswith(expected_stdout), "'%s' ends with '%s'" % (stdout, expected_stdout))
 
     def test_empty_pr(self):
         """Test use of --new-pr (dry run only) with no changes"""


### PR DESCRIPTION
support for `eb --merge-pr`, meant to help EasyBuild maintainers merging PRs (easyconfigs only for now)

checks the requirements documented at http://easybuild.readthedocs.io/en/latest/Contributing.html#requirements-for-pull-requests as best as possible, see implementation of the `check_pr_eligible_to_merge` function