### PR TITLE
also check for use of --rebuild next to --force to skip sanity check with --module-only, and also in package_step

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1895,7 +1895,7 @@ class EasyBlock(object):
 
             pkgtype = build_option('package_type')
             pkgdir_dest = os.path.abspath(package_path())
-            opt_force = build_option('force')
+            opt_force = build_option('force') or build_option('rebuild')
 
             self.log.info("Generating %s package in %s", pkgtype, pkgdir_dest)
             pkgdir_src = package(self)
@@ -2383,7 +2383,7 @@ class EasyBlock(object):
     def _skip_step(self, step, skippable):
         """Dedice whether or not to skip the specified step."""
         module_only = build_option('module_only')
-        force = build_option('force')
+        force = build_option('force') or build_option('rebuild')
         skip = False
 
         # skip step if specified as individual (skippable) step

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1235,6 +1235,17 @@ class ToyBuildTest(EnhancedTestCase):
 
         os.remove(toy_mod)
 
+        # --module-only --rebuild should be equivalent with --module-only --force
+        self.eb_main(args + ['--rebuild'], do_build=True, raise_error=True)
+        self.assertTrue(os.path.exists(toy_mod))
+
+        # make sure load statements for dependencies are included in additional module file generated with --module-only
+        modtxt = read_file(toy_mod)
+        self.assertTrue(re.search('load.*ictce/4.1.13', modtxt), "load statement for ictce/4.1.13 found in module")
+        self.assertTrue(re.search('load.*GCC/4.7.2', modtxt), "load statement for GCC/4.7.2 found in module")
+
+        os.remove(toy_mod)
+
         # installing another module under a different naming scheme and using Lua module syntax works fine
 
         # first actually build and install toy software + module


### PR DESCRIPTION
This fixes the problem reported on IRC where `--module-only --rebuild` is not equivalent with `--module-only --force`, even though the documentation suggests otherwise...