### PR TITLE
ensure clean error message on easyconfig file parse failure

### DIFF
--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -186,7 +186,7 @@ class EasyConfigFormatConfigObj(EasyConfigFormat):
 
         try:
             exec(pyheader, global_vars, local_vars)
-        except Exception as err:
+        except Exception as err:  # pylint: disable=broad-except
             err_msg = str(err)
             exc_tb = sys.exc_info()[2]
             if exc_tb.tb_next is not None:

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -188,7 +188,7 @@ class EasyConfigFormatConfigObj(EasyConfigFormat):
             exec(pyheader, global_vars, local_vars)
         except Exception as err:
             err_msg = str(err)
-            exc_tb = line_idx = sys.exc_info()[2]
+            exc_tb = sys.exc_info()[2]
             if exc_tb.tb_next is not None:
                 err_msg += " (line %d)" % exc_tb.tb_next.tb_lineno
             raise EasyBuildError("Parsing easyconfig file failed: %s",  err_msg)

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -27,8 +27,10 @@
 The main easyconfig format class
 
 :author: Stijn De Weirdt (Ghent University)
+:author: Kenneth Hoste (Ghent University)
 """
 import re
+import sys
 
 from vsc.utils import fancylogger
 
@@ -184,8 +186,12 @@ class EasyConfigFormatConfigObj(EasyConfigFormat):
 
         try:
             exec(pyheader, global_vars, local_vars)
-        except SyntaxError, err:
-            raise EasyBuildError("SyntaxError in easyconfig pyheader %s: %s", pyheader, err)
+        except Exception as err:
+            err_msg = str(err)
+            exc_tb = line_idx = sys.exc_info()[2]
+            if exc_tb.tb_next is not None:
+                err_msg += " (line %d)" % exc_tb.tb_next.tb_lineno
+            raise EasyBuildError("Parsing easyconfig file failed: %s",  err_msg)
 
         self.log.debug("pyheader final global_vars %s" % global_vars)
         self.log.debug("pyheader final local_vars %s" % local_vars)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -172,7 +172,14 @@ class EasyConfigTest(EnhancedTestCase):
 
         self.contents += "\nsyntax_error'"
         self.prep()
-        self.assertErrorRegex(EasyBuildError, "SyntaxError", EasyConfig, self.eb_file)
+        error_pattern = "Parsing easyconfig file failed: EOL while scanning string literal"
+        self.assertErrorRegex(EasyBuildError, error_pattern, EasyConfig, self.eb_file)
+
+        # introduce "TypeError: format requires mapping" issue"
+        self.contents = self.contents.replace("syntax_error'", "foo = '%(name)s %s' % version")
+        self.prep()
+        error_pattern = "Parsing easyconfig file failed: format requires a mapping \(line 8\)"
+        self.assertErrorRegex(EasyBuildError, error_pattern, EasyConfig, self.eb_file)
 
     def test_shlib_ext(self):
         """ inside easyconfigs shared_lib_ext should be set """


### PR DESCRIPTION
Without this, you sometimes get a nasty traceback when there are parsing problems with the easyconfig file, since not all mistakes lead to a `SyntaxError`.

For example, with something like this included:

```python
foo = '%(name)s %s' % version
```

You'd get a traceback for a `TypeError: format requires mapping`.

With this change, you'll now get a much cleaner error, that clearly points out the line in the easyconfig where the mistake is (hopefully).