### PR TITLE
support for 'eb --trace' (REVIEW)

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -60,7 +60,7 @@ from easybuild.framework.easyconfig.tools import get_paths_for
 from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_EASYBLOCK_RUN_STEP
 from easybuild.tools.build_details import get_build_stats
 from easybuild.tools.build_log import EasyBuildError, dry_run_msg, dry_run_warning, dry_run_set_dirs
-from easybuild.tools.build_log import print_error, print_msg
+from easybuild.tools.build_log import print_error, print_msg, trace_msg
 from easybuild.tools.config import build_option, build_path, get_log_filename, get_repository, get_repositorypath
 from easybuild.tools.config import install_path, log_path, package_path, source_paths
 from easybuild.tools.environment import restore_env, sanitize_env
@@ -819,6 +819,9 @@ class EasyBlock(object):
         # always make build dir
         self.make_dir(self.builddir, self.cfg['cleanupoldbuild'])
 
+        if build_option('trace'):
+            trace_msg("build dir: %s" % self.builddir)
+
     def gen_installdir(self):
         """
         Generate the name of the installation directory.
@@ -1554,6 +1557,17 @@ class EasyBlock(object):
                     fil[checksum_type] = compute_checksum(fil['path'], checksum_type=checksum_type)
                     self.log.info("%s checksum for %s: %s", checksum_type, fil['path'], fil[checksum_type])
 
+        # trace output for sources & patches
+        if build_option('trace'):
+            if self.src:
+                trace_msg("sources:")
+                for src in self.src:
+                    trace_msg("%s [SHA256: %s]" % (src['path'], src[CHECKSUM_TYPE_SHA256]))
+            if self.patches:
+                trace_msg("patches:")
+                for patch in self.patches:
+                    trace_msg("%s [SHA256: %s]" % (patch['path'], patch[CHECKSUM_TYPE_SHA256]))
+
         # fetch extensions
         if self.cfg['exts_list']:
             self.exts = self.fetch_extension_sources()
@@ -1605,6 +1619,8 @@ class EasyBlock(object):
         """
         for patch in self.patches:
             self.log.info("Applying patch %s" % patch['name'])
+            if build_option('trace'):
+                trace_msg("applying patch %s..." % patch['name'])
 
             # patch source at specified index (first source if not specified)
             srcind = patch.get('source', 0)
@@ -2073,6 +2089,10 @@ class EasyBlock(object):
                     self.sanity_check_fail_msgs.append("no %s of %s in %s" % (typ, xs, self.installdir))
                     self.log.warning("Sanity check: %s" % self.sanity_check_fail_msgs[-1])
 
+                if build_option('trace'):
+                    cand_paths = ' or '.join(["'%s'" % x for x in xs])
+                    trace_msg("%s %s found: %s" % (typ, cand_paths, ('FAILED', 'OK')[found]))
+
         fake_mod_data = None
         # only load fake module for non-extensions, and not during dry run
         if not (extension or self.dry_run):
@@ -2091,13 +2111,16 @@ class EasyBlock(object):
         # run sanity check commands
         for command in commands:
 
-            out, ec = run_cmd(command, simple=False, log_ok=False, log_all=False)
+            out, ec = run_cmd(command, simple=False, log_ok=False, log_all=False, trace=False)
             if ec != 0:
                 fail_msg = "sanity check command %s exited with code %s (output: %s)" % (command, ec, out)
                 self.sanity_check_fail_msgs.append(fail_msg)
                 self.log.warning("Sanity check: %s" % self.sanity_check_fail_msgs[-1])
             else:
                 self.log.info("sanity check command %s ran successfully! (output: %s)" % (command, out))
+
+            if build_option('trace'):
+                trace_msg("running command '%s'... %s" % (command, ('FAILED', 'OK')[ec == 0]))
 
         if not extension:
             failed_exts = [ext.name for ext in self.ext_instances if not ext.sanity_check_step()]
@@ -2180,6 +2203,8 @@ class EasyBlock(object):
         mod_filepath = self.mod_filepath
         if fake:
             mod_filepath = self.module_generator.get_module_filepath(fake=fake)
+        elif build_option('trace'):
+            trace_msg("generating module file @ %s..." % self.mod_filepath)
 
         txt = self.module_generator.MODULE_SHEBANG
         if txt:
@@ -2476,6 +2501,8 @@ class EasyBlock(object):
         steps = self.get_steps(run_test_cases=run_test_cases, iteration_count=self.det_iter_cnt())
 
         print_msg("building and installing %s..." % self.full_mod_name, log=self.log, silent=self.silent)
+        if build_option('trace'):
+            trace_msg("installation prefix: %s" % self.installdir)
         try:
             for (step_name, descr, step_methods, skippable) in steps:
                 if self._skip_step(step_name, skippable):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1603,7 +1603,7 @@ class EasyBlock(object):
             trace_msg("patches:")
             for patch in self.patches:
                 msg = patch['path']
-                if CHECKSUM_TYPE_SHA256 in src:
+                if CHECKSUM_TYPE_SHA256 in patch:
                     msg += " [SHA256: %s]" % patch[CHECKSUM_TYPE_SHA256]
                 trace_msg(msg)
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1595,11 +1595,17 @@ class EasyBlock(object):
         if self.src:
             trace_msg("sources:")
             for src in self.src:
-                trace_msg("%s [SHA256: %s]" % (src['path'], src[CHECKSUM_TYPE_SHA256]))
+                msg = src['path']
+                if CHECKSUM_TYPE_SHA256 in src:
+                    msg += " [SHA256: %s]" % src[CHECKSUM_TYPE_SHA256]
+                trace_msg(msg)
         if self.patches:
             trace_msg("patches:")
             for patch in self.patches:
-                trace_msg("%s [SHA256: %s]" % (patch['path'], patch[CHECKSUM_TYPE_SHA256]))
+                msg = patch['path']
+                if CHECKSUM_TYPE_SHA256 in src:
+                    msg += " [SHA256: %s]" % patch[CHECKSUM_TYPE_SHA256]
+                trace_msg(msg)
 
         # fetch extensions
         if self.cfg['exts_list']:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -62,7 +62,7 @@ from easybuild.framework.easyconfig.tools import get_paths_for
 from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_EASYBLOCK_RUN_STEP
 from easybuild.tools.build_details import get_build_stats
 from easybuild.tools.build_log import EasyBuildError, dry_run_msg, dry_run_warning, dry_run_set_dirs
-from easybuild.tools.build_log import print_error, print_msg, print_warning, trace_msg
+from easybuild.tools.build_log import print_error, print_msg, print_warning
 from easybuild.tools.config import build_option, build_path, get_log_filename, get_repository, get_repositorypath
 from easybuild.tools.config import install_path, log_path, package_path, source_paths
 from easybuild.tools.environment import restore_env, sanitize_env
@@ -83,7 +83,7 @@ from easybuild.tools.package.utilities import package
 from easybuild.tools.repository.repository import init_repository
 from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
 from easybuild.tools.systemtools import det_parallelism, use_group
-from easybuild.tools.utilities import quote_str, remove_unwanted_chars
+from easybuild.tools.utilities import quote_str, remove_unwanted_chars, trace_msg
 from easybuild.tools.version import this_is_easybuild, VERBOSE_VERSION, VERSION
 
 
