### PR TITLE
make sure location to 'eb' installed during stage 1 is included in $PATH during stage 2 of bootstrap procedure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20170706.01 484b3ae32ca7057de2ccc83820927bdaf0f4e3d3be6cda1747ec80449509a0e9"
+    - EB_BOOTSTRAP_EXPECTED="20170808.01 b78eac49374b26c78a16ea41efcde8c03d21649087f650e08f5339e8e48d7c6e"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -53,7 +53,7 @@ from distutils.version import LooseVersion
 from hashlib import md5
 
 
-EB_BOOTSTRAP_VERSION = '20170706.01'
+EB_BOOTSTRAP_VERSION = '20170808.01'
 
 # argparse preferrred, optparse deprecated >=2.7
 HAVE_ARGPARSE = False
@@ -68,6 +68,8 @@ PYPI_SOURCE_URL = 'https://pypi.python.org/packages/source'
 VSC_BASE = 'vsc-base'
 VSC_INSTALL = 'vsc-install'
 EASYBUILD_PACKAGES = [VSC_INSTALL, VSC_BASE, 'easybuild-framework', 'easybuild-easyblocks', 'easybuild-easyconfigs']
+
+STAGE1_SUBDIR = 'eb_stage1'
 
 # set print_debug to True for detailed progress info
 print_debug = os.environ.pop('EASYBUILD_BOOTSTRAP_DEBUG', False)
@@ -482,7 +484,7 @@ def stage1(tmpdir, sourcepath, distribute_egg_dir):
         run_easy_install(['--help'])
 
     # prepare install dir
-    targetdir_stage1 = os.path.join(tmpdir, 'eb_stage1')
+    targetdir_stage1 = os.path.join(tmpdir, STAGE1_SUBDIR)
     prep(targetdir_stage1)  # set PATH, Python search path
 
     # install latest EasyBuild with easy_install from PyPi
@@ -681,6 +683,14 @@ def stage2(tmpdir, templates, install_path, distribute_egg_dir, sourcepath):
 
     debug("Running EasyBuild with arguments '%s'" % ' '.join(eb_args))
     sys.argv = eb_args
+
+    # location to 'eb' command (from stage 1) may be expected to be included in $PATH
+    # it usually is there after stage1, unless 'prep' is called again with another location
+    # (only when stage 0 is not skipped)
+    # cfr. https://github.com/easybuilders/easybuild-framework/issues/2279
+    curr_path = [x for x in os.environ.get('PATH', '').split(os.pathsep) if len(x) > 0]
+    os.environ['PATH'] = os.pathsep.join([os.path.join(tmpdir, STAGE1_SUBDIR, 'bin')] + curr_path)
+    debug("$PATH: %s" % os.environ['PATH'])
 
     # install EasyBuild with EasyBuild
     from easybuild.main import main as easybuild_main


### PR DESCRIPTION
Due to the change in #2248, the location to the `eb` command *must* be available in `$PATH` in order for the bootstrap procedure to work.

This is a regression that we will fix in future versions of EasyBuild, but it doesn't hurt to also make the bootstrap script more robust in order to avoid issues as reported in #2279 to occur in the future.

The location to the `eb` command installed during stage 1 is indeed generally included in `$PATH` during the bootstrap procedure, *unless* stage 0 is not being skipped (i.e. when the `setuptools` version found is considered to be too old).