### PR TITLE
ensure $TMPDIR is set to a short path for OpenMPI v2.x

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2225,6 +2225,8 @@ class EasyBlock(object):
         if not build_option('cleanup_builddir'):
             self.log.info("Keeping builddir %s" % self.builddir)
 
+        self.toolchain.cleanup()
+
         env.restore_env_vars(self.cfg['unwanted_env_vars'])
 
         self.restore_iterate_opts()

--- a/easybuild/toolchains/mpi/openmpi.py
+++ b/easybuild/toolchains/mpi/openmpi.py
@@ -79,8 +79,12 @@ class OpenMPI(Mpi):
         self.orig_tmpdir = os.environ.get('TMPDIR')
         ompi_ver = self.get_software_version(self.MPI_MODULE_NAME)[0]
         if LooseVersion(ompi_ver) >= LooseVersion('2.0') and LooseVersion(ompi_ver) < LooseVersion('3.0'):
-            if len(self.orig_tmpdir) > 50:
-                env.setvar('TMPDIR', tempfile.mkdtemp(prefix='/tmp/'))
+            if len(self.orig_tmpdir) > 40:
+                tmpdir = tempfile.mkdtemp(prefix='/tmp/')
+                env.setvar('TMPDIR', tmpdir)
+                warn_msg = "Long $TMPDIR path may cause problems with OpenMPI 2.x, using shorter path: %s" % tmpdir
+                self.log.warning(warn_msg)
+                print_warning(warn_msg)
 
     def _set_mpi_compiler_variables(self):
         """Define MPI wrapper commands (depends on OpenMPI version) and add OMPI_* variables to set."""
@@ -112,3 +116,4 @@ class OpenMPI(Mpi):
             except OSError as err:
                 print_warning("Failed to clean up temporary directory %s: %s", tmpdir, err)
             env.setvar('TMPDIR', self.orig_tmpdir)
+            self.log.info("$TMPDIR restored to %s", self.orig_tmpdir)