@@ -832,8 +832,7 @@ class EasyBlock(object):
         # always make build dir
         self.make_dir(self.builddir, self.cfg['cleanupoldbuild'])
 
-        if build_option('trace'):
-            trace_msg("build dir: %s" % self.builddir)
+        trace_msg("build dir: %s" % self.builddir)
 
     def gen_installdir(self):
         """
@@ -1593,15 +1592,14 @@ class EasyBlock(object):
                     self.log.info("%s checksum for %s: %s", checksum_type, fil['path'], fil[checksum_type])
 
         # trace output for sources & patches
-        if build_option('trace'):
-            if self.src:
-                trace_msg("sources:")
-                for src in self.src:
-                    trace_msg("%s [SHA256: %s]" % (src['path'], src[CHECKSUM_TYPE_SHA256]))
-            if self.patches:
-                trace_msg("patches:")
-                for patch in self.patches:
-                    trace_msg("%s [SHA256: %s]" % (patch['path'], patch[CHECKSUM_TYPE_SHA256]))
+        if self.src:
+            trace_msg("sources:")
+            for src in self.src:
+                trace_msg("%s [SHA256: %s]" % (src['path'], src[CHECKSUM_TYPE_SHA256]))
+        if self.patches:
+            trace_msg("patches:")
+            for patch in self.patches:
+                trace_msg("%s [SHA256: %s]" % (patch['path'], patch[CHECKSUM_TYPE_SHA256]))
 
         # fetch extensions
         if self.cfg['exts_list']:
@@ -1654,8 +1652,7 @@ class EasyBlock(object):
         """
         for patch in self.patches:
             self.log.info("Applying patch %s" % patch['name'])
-            if build_option('trace'):
-                trace_msg("applying patch %s..." % patch['name'])
+            trace_msg("applying patch %s..." % patch['name'])
 
             # patch source at specified index (first source if not specified)
             srcind = patch.get('source', 0)
@@ -2124,9 +2121,8 @@ class EasyBlock(object):
                     self.sanity_check_fail_msgs.append("no %s of %s in %s" % (typ, xs, self.installdir))
                     self.log.warning("Sanity check: %s" % self.sanity_check_fail_msgs[-1])
 
-                if build_option('trace'):
-                    cand_paths = ' or '.join(["'%s'" % x for x in xs])
-                    trace_msg("%s %s found: %s" % (typ, cand_paths, ('FAILED', 'OK')[found]))
+                cand_paths = ' or '.join(["'%s'" % x for x in xs])
+                trace_msg("%s %s found: %s" % (typ, cand_paths, ('FAILED', 'OK')[found]))
 
         fake_mod_data = None
         # only load fake module for non-extensions, and not during dry run
@@ -2154,8 +2150,7 @@ class EasyBlock(object):
             else:
                 self.log.info("sanity check command %s ran successfully! (output: %s)" % (command, out))
 
-            if build_option('trace'):
-                trace_msg("running command '%s'... %s" % (command, ('FAILED', 'OK')[ec == 0]))
+            trace_msg("running command '%s'... %s" % (command, ('FAILED', 'OK')[ec == 0]))
 
         if not extension:
             failed_exts = [ext.name for ext in self.ext_instances if not ext.sanity_check_step()]
@@ -2238,7 +2233,7 @@ class EasyBlock(object):
         mod_filepath = self.mod_filepath
         if fake:
             mod_filepath = self.module_generator.get_module_filepath(fake=fake)
-        elif build_option('trace'):
+        else:
             trace_msg("generating module file @ %s..." % self.mod_filepath)
 
         txt = self.module_generator.MODULE_SHEBANG
@@ -2547,8 +2542,7 @@ class EasyBlock(object):
         steps = self.get_steps(run_test_cases=run_test_cases, iteration_count=self.det_iter_cnt())
 
         print_msg("building and installing %s..." % self.full_mod_name, log=self.log, silent=self.silent)
-        if build_option('trace'):
-            trace_msg("installation prefix: %s" % self.installdir)
+        trace_msg("installation prefix: %s" % self.installdir)
         try:
             for (step_name, descr, step_methods, skippable) in steps:
                 if self._skip_step(step_name, skippable):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1658,7 +1658,7 @@ class EasyBlock(object):
         """
         for patch in self.patches:
             self.log.info("Applying patch %s" % patch['name'])
-            trace_msg("applying patch %s..." % patch['name'])
+            trace_msg("applying patch %s" % patch['name'])
 
             # patch source at specified index (first source if not specified)
             srcind = patch.get('source', 0)
@@ -2156,7 +2156,7 @@ class EasyBlock(object):
             else:
                 self.log.info("sanity check command %s ran successfully! (output: %s)" % (command, out))
 
-            trace_msg("running command '%s'... %s" % (command, ('FAILED', 'OK')[ec == 0]))
+            trace_msg("running command '%s': %s" % (command, ('FAILED', 'OK')[ec == 0]))
 
         if not extension:
             failed_exts = [ext.name for ext in self.ext_instances if not ext.sanity_check_step()]
@@ -2240,7 +2240,7 @@ class EasyBlock(object):
         if fake:
             mod_filepath = self.module_generator.get_module_filepath(fake=fake)
         else:
-            trace_msg("generating module file @ %s..." % self.mod_filepath)
+            trace_msg("generating module file @ %s" % self.mod_filepath)
 
         txt = self.module_generator.MODULE_SHEBANG
         if txt:

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -112,11 +112,12 @@ class EasyBuildLog(fancylogger.FancyLogger):
 
     def experimental(self, msg, *args, **kwargs):
         """Handle experimental functionality if EXPERIMENTAL is True, otherwise log error"""
+        common_msg = "Experimental functionality. Behaviour might change/be removed later"
         if EXPERIMENTAL:
-            msg = 'Experimental functionality. Behaviour might change/be removed later. ' + msg
+            msg = common_msg + ': ' + msg
             self.warning(msg, *args, **kwargs)
         else:
-            msg = 'Experimental functionality. Behaviour might change/be removed later (use --experimental option to enable). ' + msg
+            msg = common_msg + " (use --experimental option to enable): " + msg
             raise EasyBuildError(msg, *args)
 
     def deprecated(self, msg, ver, max_ver=None, *args, **kwargs):

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -298,3 +298,8 @@ def print_warning(message, silent=False):
     """
     if not silent:
         sys.stderr.write("\nWARNING: %s\n\n" % message)
+
+
+def trace_msg(message, silent=False):
+    """Print trace message."""
+    print_msg('  >> ' + message, prefix=False)

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -37,7 +37,6 @@ import re
 import sys
 import tempfile
 from copy import copy
-from datetime import datetime
 from vsc.utils import fancylogger
 from vsc.utils.exceptions import LoggedException
 
