### PR TITLE
Make recursive-unload not generate load storms.

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -783,10 +783,12 @@ class ModuleGeneratorLua(ModuleGenerator):
         body.append(self.LOAD_TEMPLATE)
 
         if build_option('recursive_mod_unload') or recursive_unload:
-            # not wrapping the 'module load' with an is-loaded guard ensures recursive unloading;
-            # when "module unload" is called on the module in which the depedency "module load" is present,
-            # it will get translated to "module unload"
-            load_statement = body + ['']
+            # wrapping the 'module load' with an 'is-loaded or mode == unload'
+            # guard ensures recursive unloading while avoiding load storms,
+            # when "module unload" is called on the module in which the
+            # depedency "module load" is present, it will get translated
+            # to "module unload"
+            load_statement = [self.conditional_statement('isloaded("%(mod_name)s") or mode() == "unload"', '\n'.join(body), negative=True)]
         else:
             load_statement = [self.conditional_statement('isloaded("%(mod_name)s")', '\n'.join(body), negative=True)]
 

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -788,9 +788,11 @@ class ModuleGeneratorLua(ModuleGenerator):
             # when "module unload" is called on the module in which the
             # depedency "module load" is present, it will get translated
             # to "module unload"
-            load_statement = [self.conditional_statement('isloaded("%(mod_name)s") or mode() == "unload"', '\n'.join(body), negative=True)]
+            # see also http://lmod.readthedocs.io/en/latest/210_load_storms.html
+            load_guard = 'isloaded("%(mod_name)s") or mode() == "unload"'
         else:
-            load_statement = [self.conditional_statement('isloaded("%(mod_name)s")', '\n'.join(body), negative=True)]
+            load_guard = 'isloaded("%(mod_name)s")'
+        load_statement = [self.conditional_statement(load_guard, '\n'.join(body), negative=True)]
 
         return '\n'.join([''] + load_statement) % {'mod_name': mod_name}
 

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -269,10 +269,13 @@ class ModuleGeneratorTest(EnhancedTestCase):
             ])
             self.assertEqual(expected, self.modgen.load_module("mod_name"))
 
-            # with recursive unloading: no if isloaded guard
+            # with recursive unloading: if isloaded guard with unload
+            # check
             expected = '\n'.join([
                 '',
-                'load("mod_name")',
+                'if not isloaded("mod_name") or mode() == "unload" then',
+                '    load("mod_name")',
+                'end',
                 '',
             ])
             self.assertEqual(expected, self.modgen.load_module("mod_name", recursive_unload=True))


### PR DESCRIPTION
Protect the load("module") with
isloaded("module") or mode() == "unload"
that way we get recursive unload without risking load storms with Lmod.