--- a/easybuild/toolchains/mpi/openmpi.py
+++ b/easybuild/toolchains/mpi/openmpi.py
@@ -28,8 +28,13 @@ Support for OpenMPI as toolchain MPI library.
 :author: Stijn De Weirdt (Ghent University)
 :author: Kenneth Hoste (Ghent University)
 """
+import os
+import shutil
+import tempfile
 from distutils.version import LooseVersion
 
+import easybuild.tools.environment as env
+from easybuild.tools.build_log import print_warning
 from easybuild.tools.toolchain.constants import COMPILER_VARIABLES, MPI_COMPILER_VARIABLES
 from easybuild.tools.toolchain.mpi import Mpi
 from easybuild.tools.toolchain.variables import CommandFlagList
@@ -57,6 +62,26 @@ class OpenMPI(Mpi):
 
     MPI_LINK_INFO_OPTION = '-showme:link'
 
+    def __init__(self, *args, **kwargs):
+        """Toolchain constructor"""
+        super(OpenMPI, self).__init__(*args, **kwargs)
+
+        self.orig_tmpdir = None
+
+    def prepare(self, *args, **kwargs):
+        """
+        Prepare for using OpenMPI library in toolchain environment
+        """
+        super(OpenMPI, self).prepare(*args, **kwargs)
+
+        # OpenMPI 2.x trips if path specified in $TMPDIR is too long
+        # see https://www.open-mpi.org/faq/?category=osx#startup-errors-with-open-mpi-2.0.x
+        self.orig_tmpdir = os.environ.get('TMPDIR')
+        ompi_ver = self.get_software_version(self.MPI_MODULE_NAME)[0]
+        if LooseVersion(ompi_ver) >= LooseVersion('2.0') and LooseVersion(ompi_ver) < LooseVersion('3.0'):
+            if len(self.orig_tmpdir) > 50:
+                env.setvar('TMPDIR', tempfile.mkdtemp(prefix='/tmp/'))
+
     def _set_mpi_compiler_variables(self):
         """Define MPI wrapper commands (depends on OpenMPI version) and add OMPI_* variables to set."""
         ompi_ver = self.get_software_version(self.MPI_MODULE_NAME)[0]
@@ -75,3 +100,15 @@ class OpenMPI(Mpi):
             self.variables.nappend('OMPI_%s' % var, str(self.variables[var].get_first()), var_class=CommandFlagList)
 
         super(OpenMPI, self)._set_mpi_compiler_variables()
+
+    def cleanup(self, *args, **kwargs):
+        """Clean up after using OpenMPI in toolchain."""
+        super(OpenMPI, self).cleanup(*args, **kwargs)
+
+        if self.orig_tmpdir:
+            tmpdir = os.environ.get('TMPDIR')
+            try:
+                shutil.rmtree(tmpdir)
+            except OSError as err:
+                print_warning("Failed to clean up temporary directory %s: %s", tmpdir, err)
+            env.setvar('TMPDIR', self.orig_tmpdir)

--- a/easybuild/toolchains/mpi/openmpi.py
+++ b/easybuild/toolchains/mpi/openmpi.py
@@ -105,8 +105,8 @@ class OpenMPI(Mpi):
         """Clean up after using OpenMPI in toolchain."""
         super(OpenMPI, self).cleanup(*args, **kwargs)
 
-        if self.orig_tmpdir:
-            tmpdir = os.environ.get('TMPDIR')
+        tmpdir = os.environ.get('TMPDIR')
+        if tmpdir != self.orig_tmpdir:
             try:
                 shutil.rmtree(tmpdir)
             except OSError as err:

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -921,3 +921,7 @@ class Toolchain(object):
     def mpi_family(self):
         "Return type of MPI library used in this toolchain, or 'None' if MPI is not supported."
         return None
+
+    def cleanup(self):
+        """Clean up after using this toolchain"""
+        pass

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1394,7 +1394,8 @@ class ToolchainTest(EnhancedTestCase):
         copy_dir(os.path.join(test_dir, 'modules', 'OpenMPI'), os.path.join(tmp_modules, 'OpenMPI'))
 
         openmpi_module = os.path.join(tmp_modules, 'OpenMPI', '1.6.4-GCC-4.6.4')
-        write_file(openmpi_module, 'setenv EBVERSIONOPENMPI "2.0.2"', append=True)
+        ompi_mod_txt = read_file(openmpi_module)
+        write_file(openmpi_module, ompi_mod_txt.replace('1.6.4', '2.0.2'))
 
         self.modtool.use(tmp_modules)
 

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1352,6 +1352,7 @@ class ToolchainTest(EnhancedTestCase):
 
         def prep():
             """Helper function: create & prepare toolchain"""
+            self.modtool.unload(['gompi', 'OpenMPI', 'hwloc', 'GCC'])
             tc = self.get_toolchain('gompi', version='1.3.12')
             self.mock_stderr(True)
             self.mock_stdout(True)


### PR DESCRIPTION
If `$TMPDIR` is set to a long path, OpenMPI 2.x fails with an error like:

```
PMIx has detected a temporary directory name that results
in a path that is too long for the Unix domain socket:

    Temp dir: /local/305822X5092X.master21.swalot.gent.vsc/eb-riPl9d/openmpi-sessions-2540023@node2643_0/64817

Try setting your TMPDIR environmental variable to point to
something shorter in length
```

See also https://www.open-mpi.org/faq/?category=osx#startup-errors-with-open-mpi-2.0.x.

This can occur on macOS, where the default temporary directory is something weird like `/var/folders/mg/q0_5yv791yz65cdnbglcqjvc0000gp/T` rather than the more usual `/tmp`, but also in a job environment where `$TMPDIR` is set to a pre-created temporary directory that is specific to the job, e.g. `/local/305822[5092].master21.swalot.gent.vsc` for an array job in Torque (which EasyBuild garbles into `local/305822X5092X.master21.swalot.gent.vsc` to avoid using square brackets in the path name.

To ensure that OpenMPI 2.x doesn't go down on its knees because of this when installing software with EasyBuild (usually because some tests are run using `mpirun`), we can ensure that the `$TMPDIR` value is something short.