@@ -299,10 +298,3 @@ def print_warning(message, silent=False):
     """
     if not silent:
         sys.stderr.write("\nWARNING: %s\n\n" % message)
-
-
-def trace_msg(message, silent=False, timestamp=False):
-    """Print trace message."""
-    if timestamp:
-        message += " [started at: %s]" % datetime.now().strftime('%Y-%m-%d %H:%M:%S')
-    print_msg('  >> ' + message, prefix=False)

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -37,6 +37,7 @@ import re
 import sys
 import tempfile
 from copy import copy
+from datetime import datetime
 from vsc.utils import fancylogger
 from vsc.utils.exceptions import LoggedException
 
@@ -300,6 +301,8 @@ def print_warning(message, silent=False):
         sys.stderr.write("\nWARNING: %s\n\n" % message)
 
 
-def trace_msg(message, silent=False):
+def trace_msg(message, silent=False, timestamp=False):
     """Print trace message."""
+    if timestamp:
+        message += " [started at: %s]" % datetime.now().strftime('%Y-%m-%d %H:%M:%S')
     print_msg('  >> ' + message, prefix=False)

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -168,6 +168,7 @@ BUILD_OPTIONS_CMDLINE = {
         'set_gid_bit',
         'skip_test_cases',
         'sticky_bit',
+        'trace',
         'upload_test_report',
         'update_modules_tool_cache',
         'use_ccache',

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -270,7 +270,8 @@ class ModulesTool(object):
             else:
                 out, ec = None, 1
         else:
-            out, ec = run_cmd("type module", simple=False, log_ok=False, log_all=False, force_in_dry_run=True)
+            cmd = "type module"
+            out, ec = run_cmd(cmd, simple=False, log_ok=False, log_all=False, force_in_dry_run=True, trace=False)
 
         if regex is None:
             regex = r".*%s" % os.path.basename(self.cmd)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -390,6 +390,7 @@ class EasyBuildOptions(GeneralOption):
             'set-gid-bit': ("Set group ID bit on newly created directories", None, 'store_true', False),
             'sticky-bit': ("Set sticky bit on newly created directories", None, 'store_true', False),
             'skip-test-cases': ("Skip running test cases", None, 'store_true', False, 't'),
+            'trace': ("Provide more information in output to stdout on progress", None, 'store_true', False, 'T'),
             'umask': ("umask to use (e.g. '022'); non-user write permissions on install directories are removed",
                       None, 'store', None),
             'update-modules-tool-cache': ("Update modules tool cache file(s) after generating module file",
@@ -1243,7 +1244,7 @@ def set_tmpdir(tmpdir=None, raise_error=False):
         fd, tmptest_file = tempfile.mkstemp()
         os.close(fd)
         os.chmod(tmptest_file, 0700)
-        if not run_cmd(tmptest_file, simple=True, log_ok=False, regexp=False, force_in_dry_run=True):
+        if not run_cmd(tmptest_file, simple=True, log_ok=False, regexp=False, force_in_dry_run=True, trace=False):
             msg = "The temporary directory (%s) does not allow to execute files. " % tempfile.gettempdir()
             msg += "This can cause problems in the build process, consider using --tmpdir."
             if raise_error:

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -135,7 +135,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
         cmd_log_fn, cmd_log = None, None
 
     if trace:
-        trace_msg("running command '%s' (output in %s)..." % (cmd_msg, cmd_log_fn), timestamp=True)
+        trace_msg("running command '%s' (output in %s)" % (cmd_msg, cmd_log_fn), timestamp=True)
 
     # early exit in 'dry run' mode, after printing the command that would be run (unless running the command is forced)
     if not force_in_dry_run and build_option('extended_dry_run'):
@@ -243,7 +243,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
         cmd_log_fn, cmd_log = None, None
 
     if trace:
-        trace_msg("running interactive command '%s' (output in %s)..." % (cmd.strip(), cmd_log_fn), timestamp=True)
+        trace_msg("running interactive command '%s' (output in %s)" % (cmd.strip(), cmd_log_fn), timestamp=True)
 
     # early exit in 'dry run' mode, after printing the command that would be run
     if build_option('extended_dry_run'):

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -203,7 +203,8 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
     return parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp)
 
 
-def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, regexp=True, std_qa=None, path=None, maxhits=50):
+def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, regexp=True, std_qa=None, path=None,
+               maxhits=50, trace=True):
     """
     Run specified interactive command (in a subshell)
     :param cmd: command to run
@@ -215,6 +216,8 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
     :param regex: regex used to check the output for errors; if True it will use the default (see parse_log_for_error)
     :param std_qa: dictionary which maps question regex patterns to answers
     :param path: path to execute the command is; current working directory is used if unspecified
+    :param maxhits: maximum number of cycles (seconds) without being able to find a known question
+    :param trace: print command being executed as part of trace output
     """
     cwd = os.getcwd()
 

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -115,7 +115,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
     cwd = os.getcwd()
 
     if trace and build_option('trace'):
-        trace_msg("running command '%s'..." % cmd.strip())
+        trace_msg("running command '%s'..." % cmd.strip(), timestamp=True)
 
     # early exit in 'dry run' mode, after printing the command that would be run (unless running the command is forced)
     if not force_in_dry_run and build_option('extended_dry_run'):
@@ -217,6 +217,9 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
     :param path: path to execute the command is; current working directory is used if unspecified
     """
     cwd = os.getcwd()
+
+    if trace and build_option('trace'):
+        trace_msg("running interactive command '%s'..." % cmd.strip(), timestamp=True)
 
     # early exit in 'dry run' mode, after printing the command that would be run
     if build_option('extended_dry_run'):

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -45,7 +45,7 @@ from vsc.utils import fancylogger
 
 from easybuild.tools.asyncprocess import PIPE, STDOUT, Popen, recv_some, send_all
 from easybuild.tools.config import ERROR, IGNORE, WARN, build_option
-from easybuild.tools.build_log import EasyBuildError, dry_run_msg
+from easybuild.tools.build_log import EasyBuildError, dry_run_msg, trace_msg
 
 
 _log = fancylogger.getLogger('run', fname=False)
@@ -93,7 +93,7 @@ def run_cmd_cache(func):
 
 @run_cmd_cache
 def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True, log_output=False, path=None,
-            force_in_dry_run=False, verbose=True, shell=True):
+            force_in_dry_run=False, verbose=True, shell=True, trace=True):
     """
     Run specified command (in a subshell)
     :param cmd: command to run
@@ -107,8 +107,12 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
     :param force_in_dry_run: force running the command during dry run
     :param verbose: include message on running the command in dry run output
     :param shell: allow commands to not run in a shell (especially useful for cmd lists)
+    :param trace: print command being executed as part of trace output
     """
     cwd = os.getcwd()
+
+    if trace and build_option('trace'):
+        trace_msg("running command '%s'..." % cmd.strip())
 
     # early exit in 'dry run' mode, after printing the command that would be run (unless running the command is forced)
     if not force_in_dry_run and build_option('extended_dry_run'):

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -44,8 +44,9 @@ import time
 from vsc.utils import fancylogger
 
 from easybuild.tools.asyncprocess import PIPE, STDOUT, Popen, recv_some, send_all
+from easybuild.tools.build_log import EasyBuildError, dry_run_msg
 from easybuild.tools.config import ERROR, IGNORE, WARN, build_option
-from easybuild.tools.build_log import EasyBuildError, dry_run_msg, trace_msg
+from easybuild.tools.utilities import trace_msg
 
 
 _log = fancylogger.getLogger('run', fname=False)
@@ -114,7 +115,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
     """
     cwd = os.getcwd()
 
-    if trace and build_option('trace'):
+    if trace:
         trace_msg("running command '%s'..." % cmd.strip(), timestamp=True)
 
     # early exit in 'dry run' mode, after printing the command that would be run (unless running the command is forced)
@@ -221,7 +222,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
     """
     cwd = os.getcwd()
 
