### PR TITLE
improve trace output for executed commands + drop requirement for --experimental for --trace

### DIFF
--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -311,8 +311,8 @@ def time_str_since(start_time):
              format: "[[%d hours, ]%d mins, ]%d sec(s)"
     """
     tot_time = datetime.now() - start_time
-    if tot_time.seconds > 0:
-        tot_secs = tot_time.seconds + tot_time.days * 24 * 3600
+    tot_secs = tot_time.seconds + tot_time.days * 24 * 3600
+    if tot_secs > 0:
         res = datetime.utcfromtimestamp(tot_secs).strftime('%Hh%Mm%Ss')
     else:
         res = "< 1s"

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -312,7 +312,8 @@ def time_str_since(start_time):
     """
     tot_time = datetime.now() - start_time
     if tot_time.seconds > 0:
-        res = datetime.utcfromtimestamp(tot_time.total_seconds()).strftime('%Hh%Mm%Ss')
+        tot_secs = tot_time.seconds + tot_time.days * 24 * 3600
+        res = datetime.utcfromtimestamp(tot_secs).strftime('%Hh%Mm%Ss')
     else:
         res = "< 1s"
 

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -37,6 +37,7 @@ import re
 import sys
 import tempfile
 from copy import copy
+from datetime import datetime
 from vsc.utils import fancylogger
 from vsc.utils.exceptions import LoggedException
 
@@ -299,3 +300,34 @@ def print_warning(message, silent=False):
     """
     if not silent:
         sys.stderr.write("\nWARNING: %s\n\n" % message)
+
+
+def time_str_since(start_time):
+    """
+    Return string representing amount of time that has passed since specified timestamp
+
+    :param start_time: datetime value representing start time
+    :return: string value representing amount of time passed since start_time;
+             format: "[[%d hours, ]%d mins, ]%d sec(s)"
+    """
+    tot_time = datetime.now() - start_time
+    if tot_time.seconds > 0:
+        hours, mins, secs = 0, 0, tot_time.seconds
+        if secs >= 60:
+            mins = secs / 60
+            secs = secs % 60
+        if mins >= 60:
+            hours = mins / 60
+            mins = mins % 60
+
+        res = ''
+        if hours:
+            res += '%dh' % hours
+        if hours or mins:
+            res += '%dm' % mins
+        res += '%ds' % secs
+
+    else:
+        res = "< 1s"
+
+    return res

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -312,21 +312,7 @@ def time_str_since(start_time):
     """
     tot_time = datetime.now() - start_time
     if tot_time.seconds > 0:
-        hours, mins, secs = 0, 0, tot_time.seconds
-        if secs >= 60:
-            mins = secs / 60
-            secs = secs % 60
-        if mins >= 60:
-            hours = mins / 60
-            mins = mins % 60
-
-        res = ''
-        if hours:
-            res += '%dh' % hours
-        if hours or mins:
-            res += '%dm' % mins
-        res += '%ds' % secs
-
+        res = datetime.utcfromtimestamp(tot_time.total_seconds()).strftime('%Hh%Mm%Ss')
     else:
         res = "< 1s"
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -879,7 +879,7 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None):
         _log.debug("Using specified patch level %d for patch %s" % (level, patch_file))
 
     patch_cmd = "patch -b -p%s -i %s" % (level, apatch)
-    out, ec = run.run_cmd(patch_cmd, simple=False, path=adest, log_ok=False)
+    out, ec = run.run_cmd(patch_cmd, simple=False, path=adest, log_ok=False, trace=False)
 
     if ec:
         raise EasyBuildError("Couldn't apply patch file %s. Process exited with code %s: %s", patch_file, ec, out)

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -164,10 +164,7 @@ def only_if_module_is_available(modnames, pkgname=None, url=None):
     return wrap
 
 
-def trace_msg(message, silent=False, timestamp=False):
+def trace_msg(message, silent=False):
     """Print trace message."""
     if build_option('trace'):
