### PR TITLE
avoid introducing duplicate entry for 'checksums' in exts_list with --inject-checksums

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2955,8 +2955,9 @@ def inject_checksums(ecs, checksum_type):
                         exts_list_lines[-1] += ' {'
 
                     for key, val in sorted(ext_options.items()):
-                        val = quote_str(val, prefer_single_quotes=True)
-                        exts_list_lines.append("%s'%s': %s," % (INDENT_4SPACES * 2, key, val))
+                        if key != 'checksums':
+                            val = quote_str(val, prefer_single_quotes=True)
+                            exts_list_lines.append("%s'%s': %s," % (INDENT_4SPACES * 2, key, val))
 
                     # if any checksums were collected, inject them for this extension
                     if ext_checksums:

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
@@ -23,11 +23,12 @@ patches = ['toy-0.0_typo.patch']
 exts_list = [
     ('bar', '0.0', {
         'buildopts': " && gcc bar.c -o anotherbar",
+        'checksums': ['f3676716b610545a4e8035087f5be0a0248adee0abb3930d3edb76d498ae91e7'],  # checksum for 
+        # custom extension filter to verify use of stdin value being passed to filter command
+        'exts_filter': ("cat | grep '^bar$'", '%(name)s'),
         'patches': ['bar-0.0_typo.patch'],
         'toy_ext_param': "mv anotherbar bar_bis",
         'unknowneasyconfigparameterthatshouldbeignored': 'foo',
-        # custom extension filter to verify use of stdin value being passed to filter command
-        'exts_filter': ("cat | grep '^bar$'", '%(name)s'),
     }),
     ('barbar', '0.0'),
 ]

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3361,6 +3361,13 @@ class CommandLineOptionsTest(EnhancedTestCase):
         warning_msg = "WARNING: Found existing checksums in test.eb, overwriting them (due to use of --force)..."
         self.assertEqual(stderr, warning_msg)
 
+        # make sure checksums are only there once...
+        ec_txt = read_file(test_ec)
+        # exactly one definition of 'checksums' easyconfig parameter
+        self.assertEqual(re.findall('^checksums', ec_txt, re.M), ['checksums'])
+        # exactly two checksum specs for extensions, one list of checksums for each extension
+        self.assertEqual(re.findall("[ ]*'checksums'", ec_txt, re.M), ["        'checksums'", "        'checksums'"])
+
         # no parse errors for updated easyconfig file...
         ec = EasyConfigParser(test_ec).get_config_dict()
         self.assertEqual(ec['sources'], ['%(name)s-%(version)s.tar.gz'])


### PR DESCRIPTION
Bug fix for `--inject-checksums` that was merged in #2286.

If checksums are already specified for extensions, you may end up with a result like this without this fix (note that `checksums` is specified twice).

```
exts_list = [
    ...
    ('Bundle::BioPerl', '2.1.9', {
        'checksums': ['<previous, possible wrong, checksum>'],
        'source_tmpl': 'Bundle-BioPerl-%(version)s.tar.gz',
        'source_urls': ['https://cpan.metacpan.org/authors/id/C/CJ/CJFIELDS'],
        'checksums': [
            '<new checksum>',  # Bundle-BioPerl-2.1.9.tar.gz
        ],
    }),
    ...
```