-    if trace and build_option('trace'):
+    if trace:
         trace_msg("running interactive command '%s'..." % cmd.strip(), timestamp=True)
 
     # early exit in 'dry run' mode, after printing the command that would be run

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -115,15 +115,34 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
     """
     cwd = os.getcwd()
 
+    if isinstance(cmd, basestring):
+        cmd_msg = cmd.strip()
+    elif isinstance(cmd, list):
+        cmd_msg = ' '.join(cmd)
+    else:
+        raise EasyBuildError("Unknown command type ('%s'): %s", type(cmd), cmd)
+
+    if log_output or (trace and build_option('trace')):
+        # collect output of running command in temporary log file, if desired
+        fd, cmd_log_fn = tempfile.mkstemp(suffix='.log', prefix='easybuild-run_cmd-')
+        os.close(fd)
+        try:
+            cmd_log = open(cmd_log_fn, 'w')
+        except IOError as err:
+            raise EasyBuildError("Failed to open temporary log file for output of command: %s", err)
+        _log.debug('run_cmd: Output of "%s" will be logged to %s' % (cmd, cmd_log_fn))
+    else:
+        cmd_log_fn, cmd_log = None, None
+
     if trace:
-        trace_msg("running command '%s'..." % cmd.strip(), timestamp=True)
+        trace_msg("running command '%s' (output in %s)..." % (cmd_msg, cmd_log_fn), timestamp=True)
 
     # early exit in 'dry run' mode, after printing the command that would be run (unless running the command is forced)
     if not force_in_dry_run and build_option('extended_dry_run'):
         if path is None:
             path = cwd
         if verbose:
-            dry_run_msg("  running command \"%s\"" % cmd, silent=build_option('silent'))
+            dry_run_msg("  running command \"%s\"" % cmd_msg, silent=build_option('silent'))
             dry_run_msg("  (in %s)" % path, silent=build_option('silent'))
 
         # make sure we get the type of the return value right
@@ -140,15 +159,10 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
         _log.debug("run_cmd: running cmd %s (in %s)" % (cmd, os.getcwd()))
     except OSError, err:
         _log.warning("Failed to change to %s: %s" % (path, err))
-        _log.info("running cmd %s in non-existing directory, might fail!" % cmd)
+        _log.info("running cmd %s in non-existing directory, might fail!", cmd)
 
-    # # Log command output
-    if log_output:
-        runLog = tempfile.NamedTemporaryFile(suffix='.log', prefix='easybuild-run_cmd-')
-        _log.debug('run_cmd: Command output will be logged to %s' % runLog.name)
-        runLog.write(cmd + "\n\n")
-    else:
-        runLog = None
+    if cmd_log:
+        cmd_log.write("# output for command: %s\n\n" % cmd_msg)
     
     exec_cmd = "/bin/bash"
 
@@ -178,23 +192,17 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
         # need to read from time to time.
         # - otherwise the stdout/stderr buffer gets filled and it all stops working
         output = p.stdout.read(readSize)
-        if runLog:
-            runLog.write(output)
+        if cmd_log:
+            cmd_log.write(output)
         stdouterr += output
         ec = p.poll()
 
     # read remaining data (all of it)
     output = p.stdout.read()
-    if runLog:
-        runLog.write(output)
+    if cmd_log:
+        cmd_log.write(output)
+        cmd_log.close()
     stdouterr += output
-
-    # not needed anymore. subprocess does this correct?
-    # ec=os.WEXITSTATUS(ec)
-
-    # # Command log output
-    if log_output:
-        runLog.close()
 
     try:
         os.chdir(cwd)
@@ -222,8 +230,20 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
     """
     cwd = os.getcwd()
 
+    if log_all or (trace and build_option('trace')):
+        # collect output of running command in temporary log file, if desired
+        fd, cmd_log_fn = tempfile.mkstemp(suffix='.log', prefix='easybuild-run_cmd_qa-')
+        os.close(fd)
+        try:
+            cmd_log = open(cmd_log_fn, 'w')
+        except IOError as err:
+            raise EasyBuildError("Failed to open temporary log file for output of interactive command: %s", err)
+        _log.debug('run_cmd_qa: Output of "%s" will be logged to %s' % (cmd, cmd_log_fn))
+    else:
+        cmd_log_fn, cmd_log = None, None
+
     if trace:
-        trace_msg("running interactive command '%s'..." % cmd.strip(), timestamp=True)
+        trace_msg("running interactive command '%s' (output in %s)..." % (cmd.strip(), cmd_log_fn), timestamp=True)
 
     # early exit in 'dry run' mode, after printing the command that would be run
     if build_option('extended_dry_run'):
@@ -281,23 +301,23 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
         # list is manipulated when answering matching question, so return a copy
         return answers[:]
 
-    newQA = {}
-    _log.debug("newQA: ")
+    new_qa = {}
+    _log.debug("new_qa: ")
     for question, answers in qa.items():
         answers = check_answers_list(answers)
         (answers, regQ) = process_QA(question, answers)
-        newQA[regQ] = answers
-        _log.debug("newqa[%s]: %s" % (regQ.pattern, newQA[regQ]))
+        new_qa[regQ] = answers
+        _log.debug("new_qa[%s]: %s" % (regQ.pattern, new_qa[regQ]))
 
-    newstdQA = {}
+    new_std_qa = {}
     if std_qa:
         for question, answers in std_qa.items():
             regQ = re.compile(r"" + question + r"[\s\n]*$")
             answers = check_answers_list(answers)
             for i in [idx for idx, a in enumerate(answers) if not a.endswith('\n')]:
                 answers[i] += '\n'
-            newstdQA[regQ] = answers
-            _log.debug("newstdQA[%s]: %s" % (regQ.pattern, newstdQA[regQ]))
+            new_std_qa[regQ] = answers
+            _log.debug("new_std_qa[%s]: %s" % (regQ.pattern, new_std_qa[regQ]))
 
     new_no_qa = []
     if no_qa:
@@ -310,15 +330,8 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
     # - this needs asynchronous stdout
 
     # # Log command output
-    if log_all:
-        try:
-            runLog = tempfile.NamedTemporaryFile(suffix='.log', prefix='easybuild-cmdqa-')
-            _log.debug('run_cmd_qa: Command output will be logged to %s' % runLog.name)
-            runLog.write(cmd + "\n\n")
-        except IOError, err:
-            raise EasyBuildError("Opening log file for Q&A failed: %s", err)
-    else:
-        runLog = None
+    if cmd_log:
+        cmd_log.write("# output for interactive command: %s\n\n" % cmd)
 
     try:
         p = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT, stdin=PIPE, close_fds=True, executable="/bin/bash")
@@ -326,77 +339,77 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
         raise EasyBuildError("run_cmd_qa init cmd %s failed:%s", cmd, err)
 
     ec = p.poll()
-    stdoutErr = ''
-    oldLenOut = -1
-    hitCount = 0
+    stdout_err = ''
+    old_len_out = -1
+    hit_count = 0
 
     while ec is None:
         # need to read from time to time.
         # - otherwise the stdout/stderr buffer gets filled and it all stops working
         try:
