### PR TITLE
pass down stdin in 'import' check for extensions during sanity check

### DIFF
--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -174,7 +174,7 @@ class Extension(object):
             if inp:
                 stdin = inp % template
             # set log_ok to False so we can catch the error instead of run_cmd
-            (output, ec) = run_cmd(cmd, log_ok=False, simple=False, regexp=False)
+            (output, ec) = run_cmd(cmd, log_ok=False, simple=False, regexp=False, inp=stdin)
 
             if ec:
                 msg = "%s failed to install, cmd '%s' (stdin: %s) output: %s" % (self.name, cmd, stdin, output)

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -141,7 +141,7 @@ class Extension(object):
         exts_filter = self.cfg['exts_filter']
         self.cfg.enable_templating = True
 
-        if not exts_filter is None:
+        if exts_filter is not None:
             cmd, inp = exts_filter
         else:
             self.log.debug("no exts_filter setting found, skipping sanitycheck")

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -75,14 +75,16 @@ def run_cmd_cache(func):
     @functools.wraps(func)
     def cache_aware_func(cmd, *args, **kwargs):
         """Retrieve cached result of selected commands, or run specified and collect & cache result."""
+        # cache key is combination of command and input provided via stdin
+        key = (cmd, kwargs.get('inp', None))
         # fetch from cache if available, cache it if it's not, but only on cmd strings
-        if isinstance(cmd, basestring) and cmd in cache:
-            _log.debug("Using cached value for command '%s': %s", cmd, cache[cmd])
-            return cache[cmd]
+        if isinstance(cmd, basestring) and key in cache:
+            _log.debug("Using cached value for command '%s': %s", cmd, cache[key])
+            return cache[key]
         else:
             res = func(cmd, *args, **kwargs)
             if cmd in CACHED_COMMANDS:
-                cache[cmd] = res
+                cache[key] = res
             return res
 
     # expose clear method of cache to wrapped function

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -87,8 +87,9 @@ def run_cmd_cache(func):
                 cache[key] = res
             return res
 
-    # expose clear method of cache to wrapped function
+    # expose clear/update methods of cache to wrapped function
     cache_aware_func.clear_cache = cache.clear
+    cache_aware_func.update_cache = cache.update
 
     return cache_aware_func
 

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
@@ -26,6 +26,8 @@ exts_list = [
         'patches': ['bar-0.0_typo.patch'],
         'toy_ext_param': "mv anotherbar bar_bis",
         'unknowneasyconfigparameterthatshouldbeignored': 'foo',
+        # custom extension filter to verify use of stdin value being passed to filter command
+        'exts_filter': ("cat | grep '^bar$'", '%(name)s'),
     }),
     ('barbar', '0.0'),
 ]

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -132,6 +132,17 @@ class RunTest(EnhancedTestCase):
         self.assertEqual(ec, 123)
         self.assertEqual(cached_out, "123456")
 
+        # also test with command that uses stdin
+        (out, ec) = run_cmd("cat", inp='foo')
+        self.assertEqual(ec, 0)
+        self.assertEqual(out, 'foo')
+
+        # inject different output for cat with 'foo' as stdin to check whether cached value is used
+        run_cmd.update_cache({('cat', 'foo'): ('bar', 123)})
+        (cached_out, ec) = run_cmd("cat", inp='foo')
+        self.assertEqual(ec, 123)
+        self.assertEqual(cached_out, 'bar')
+
         run_cmd.clear_cache()
 
     def test_parse_log_error(self):

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -118,6 +118,22 @@ class RunTest(EnhancedTestCase):
         self.assertEqual(True, run_cmd("echo hello", simple=True))
         self.assertEqual(False, run_cmd("exit 1", simple=True, log_all=False, log_ok=False))
 
+    def test_run_cmd_cache(self):
+        """Test caching for run_cmd"""
+        (first_out, ec) = run_cmd("ulimit -u")
+        self.assertEqual(ec, 0)
+        (cached_out, ec) = run_cmd("ulimit -u")
+        self.assertEqual(ec, 0)
+        self.assertEqual(first_out, cached_out)
+
+        # inject value into cache to check whether executing command again really returns cached value
+        run_cmd.update_cache({("ulimit -u", None): ("123456", 123)})
+        (cached_out, ec) = run_cmd("ulimit -u")
+        self.assertEqual(ec, 123)
+        self.assertEqual(cached_out, "123456")
+
+        run_cmd.clear_cache()
+
     def test_parse_log_error(self):
         """Test basic parse_log_for_error functionality."""
         errors = parse_log_for_error("error failed", True)


### PR DESCRIPTION
By not passing down `stdin` into `run_cmd` in the `sanity_check` implementation for extensions, the 'import' check for R libraries is basically being skipped...

In addition, the caching mechanism for `run_cmd` should also take into account the `inp` argument.