### PR TITLE
strip provided GitHub token of spaces in --install-github-token

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1222,7 +1222,7 @@ def install_github_token(github_user, silent=False):
                                  current_token, github_user)
 
     # get token to install
-    token = getpass.getpass(prompt="Token: ")
+    token = getpass.getpass(prompt="Token: ").strip()
 
     # validate token before installing it
     print_msg("Validating token...", prefix=False, silent=silent)

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -207,8 +207,9 @@ class GithubTest(EnhancedTestCase):
         self.assertEqual(gh.fetch_github_token(random_user), None)
 
         # poor mans mocking of getpass
+        # inject leading/trailing spaces to verify stripping of provided value
         def fake_getpass(*args, **kwargs):
-            return self.github_token
+            return ' ' + self.github_token + '  '
 
         orig_getpass = gh.getpass.getpass
         gh.getpass.getpass = fake_getpass


### PR DESCRIPTION
fix for https://github.com/easybuilders/easybuild/issues/357

cc @schiotz