-            tmpOut = recv_some(p)
-            if runLog:
-                runLog.write(tmpOut)
-            stdoutErr += tmpOut
+            out = recv_some(p)
+            if cmd_log:
+                cmd_log.write(out)
+            stdout_err += out
         # recv_some may throw Exception
         except (IOError, Exception), err:
-            _log.debug("run_cmd_qa cmd %s: read failed: %s" % (cmd, err))
-            tmpOut = None
+            _log.debug("run_cmd_qa cmd %s: read failed: %s", cmd, err)
+            out = None
 
         hit = False
-        for question, answers in newQA.items():
-            res = question.search(stdoutErr)
-            if tmpOut and res:
+        for question, answers in new_qa.items():
+            res = question.search(stdout_err)
+            if out and res:
                 fa = answers[0] % res.groupdict()
                 # cycle through list of answers
                 last_answer = answers.pop(0)
                 answers.append(last_answer)
-                _log.debug("List of answers for question %s after cycling: %s" % (question.pattern, answers))
+                _log.debug("List of answers for question %s after cycling: %s", question.pattern, answers)
 
-                _log.debug("run_cmd_qa answer %s question %s out %s" % (fa, question.pattern, stdoutErr[-50:]))
+                _log.debug("run_cmd_qa answer %s question %s out %s", fa, question.pattern, stdout_err[-50:])
                 send_all(p, fa)
                 hit = True
                 break
         if not hit:
-            for question, answers in newstdQA.items():
-                res = question.search(stdoutErr)
-                if tmpOut and res:
+            for question, answers in new_std_qa.items():
+                res = question.search(stdout_err)
+                if out and res:
                     fa = answers[0] % res.groupdict()
                     # cycle through list of answers
                     last_answer = answers.pop(0)
                     answers.append(last_answer)
-                    _log.debug("List of answers for question %s after cycling: %s" % (question.pattern, answers))
+                    _log.debug("List of answers for question %s after cycling: %s", question.pattern, answers)
 
-                    _log.debug("run_cmd_qa answer %s std question %s out %s" % (fa, question.pattern, stdoutErr[-50:]))
+                    _log.debug("run_cmd_qa answer %s std question %s out %s", fa, question.pattern, stdout_err[-50:])
                     send_all(p, fa)
                     hit = True
                     break
             if not hit:
-                if len(stdoutErr) > oldLenOut:
-                    oldLenOut = len(stdoutErr)
+                if len(stdout_err) > old_len_out:
+                    old_len_out = len(stdout_err)
                 else:
                     noqa = False
                     for r in new_no_qa:
-                        if r.search(stdoutErr):
-                            _log.debug("runqanda: noQandA found for out %s" % stdoutErr[-50:])
+                        if r.search(stdout_err):
+                            _log.debug("runqanda: noQandA found for out %s", stdout_err[-50:])
                             noqa = True
                     if not noqa:
-                        hitCount += 1
+                        hit_count += 1
             else:
-                hitCount = 0
+                hit_count = 0
         else:
-            hitCount = 0
+            hit_count = 0
 
-        if hitCount > maxhits:
+        if hit_count > maxhits:
             # explicitly kill the child process before exiting
             try:
                 os.killpg(p.pid, signal.SIGKILL)
                 os.kill(p.pid, signal.SIGKILL)
-            except OSError, err:
-                _log.debug("run_cmd_qa exception caught when killing child process: %s" % err)
-            _log.debug("run_cmd_qa: full stdouterr: %s" % stdoutErr)
+            except OSError as err:
+                _log.debug("run_cmd_qa exception caught when killing child process: %s", err)
+            _log.debug("run_cmd_qa: full stdouterr: %s", stdout_err)
             raise EasyBuildError("run_cmd_qa: cmd %s : Max nohits %s reached: end of output %s",
-                                 cmd, maxhits, stdoutErr[-500:])
+                                 cmd, maxhits, stdout_err[-500:])
 
         # the sleep below is required to avoid exiting on unknown 'questions' too early (see above)
         time.sleep(1)
@@ -405,22 +418,20 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
     # Process stopped. Read all remaining data
     try:
         if p.stdout:
-            readTxt = p.stdout.read()
-            stdoutErr += readTxt
-            if runLog:
-                runLog.write(readTxt)
-    except IOError, err:
-        _log.debug("runqanda cmd %s: remaining data read failed: %s" % (cmd, err))
-
-    # Not needed anymore. Subprocess does this correct?
-    # ec=os.WEXITSTATUS(ec)
+            out = p.stdout.read()
+            stdout_err += out
+            if cmd_log:
+                cmd_log.write(out)
+                cmd_log.close()
+    except IOError as err:
+        _log.debug("runqanda cmd %s: remaining data read failed: %s", cmd, err)
 
     try:
         os.chdir(cwd)
     except OSError, err:
         raise EasyBuildError("Failed to return to %s after executing command: %s", cwd, err)
 
-    return parse_cmd_output(cmd, stdoutErr, ec, simple, log_all, log_ok, regexp)
+    return parse_cmd_output(cmd, stdout_err, ec, simple, log_all, log_ok, regexp)
 
 
 def parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp):

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -135,7 +135,7 @@ def get_avail_core_count():
         core_cnt = int(sum(sched_getaffinity().cpus))
     else:
         # BSD-type systems
-        out, _ = run_cmd('sysctl -n hw.ncpu', force_in_dry_run=True)
+        out, _ = run_cmd('sysctl -n hw.ncpu', force_in_dry_run=True, trace=False)
         try:
             if int(out) > 0:
                 core_cnt = int(out)
@@ -172,7 +172,7 @@ def get_total_memory():
     elif os_type == DARWIN:
         cmd = "sysctl -n hw.memsize"
         _log.debug("Trying to determine total memory size on Darwin via cmd '%s'", cmd)
-        out, ec = run_cmd(cmd, force_in_dry_run=True)
+        out, ec = run_cmd(cmd, force_in_dry_run=True, trace=False)
         if ec == 0:
             memtotal = int(out.strip()) / (1024**2)
 
@@ -248,7 +248,7 @@ def get_cpu_vendor():
 
     elif os_type == DARWIN:
         cmd = "sysctl -n machdep.cpu.vendor"
-        out, ec = run_cmd(cmd, force_in_dry_run=True)
+        out, ec = run_cmd(cmd, force_in_dry_run=True, trace=False)
         out = out.strip()
         if ec == 0 and out in VENDOR_IDS:
             vendor = VENDOR_IDS[out]
@@ -332,7 +332,7 @@ def get_cpu_model():
 
     elif os_type == DARWIN:
         cmd = "sysctl -n machdep.cpu.brand_string"
-        out, ec = run_cmd(cmd, force_in_dry_run=True)
+        out, ec = run_cmd(cmd, force_in_dry_run=True, trace=False)
         if ec == 0:
             model = out.strip()
             _log.debug("Determined CPU model on Darwin using cmd '%s': %s" % (cmd, model))
@@ -377,7 +377,7 @@ def get_cpu_speed():
     elif os_type == DARWIN:
         cmd = "sysctl -n hw.cpufrequency_max"
         _log.debug("Trying to determine CPU frequency on Darwin via cmd '%s'" % cmd)
-        out, ec = run_cmd(cmd, force_in_dry_run=True)
+        out, ec = run_cmd(cmd, force_in_dry_run=True, trace=False)
         if ec == 0:
             # returns clock frequency in cycles/sec, but we want MHz
             cpu_freq = float(out.strip()) / (1000 ** 2)