-        _log.experimental("Using --trace")
-        if timestamp:
-            message += " [started at: %s]" % datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         print_msg('  >> ' + message, prefix=False)

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -32,11 +32,12 @@ import re
 import sys
 import tempfile
 from distutils.version import LooseVersion
+from datetime import datetime, timedelta
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
 from vsc.utils.fancylogger import getLogger, getRootLoggerName, logToFile, setLogFormat
 
-from easybuild.tools.build_log import LOGGING_FORMAT, EasyBuildError, print_msg, print_warning
+from easybuild.tools.build_log import LOGGING_FORMAT, EasyBuildError, print_msg, print_warning, time_str_since
 from easybuild.tools.filetools import read_file, write_file
 
 
@@ -253,6 +254,20 @@ class BuildLogTest(EnhancedTestCase):
         run_check("testing, 1, 2, 3", expected_stderr="testing, 1, 2, 3", stderr=True, prefix=False, newline=False)
         run_check("testing, 1, 2, 3", silent=True)
         run_check("testing, 1, 2, 3", silent=True, stderr=True)
+
+    def test_time_str_since(self):
+        """Test time_str_since"""
+        self.assertEqual(time_str_since(datetime.now()), '< 1s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=1.1)), '1s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=37.1)), '37s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=60.1)), '1m0s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=81.1)), '1m21s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=1358.1)), '22m38s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=3600.1)), '1h0m0s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=3960.1)), '1h6m0s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=4500.1)), '1h15m0s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=12305.1)), '3h25m5s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=54321.1)), '15h5m21s')
 
 
 def suite():

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -258,16 +258,16 @@ class BuildLogTest(EnhancedTestCase):
     def test_time_str_since(self):
         """Test time_str_since"""
         self.assertEqual(time_str_since(datetime.now()), '< 1s')
-        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=1.1)), '1s')
-        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=37.1)), '37s')
-        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=60.1)), '1m0s')
-        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=81.1)), '1m21s')
-        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=1358.1)), '22m38s')
-        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=3600.1)), '1h0m0s')
-        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=3960.1)), '1h6m0s')
-        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=4500.1)), '1h15m0s')
-        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=12305.1)), '3h25m5s')
-        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=54321.1)), '15h5m21s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=1.1)), '00h00m01s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=37.1)), '00h00m37s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=60.1)), '00h01m00s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=81.1)), '00h01m21s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=1358.1)), '00h22m38s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=3600.1)), '01h00m00s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=3960.1)), '01h06m00s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=4500.1)), '01h15m00s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=12305.1)), '03h25m05s')
+        self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=54321.1)), '15h05m21s')
 
 
 def suite():

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -132,7 +132,8 @@ class RunTest(EnhancedTestCase):
         pattern = "^  >> running command:\n"
         pattern += "\t\[started at: .*\]\n"
         pattern += "\t\[output logged in .*\]\n"
-        pattern += "\techo hello"
+        pattern += "\techo hello\n"
+        pattern += '  >> command completed: exit 0, ran in .*'
         regex = re.compile(pattern)
         self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
 
@@ -184,7 +185,8 @@ class RunTest(EnhancedTestCase):
         pattern = "^  >> running interactive command:\n"
         pattern += "\t\[started at: .*\]\n"
         pattern += "\t\[output logged in .*\]\n"
-        pattern += "\techo \'n: \'; read n; seq 1 \$n"
+        pattern += "\techo \'n: \'; read n; seq 1 \$n\n"
+        pattern += '  >> interactive command completed: exit 0, ran in .*'
         self.assertTrue(re.search(pattern, stdout), "Pattern '%s' found in: %s" % (pattern, stdout))
 
         # trace output can be disabled on a per-command basis

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -129,7 +129,11 @@ class RunTest(EnhancedTestCase):
         self.mock_stdout(False)
         self.mock_stderr(False)
         self.assertEqual(stderr, '')
