### PR TITLE
add 'rpath' easyconfig parameter to enable use of RPATH regardless of EasyBuild configuration

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1654,7 +1654,8 @@ class EasyBlock(object):
             self.rpath_filter_dirs.append(self.builddir)
 
         # prepare toolchain: load toolchain module and dependencies, set up build environment
-        self.toolchain.prepare(self.cfg['onlytcmod'], silent=self.silent, rpath_filter_dirs=self.rpath_filter_dirs)
+        self.toolchain.prepare(self.cfg['onlytcmod'], silent=self.silent, rpath=self.cfg['rpath'],
+                               rpath_filter_dirs=self.rpath_filter_dirs)
 
         # handle allowed system dependencies
         for (name, version) in self.cfg['allow_system_deps']:
@@ -1818,7 +1819,7 @@ class EasyBlock(object):
                 # don't reload modules for toolchain, there is no need since they will be loaded already;
                 # the (fake) module for the parent software gets loaded before installing extensions
                 inst.toolchain.prepare(onlymod=self.cfg['onlytcmod'], silent=True, loadmod=False,
-                                       rpath_filter_dirs=self.rpath_filter_dirs)
+                                       rpath=self.cfg['rpath'], rpath_filter_dirs=self.rpath_filter_dirs)
 
             # real work
             inst.prerun()

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -99,6 +99,7 @@ DEFAULT_CONFIG = {
     'preconfigopts': ['', 'Extra options pre-passed to configure.', BUILD],
     'preinstallopts': ['', 'Extra prefix options for installation.', BUILD],
     'postinstallcmds': [[], 'Commands to run after the install step.', BUILD],
+    'rpath': [False, "Use RPATH linking (regardless of --rpath configuration option)", BUILD],
     'runtest': [None, ('Indicates if a test should be run after make; should specify argument '
                        'after make (for e.g.,"test" for make test)'), BUILD],
     'sanity_check_commands': [[], ("format: [(name, options)] e.g. [('gzip','-h')]. "

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -637,7 +637,7 @@ class Toolchain(object):
 
         return (c_comps, fortran_comps)
 
-    def prepare(self, onlymod=None, silent=False, loadmod=True, rpath_filter_dirs=None):
+    def prepare(self, onlymod=None, silent=False, loadmod=True, rpath=None, rpath_filter_dirs=None):
         """
         Prepare a set of environment parameters based on name/version of toolchain
         - load modules for toolchain and dependencies
@@ -648,6 +648,7 @@ class Toolchain(object):
                          (If string: comma separated list of variables that will be ignored).
         :param silent: keep quiet, or not (mostly relates to extended dry run output)
         :param loadmod: whether or not to (re)load the toolchain module, and the modules for the dependencies
+        :param rpath: enable RPATH linking (regardless of 'rpath' configuration option)
         :param rpath_filter_dirs: extra directories to include in RPATH filter (e.g. build dir, tmpdir, ...)
         """
         if loadmod:
@@ -679,12 +680,20 @@ class Toolchain(object):
             if build_option('use_%s' % cache_tool):
                 self.prepare_compiler_cache(cache_tool)
 
-        if build_option('rpath'):
+        if rpath:
+            self.use_rpath = True
+            self.log.info("Enabling RPATH linking, as explicitely specified for this installation")
+        elif build_option('rpath'):
             if self.options.get('rpath', True):
-                self.prepare_rpath_wrappers()
                 self.use_rpath = True
+                self.log.info("Enabling RPATH linking, as configured")
             else:
-                self.log.info("Not putting RPATH wrappers in place, disabled via 'rpath' toolchain option")
+                self.log.info("Not enabling use of RPATH linking, disabled via 'rpath' toolchain option")
+        else:
+            self.log.info("Not enabling use of RPATH linking, not requested")
+
+        if self.use_rpath:
+            self.prepare_rpath_wrappers()
 
     def comp_cache_compilers(self, cache_tool):
         """

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1436,13 +1436,21 @@ class ToyBuildTest(EnhancedTestCase):
         # also test use of --rpath-filter
         self.test_toy_build(extra_args=['--rpath', '--rpath-filter=/test.*,/foo.*', '--experimental'], raise_error=True)
 
-        # test use of rpath toolchain option
+        # test use of rpath toolchain option to selectively disable use of RPATH
         test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
-        toy_ec_txt = read_file(os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb'))
+        toy_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
+        toy_ec_txt = read_file(toy_ec)
         toy_ec_txt += "\ntoolchainopts = {'rpath': False}\n"
         toy_ec = os.path.join(self.test_prefix, 'toy.eb')
         write_file(toy_ec, toy_ec_txt)
         self.test_toy_build(ec_file=toy_ec, extra_args=['--rpath', '--experimental'], raise_error=True)
+
+        # test use of rpath easyconfig parameter to selectively enable use of RPATH regardless of configuration
+        toy_ec_txt = read_file(toy_ec)
+        toy_ec_txt += "\nrpath = True\n"
+        toy_ec = os.path.join(self.test_prefix, 'toy.eb')
+        write_file(toy_ec, toy_ec_txt)
+        self.test_toy_build(ec_file=toy_ec, extra_args=['--experimental'], raise_error=True)
 
     def test_toy_modaltsoftname(self):
         """Build two dependent toys as in test_toy_toy but using modaltsoftname"""


### PR DESCRIPTION
We already have an `rpath` toolchain option that can be used to selectively *disable* the use of RPATH even if EasyBuild is configured to use RPATH linking via `--rpath`.

In some cases, it may also be interesting to be able to selectively enforce the use of RPATH, regardless of how EasyBuild was configured; see for example https://github.com/easybuilders/easybuild-easyconfigs/pull/4962#pullrequestreview-54647218

If the `rpath` easyconfig parameter is defined as `True`, RPATH linking is always performed, regardless of the EasyBuild configuration option `--rpath`.
If `--rpath` is used, RPATH linking is enabled, unless it's specifically disabled by setting the `rpath` toolchain option to `False` (`True` being the default value).

After implementing this, which was pretty straightforward, I'm starting to have 2nd thoughts about this approach, since having both an `rpath` toolchain option and easyconfig parameter (on top of the `--rpath` configuration option...) may lead to confusion...