@@ -423,7 +423,7 @@ def get_cpu_features():
         for feature_set in ['extfeatures', 'features', 'leaf7_features']:
             cmd = "sysctl -n machdep.cpu.%s" % feature_set
             _log.debug("Trying to determine CPU features on Darwin via cmd '%s'", cmd)
-            out, ec = run_cmd(cmd, force_in_dry_run=True)
+            out, ec = run_cmd(cmd, force_in_dry_run=True, trace=False)
             if ec == 0:
                 cpu_feat.extend(out.strip().lower().split())
 
@@ -567,11 +567,11 @@ def check_os_dependency(dep):
     cmd = None
     if which('rpm'):
         cmd = "rpm -q %s" % dep
-        found = run_cmd(cmd, simple=True, log_all=False, log_ok=False, force_in_dry_run=True)
+        found = run_cmd(cmd, simple=True, log_all=False, log_ok=False, force_in_dry_run=True, trace=False)
 
     if not found and which('dpkg'):
         cmd = "dpkg -s %s" % dep
-        found = run_cmd(cmd, simple=True, log_all=False, log_ok=False, force_in_dry_run=True)
+        found = run_cmd(cmd, simple=True, log_all=False, log_ok=False, force_in_dry_run=True, trace=False)
 
     if cmd is None:
         # fallback for when os-dependency is a binary/library
@@ -580,7 +580,7 @@ def check_os_dependency(dep):
         # try locate if it's available
         if not found and which('locate'):
             cmd = 'locate --regexp "/%s$"' % dep
-            found = run_cmd(cmd, simple=True, log_all=False, log_ok=False, force_in_dry_run=True)
+            found = run_cmd(cmd, simple=True, log_all=False, log_ok=False, force_in_dry_run=True, trace=False)
 
     return found
 
@@ -590,7 +590,7 @@ def get_tool_version(tool, version_option='--version'):
     Get output of running version option for specific command line tool.
     Output is returned as a single-line string (newlines are replaced by '; ').
     """
-    out, ec = run_cmd(' '.join([tool, version_option]), simple=False, log_ok=False, force_in_dry_run=True)
+    out, ec = run_cmd(' '.join([tool, version_option]), simple=False, log_ok=False, force_in_dry_run=True, trace=False)
     if ec:
         _log.warning("Failed to determine version of %s using '%s %s': %s" % (tool, tool, version_option, out))
         return UNKNOWN
@@ -602,7 +602,7 @@ def get_gcc_version():
     """
     Process `gcc --version` and return the GCC version.
     """
-    out, ec = run_cmd('gcc --version', simple=False, log_ok=False, force_in_dry_run=True, verbose=False)
+    out, ec = run_cmd('gcc --version', simple=False, log_ok=False, force_in_dry_run=True, verbose=False, trace=False)
     res = None
     if ec:
         _log.warning("Failed to determine the version of GCC: %s", out)
@@ -709,7 +709,7 @@ def det_parallelism(par=None, maxpar=None):
     else:
         par = get_avail_core_count()
         # check ulimit -u
-        out, ec = run_cmd('ulimit -u', force_in_dry_run=True)
+        out, ec = run_cmd('ulimit -u', force_in_dry_run=True, trace=False)
         try:
             if out.startswith("unlimited"):
                 out = 2 ** 32 - 1

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -39,7 +39,7 @@ from vsc.utils import fancylogger
 from vsc.utils.missing import nub
 
 import easybuild.tools.toolchain
-from easybuild.tools.build_log import EasyBuildError, dry_run_msg 
+from easybuild.tools.build_log import EasyBuildError, dry_run_msg
 from easybuild.tools.config import build_option, install_path
 from easybuild.tools.environment import setvar
 from easybuild.tools.filetools import adjust_permissions, find_eb_script, mkdir, read_file, which, write_file
@@ -540,7 +540,7 @@ class Toolchain(object):
                     for dep_mod in run_dep_mods:
                         trace_msg(' * ' + dep_mod)
                 else:
-                    trace_msg("(no build dependencies specified)")
+                    trace_msg("(no (runtime) dependencies specified)")
 
         # append dependency modules to list of modules
         self.modules.extend(dep_mods)

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -523,11 +523,24 @@ class Toolchain(object):
         else:
             # load modules for all dependencies
             self.log.debug("Loading modules for dependencies: %s", dep_mods)
-            if dep_mods:
-                trace_msg("loading modules for dependencies:")
-                for dep_mod in dep_mods:
-                    trace_msg(' * ' + dep_mod)
             self.modules_tool.load(dep_mods)
+
+            if self.dependencies:
+                build_dep_mods = [dep['short_mod_name'] for dep in self.dependencies if dep['build_only']]
+                if build_dep_mods:
+                    trace_msg("loading modules for build dependencies:")
+                    for dep_mod in build_dep_mods:
+                        trace_msg(' * ' + dep_mod)
+                else:
+                    trace_msg("(no build dependencies specified)")
+
+                run_dep_mods = [dep['short_mod_name'] for dep in self.dependencies if not dep['build_only']]
+                if run_dep_mods:
+                    trace_msg("loading modules for (runtime) dependencies:")
+                    for dep_mod in run_dep_mods:
+                        trace_msg(' * ' + dep_mod)
+                else:
+                    trace_msg("(no build dependencies specified)")
 
         # append dependency modules to list of modules
         self.modules.extend(dep_mods)

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -39,7 +39,7 @@ from vsc.utils import fancylogger
 from vsc.utils.missing import nub
 
 import easybuild.tools.toolchain
-from easybuild.tools.build_log import EasyBuildError, dry_run_msg, trace_msg
+from easybuild.tools.build_log import EasyBuildError, dry_run_msg 
 from easybuild.tools.config import build_option, install_path
 from easybuild.tools.environment import setvar
 from easybuild.tools.filetools import adjust_permissions, find_eb_script, mkdir, read_file, which, write_file
@@ -50,6 +50,7 @@ from easybuild.tools.systemtools import LINUX, get_os_type
 from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME, DUMMY_TOOLCHAIN_VERSION
 from easybuild.tools.toolchain.options import ToolchainOptions
 from easybuild.tools.toolchain.toolchainvariables import ToolchainVariables
+from easybuild.tools.utilities import trace_msg
 
 
 _log = fancylogger.getLogger('tools.toolchain', fname=False)
@@ -492,8 +493,7 @@ class Toolchain(object):
 
             # load modules for all dependencies
             self.log.debug("Loading module for toolchain: %s", tc_mod)
-            if build_option('trace'):
-                trace_msg("loading toolchain module: " + tc_mod)
+            trace_msg("loading toolchain module: " + tc_mod)
             self.modules_tool.load([tc_mod])
 
         # append toolchain module to list of modules
@@ -523,7 +523,7 @@ class Toolchain(object):
         else:
             # load modules for all dependencies
             self.log.debug("Loading modules for dependencies: %s", dep_mods)
-            if dep_mods and build_option('trace'):
+            if dep_mods:
                 trace_msg("loading modules for dependencies:")
                 for dep_mod in dep_mods:
                     trace_msg(' * ' + dep_mod)
@@ -661,8 +661,7 @@ class Toolchain(object):
 
         if self.name != DUMMY_TOOLCHAIN_NAME:
 
-            if build_option('trace'):
-                trace_msg("defining build environment for %s/%s toolchain" % (self.name, self.version))
+            trace_msg("defining build environment for %s/%s toolchain" % (self.name, self.version))
 
             if not self.dry_run:
                 self._verify_toolchain()

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -39,7 +39,7 @@ from vsc.utils import fancylogger
 from vsc.utils.missing import nub
 
 import easybuild.tools.toolchain
-from easybuild.tools.build_log import EasyBuildError, dry_run_msg
+from easybuild.tools.build_log import EasyBuildError, dry_run_msg, trace_msg
 from easybuild.tools.config import build_option, install_path
 from easybuild.tools.environment import setvar
 from easybuild.tools.filetools import adjust_permissions, find_eb_script, mkdir, read_file, which, write_file
@@ -492,6 +492,8 @@ class Toolchain(object):
 
             # load modules for all dependencies
             self.log.debug("Loading module for toolchain: %s", tc_mod)
+            if build_option('trace'):
+                trace_msg("loading toolchain module: " + tc_mod)
             self.modules_tool.load([tc_mod])
 
         # append toolchain module to list of modules
@@ -521,6 +523,10 @@ class Toolchain(object):
         else:
             # load modules for all dependencies
             self.log.debug("Loading modules for dependencies: %s", dep_mods)
+            if dep_mods and build_option('trace'):
+                trace_msg("loading modules for dependencies:")
+                for dep_mod in dep_mods:
+                    trace_msg(' * ' + dep_mod)
             self.modules_tool.load(dep_mods)
 
         # append dependency modules to list of modules
@@ -654,6 +660,9 @@ class Toolchain(object):
             self._load_modules(silent=silent)
 
         if self.name != DUMMY_TOOLCHAIN_NAME:
+
+            if build_option('trace'):
+                trace_msg("defining build environment for %s/%s toolchain" % (self.name, self.version))
 
             if not self.dry_run:
                 self._verify_toolchain()

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -167,6 +167,7 @@ def only_if_module_is_available(modnames, pkgname=None, url=None):
 def trace_msg(message, silent=False, timestamp=False):
     """Print trace message."""
     if build_option('trace'):
+        _log.experimental("Using --trace")
         if timestamp:
             message += " [started at: %s]" % datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         print_msg('  >> ' + message, prefix=False)

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -31,10 +31,12 @@ import glob
 import os
 import string
 import sys
+from datetime import datetime
 from vsc.utils import fancylogger
 
 import easybuild.tools.environment as env
-from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.build_log import EasyBuildError, print_msg
+from easybuild.tools.config import build_option
 
 
 _log = fancylogger.getLogger('tools.utilities')
@@ -160,3 +162,11 @@ def only_if_module_is_available(modnames, pkgname=None, url=None):
             return error
 
     return wrap
+
+
+def trace_msg(message, silent=False, timestamp=False):
+    """Print trace message."""
+    if build_option('trace'):
+        if timestamp:
+            message += " [started at: %s]" % datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+        print_msg('  >> ' + message, prefix=False)

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -39,6 +39,7 @@ from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_
 from unittest import TextTestRunner
 from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
 
+import easybuild.tools.utilities
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, read_file, write_file
 from easybuild.tools.run import run_cmd, run_cmd_qa, parse_log_for_error
@@ -47,6 +48,18 @@ from easybuild.tools.run import _log as run_log
 
 class RunTest(EnhancedTestCase):
     """ Testcase for run module """
+
+    def setUp(self):
+        """Set up test."""
+        super(RunTest, self).setUp()
+        self.orig_experimental = easybuild.tools.utilities._log.experimental
+
+    def tearDown(self):
+        """Test cleanup."""
+        super(RunTest, self).tearDown()
+
+        # restore log.experimental
+        easybuild.tools.utilities._log.experimental = self.orig_experimental
 
     def test_run_cmd(self):
         """Basic test for run_cmd function."""
@@ -103,6 +116,9 @@ class RunTest(EnhancedTestCase):
 
     def test_run_cmd_trace(self):
         """Test run_cmd under --trace"""
+        # replace log.experimental with log.warning to allow experimental code
+        easybuild.tools.utilities._log.experimental = easybuild.tools.utilities._log.warning
+
         init_config(build_options={'trace': True})
 
         self.mock_stdout(True)
@@ -148,6 +164,9 @@ class RunTest(EnhancedTestCase):
 
     def test_run_cmd_qa_trace(self):
         """Test run_cmd under --trace"""
+        # replace log.experimental with log.warning to allow experimental code
+        easybuild.tools.utilities._log.experimental = easybuild.tools.utilities._log.warning
+
         init_config(build_options={'trace': True})
 
         self.mock_stdout(True)

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -29,6 +29,7 @@ Unit tests for filetools.py
 @author: Kenneth Hoste (Ghent University)
 @author: Stijn De Weirdt (Ghent University)
 """
