### PR TITLE
make resolve_path robust against None path being provided

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -251,11 +251,12 @@ def get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None):
     path_list.extend(sys.path)
 
     # figure out installation prefix, e.g. distutils install path for easyconfigs
-    eb_path = resolve_path(which('eb'))
+    eb_path = which('eb')
     if eb_path is None:
         _log.warning("'eb' not found in $PATH, failed to determine installation prefix")
     else:
-        # eb should reside in <install_prefix>/bin/eb
+        # real location to 'eb' should be <install_prefix>/bin/eb
+        eb_path = resolve_path(eb_path)
         install_prefix = os.path.dirname(os.path.dirname(eb_path))
         path_list.append(install_prefix)
         _log.debug("Also considering installation prefix %s..." % install_prefix)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -180,10 +180,13 @@ def resolve_path(path):
 
     :param path: path that (maybe) contains symlinks
     """
-    try:
-        resolved_path = os.path.realpath(path)
-    except OSError as err:
-        raise EasyBuildError("Resolving path %s failed: %s", path, err)
+    if path is None:
+        resolved_path = None
+    else:
+        try:
+            resolved_path = os.path.realpath(path)
+        except OSError as err:
+            raise EasyBuildError("Resolving path %s failed: %s", path, err)
 
     return resolved_path
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -182,7 +182,7 @@ def resolve_path(path):
     """
     try:
         resolved_path = os.path.realpath(path)
-    except OSError as err:
+    except (AttributeError, OSError) as err:
         raise EasyBuildError("Resolving path %s failed: %s", path, err)
 
     return resolved_path

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -180,13 +180,10 @@ def resolve_path(path):
 
     :param path: path that (maybe) contains symlinks
     """
-    if path is None:
-        resolved_path = None
-    else:
-        try:
-            resolved_path = os.path.realpath(path)
-        except OSError as err:
-            raise EasyBuildError("Resolving path %s failed: %s", path, err)
+    try:
+        resolved_path = os.path.realpath(path)
+    except OSError as err:
+        raise EasyBuildError("Resolving path %s failed: %s", path, err)
 
     return resolved_path
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -59,7 +59,7 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import module_classes
 from easybuild.tools.configobj import ConfigObj
 from easybuild.tools.docs import avail_easyconfig_constants, avail_easyconfig_templates
-from easybuild.tools.filetools import adjust_permissions, copy_file, mkdir, read_file, symlink, write_file
+from easybuild.tools.filetools import adjust_permissions, copy_file, mkdir, read_file, symlink, which, write_file
 from easybuild.tools.module_naming_scheme.toolchain import det_toolchain_compilers, det_toolchain_mpi
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.options import parse_external_modules_metadata
@@ -2089,6 +2089,13 @@ class EasyConfigTest(EnhancedTestCase):
     def test_get_paths_for(self):
         """Test for get_paths_for"""
         orig_path = os.getenv('PATH', '')
+
+        # get_paths_for should be robust against not having any 'eb' command available through $PATH
+        path = []
+        for subdir in orig_path.split(os.pathsep):
+            if not os.path.exists(os.path.join(subdir, 'eb')):
+                path.append(subdir)
+        os.environ['PATH'] = os.pathsep.join(path)
 
         top_dir = os.path.dirname(os.path.abspath(__file__))
         mkdir(os.path.join(self.test_prefix, 'easybuild'))

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -410,6 +410,7 @@ class FileToolsTest(EnhancedTestCase):
         self.assertEqual(test_dir, ft.resolve_path(link_dir))
         self.assertEqual(os.path.join(os.path.realpath(self.test_prefix), 'test', 'test.txt'), ft.resolve_path(link))
         self.assertEqual(ft.read_file(link), "test123")
+        self.assertErrorRegex(EasyBuildError, "Resolving path .* failed", ft.resolve_path, None)
 
     def test_remove_symlinks(self):
         """Test remove valid and invalid symlinks"""

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -410,7 +410,6 @@ class FileToolsTest(EnhancedTestCase):
         self.assertEqual(test_dir, ft.resolve_path(link_dir))
         self.assertEqual(os.path.join(os.path.realpath(self.test_prefix), 'test', 'test.txt'), ft.resolve_path(link))
         self.assertEqual(ft.read_file(link), "test123")
-        self.assertEqual(ft.resolve_path(None), None)
 
     def test_remove_symlinks(self):
         """Test remove valid and invalid symlinks"""

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -410,6 +410,7 @@ class FileToolsTest(EnhancedTestCase):
         self.assertEqual(test_dir, ft.resolve_path(link_dir))
         self.assertEqual(os.path.join(os.path.realpath(self.test_prefix), 'test', 'test.txt'), ft.resolve_path(link))
         self.assertEqual(ft.read_file(link), "test123")
+        self.assertEqual(ft.resolve_path(None), None)
 
     def test_remove_symlinks(self):
         """Test remove valid and invalid symlinks"""


### PR DESCRIPTION
companion fix for #2279 (alongside updated bootstrap script in #2281)

If this had been part of #2248, bootstrapping EasyBuild v3.3.1 would not have been broken as reported in #2279