-        regex = re.compile("^  >> running command 'echo hello' \(output in .*\) \[started at: .*\]")
+        pattern = "^  >> running command:\n"
+        pattern += "\t\[started at: .*\]\n"
+        pattern += "\t\[output logged in .*\]\n"
+        pattern += "\techo hello"
+        regex = re.compile(pattern)
         self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
 
         # trace output can be disabled on a per-command basis
@@ -177,8 +181,10 @@ class RunTest(EnhancedTestCase):
         self.mock_stdout(False)
         self.mock_stderr(False)
         self.assertEqual(stderr, '')
-        pattern = "^  >> running interactive command 'echo \'n: \'; read n; seq 1 \$n' "
-        pattern += "\(output in .*\) \[started at: .*\]"
+        pattern = "^  >> running interactive command:\n"
+        pattern += "\t\[started at: .*\]\n"
+        pattern += "\t\[output logged in .*\]\n"
+        pattern += "\techo \'n: \'; read n; seq 1 \$n"
         self.assertTrue(re.search(pattern, stdout), "Pattern '%s' found in: %s" % (pattern, stdout))
 
         # trace output can be disabled on a per-command basis

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1719,7 +1719,8 @@ class ToyBuildTest(EnhancedTestCase):
             "^  >> installation prefix: .*/software/toy/0\.0$",
             "^== fetching files\.\.\.\n  >> sources:\n  >> .*/toy-0\.0\.tar\.gz \[SHA256: 44332000.*\]$",
             "^  >> applying patch toy-0\.0_typo\.patch$",
-            "^  >> running command:\n\t\[started at: .*\]\n\t\[output logged in .*\]\n\tgcc toy.c -o toy$",
+            "^  >> running command:\n\t\[started at: .*\]\n\t\[output logged in .*\]\n\tgcc toy.c -o toy\n" +
+            "  >> command completed: exit 0, ran in .*",
             '^' + '\n'.join([
                 "== sanity checking\.\.\.",
                 "  >> file 'bin/yot' or 'bin/toy' found: OK",

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1719,7 +1719,7 @@ class ToyBuildTest(EnhancedTestCase):
             "^  >> installation prefix: .*/software/toy/0\.0$",
             "^== fetching files\.\.\.\n  >> sources:\n  >> .*/toy-0\.0\.tar\.gz \[SHA256: 44332000.*\]$",
             "^  >> applying patch toy-0\.0_typo\.patch$",
-            "^  >> running command 'gcc toy.c -o toy' \(output in .*\) \[started at: .*\]$",
+            "^  >> running command:\n\t\[started at: .*\]\n\t\[output logged in .*\]\n\tgcc toy.c -o toy$",
             '^' + '\n'.join([
                 "== sanity checking\.\.\.",
                 "  >> file 'bin/yot' or 'bin/toy' found: OK",


### PR DESCRIPTION
Example output with EasyBuild v3.4.0:

```
== configuring...
  >> running command './configure --prefix=/Users/kehoste/.local/easybuild/software/zlib/1.2.11' (output in /tmp/eb-508__5/easybuild-run_cmd-GQnYWm.log) [started at: 2017-09-15 20:58:04]
== building...
  >> running command 'make -j 4 CFLAGS="-O2 -fPIC"' (output in /tmp/eb-508__5/easybuild-run_cmd-NXCfvW.log) [started at: 2017-09-15 20:58:05]
```

Example output with this patch included:

```
== configuring...
  >> running command:
	[started at: 2017-09-15 20:56:14]
	[output logged in /tmp/eb-c13cXN/easybuild-run_cmd-pV_hJa.log]
	./configure --prefix=/Users/kehoste/.local/easybuild/software/zlib/1.2.11
  >> command completed: exit 0, ran in 1s
== building...
  >> running command:
	[started at: 2017-09-15 20:56:15]
	[output logged in /tmp/eb-c13cXN/easybuild-run_cmd-i0AnOq.log]
	make -j 4 CFLAGS="-O2 -fPIC"
  >> command completed: exit 0, ran in 3s
```