+import glob
 import os
 import re
 import signal
@@ -85,12 +86,92 @@ class RunTest(EnhancedTestCase):
         self.assertEqual(len(out), len("hello\n"*300))
         self.assertEqual(ec, 0)
 
+    def test_run_cmd_log_output(self):
+        """Test run_cmd with log_output enabled"""
+        (out, ec) = run_cmd("seq 1 100", log_output=True)
+        self.assertEqual(ec, 0)
+        self.assertTrue(out.startswith("1\n2\n"))
+        self.assertTrue(out.endswith("99\n100\n"))
+
+        run_cmd_logs = glob.glob(os.path.join(self.test_prefix, '*', 'easybuild-run_cmd*.log'))
+        self.assertEqual(len(run_cmd_logs), 1)
+        run_cmd_log_txt = read_file(run_cmd_logs[0])
+        self.assertTrue(run_cmd_log_txt.startswith("# output for command: seq 1 100\n\n"))
+        run_cmd_log_lines = run_cmd_log_txt.split('\n')
+        self.assertEqual(run_cmd_log_lines[2:5], ['1', '2', '3'])
+        self.assertEqual(run_cmd_log_lines[-4:-1], ['98', '99', '100'])
+
+    def test_run_cmd_trace(self):
+        """Test run_cmd under --trace"""
+        init_config(build_options={'trace': True})
+
+        self.mock_stdout(True)
+        self.mock_stderr(True)
+        (out, ec) = run_cmd("echo hello")
+        stdout = self.get_stdout()
+        stderr = self.get_stderr()
+        self.mock_stdout(False)
+        self.mock_stderr(False)
+        self.assertEqual(stderr, '')
+        regex = re.compile("^  >> running command 'echo hello' \(output in .*\)\.\.\. \[started at: .*\]")
+        self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
+
+        # trace output can be disabled on a per-command basis
+        self.mock_stdout(True)
+        self.mock_stderr(True)
+        (out, ec) = run_cmd("echo hello", trace=False)
+        stdout = self.get_stdout()
+        stderr = self.get_stderr()
+        self.mock_stdout(False)
+        self.mock_stderr(False)
+        self.assertEqual(stdout, '')
+        self.assertEqual(stderr, '')
+
     def test_run_cmd_qa(self):
         """Basic test for run_cmd_qa function."""
