### PR TITLE
remove 'provides' line from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,6 @@ implement support for installing particular (groups of) software packages.""",
         "Topic :: Software Development :: Build Tools",
     ],
     platforms="Linux",
-    provides=["eb"] + easybuild_packages,
     test_suite="test.framework.suite",
     zip_safe=False,
     install_requires=[


### PR DESCRIPTION
I had to remove the `provides` line from `setup.py` in order to be able to release EasyBuild v3.3.1 with a recent version of `setuptools`, to work around this problem:

```
Upload failed (400): provides: Must be a valid Python identifier.
error: Upload failed (400): provides: Must be a valid Python identifier.
```

As far as I can tell, no information is lost by dropping this line.