### PR TITLE
fix error message when --use-ccache is used but ccache is not available in $PATH

### DIFF
--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -727,7 +727,7 @@ class Toolchain(object):
 
         cache_path = which(cache_tool)
         if cache_path is None:
-            raise EasyBuildError("%s binary not found in $PATH, required by --use-compiler-cache", cache)
+            raise EasyBuildError("%s binary not found in $PATH, required by --use-compiler-cache", cache_tool)
         else:
             self.symlink_commands({cache_tool: (cache_path, compilers)})
 

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -991,8 +991,11 @@ class ToolchainTest(EnhancedTestCase):
             "--debug",
             "--disable-cleanup-tmpdir",
         ]
-        msg = "ccache binary not found in \$PATH, required by --use-compiler-cache"
-        self.assertErrorRegex(EasyBuildError, msg, self.eb_main, args, raise_error=True, do_build=True, reset_env=False)
+
+        ccache = which('ccache')
+        if ccache is None:
+            msg = "ccache binary not found in \$PATH, required by --use-compiler-cache"
+            self.assertErrorRegex(EasyBuildError, msg, self.eb_main, args, raise_error=True, do_build=True)
 
         # generate shell script to mock ccache/f90cache
         for cache_tool in ['ccache', 'f90cache']:

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -981,6 +981,19 @@ class ToolchainTest(EnhancedTestCase):
 
     def test_compiler_cache(self):
         """Test ccache"""
+        topdir = os.path.dirname(os.path.abspath(__file__))
+        eb_file = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
+
+        args = [
+            eb_file,
+            "--use-ccache=%s" % os.path.join(self.test_prefix, 'ccache'),
+            "--force",
+            "--debug",
+            "--disable-cleanup-tmpdir",
+        ]
+        msg = "ccache binary not found in \$PATH, required by --use-compiler-cache"
+        self.assertErrorRegex(EasyBuildError, msg, self.eb_main, args, raise_error=True, do_build=True, reset_env=False)
+
         # generate shell script to mock ccache/f90cache
         for cache_tool in ['ccache', 'f90cache']:
             path = os.path.join(self.test_prefix, 'scripts')
@@ -1004,19 +1017,8 @@ class ToolchainTest(EnhancedTestCase):
 
         prepped_path_envvar = os.environ['PATH']
 
-        topdir = os.path.dirname(os.path.abspath(__file__))
-        eb_file = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
-
         ccache_dir = os.path.join(self.test_prefix, 'ccache')
         mkdir(ccache_dir, parents=True)
-
-        args = [
-            eb_file,
-            "--use-ccache=%s" % os.path.join(self.test_prefix, 'ccache'),
-            "--force",
-            "--debug",
-            "--disable-cleanup-tmpdir",
-        ]
 
         out = self.eb_main(args, raise_error=True, do_build=True, reset_env=False)
 


### PR DESCRIPTION
fix for nasty traceback:

```
ERROR: Traceback (most recent call last):
  File "/prefix/lib/python2.6/site-packages/easybuild_framework-3.4.0.dev0-py2.7.egg/easybuild/main.py", line 118, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/prefix/lib/python2.6/site-packages/easybuild_framework-3.4.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2619, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/prefix/lib/python2.6/site-packages/easybuild_framework-3.4.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2535, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/prefix/lib/python2.6/site-packages/easybuild_framework-3.4.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2413, in run_step
    step_method(self)()
  File "/prefix/lib/python2.6/site-packages/easybuild_framework-3.4.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 1692, in prepare_step
    self.toolchain.prepare(self.cfg['onlytcmod'], silent=self.silent, rpath_filter_dirs=self.rpath_filter_dirs)
  File "/prefix/lib/python2.6/site-packages/easybuild_framework-3.4.0.dev0-py2.7.egg/easybuild/tools/toolchain/toolchain.py", line 680, in prepare
    self.prepare_compiler_cache(cache_tool)
  File "/prefix/lib/python2.6/site-packages/easybuild_framework-3.4.0.dev0-py2.7.egg/easybuild/tools/toolchain/toolchain.py", line 730, in prepare_compiler_cache
    raise EasyBuildError("%s binary not found in $PATH, required by --use-compiler-cache", cache)
NameError: global name 'cache' is not defined
```