-        (out, ec) = run_cmd_qa("echo question; read x; echo $x", {"question": "answer"})
+        (out, ec) = run_cmd_qa("echo question; read x; echo $x", {'question': 'answer'})
         self.assertEqual(out, "question\nanswer\n")
         # no reason echo hello could fail
         self.assertEqual(ec, 0)
+
+    def test_run_cmd_qa_log_all(self):
+        """Test run_cmd_qa with log_output enabled"""
+        (out, ec) = run_cmd_qa("echo 'n: '; read n; seq 1 $n", {'n: ': '5'}, log_all=True)
+        self.assertEqual(ec, 0)
+        self.assertEquals(out, "n: \n1\n2\n3\n4\n5\n")
+
+        run_cmd_logs = glob.glob(os.path.join(self.test_prefix, '*', 'easybuild-run_cmd_qa*.log'))
+        self.assertEqual(len(run_cmd_logs), 1)
+        run_cmd_log_txt = read_file(run_cmd_logs[0])
+        extra_pref = "# output for interactive command: echo 'n: '; read n; seq 1 $n\n\n"
+        self.assertEquals(run_cmd_log_txt, extra_pref + "n: \n1\n2\n3\n4\n5\n")
+
+    def test_run_cmd_qa_trace(self):
+        """Test run_cmd under --trace"""
+        init_config(build_options={'trace': True})
+
+        self.mock_stdout(True)
+        self.mock_stderr(True)
+        (out, ec) = run_cmd_qa("echo 'n: '; read n; seq 1 $n", {'n: ': '5'})
+        stdout = self.get_stdout()
+        stderr = self.get_stderr()
+        self.mock_stdout(False)
+        self.mock_stderr(False)
+        self.assertEqual(stderr, '')
+        pattern = "^  >> running interactive command 'echo \'n: \'; read n; seq 1 \$n' "
+        pattern += "\(output in .*\)\.\.\. \[started at: .*\]"
+        self.assertTrue(re.search(pattern, stdout), "Pattern '%s' found in: %s" % (pattern, stdout))
+
+        # trace output can be disabled on a per-command basis
+        self.mock_stdout(True)
+        self.mock_stderr(True)
+        (out, ec) = run_cmd("echo hello", trace=False)
+        stdout = self.get_stdout()
+        stderr = self.get_stderr()
+        self.mock_stdout(False)
+        self.mock_stderr(False)
+        self.assertEqual(stdout, '')
+        self.assertEqual(stderr, '')
 
     def test_run_cmd_qa_answers(self):
         """Test providing list of answers in run_cmd_qa."""

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -129,7 +129,7 @@ class RunTest(EnhancedTestCase):
         self.mock_stdout(False)
         self.mock_stderr(False)
         self.assertEqual(stderr, '')
-        regex = re.compile("^  >> running command 'echo hello' \(output in .*\)\.\.\. \[started at: .*\]")
+        regex = re.compile("^  >> running command 'echo hello' \(output in .*\) \[started at: .*\]")
         self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
 
         # trace output can be disabled on a per-command basis
@@ -178,7 +178,7 @@ class RunTest(EnhancedTestCase):
         self.mock_stderr(False)
         self.assertEqual(stderr, '')
         pattern = "^  >> running interactive command 'echo \'n: \'; read n; seq 1 \$n' "
-        pattern += "\(output in .*\)\.\.\. \[started at: .*\]"
+        pattern += "\(output in .*\) \[started at: .*\]"
         self.assertTrue(re.search(pattern, stdout), "Pattern '%s' found in: %s" % (pattern, stdout))
 
         # trace output can be disabled on a per-command basis

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -753,6 +753,7 @@ class ToolchainTest(EnhancedTestCase):
                 'full_mod_name': 'OpenMPI/1.6.4-GCC-4.6.4',
                 'short_mod_name': 'OpenMPI/1.6.4-GCC-4.6.4',
                 'external_module': False,
+                'build_only': False,
             },
         ]
         tc.add_dependencies(deps)
@@ -770,6 +771,7 @@ class ToolchainTest(EnhancedTestCase):
                 'short_mod_name': 'OpenMPI/1.6.4-GCC-4.6.4',
                 'external_module': False,
                 'external_module_metadata': {},
+                'build_only': False,
             },
             # no metadata available
             {
@@ -779,6 +781,7 @@ class ToolchainTest(EnhancedTestCase):
                 'short_mod_name': 'toy/0.0',
                 'external_module': True,
                 'external_module_metadata': {},
+                'build_only': False,
             }
         ]
         tc = self.get_toolchain('GCC', version='4.6.4')
@@ -799,7 +802,8 @@ class ToolchainTest(EnhancedTestCase):
                 'name': ['toy', 'foobar'],
                 'version': ['1.2.3', '4.5'],
                 'prefix': 'FOOBAR_PREFIX',
-            }
+            },
+            'build_only': False,
         }
         tc = self.get_toolchain('GCC', version='4.6.4')
         tc.add_dependencies(deps)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1718,14 +1718,14 @@ class ToyBuildTest(EnhancedTestCase):
         patterns = [
             "^  >> installation prefix: .*/software/toy/0\.0$",
             "^== fetching files\.\.\.\n  >> sources:\n  >> .*/toy-0\.0\.tar\.gz \[SHA256: 44332000.*\]$",
-            "^  >> applying patch toy-0\.0_typo\.patch\.\.\.$",
-            "^  >> running command 'gcc toy.c -o toy' \(output in .*\)\.\.\. \[started at: .*\]$",
+            "^  >> applying patch toy-0\.0_typo\.patch$",
+            "^  >> running command 'gcc toy.c -o toy' \(output in .*\) \[started at: .*\]$",
             '^' + '\n'.join([
                 "== sanity checking\.\.\.",
                 "  >> file 'bin/yot' or 'bin/toy' found: OK",
                 "  >> \(non-empty\) directory 'bin' found: OK",
             ]) + '$',
-            "^== creating module\.\.\.\n  >> generating module file @ .*/modules/all/toy/0\.0(?:\.lua)?\.\.\.$",
+            "^== creating module\.\.\.\n  >> generating module file @ .*/modules/all/toy/0\.0(?:\.lua)?$",
         ]
         for pattern in patterns:
             regex = re.compile(pattern, re.M)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1725,7 +1725,7 @@ class ToyBuildTest(EnhancedTestCase):
                 "  >> file 'bin/yot' or 'bin/toy' found: OK",
                 "  >> \(non-empty\) directory 'bin' found: OK",
             ]) + '$',
-            "^== creating module\.\.\.\n  >> generating module file @ .*/modules/all/toy/0\.0\.lua\.\.\.$",
+            "^== creating module\.\.\.\n  >> generating module file @ .*/modules/all/toy/0\.0(?:\.lua)?\.\.\.$",
         ]
         for pattern in patterns:
             regex = re.compile(pattern, re.M)


### PR DESCRIPTION
* [x] add `--trace`/`-T` command line option
* [x] trace messages in various steps executed by `easyblock.py`
* [x] trace messages for executed commands
* [x] discriminate between build & runtime deps in trace output
* [x] generate per-command output logs in temporary directory under `--trace`
* [x] require `--experimental` for `--trace` for now...
* [x] add test for `--trace`
* [x] update docs (see https://github.com/easybuilders/easybuild/pull/372)