### PR TITLE
Add a architecture env variable to the user subdir module path.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20170808.01 b78eac49374b26c78a16ea41efcde8c03d21649087f650e08f5339e8e48d7c6e"
+    - EB_BOOTSTRAP_EXPECTED="20170808.01 7a22faf5ee9d249807fd883e435008fb84c11129425ec09d3cc76918b36ef3d5"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - if [ "x$TEST_EASYBUILD_MODULES_TOOL" != 'xEnvironmentModules' ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20180117.01 ddb59fdc97e724c626a85001bd7a9a955b0c7b007f2e1d63a0750f0f7e59e12a"
+    - EB_BOOTSTRAP_EXPECTED="20180117.01 602704b07d8f9e75907ebf2823e9d70cef85c515985eddfbf98a88669cf86cf2"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20180117.01 602704b07d8f9e75907ebf2823e9d70cef85c515985eddfbf98a88669cf86cf2"
+    - EB_BOOTSTRAP_EXPECTED="20180117.01 c3e828769fe30f9e4798972f7ab052632047e5df3224e002d3d2599033678745"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20180117.01 c3e828769fe30f9e4798972f7ab052632047e5df3224e002d3d2599033678745"
+    - EB_BOOTSTRAP_EXPECTED="20180201.01 9d6278409b3d9ecf034bd28384da25c14ebfe773606d4fa800e51ed11667e851"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ before_install:
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install pydot==1.1.0; else pip install pydot; fi
     # paramiko (dep for GC3Pie) 2.4.0 & more recent doesn't work with Python 2.6
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'paramiko<2.4.0'; else pip install paramiko; fi
+    # SQLAlchemy (dep for GC3Pie) 1.2.0 & more recent doesn't work with Python 2.6
+    - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'SQLAlchemy<1.2.0'; else pip install SQLAlchemy; fi
     # optional Python packages for EasyBuild
     - pip install autopep8 GC3Pie pycodestyle python-graph-dot python-hglib PyYAML
     # git config is required to make actual git commits (cfr. tests for GitRepository)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - LMOD_VERSION=7.4 TEST_EASYBUILD_MODULE_SYNTAX=Tcl
     - ENV_MOD_VERSION=3.2.10 TEST_EASYBUILD_MODULES_TOOL=EnvironmentModulesC TEST_EASYBUILD_MODULE_SYNTAX=Tcl
     - ENV_MOD_TCL_VERSION=1.147 TEST_EASYBUILD_MODULES_TOOL=EnvironmentModulesTcl TEST_EASYBUILD_MODULE_SYNTAX=Tcl
+    - ENV_MOD_VERSION=4.0.0 TEST_EASYBUILD_MODULE_SYNTAX=Tcl TEST_EASYBUILD_MODULES_TOOL=EnvironmentModules
 matrix:
   # mark build as finished as soon as job has failed
   fast_finish: true
@@ -64,7 +65,7 @@ script:
     # make sure 'ml' alias is defined, otherwise sourcing the init script fails (silently) for Lmod (< 5.9.3)
     - if [ ! -z $MOD_INIT ] && [ ! -z $LMOD_VERSION ]; then alias ml=foobar; fi
     # set up environment for modules tool (if $MOD_INIT is defined)
-    - if [ ! -z $MOD_INIT ]; then source $MOD_INIT; fi
+    - if [ ! -z $MOD_INIT ]; then source $MOD_INIT; type module; fi
     # install GitHub token
     - if [ ! -z $GITHUB_TOKEN ]; then
         if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ];

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20180105.01 ac138fa34ecf488f28955fa174038a141fdd3cc74453849944a78d1704a5bc88"
+    - EB_BOOTSTRAP_EXPECTED="20180117.01 ddb59fdc97e724c626a85001bd7a9a955b0c7b007f2e1d63a0750f0f7e59e12a"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,8 +96,12 @@ script:
     - EB_BOOTSTRAP_EXPECTED="20170808.01 b78eac49374b26c78a16ea41efcde8c03d21649087f650e08f5339e8e48d7c6e"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
-    - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap
+    - if [ "x$TEST_EASYBUILD_MODULES_TOOL" != 'xEnvironmentModules' ]; then
+        python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap;
+      fi;
     # unset $PYTHONPATH to avoid mixing two EasyBuild 'installations' when testing bootstrapped EasyBuild module
     - unset PYTHONPATH
     # simply sanity check on bootstrapped EasyBuild module
-    - module use /tmp/$TRAVIS_JOB_ID/eb_bootstrap/modules/all; module load EasyBuild; eb --version
+    - if [ "x$TEST_EASYBUILD_MODULES_TOOL" != 'xEnvironmentModules' ]; then
+        module use /tmp/$TRAVIS_JOB_ID/eb_bootstrap/modules/all; module load EasyBuild; eb --version;
+      fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,15 +93,11 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20170808.01 7a22faf5ee9d249807fd883e435008fb84c11129425ec09d3cc76918b36ef3d5"
+    - EB_BOOTSTRAP_EXPECTED="20180105.01 ac138fa34ecf488f28955fa174038a141fdd3cc74453849944a78d1704a5bc88"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
-    - if [ "x$TEST_EASYBUILD_MODULES_TOOL" != 'xEnvironmentModules' ]; then
-        python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap;
-      fi;
+    - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap
     # unset $PYTHONPATH to avoid mixing two EasyBuild 'installations' when testing bootstrapped EasyBuild module
     - unset PYTHONPATH
     # simply sanity check on bootstrapped EasyBuild module
-    - if [ "x$TEST_EASYBUILD_MODULES_TOOL" != 'xEnvironmentModules' ]; then
-        module use /tmp/$TRAVIS_JOB_ID/eb_bootstrap/modules/all; module load EasyBuild; eb --version;
-      fi;
+    - module use /tmp/$TRAVIS_JOB_ID/eb_bootstrap/modules/all; module load EasyBuild; eb --version

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -7,23 +7,22 @@ v3.5.0 (December 12th 2017)
 ---------------------------
 
 feature release
+- add support for implementing pre- and post-step hooks (#2343)
 - various enhancements, including:
-  - add framework support for foss-like toolchain with Spectrum MPI: gsolf (#2329)
-  - add support for --preview-pr (#2331)
+  - add support for foss-like toolchain with Spectrum MPI: gsolf (#2329)
+  - add support for --preview-pr (#2331, #2337, #2348)
+    - see also http://easybuild.readthedocs.io/en/latest/Integration_with_GitHub.html#previewing-easyconfig-pull-requests-preview-pr
   - flesh out find_extension function, hoist dict with extract commands into a constant (#2336)
   - add support for using self.start_dir rather than using self.cfg['start_dir'] (#2339)
-  - add support for 'exts_default_options' easyconfig parameter (#2345)
-  - allow use of `start_dir` in extensions (#2353)
+  - add support for 'exts_default_options' easyconfig parameter (#2345, #2346)
+  - allow use of 'start_dir' easyconfig parameter in extensions (#2353)
 - various bug fixes, including:
-  - fix typo in Class and comment, giolf != goolf. (#2327)
+  - fix typo in 'giolf' toolchain definition (#2327)
   - fix minor issues with --inject-checksums (#2333)
-  - fix bug that slipped in with #2331 (#2337)
   - fix error message when 'gv' Python package is not available (#2340)
   - install paramiko version < 2.4.0 for Python 2.6 in Travis config (#2344)
-  - take exts_default_options easyconfig parameter into account for --inject-checksums (#2346)
-  - disable broken log rotation, avoid duplicate logging of output of executed commands under `--debug` (#2347)
-  - skip testing of --preview-pr if no GitHub token is available (#2348)
-  - use absolute paths to lib and lib64 icw $ORIGIN for the RPATH (#2358)
+  - disable broken log rotation, avoid duplicate logging of output of executed commands under '--debug' (#2347)
+  - also include $ORIGIN and absolute paths to 'lib' and 'lib64' subdirectories in RPATH locations (#2358)
 
 
 v3.4.1 (October 17th 2017)

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -3,6 +3,29 @@ For more detailed information, please see the git log.
 
 These release notes can also be consulted at https://easybuild.readthedocs.io/en/latest/Release_notes.html.
 
+v3.5.0 (December 12th 2017)
+---------------------------
+
+feature release
+- various enhancements, including:
+  - add framework support for foss-like toolchain with Spectrum MPI: gsolf (#2329)
+  - add support for --preview-pr (#2331)
+  - flesh out find_extension function, hoist dict with extract commands into a constant (#2336)
+  - add support for using self.start_dir rather than using self.cfg['start_dir'] (#2339)
+  - add support for 'exts_default_options' easyconfig parameter (#2345)
+  - allow use of `start_dir` in extensions (#2353)
+- various bug fixes, including:
+  - fix typo in Class and comment, giolf != goolf. (#2327)
+  - fix minor issues with --inject-checksums (#2333)
+  - fix bug that slipped in with #2331 (#2337)
+  - fix error message when 'gv' Python package is not available (#2340)
+  - install paramiko version < 2.4.0 for Python 2.6 in Travis config (#2344)
+  - take exts_default_options easyconfig parameter into account for --inject-checksums (#2346)
+  - disable broken log rotation, avoid duplicate logging of output of executed commands under `--debug` (#2347)
+  - skip testing of --preview-pr if no GitHub token is available (#2348)
+  - use absolute paths to lib and lib64 icw $ORIGIN for the RPATH (#2358)
+
+
 v3.4.1 (October 17th 2017)
 --------------------------
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -12,7 +12,7 @@ bugfix release
   - add support for Environment Modules 4 (#2365)
 - various bug fixes, including:
   - install SQLAlchemy < 1.2.0 with Python 2.6 in Travis config (#2367)
-  - make code in `tools/job/gc3pie.py` forward-compatible with GC3Pie 2.5 (#2373)
+  - make code in easybuild/tools/job/gc3pie.py forward-compatible with GC3Pie 2.5 (#2373)
 
 
 v3.5.0 (December 15th 2017)

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -24,6 +24,7 @@ feature release
   - install paramiko version < 2.4.0 for Python 2.6 in Travis config (#2344)
   - disable broken log rotation, avoid duplicate logging of output of executed commands under '--debug' (#2347)
   - also include $ORIGIN and absolute paths to 'lib' and 'lib64' subdirectories in RPATH locations (#2358)
+  - fix repo references in install-EasyBuild-develop.sh script (#2360)
 
 
 v3.4.1 (October 17th 2017)

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -3,7 +3,7 @@ For more detailed information, please see the git log.
 
 These release notes can also be consulted at https://easybuild.readthedocs.io/en/latest/Release_notes.html.
 
-v3.5.0 (December 12th 2017)
+v3.5.0 (December 15th 2017)
 ---------------------------
 
 feature release

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -3,6 +3,18 @@ For more detailed information, please see the git log.
 
 These release notes can also be consulted at https://easybuild.readthedocs.io/en/latest/Release_notes.html.
 
+v3.5.1 (January 16th 2018)
+--------------------------
+
+bugfix release
+- various enhancements, including:
+  - add definition of giolfc toolchain (#2359)
+  - add support for Environment Modules 4 (#2365)
+- various bug fixes, including:
+  - install SQLAlchemy < 1.2.0 with Python 2.6 in Travis config (#2367)
+  - make code in `tools/job/gc3pie.py` forward-compatible with GC3Pie 2.5 (#2373)
+
+
 v3.5.0 (December 15th 2017)
 ---------------------------
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -8,6 +8,7 @@ v3.5.0 (December 12th 2017)
 
 feature release
 - add support for implementing pre- and post-step hooks (#2343)
+  - documentation available at http://easybuild.readthedocs.io/en/latest/Hooks.html
 - various enhancements, including:
   - add support for foss-like toolchain with Spectrum MPI: gsolf (#2329)
   - add support for --preview-pr (#2331, #2337, #2348)

--- a/easybuild/__init__.py
+++ b/easybuild/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2011-2017 Ghent University
+# Copyright 2011-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/__init__.py
+++ b/easybuild/framework/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -198,6 +198,9 @@ class EasyBlock(object):
         # list of locations to include in RPATH filter used by toolchain
         self.rpath_filter_dirs = []
 
+        # list of locations to include in RPATH used by toolchain
+        self.rpath_include_dirs = []
+
         # logging
         self.log = None
         self.logfile = None
@@ -1738,8 +1741,15 @@ class EasyBlock(object):
         if not self.build_in_installdir:
             self.rpath_filter_dirs.append(self.builddir)
 
+        # always include self.installdir+'/lib' and self.installdir+'/lib64' and $ORIGIN
+        # $ORIGIN will be resolved by the loader to be the full path to the executable or shared object
+        # see also https://linux.die.net/man/8/ld-linux;
+        self.rpath_include_dirs.append(self.installdir+'/lib')
+        self.rpath_include_dirs.append(self.installdir+'/lib64')
+        self.rpath_include_dirs.append('$ORIGIN')
+
         # prepare toolchain: load toolchain module and dependencies, set up build environment
-        self.toolchain.prepare(self.cfg['onlytcmod'], silent=self.silent, rpath_filter_dirs=self.rpath_filter_dirs)
+        self.toolchain.prepare(self.cfg['onlytcmod'], silent=self.silent, rpath_filter_dirs=self.rpath_filter_dirs, rpath_include_dirs=self.rpath_include_dirs)
 
         # handle allowed system dependencies
         for (name, version) in self.cfg['allow_system_deps']:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1749,7 +1749,8 @@ class EasyBlock(object):
         self.rpath_include_dirs.append('$ORIGIN')
 
         # prepare toolchain: load toolchain module and dependencies, set up build environment
-        self.toolchain.prepare(self.cfg['onlytcmod'], silent=self.silent, rpath_filter_dirs=self.rpath_filter_dirs, rpath_include_dirs=self.rpath_include_dirs)
+        self.toolchain.prepare(self.cfg['onlytcmod'], silent=self.silent, rpath_filter_dirs=self.rpath_filter_dirs, 
+                               rpath_include_dirs=self.rpath_include_dirs)
 
         # handle allowed system dependencies
         for (name, version) in self.cfg['allow_system_deps']:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1179,13 +1179,10 @@ class EasyBlock(object):
             if user_modpath:
                 # If a mod_path_suffix is being used, we should respect it
                 mod_path_suffix = build_option('suffix_modules_path')
-                # Use arch env if required
-                arch_env_name = build_option('subdir_arch_env')
                 user_modpath_exts = ActiveMNS().det_user_modpath_extensions(self.cfg)
                 self.log.debug("Including user module path extensions returned by naming scheme: %s", user_modpath_exts)
                 txt += self.module_generator.use(user_modpath_exts, prefix=self.module_generator.getenv_cmd('HOME'),
-                     guarded=True, user_modpath=user_modpath, mod_path_suffix=mod_path_suffix,
-                     arch_env_name=arch_env_name)
+                     guarded=True, user_modpath=user_modpath, mod_path_suffix=mod_path_suffix)
         else:
             self.log.debug("Not including module path extensions, as specified.")
         return txt

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -72,7 +72,9 @@ from easybuild.tools.filetools import adjust_permissions, apply_patch, back_up_f
 from easybuild.tools.filetools import compute_checksum, copy_file, derive_alt_pypi_url, diff_files, download_file
 from easybuild.tools.filetools import encode_class_name, extract_file, is_alt_pypi_url, mkdir, move_logs, read_file
 from easybuild.tools.filetools import remove_file, rmtree2, verify_checksum, weld_paths, write_file
-from easybuild.tools.hooks import run_hook
+from easybuild.tools.hooks import BUILD_STEP, CLEANUP_STEP, CONFIGURE_STEP, EXTENSIONS_STEP, FETCH_STEP, INSTALL_STEP
+from easybuild.tools.hooks import MODULE_STEP, PACKAGE_STEP, PATCH_STEP, PERMISSIONS_STEP, POSTPROC_STEP, PREPARE_STEP
+from easybuild.tools.hooks import READY_STEP, SANITYCHECK_STEP, SOURCE_STEP, TEST_STEP, TESTCASES_STEP, run_hook
 from easybuild.tools.run import run_cmd
 from easybuild.tools.jenkins import write_to_xml
 from easybuild.tools.module_generator import ModuleGeneratorLua, ModuleGeneratorTcl, module_generator, dependencies_for
@@ -87,23 +89,6 @@ from easybuild.tools.systemtools import det_parallelism, use_group
 from easybuild.tools.utilities import quote_str, remove_unwanted_chars, trace_msg
 from easybuild.tools.version import this_is_easybuild, VERBOSE_VERSION, VERSION
 
-
-BUILD_STEP = 'build'
-CLEANUP_STEP = 'cleanup'
-CONFIGURE_STEP = 'configure'
-EXTENSIONS_STEP = 'extensions'
-FETCH_STEP = 'fetch'
-MODULE_STEP = 'module'
-PACKAGE_STEP = 'package'
-PATCH_STEP = 'patch'
-PERMISSIONS_STEP = 'permissions'
-POSTPROC_STEP = 'postproc'
-PREPARE_STEP = 'prepare'
-READY_STEP = 'ready'
-SANITYCHECK_STEP = 'sanitycheck'
-SOURCE_STEP = 'source'
-TEST_STEP = 'test'
-TESTCASES_STEP = 'testcases'
 
 MODULE_ONLY_STEPS = [MODULE_STEP, PREPARE_STEP, READY_STEP, SANITYCHECK_STEP]
 
@@ -2529,7 +2514,7 @@ class EasyBlock(object):
             (False, lambda x: x.make_installdir),
             (True, lambda x: x.install_step),
         ]
-        install_step_spec = lambda initial: get_step('install', "installing", install_substeps, True, initial=initial)
+        install_step_spec = lambda init: get_step(INSTALL_STEP, "installing", install_substeps, True, initial=init)
 
         # format for step specifications: (stop_name: (description, list of functions, skippable))
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1726,12 +1726,14 @@ class EasyBlock(object):
         if not self.build_in_installdir:
             self.rpath_filter_dirs.append(self.builddir)
 
-        # always include self.installdir+'/lib' and self.installdir+'/lib64' and $ORIGIN
+        # always include '<installdir>/lib', '<installdir>/lib64', $ORIGIN, $ORIGIN/../lib and $ORIGIN/../lib64
         # $ORIGIN will be resolved by the loader to be the full path to the executable or shared object
         # see also https://linux.die.net/man/8/ld-linux;
-        self.rpath_include_dirs.append(self.installdir+'/lib')
-        self.rpath_include_dirs.append(self.installdir+'/lib64')
+        self.rpath_include_dirs.append(os.path.join(self.installdir, 'lib'))
+        self.rpath_include_dirs.append(os.path.join(self.installdir, 'lib64'))
         self.rpath_include_dirs.append('$ORIGIN')
+        self.rpath_include_dirs.append('$ORIGIN/../lib')
+        self.rpath_include_dirs.append('$ORIGIN/../lib64')
 
         # prepare toolchain: load toolchain module and dependencies, set up build environment
         self.toolchain.prepare(self.cfg['onlytcmod'], silent=self.silent, rpath_filter_dirs=self.rpath_filter_dirs, 

--- a/easybuild/framework/easyconfig/__init__.py
+++ b/easybuild/framework/easyconfig/__init__.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/constants.py
+++ b/easybuild/framework/easyconfig/constants.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/format/__init__.py
+++ b/easybuild/framework/easyconfig/format/__init__.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/format/convert.py
+++ b/easybuild/framework/easyconfig/format/convert.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/format/format.py
+++ b/easybuild/framework/easyconfig/format/format.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/format/two.py
+++ b/easybuild/framework/easyconfig/format/two.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/format/version.py
+++ b/easybuild/framework/easyconfig/format/version.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/format/yeb.py
+++ b/easybuild/framework/easyconfig/format/yeb.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/licenses.py
+++ b/easybuild/framework/easyconfig/licenses.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/style.py
+++ b/easybuild/framework/easyconfig/style.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2016-2017 Ghent University
+# Copyright 2016-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -32,7 +32,7 @@ from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extension import Extension
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import apply_patch, extract_file
+from easybuild.tools.filetools import apply_patch, change_dir, extract_file
 from easybuild.tools.utilities import remove_unwanted_chars
 
 
@@ -100,6 +100,10 @@ class ExtensionEasyBlock(EasyBlock, Extension):
         if unpack_src:
             targetdir = os.path.join(self.master.builddir, remove_unwanted_chars(self.name))
             self.ext_dir = extract_file("%s" % self.src, targetdir, extra_options=self.unpack_options)
+
+            if self.cfg['start_dir'] and os.path.isdir(self.cfg['start_dir']):
+                self.log.debug("Using start_dir: %s", self.cfg['start_dir'])
+                change_dir(self.cfg['start_dir'])
 
         # patch if needed
         if self.patches:

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of the University of Ghent (http://ugent.be/hpc).

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -81,8 +81,8 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             # name and version properties of EasyBlock are used, so make sure name and version are correct
             self.cfg['name'] = self.ext.get('name', None)
             self.cfg['version'] = self.ext.get('version', None)
-            # We cannot inherit the start_dir from the easyconfig. It should be specified in the extension
-            # itself or be empty.
+            # We can't inherit the 'start_dir' value from the parent (which will be set, and will most likely be wrong).
+            # It should be specified for the extension specifically, or be empty (so it is auto-derived).
             self.cfg['start_dir'] = self.ext.get('options', {}).get('start_dir', None)
             self.builddir = self.master.builddir
             self.installdir = self.master.installdir

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -81,6 +81,7 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             # name and version properties of EasyBlock are used, so make sure name and version are correct
             self.cfg['name'] = self.ext.get('name', None)
             self.cfg['version'] = self.ext.get('version', None)
+            self.cfg['start_dir'] = self.ext.get('options', {}).get('start_dir', None)
             self.builddir = self.master.builddir
             self.installdir = self.master.installdir
             self.modules_tool = self.master.modules_tool

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -102,9 +102,9 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             targetdir = os.path.join(self.master.builddir, remove_unwanted_chars(self.name))
             self.ext_dir = extract_file("%s" % self.src, targetdir, extra_options=self.unpack_options)
 
-            if self.cfg['start_dir'] and os.path.isdir(self.cfg['start_dir']):
-                self.log.debug("Using start_dir: %s", self.cfg['start_dir'])
-                change_dir(self.cfg['start_dir'])
+            if self.start_dir and os.path.isdir(self.start_dir]):
+                self.log.debug("Using start_dir: %s", self.start_dir)
+                change_dir(self.start_dir)
 
         # patch if needed
         if self.patches:

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -81,6 +81,8 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             # name and version properties of EasyBlock are used, so make sure name and version are correct
             self.cfg['name'] = self.ext.get('name', None)
             self.cfg['version'] = self.ext.get('version', None)
+            # We cannot inherit the start_dir from the easyconfig. It should be specified in the extension
+            # itself or be empty.
             self.cfg['start_dir'] = self.ext.get('options', {}).get('start_dir', None)
             self.builddir = self.master.builddir
             self.installdir = self.master.installdir

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -104,7 +104,7 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             targetdir = os.path.join(self.master.builddir, remove_unwanted_chars(self.name))
             self.ext_dir = extract_file("%s" % self.src, targetdir, extra_options=self.unpack_options)
 
-            if self.start_dir and os.path.isdir(self.start_dir]):
+            if self.start_dir and os.path.isdir(self.start_dir):
                 self.log.debug("Using start_dir: %s", self.start_dir)
                 change_dir(self.start_dir)
 

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -467,7 +467,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     # build software, will exit when errors occurs (except when testing)
     if not testing or (testing and do_build):
         exit_on_failure = not options.dump_test_report and not options.upload_test_report
-        hooks = load_hooks(build_option('hooks'))
+        hooks = load_hooks(options.hooks)
 
         ecs_with_res = build_and_install_software(ordered_ecs, init_session_state, hooks=hooks,
                                                   exit_on_failure=exit_on_failure)

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -61,7 +61,7 @@ from easybuild.tools.docs import list_software
 from easybuild.tools.filetools import adjust_permissions, cleanup, write_file
 from easybuild.tools.github import check_github, find_easybuild_easyconfig, install_github_token
 from easybuild.tools.github import new_pr, merge_pr, update_pr
-from easybuild.tools.hooks import load_hooks, run_hook
+from easybuild.tools.hooks import START, END, load_hooks, run_hook
 from easybuild.tools.modules import modules_tool
 from easybuild.tools.options import parse_external_modules_metadata, process_software_build_specs, use_color
 from easybuild.tools.robot import check_conflicts, det_robot_path, dry_run, resolve_dependencies, search_easyconfigs
@@ -119,7 +119,7 @@ def build_and_install_software(ecs, init_session_state, exit_on_failure=True, ho
     # e.g. via easyconfig.handle_allowed_system_deps
     init_env = copy.deepcopy(os.environ)
 
-    run_hook('start', hooks)
+    run_hook(START, hooks)
 
     res = []
     for ec in ecs:
@@ -164,7 +164,7 @@ def build_and_install_software(ecs, init_session_state, exit_on_failure=True, ho
 
         res.append((ec, ec_res))
 
-    run_hook('end', hooks)
+    run_hook(END, hooks)
 
     return res
 
@@ -466,7 +466,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
 
     # build software, will exit when errors occurs (except when testing)
     if not testing or (testing and do_build):
-        exit_on_failure = not options.dump_test_report and not options.upload_test_report
+        exit_on_failure = not (options.dump_test_report or options.upload_test_report)
         hooks = load_hooks(options.hooks)
 
         ecs_with_res = build_and_install_software(ordered_ecs, init_session_state,

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -105,14 +105,14 @@ def find_easyconfigs_by_specs(build_specs, robot_path, try_to_generate, testing=
     return [(ec_file, generated)]
 
 
-def build_and_install_software(ecs, init_session_state, hooks=None, exit_on_failure=True):
+def build_and_install_software(ecs, init_session_state, exit_on_failure=True, hooks=None):
     """
     Build and install software for all provided parsed easyconfig files.
 
     :param ecs: easyconfig files to install software with
     :param init_session_state: initial session state, to use in test reports
-    :param hooks: list of defined pre- and post-step hooks
     :param exit_on_failure: whether or not to exit on installation failure
+    :param hooks: list of defined pre- and post-step hooks
     """
     # obtain a copy of the starting environment so each build can start afresh
     # we shouldn't use the environment from init_session_state, since relevant env vars might have been set since
@@ -469,8 +469,8 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
         exit_on_failure = not options.dump_test_report and not options.upload_test_report
         hooks = load_hooks(options.hooks)
 
-        ecs_with_res = build_and_install_software(ordered_ecs, init_session_state, hooks=hooks,
-                                                  exit_on_failure=exit_on_failure)
+        ecs_with_res = build_and_install_software(ordered_ecs, init_session_state,
+                                                  exit_on_failure=exit_on_failure, hooks=hooks)
     else:
         ecs_with_res = [(ec, {}) for ec in ordered_ecs]
 

--- a/easybuild/scripts/add_header.py
+++ b/easybuild/scripts/add_header.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC-UGent team.

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -705,6 +705,9 @@ def stage2(tmpdir, templates, install_path, distribute_egg_dir, sourcepath):
     from easybuild.main import main as easybuild_main
     easybuild_main()
 
+    if print_debug:
+        os.environ['EASYBUILD_DEBUG'] = '1'
+
     # make sure the EasyBuild module was actually installed
     # EasyBuild configuration options that are picked up from configuration files/environment may break the bootstrap,
     # for example by having $EASYBUILD_VERSION defined or via a configuration file specifies a value for 'stop'...

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -249,16 +249,18 @@ def check_module_command(tmpdir):
 
     # order matters, which is why we don't use a dict
     known_module_commands = [
-        ('modulecmd.tcl', 'EnvironmentModules'),
         ('lmod', 'Lmod'),
         ('modulecmd', 'EnvironmentModulesC'),
-        ('modulecmd.tcl', 'EnvironmentModulesTcl'),
+        ('modulecmd.tcl', 'EnvironmentModules'),
     ]
     out = os.path.join(tmpdir, 'module_command.out')
     modtool = None
     for modcmd, modtool in known_module_commands:
         if check_cmd_help(modcmd):
-            easybuild_modules_tool = modtool
+            if 'MODULESHOME' in os.environ:
+                easybuild_modules_tool = 'EnvironmentModules'
+            else:
+                easybuild_modules_tool = 'EnvironmentModulesTcl'
             info("Found module command '%s' (%s), so using it." % (modcmd, modtool))
             break
         elif modcmd == 'lmod':

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -53,7 +53,7 @@ from distutils.version import LooseVersion
 from hashlib import md5
 
 
-EB_BOOTSTRAP_VERSION = '20180117.01'
+EB_BOOTSTRAP_VERSION = '20180201.01'
 
 # argparse preferrred, optparse deprecated >=2.7
 HAVE_ARGPARSE = False

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -53,7 +53,7 @@ from distutils.version import LooseVersion
 from hashlib import md5
 
 
-EB_BOOTSTRAP_VERSION = '20170808.01'
+EB_BOOTSTRAP_VERSION = '20180105.01'
 
 # argparse preferrred, optparse deprecated >=2.7
 HAVE_ARGPARSE = False
@@ -240,7 +240,7 @@ def check_module_command(tmpdir):
 
     def check_cmd_help(modcmd):
         """Check 'help' output for specified command."""
-        modcmd_re = re.compile(r'module\s.*command\s')
+        modcmd_re = re.compile(r'module\s.*command')
         cmd = "%s python help" % modcmd
         os.system("%s > %s 2>&1" % (cmd, out))
         txt = open(out, 'r').read()
@@ -249,6 +249,7 @@ def check_module_command(tmpdir):
 
     # order matters, which is why we don't use a dict
     known_module_commands = [
+        ('modulecmd.tcl', 'EnvironmentModules'),
         ('lmod', 'Lmod'),
         ('modulecmd', 'EnvironmentModulesC'),
         ('modulecmd.tcl', 'EnvironmentModulesTcl'),
@@ -266,6 +267,14 @@ def check_module_command(tmpdir):
             if modcmd and check_cmd_help(modcmd):
                 easybuild_modules_tool = modtool
                 info("Found module command '%s' via $LMOD_CMD (%s), so using it." % (modcmd, modtool))
+                break
+        elif modtool == 'EnvironmentModules':
+            # check value of $MODULESHOME as fallback
+            moduleshome = os.environ.get('MODULESHOME', 'MODULESHOME_NOT_DEFINED')
+            modcmd = os.path.join(moduleshome, 'libexec', 'modulecmd.tcl')
+            if os.path.exists(modcmd) and check_cmd_help(modcmd):
+                easybuild_modules_tool = modtool
+                info("Found module command '%s' via $MODULESHOME (%s), so using it." % (modcmd, modtool))
                 break
 
     if easybuild_modules_tool is None:

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -53,7 +53,7 @@ from distutils.version import LooseVersion
 from hashlib import md5
 
 
-EB_BOOTSTRAP_VERSION = '20180105.01'
+EB_BOOTSTRAP_VERSION = '20180117.01'
 
 # argparse preferrred, optparse deprecated >=2.7
 HAVE_ARGPARSE = False

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -247,6 +247,15 @@ def check_module_command(tmpdir):
         debug("Output from %s: %s" % (cmd, txt))
         return modcmd_re.search(txt)
 
+    def is_modulecmd_tcl_modulestcl():
+        """Determine if modulecmd.tcl is EnvironmentModulesTcl."""
+        modcmd_re = re.compile('Modules Release Tcl')
+        cmd = "modulecmd.tcl python --version"
+        os.system("%s > %s 2>&1" % (cmd, out))
+        txt = open(out, 'r').read()
+        debug("Output from %s: %s" % (cmd, txt))
+        return modcmd_re.search(txt)
+
     # order matters, which is why we don't use a dict
     known_module_commands = [
         ('lmod', 'Lmod'),
@@ -257,10 +266,10 @@ def check_module_command(tmpdir):
     modtool = None
     for modcmd, modtool in known_module_commands:
         if check_cmd_help(modcmd):
-            if 'MODULESHOME' in os.environ:
-                easybuild_modules_tool = 'EnvironmentModules'
-            else:
-                easybuild_modules_tool = 'EnvironmentModulesTcl'
+            # distinguish between EnvironmentModulesTcl and EnvironmentModules
+            if modcmd == 'modulecmd.tcl' and is_modulecmd_tcl_modulestcl():
+                modtool = 'EnvironmentModulesTcl'
+            easybuild_modules_tool = modtool
             info("Found module command '%s' (%s), so using it." % (modcmd, modtool))
             break
         elif modcmd == 'lmod':

--- a/easybuild/scripts/fix_broken_easyconfigs.py
+++ b/easybuild/scripts/fix_broken_easyconfigs.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/scripts/fix_docs.py
+++ b/easybuild/scripts/fix_docs.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2016-2017 Ghent University
+# Copyright 2016-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/scripts/generate_software_list.py
+++ b/easybuild/scripts/generate_software_list.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of the University of Ghent (http://ugent.be/hpc).

--- a/easybuild/scripts/install-EasyBuild-develop.sh
+++ b/easybuild/scripts/install-EasyBuild-develop.sh
@@ -28,11 +28,20 @@ github_clone_branch()
     echo "=== Cloning ${GITHUB_USERNAME}/${REPO} ..."
     git clone --branch "${BRANCH}" "git@github.com:${GITHUB_USERNAME}/${REPO}.git"
 
-    echo "=== Adding and fetching HPC-UGent GitHub repository @ easybuilders/${REPO} ..."
-    cd "${REPO}"
-    git remote add "github_easybuilders" "git@github.com/easybuilders/${REPO}.git"
-    git fetch github_easybuilders
-    git branch --set-upstream "${BRANCH}" "github_easybuilders/${BRANCH}"
+    if [[ "$REPO" == "vsc"* ]]
+    then
+	echo "=== Adding and fetching HPC-UGent GitHub repository @ hpcugent/${REPO} ..."
+	cd "${REPO}"
+	git remote add "github_hpcugent" "git@github.com:hpcugent/${REPO}.git"
+	git fetch github_hpcugent
+	git branch --set-upstream "${BRANCH}" "github_hpcugent/${BRANCH}"
+    else
+	echo "=== Adding and fetching EasyBuilders GitHub repository @ easybuilders/${REPO} ..."
+	cd "${REPO}"
+	git remote add "github_easybuilders" "git@github.com:easybuilders/${REPO}.git"
+	git fetch github_easybuilders
+	git branch --set-upstream "${BRANCH}" "github_easybuilders/${BRANCH}"
+    fi
 }
 
 # Print the content of the module
@@ -116,7 +125,7 @@ github_clone_branch "easybuild-easyconfigs" "develop"
 github_clone_branch "easybuild" "develop"
 
 # Clone wiki repository with the 'master' branch
-github_clone_branch "easybuild-wiki" "master"
+#github_clone_branch "easybuild-wiki" "master"
 
 # Create the module file
 EB_DEVEL_MODULE_NAME="EasyBuild-develop"

--- a/easybuild/scripts/install_eb_dep.sh
+++ b/easybuild/scripts/install_eb_dep.sh
@@ -15,11 +15,16 @@ PKG_VERSION=`echo $PKG | sed 's/.*-//g'`
 CONFIG_OPTIONS=
 PRECONFIG_CMD=
 
-if [ x$PKG_NAME == 'xmodules' ]; then
+if [ x$PKG_NAME == 'xmodules' ] && [ x$PKG_VERSION == 'x3.2.10' ]; then
     PKG_URL="http://prdownloads.sourceforge.net/modules/${PKG}.tar.gz"
     BACKUP_PKG_URL="https://easybuilders.github.io/easybuild/files/${PKG}.tar.gz"
     export PATH=$PREFIX/Modules/$PKG_VERSION/bin:$PATH
     export MOD_INIT=$HOME/Modules/$PKG_VERSION/init/bash
+
+elif [ x$PKG_NAME == 'xmodules' ]; then
+    PKG_URL="http://prdownloads.sourceforge.net/modules/${PKG}.tar.gz"
+    export PATH=$PREFIX/bin:$PATH
+    export MOD_INIT=$HOME/init/bash
 
 elif [ x$PKG_NAME == 'xlua' ]; then
     PKG_URL="http://downloads.sourceforge.net/project/lmod/${PKG}.tar.gz"
@@ -55,7 +60,7 @@ fi
 set -e
 
 # environment-modules needs a patch to work with Tcl8.6
-if [ x$PKG_NAME == 'xmodules' ]; then
+if [ x$PKG_NAME == 'xmodules' ] && [ x$PKG_VERSION == 'x3.2.10' ]; then
     wget -O 'modules-tcl8.6.patch' 'https://easybuilders.github.io/easybuild/files/modules-3.2.10-tcl8.6.patch'
     patch ${PKG}/cmdModule.c modules-tcl8.6.patch
 fi

--- a/easybuild/scripts/mk_tmpl_easyblock_for.py
+++ b/easybuild/scripts/mk_tmpl_easyblock_for.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/scripts/port_easyblock.py
+++ b/easybuild/scripts/port_easyblock.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/scripts/prep_for_release.py
+++ b/easybuild/scripts/prep_for_release.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/scripts/repo_setup.py
+++ b/easybuild/scripts/repo_setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -53,7 +53,10 @@ if rpath_filter:
 else:
     rpath_filter = None
 
-rpath_include = rpath_include.split(',')
+if not rpath_include:
+    rpath_include = []
+else:
+    rpath_include = rpath_include.split(',')
 
 version_mode = False
 cmd_args, cmd_args_rpath = [], []
@@ -110,8 +113,9 @@ while idx < len(args):
 cmd_args = cmd_args_rpath + cmd_args
 
 cmd_args_rpath = []
-for path in rpath_include:
-    cmd_args_rpath.append(flag_prefix + '-rpath=%s' % path)
+if rpath_include:
+    for path in rpath_include:
+        cmd_args_rpath.append(flag_prefix + '-rpath=%s' % path)
 
 
 if not version_mode:

--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -38,7 +38,8 @@ import sys
 
 cmd = sys.argv[1]
 rpath_filter = sys.argv[2]
-args = sys.argv[3:]
+rpath_include = sys.argv[3]
+args = sys.argv[4:]
 
 # wheter or not to use -Wl to pass options to the linker
 if cmd in ['ld', 'ld.gold', 'ld.bfd']:
@@ -51,6 +52,8 @@ if rpath_filter:
     rpath_filter = re.compile('^%s$' % '|'.join(rpath_filter))
 else:
     rpath_filter = None
+
+rpath_include = rpath_include.split(',')
 
 version_mode = False
 cmd_args, cmd_args_rpath = [], []
@@ -106,13 +109,13 @@ while idx < len(args):
 # add -rpath flags in front
 cmd_args = cmd_args_rpath + cmd_args
 
+cmd_args_rpath = []
+for path in rpath_include:
+    cmd_args_rpath.append(flag_prefix + '-rpath=%s' % path)
+
+
 if not version_mode:
-    cmd_args = [
-        # always include '$ORIGIN/../lib' and '$ORIGIN/../lib64'
-        # $ORIGIN will be resolved by the loader to be the full path to the 'executable'
-        # see also https://linux.die.net/man/8/ld-linux;
-        flag_prefix + '-rpath=$ORIGIN/../lib',
-        flag_prefix + '-rpath=$ORIGIN/../lib64',
+    cmd_args = cmd_args_rpath + [
         # try to make sure that RUNPATH is not used by always injecting --disable-new-dtags
         flag_prefix + '--disable-new-dtags',
     ] + cmd_args

--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -53,10 +53,10 @@ if rpath_filter:
 else:
     rpath_filter = None
 
-if not rpath_include:
-    rpath_include = []
-else:
+if rpath_include:
     rpath_include = rpath_include.split(',')
+else:
+    rpath_include = []
 
 version_mode = False
 cmd_args, cmd_args_rpath = [], []
@@ -112,11 +112,7 @@ while idx < len(args):
 # add -rpath flags in front
 cmd_args = cmd_args_rpath + cmd_args
 
-cmd_args_rpath = []
-if rpath_include:
-    for path in rpath_include:
-        cmd_args_rpath.append(flag_prefix + '-rpath=%s' % path)
-
+cmds_args_rpath = [flag_prefix + '-rpath=%s' % inc for inc in rpath_include]
 
 if not version_mode:
     cmd_args = cmd_args_rpath + [

--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -112,7 +112,7 @@ while idx < len(args):
 # add -rpath flags in front
 cmd_args = cmd_args_rpath + cmd_args
 
-cmds_args_rpath = [flag_prefix + '-rpath=%s' % inc for inc in rpath_include]
+cmd_args_rpath = [flag_prefix + '-rpath=%s' % inc for inc in rpath_include]
 
 if not version_mode:
     cmd_args = cmd_args_rpath + [

--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 ##
-# Copyright 2016-2017 Ghent University
+# Copyright 2016-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/scripts/rpath_wrapper_template.sh.in
+++ b/easybuild/scripts/rpath_wrapper_template.sh.in
@@ -46,8 +46,8 @@ CMD=`basename $0`
 log "found CMD: $CMD | original command: %(orig_cmd)s | orig args: '$(echo \"$@\")'"
 
 # rpath_args.py script spits out statement that defines $CMD_ARGS
-log "%(python)s -O %(rpath_args_py)s $CMD '%(rpath_filter)s' $(echo \"$@\")'"
-rpath_args_out=$(%(python)s -O %(rpath_args_py)s $CMD '%(rpath_filter)s' "$@")
+log "%(python)s -O %(rpath_args_py)s $CMD '%(rpath_filter)s' '%(rpath_include)s' $(echo \"$@\")'"
+rpath_args_out=$(%(python)s -O %(rpath_args_py)s $CMD '%(rpath_filter)s' '%(rpath_include)s' "$@")
 
 log "rpath_args_out:
 $rpath_args_out"

--- a/easybuild/toolchains/__init__.py
+++ b/easybuild/toolchains/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/cgmpich.py
+++ b/easybuild/toolchains/cgmpich.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is triple-licensed under GPLv2 (see below), MIT, and
 # BSD three-clause licenses.

--- a/easybuild/toolchains/cgmpolf.py
+++ b/easybuild/toolchains/cgmpolf.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is triple-licensed under GPLv2 (see below), MIT, and
 # BSD three-clause licenses.

--- a/easybuild/toolchains/cgmvapich2.py
+++ b/easybuild/toolchains/cgmvapich2.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is triple-licensed under GPLv2 (see below), MIT, and
 # BSD three-clause licenses.

--- a/easybuild/toolchains/cgmvolf.py
+++ b/easybuild/toolchains/cgmvolf.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is triple-licensed under GPLv2 (see below), MIT, and
 # BSD three-clause licenses.

--- a/easybuild/toolchains/cgompi.py
+++ b/easybuild/toolchains/cgompi.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is triple-licensed under GPLv2 (see below), MIT, and
 # BSD three-clause licenses.

--- a/easybuild/toolchains/cgoolf.py
+++ b/easybuild/toolchains/cgoolf.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is triple-licensed under GPLv2 (see below), MIT, and
 # BSD three-clause licenses.

--- a/easybuild/toolchains/clanggcc.py
+++ b/easybuild/toolchains/clanggcc.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is triple-licensed under GPLv2 (see below), MIT, and
 # BSD three-clause licenses.

--- a/easybuild/toolchains/compiler/__init__.py
+++ b/easybuild/toolchains/compiler/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/compiler/clang.py
+++ b/easybuild/toolchains/compiler/clang.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is triple-licensed under GPLv2 (see below), MIT, and
 # BSD three-clause licenses.

--- a/easybuild/toolchains/compiler/craype.py
+++ b/easybuild/toolchains/compiler/craype.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/compiler/cuda.py
+++ b/easybuild/toolchains/compiler/cuda.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/compiler/dummycompiler.py
+++ b/easybuild/toolchains/compiler/dummycompiler.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/craycce.py
+++ b/easybuild/toolchains/craycce.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/craygnu.py
+++ b/easybuild/toolchains/craygnu.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/crayintel.py
+++ b/easybuild/toolchains/crayintel.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/craypgi.py
+++ b/easybuild/toolchains/craypgi.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2014-2015 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/dummy.py
+++ b/easybuild/toolchains/dummy.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/fft/__init__.py
+++ b/easybuild/toolchains/fft/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/fft/fftw.py
+++ b/easybuild/toolchains/fft/fftw.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/foss.py
+++ b/easybuild/toolchains/foss.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gcc.py
+++ b/easybuild/toolchains/gcc.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gcccore.py
+++ b/easybuild/toolchains/gcccore.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gcccuda.py
+++ b/easybuild/toolchains/gcccuda.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gimkl.py
+++ b/easybuild/toolchains/gimkl.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gimpi.py
+++ b/easybuild/toolchains/gimpi.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gimpic.py
+++ b/easybuild/toolchains/gimpic.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gimpic.py
+++ b/easybuild/toolchains/gimpic.py
@@ -1,0 +1,40 @@
+##
+# Copyright 2012-2017 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for gimpic compiler toolchain (includes GCC and IntelMPI and CUDA).
+
+:author: Kenneth Hoste (Ghent University)
+:author: Fotis Georgatos (Uni.Lu, NTUA)
+:author: Ake Sandgren (HPC2N, Umea University)
+"""
+
+from easybuild.toolchains.gcccuda import GccCUDA
+from easybuild.toolchains.mpi.intelmpi import IntelMPI
+
+
+class Gimpic(GccCUDA, IntelMPI):
+    """Compiler toolchain with GCC+CUDA and IntelMPI."""
+    NAME = 'gimpic'
+    SUBTOOLCHAIN = GccCUDA.NAME

--- a/easybuild/toolchains/giolf.py
+++ b/easybuild/toolchains/giolf.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/giolfc.py
+++ b/easybuild/toolchains/giolfc.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/giolfc.py
+++ b/easybuild/toolchains/giolfc.py
@@ -1,0 +1,41 @@
+##
+# Copyright 2013-2017 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for giolfc compiler toolchain (includes GCC+CUDA, IntelMPI, OpenBLAS, LAPACK, ScaLAPACK and FFTW).
+
+:author: Kenneth Hoste (Ghent University)
+:author: Ake Sandgren (HPC2N, Umea University)
+"""
+
+from easybuild.toolchains.gimpic import Gimpic
+from easybuild.toolchains.fft.fftw import Fftw
+from easybuild.toolchains.linalg.openblas import OpenBLAS
+from easybuild.toolchains.linalg.scalapack import ScaLAPACK
+
+class Giolfc(Gimpic, OpenBLAS, ScaLAPACK, Fftw):
+    """Compiler toolchain with GCC+CUDA, IntelMPI, OpenBLAS, ScaLAPACK and FFTW."""
+    NAME = 'giolfc'
+    SUBTOOLCHAIN = Gimpic.NAME
+

--- a/easybuild/toolchains/gmacml.py
+++ b/easybuild/toolchains/gmacml.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gmpich.py
+++ b/easybuild/toolchains/gmpich.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gmpich2.py
+++ b/easybuild/toolchains/gmpich2.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gmpolf.py
+++ b/easybuild/toolchains/gmpolf.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is triple-licensed under GPLv2 (see below), MIT, and
 # BSD three-clause licenses.

--- a/easybuild/toolchains/gmvapich2.py
+++ b/easybuild/toolchains/gmvapich2.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gmvolf.py
+++ b/easybuild/toolchains/gmvolf.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is triple-licensed under GPLv2 (see below), MIT, and
 # BSD three-clause licenses.

--- a/easybuild/toolchains/gnu.py
+++ b/easybuild/toolchains/gnu.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/goalf.py
+++ b/easybuild/toolchains/goalf.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gompi.py
+++ b/easybuild/toolchains/gompi.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gompic.py
+++ b/easybuild/toolchains/gompic.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/goolf.py
+++ b/easybuild/toolchains/goolf.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/goolfc.py
+++ b/easybuild/toolchains/goolfc.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gpsmpi.py
+++ b/easybuild/toolchains/gpsmpi.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gpsolf.py
+++ b/easybuild/toolchains/gpsolf.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is triple-licensed under GPLv2 (see below), MIT, and
 # BSD three-clause licenses.

--- a/easybuild/toolchains/gqacml.py
+++ b/easybuild/toolchains/gqacml.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gsmpi.py
+++ b/easybuild/toolchains/gsmpi.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/gsolf.py
+++ b/easybuild/toolchains/gsolf.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/iccifort.py
+++ b/easybuild/toolchains/iccifort.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/iccifortcuda.py
+++ b/easybuild/toolchains/iccifortcuda.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/ictce.py
+++ b/easybuild/toolchains/ictce.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/iimkl.py
+++ b/easybuild/toolchains/iimkl.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/iimpi.py
+++ b/easybuild/toolchains/iimpi.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/iimpic.py
+++ b/easybuild/toolchains/iimpic.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/iiqmpi.py
+++ b/easybuild/toolchains/iiqmpi.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/impich.py
+++ b/easybuild/toolchains/impich.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/impmkl.py
+++ b/easybuild/toolchains/impmkl.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/intel-para.py
+++ b/easybuild/toolchains/intel-para.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/intel.py
+++ b/easybuild/toolchains/intel.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/intelcuda.py
+++ b/easybuild/toolchains/intelcuda.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/iomkl.py
+++ b/easybuild/toolchains/iomkl.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/iompi.py
+++ b/easybuild/toolchains/iompi.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/ipsmpi.py
+++ b/easybuild/toolchains/ipsmpi.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/iqacml.py
+++ b/easybuild/toolchains/iqacml.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/ismkl.py
+++ b/easybuild/toolchains/ismkl.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/linalg/__init__.py
+++ b/easybuild/toolchains/linalg/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/linalg/acml.py
+++ b/easybuild/toolchains/linalg/acml.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/linalg/atlas.py
+++ b/easybuild/toolchains/linalg/atlas.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/linalg/blacs.py
+++ b/easybuild/toolchains/linalg/blacs.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/linalg/flame.py
+++ b/easybuild/toolchains/linalg/flame.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/linalg/gotoblas.py
+++ b/easybuild/toolchains/linalg/gotoblas.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/linalg/lapack.py
+++ b/easybuild/toolchains/linalg/lapack.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/linalg/libsci.py
+++ b/easybuild/toolchains/linalg/libsci.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/linalg/openblas.py
+++ b/easybuild/toolchains/linalg/openblas.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/linalg/scalapack.py
+++ b/easybuild/toolchains/linalg/scalapack.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/mpi/__init__.py
+++ b/easybuild/toolchains/mpi/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/mpi/craympich.py
+++ b/easybuild/toolchains/mpi/craympich.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/mpi/intelmpi.py
+++ b/easybuild/toolchains/mpi/intelmpi.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/mpi/mpich.py
+++ b/easybuild/toolchains/mpi/mpich.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/mpi/mpich2.py
+++ b/easybuild/toolchains/mpi/mpich2.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/mpi/mvapich2.py
+++ b/easybuild/toolchains/mpi/mvapich2.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/mpi/openmpi.py
+++ b/easybuild/toolchains/mpi/openmpi.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/mpi/psmpi.py
+++ b/easybuild/toolchains/mpi/psmpi.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/mpi/qlogicmpi.py
+++ b/easybuild/toolchains/mpi/qlogicmpi.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/mpi/spectrummpi.py
+++ b/easybuild/toolchains/mpi/spectrummpi.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/pomkl.py
+++ b/easybuild/toolchains/pomkl.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/toolchains/pompi.py
+++ b/easybuild/toolchains/pompi.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/__init__.py
+++ b/easybuild/tools/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/asyncprocess.py
+++ b/easybuild/tools/asyncprocess.py
@@ -1,6 +1,6 @@
 ##
 # Copyright 2005 Josiah Carlson
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # The Asynchronous Python Subprocess recipe was originally created by Josiah Carlson.
 # and released under the GPL v2 on March 14, 2012

--- a/easybuild/tools/build_details.py
+++ b/easybuild/tools/build_details.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -121,7 +121,6 @@ BUILD_OPTIONS_CMDLINE = {
         'force_download',
         'from_pr',
         'git_working_dirs_path',
-        'hooks',
         'github_user',
         'github_org',
         'group',

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -147,7 +147,6 @@ BUILD_OPTIONS_CMDLINE = {
         'skip',
         'stop',
         'subdir_user_modules',
-        'subdir_arch_env',
         'test_report_env_filter',
         'testoutput',
         'umask',

--- a/easybuild/tools/convert.py
+++ b/easybuild/tools/convert.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/deprecated/__init__.py
+++ b/easybuild/tools/deprecated/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/environment.py
+++ b/easybuild/tools/environment.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -42,7 +42,6 @@ import difflib
 import fileinput
 import glob
 import hashlib
-import imp
 import os
 import re
 import shutil

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/hooks.py
+++ b/easybuild/tools/hooks.py
@@ -55,12 +55,19 @@ SOURCE_STEP = 'source'
 TEST_STEP = 'test'
 TESTCASES_STEP = 'testcases'
 
+START = 'start'
+END = 'end'
+
+PRE_PREF = 'pre_'
+POST_PREF = 'post_'
+HOOK_SUFF = '_hook'
+
 # list of names for steps in installation procedure (in order of execution)
 STEP_NAMES = [FETCH_STEP, READY_STEP, SOURCE_STEP, PATCH_STEP, PREPARE_STEP, CONFIGURE_STEP, BUILD_STEP, TEST_STEP,
               INSTALL_STEP, EXTENSIONS_STEP, POSTPROC_STEP, SANITYCHECK_STEP, CLEANUP_STEP, MODULE_STEP,
               PERMISSIONS_STEP, PACKAGE_STEP, TESTCASES_STEP]
 
-KNOWN_HOOKS = ['%s_hook' % h for h in ['start'] + [p + '_' + s for s in STEP_NAMES for p in ['pre', 'post']] + ['end']]
+KNOWN_HOOKS = [h + HOOK_SUFF for h in [START] + [p + s for s in STEP_NAMES for p in [PRE_PREF, POST_PREF]] + [END]]
 
 
 def load_hooks(hooks_path):
@@ -78,7 +85,7 @@ def load_hooks(hooks_path):
                 # import module that defines hooks, and collect all functions of which name ends with '_hook'
                 imported_hooks = imp.load_source(hooks_filename, hooks_path)
                 for attr in dir(imported_hooks):
-                    if attr.endswith('_hook'):
+                    if attr.endswith(HOOK_SUFF):
                         hook = getattr(imported_hooks, attr)
                         if callable(hook):
                             hooks.update({attr: hook})
@@ -133,13 +140,13 @@ def find_hook(label, hooks, pre_step_hook=False, post_step_hook=False):
     res = None
 
     if pre_step_hook:
-        hook_prefix = 'pre_'
+        hook_prefix = PRE_PREF
     elif post_step_hook:
-        hook_prefix = 'post_'
+        hook_prefix = POST_PREF
     else:
         hook_prefix = ''
 
-    hook_name = hook_prefix + label + '_hook'
+    hook_name = hook_prefix + label + HOOK_SUFF
 
     for key in hooks:
         if key == hook_name:

--- a/easybuild/tools/hooks.py
+++ b/easybuild/tools/hooks.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2018-2018 Ghent University
+# Copyright 2017-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/hooks.py
+++ b/easybuild/tools/hooks.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2017-2017 Ghent University
+# Copyright 2018-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/hooks.py
+++ b/easybuild/tools/hooks.py
@@ -114,7 +114,7 @@ def verify_hooks(hooks):
             if close_matching_hooks:
                 error_lines[-1] += " (did you mean %s?)" % ', or '.join("'%s'" % h for h in close_matching_hooks)
 
-        error_lines.extend(['', "List of known hooks: %s" % ', '.join(KNOWN_HOOKS)])
+        error_lines.extend(['', "Run 'eb --avail-hooks' to get an overview of known hooks"])
 
         raise EasyBuildError('\n'.join(error_lines))
     else:

--- a/easybuild/tools/hooks.py
+++ b/easybuild/tools/hooks.py
@@ -31,6 +31,8 @@ import imp
 import os
 from vsc.utils import fancylogger
 
+from easybuild.tools.build_log import EasyBuildError
+
 
 _log = fancylogger.getLogger('hooks', fname=False)
 
@@ -38,7 +40,11 @@ _log = fancylogger.getLogger('hooks', fname=False)
 def load_hooks(hooks_path):
     """Load defined hooks (if any)."""
     hooks = []
+
     if hooks_path:
+        if not os.path.exists(hooks_path):
+            raise EasyBuildError("Specified path for hooks implementation does not exist: %s", hooks_path)
+
         (hooks_dir, hooks_filename) = os.path.split(hooks_path)
         (hooks_mod_name, hooks_file_ext) = os.path.splitext(hooks_filename)
         if hooks_file_ext == '.py':

--- a/easybuild/tools/include.py
+++ b/easybuild/tools/include.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # #
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/jenkins.py
+++ b/easybuild/tools/jenkins.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/job/__init__.py
+++ b/easybuild/tools/job/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2011-2017 Ghent University
+# Copyright 2011-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/job/backend.py
+++ b/easybuild/tools/job/backend.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/job/gc3pie.py
+++ b/easybuild/tools/job/gc3pie.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2018 Ghent University
 # Copyright 2015 S3IT, University of Zurich
 #
 # This file is part of EasyBuild,

--- a/easybuild/tools/job/gc3pie.py
+++ b/easybuild/tools/job/gc3pie.py
@@ -219,6 +219,15 @@ class GC3Pie(JobBackend):
         # see https://gc3pie.readthedocs.org/en/latest/programmers/api/gc3libs/core.html#gc3libs.core.Engine
         self._engine.retrieve_overwrites = True
 
+        # `Engine.stats()` (which is used later on in `_print_status_report()`)
+        # changed between 2.4.2 and 2.5.0.dev -- make sure we stay compatible
+        # with both
+        try:
+            self._engine.init_stats_for(Application)
+        except AttributeError:
+            _log.debug("No `init_stats_for` method in the Engine class;"
+                       " assuming pre-2.5.0 GC3Pie and ignoring error.")
+
         # Add your application to the engine. This will NOT submit
         # your application yet, but will make the engine *aware* of
         # the application.

--- a/easybuild/tools/job/pbs_python.py
+++ b/easybuild/tools/job/pbs_python.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/module_naming_scheme/__init__.py
+++ b/easybuild/tools/module_naming_scheme/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2011-2017 Ghent University
+# Copyright 2011-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/module_naming_scheme/categorized_mns.py
+++ b/easybuild/tools/module_naming_scheme/categorized_mns.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2016 Ghent University
+# Copyright 2016-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/module_naming_scheme/easybuild_mns.py
+++ b/easybuild/tools/module_naming_scheme/easybuild_mns.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/module_naming_scheme/hierarchical_mns.py
+++ b/easybuild/tools/module_naming_scheme/hierarchical_mns.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/module_naming_scheme/migrate_from_eb_to_hmns.py
+++ b/easybuild/tools/module_naming_scheme/migrate_from_eb_to_hmns.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/module_naming_scheme/mns.py
+++ b/easybuild/tools/module_naming_scheme/mns.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2011-2017 Ghent University
+# Copyright 2011-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/module_naming_scheme/toolchain.py
+++ b/easybuild/tools/module_naming_scheme/toolchain.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/module_naming_scheme/utilities.py
+++ b/easybuild/tools/module_naming_scheme/utilities.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -240,29 +240,23 @@ class ModulesTool(object):
             raise EasyBuildError("Failed to check version: %s", err)
 
         if self.REQ_VERSION is None and self.MAX_VERSION is None:
-                self.log.debug("No version requirement defined.")
-        else:
-            if self.REQ_VERSION is None: # MAX_VERSION is not None
-                self.log.debug("No required minimum version defined.")
-                if StrictVersion(self.version) > StrictVersion(self.MAX_VERSION):
-                    raise EasyBuildError("EasyBuild requires v%s <= v%s (no rc), found v%s",
-                                         self.__class__.__name__, self.version, self.MAX_VERSION)
-                else:
-                    self.log.debug('Version %s matches requirement <= %s' % (self.version, self.MAX_VERSION))
-            elif self.MAX_VERSION is None: # REQ_VERSION is not None
-                self.log.debug("No allowed maximum version defined.")
-                if StrictVersion(self.version) < StrictVersion(self.REQ_VERSION):
-                    raise EasyBuildError("EasyBuild requires v%s >= v%s (no rc), found v%s",
-                                         self.__class__.__name__, self.REQ_VERSION, self.version)
-                else:
-                    self.log.debug('Version %s matches requirement >= %s' % (self.version, self.REQ_VERSION))
+            self.log.debug("No version requirement defined.")
+
+        if self.REQ_VERSION is not None:
+            self.log.debug("Required minimum version defined.")
+            if StrictVersion(self.version) < StrictVersion(self.REQ_VERSION):
+                raise EasyBuildError("EasyBuild requires v%s >= v%s, found v%s",
+                                     self.__class__.__name__, self.version, self.REQ_VERSION)
             else:
-                self.log.debug("Required minimum version and maximum allowed version defined.")
-                # Check that we have not made a mistake and set REQ_VERSION > MAX_VERSION
-                if StrictVersion(self.REQ_VERSION) > StrictVersion(self.MAX_VERSION):
-                    raise EasyBuildError("v%s, REQ_VERSION must be <= MAX_VERSION", self.__class__)
-                else:
-                    self.log.debug('Version %s matches requirements >= %s, <= %s' % (self.version, self.REQ_VERSION, self.MAX_VERSION))
+                self.log.debug('Version %s matches requirement >= %s', self.version, self.REQ_VERSION)
+
+        if self.MAX_VERSION is not None:
+            self.log.debug("Maximum allowed version defined.")
+            if StrictVersion(self.version) > StrictVersion(self.MAX_VERSION):
+                raise EasyBuildError("EasyBuild requires v%s <= v%s, found v%s",
+                                     self.__class__.__name__, self.version, self.MAX_VERSION)
+            else:
+                self.log.debug('Version %s matches requirement <= %s', self.version, self.MAX_VERSION)
 
         MODULE_VERSION_CACHE[self.COMMAND] = self.version
 
@@ -1015,18 +1009,12 @@ class EnvironmentModulesC(ModulesTool):
     """Interface to (C) environment modules (modulecmd)."""
     COMMAND = "modulecmd"
     REQ_VERSION = '3.2.10'
-    MAX_VERSION = '3.2.10'
+    MAX_VERSION = '3.99'
     VERSION_REGEXP = r'^\s*(VERSION\s*=\s*)?(?P<version>\d\S*)\s*'
 
     def update(self):
         """Update after new modules were added."""
         pass
-
-class EnvironmentModules4(EnvironmentModulesC):
-    """Interface to environment modules 4+."""
-    REQ_VERSION = '4.0.0'
-    MAX_VERSION = None
-    VERSION_REGEXP = r'^Modules\s+Release\s+(?P<version>\d\S*)\s'
 
 class EnvironmentModulesTcl(EnvironmentModulesC):
     """Interface to (Tcl) environment modules (modulecmd.tcl)."""

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1090,11 +1090,12 @@ class EnvironmentModulesTcl(EnvironmentModulesC):
 
 class EnvironmentModules(EnvironmentModulesTcl):
     """Interface to environment modules 4.0+"""
-    COMMAND = os.environ['MODULESHOME'] + '/libexec/modulecmd.tcl'
+    COMMAND = os.path.join(os.environ['MODULESHOME'], 'libexec', 'modulecmd.tcl')
     REQ_VERSION = '4.0.0'
     MAX_VERSION = None
     VERSION_REGEXP = r'^Modules\s+Release\s+(?P<version>\d\S*)\s'
-    
+
+
 class Lmod(ModulesTool):
     """Interface to Lmod."""
     COMMAND = 'lmod'

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1026,7 +1026,6 @@ class EnvironmentModulesTcl(EnvironmentModulesC):
     COMMAND_SHELL = ['tclsh']
     VERSION_OPTION = ''
     REQ_VERSION = None
-    MAX_VERSION = '1.923'
     VERSION_REGEXP = r'^Modules\s+Release\s+Tcl\s+(?P<version>\d\S*)\s'
 
     def set_path_env_var(self, key, paths):

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -542,7 +542,7 @@ class ModulesTool(object):
         Purge loaded modules.
         """
         self.log.debug("List of loaded modules before purge: %s" % os.getenv('_LMFILES_'))
-        self.run_module('purge', '')
+        self.run_module('purge')
 
     def show(self, mod_name):
         """

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1090,7 +1090,7 @@ class EnvironmentModulesTcl(EnvironmentModulesC):
 
 class EnvironmentModules(EnvironmentModulesTcl):
     """Interface to environment modules 4.0+"""
-    COMMAND = os.path.join(os.getenv('MODULESHOME'), 'libexec', 'modulecmd.tcl')
+    COMMAND = os.path.join(os.getenv('MODULESHOME', 'MODULESHOME_NOT_DEFINED'), 'libexec', 'modulecmd.tcl')
     REQ_VERSION = '4.0.0'
     MAX_VERSION = None
     VERSION_REGEXP = r'^Modules\s+Release\s+(?P<version>\d\S*)\s'

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -144,6 +144,8 @@ class ModulesTool(object):
     VERSION_OPTION = '--version'
     # minimal required version (StrictVersion; suffix rc replaced with b (and treated as beta by StrictVersion))
     REQ_VERSION = None
+    # maximum version allowed (StrictVersion; suffix rc replaced with b (and treated as beta by StrictVersion))
+    MAX_VERSION = None
     # the regexp, should have a "version" group (multiline search)
     VERSION_REGEXP = None
     # modules tool user cache directory
@@ -237,14 +239,30 @@ class ModulesTool(object):
         except (OSError), err:
             raise EasyBuildError("Failed to check version: %s", err)
 
-        if self.REQ_VERSION is None:
-            self.log.debug("No version requirement defined.")
+        if self.REQ_VERSION is None and self.MAX_VERSION is None:
+                self.log.debug("No version requirement defined.")
         else:
-            if StrictVersion(self.version) < StrictVersion(self.REQ_VERSION):
-                raise EasyBuildError("EasyBuild requires v%s >= v%s (no rc), found v%s",
-                                     self.__class__.__name__, self.REQ_VERSION, self.version)
+            if self.REQ_VERSION is None: # MAX_VERSION is not None
+                self.log.debug("No required minimum version defined.")
+                if StrictVersion(self.version) > StrictVersion(self.MAX_VERSION):
+                    raise EasyBuildError("EasyBuild requires v%s <= v%s (no rc), found v%s",
+                                         self.__class__.__name__, self.version, self.MAX_VERSION)
+                else:
+                    self.log.debug('Version %s matches requirement <= %s' % (self.version, self.MAX_VERSION))
+            elif self.MAX_VERSION is None: # REQ_VERSION is not None
+                self.log.debug("No allowed maximum version defined.")
+                if StrictVersion(self.version) < StrictVersion(self.REQ_VERSION):
+                    raise EasyBuildError("EasyBuild requires v%s >= v%s (no rc), found v%s",
+                                         self.__class__.__name__, self.REQ_VERSION, self.version)
+                else:
+                    self.log.debug('Version %s matches requirement >= %s' % (self.version, self.REQ_VERSION))
             else:
-                self.log.debug('Version %s matches requirement %s' % (self.version, self.REQ_VERSION))
+                self.log.debug("Required minimum version and maximum allowed version defined.")
+                # Check that we have not made a mistake and set REQ_VERSION > MAX_VERSION
+                if StrictVersion(self.REQ_VERSION) > StrictVersion(self.MAX_VERSION):
+                    raise EasyBuildError("v%s, REQ_VERSION must be <= MAX_VERSION", self.__class__)
+                else:
+                    self.log.debug('Version %s matches requirements >= %s, <= %s' % (self.version, self.REQ_VERSION, self.MAX_VERSION))
 
         MODULE_VERSION_CACHE[self.COMMAND] = self.version
 
@@ -997,12 +1015,18 @@ class EnvironmentModulesC(ModulesTool):
     """Interface to (C) environment modules (modulecmd)."""
     COMMAND = "modulecmd"
     REQ_VERSION = '3.2.10'
+    MAX_VERSION = '3.2.10'
     VERSION_REGEXP = r'^\s*(VERSION\s*=\s*)?(?P<version>\d\S*)\s*'
 
     def update(self):
         """Update after new modules were added."""
         pass
 
+class EnvironmentModules4(EnvironmentModulesC):
+    """Interface to environment modules 4+."""
+    REQ_VERSION = '4.0.0'
+    MAX_VERSION = None
+    VERSION_REGEXP = r'^Modules\s+Release\s+(?P<version>\d\S*)\s'
 
 class EnvironmentModulesTcl(EnvironmentModulesC):
     """Interface to (Tcl) environment modules (modulecmd.tcl)."""
@@ -1014,6 +1038,7 @@ class EnvironmentModulesTcl(EnvironmentModulesC):
     COMMAND_SHELL = ['tclsh']
     VERSION_OPTION = ''
     REQ_VERSION = None
+    MAX_VERSION = '1.923'
     VERSION_REGEXP = r'^Modules\s+Release\s+Tcl\s+(?P<version>\d\S*)\s'
 
     def set_path_env_var(self, key, paths):

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1088,6 +1088,13 @@ class EnvironmentModulesTcl(EnvironmentModulesC):
             self.set_mod_paths()
 
 
+class EnvironmentModules(EnvironmentModulesTcl):
+    """Interface to environment modules 4.0+"""
+    COMMAND = os.environ['MODULESHOME'] + '/libexec/modulecmd.tcl'
+    REQ_VERSION = '4.0.0'
+    MAX_VERSION = None
+    VERSION_REGEXP = r'^Modules\s+Release\s+(?P<version>\d\S*)\s'
+    
 class Lmod(ModulesTool):
     """Interface to Lmod."""
     COMMAND = 'lmod'

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1090,7 +1090,7 @@ class EnvironmentModulesTcl(EnvironmentModulesC):
 
 class EnvironmentModules(EnvironmentModulesTcl):
     """Interface to environment modules 4.0+"""
-    COMMAND = os.path.join(os.environ['MODULESHOME'], 'libexec', 'modulecmd.tcl')
+    COMMAND = os.path.join(os.getenv('MODULESHOME'), 'libexec', 'modulecmd.tcl')
     REQ_VERSION = '4.0.0'
     MAX_VERSION = None
     VERSION_REGEXP = r'^Modules\s+Release\s+(?P<version>\d\S*)\s'

--- a/easybuild/tools/multidiff.py
+++ b/easybuild/tools/multidiff.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -73,6 +73,7 @@ from easybuild.tools.environment import restore_env, unset_env_vars
 from easybuild.tools.filetools import CHECKSUM_TYPE_SHA256, CHECKSUM_TYPES, mkdir
 from easybuild.tools.github import GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, HAVE_GITHUB_API, HAVE_KEYRING
 from easybuild.tools.github import fetch_github_token
+from easybuild.tools.hooks import KNOWN_HOOKS
 from easybuild.tools.include import include_easyblocks, include_module_naming_schemes, include_toolchains
 from easybuild.tools.job.backend import avail_job_backends
 from easybuild.tools.modules import avail_modules_tools
@@ -515,6 +516,7 @@ class EasyBuildOptions(GeneralOption):
             'avail-easyconfig-templates': (("Show all template names and template constants "
                                             "that can be used in easyconfigs."),
                                            None, 'store_true', False),
+            'avail-hooks': ("Show list of known hooks", None, 'store_true', False),
             'avail-toolchain-opts': ("Show options for toolchain", 'str', 'store', None),
             'check-conflicts': ("Check for version conflicts in dependency graphs", None, 'store_true', False),
             'dep-graph': ("Create dependency graph", None, 'store', None, {'metavar': 'depgraph.<ext>'}),
@@ -729,6 +731,7 @@ class EasyBuildOptions(GeneralOption):
                 self.options.avail_repositories, self.options.show_default_moduleclasses,
                 self.options.avail_modules_tools, self.options.avail_module_naming_schemes,
                 self.options.show_default_configfiles, self.options.avail_toolchain_opts,
+                self.options.avail_hooks,
                 ]):
             build_easyconfig_constants_dict()  # runs the easyconfig constants sanity check
             self._postprocess_list_avail()
@@ -909,6 +912,9 @@ class EasyBuildOptions(GeneralOption):
         # dump default moduleclasses with description
         if self.options.show_default_moduleclasses:
             msg += self.show_default_moduleclasses()
+
+        if self.options.avail_hooks:
+            msg += self.avail_list('hooks (in order of execution)', KNOWN_HOOKS)
 
         if self.options.unittest_file:
             self.log.info(msg)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -486,7 +486,6 @@ class EasyBuildOptions(GeneralOption):
             'subdir-software': ("Installpath subdir for software",
                                 None, 'store', DEFAULT_PATH_SUBDIRS['subdir_software']),
             'subdir-user-modules': ("Base path of user-specific modules relative to their $HOME", None, 'store', None),
-            'subdir-arch-env': ("Name of environment variable to add to user-specific module path", None, 'store', None),
             'suffix-modules-path': ("Suffix for module files install path", None, 'store', GENERAL_CLASS),
             # this one is sort of an exception, it's something jobscripts can set,
             # has no real meaning for regular eb usage

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -70,7 +70,7 @@ from easybuild.tools.docs import avail_cfgfile_constants, avail_easyconfig_const
 from easybuild.tools.docs import avail_toolchain_opts, avail_easyconfig_params, avail_easyconfig_templates
 from easybuild.tools.docs import list_easyblocks, list_toolchains
 from easybuild.tools.environment import restore_env, unset_env_vars
-from easybuild.tools.filetools import CHECKSUM_TYPE_SHA256, CHECKSUM_TYPES, mkdir, resolve_path
+from easybuild.tools.filetools import CHECKSUM_TYPE_SHA256, CHECKSUM_TYPES, mkdir
 from easybuild.tools.github import GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO, HAVE_GITHUB_API, HAVE_KEYRING
 from easybuild.tools.github import fetch_github_token
 from easybuild.tools.include import include_easyblocks, include_module_naming_schemes, include_toolchains
@@ -780,10 +780,6 @@ class EasyBuildOptions(GeneralOption):
 
         # handle configuration options that affect other configuration options
         self._postprocess_config()
-
-        # make sure absolute path is used for location of hooks
-        if self.options.hooks:
-            self.options.hooks = resolve_path(self.options.hooks)
 
         # show current configuration and exit, if requested
         if self.options.show_config or self.options.show_full_config:

--- a/easybuild/tools/package/__init__.py
+++ b/easybuild/tools/package/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/package/package_naming_scheme/__init__.py
+++ b/easybuild/tools/package/package_naming_scheme/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/package/package_naming_scheme/easybuild_pns.py
+++ b/easybuild/tools/package/package_naming_scheme/easybuild_pns.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/package/package_naming_scheme/pns.py
+++ b/easybuild/tools/package/package_naming_scheme/pns.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/package/utilities.py
+++ b/easybuild/tools/package/utilities.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/repository/__init__.py
+++ b/easybuild/tools/repository/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2011-2017 Ghent University
+# Copyright 2011-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/repository/filerepo.py
+++ b/easybuild/tools/repository/filerepo.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/repository/gitrepo.py
+++ b/easybuild/tools/repository/gitrepo.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/repository/hgrepo.py
+++ b/easybuild/tools/repository/hgrepo.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2014 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/repository/repository.py
+++ b/easybuild/tools/repository/repository.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/repository/svnrepo.py
+++ b/easybuild/tools/repository/svnrepo.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2011-2017 Ghent University
+# Copyright 2011-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/testing.py
+++ b/easybuild/tools/testing.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/toolchain/__init__.py
+++ b/easybuild/tools/toolchain/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -291,14 +291,17 @@ class Compiler(Toolchain):
 
             # optarch has been validated as complex string with multiple compilers and converted to a dictionary
             elif isinstance(optarch, dict):
-                current_compiler = getattr(self, 'COMPILER_FAMILY', None)
-                if current_compiler in optarch:
-                    if optarch[current_compiler] == OPTARCH_GENERIC:
-                        use_generic = True
-                    else:
+                # first try module names, than the family in optarch
+                current_compiler_names = (getattr(self, 'COMPILER_MODULE_NAME', []) +
+                                          [getattr(self, 'COMPILER_FAMILY', None)])
+                for current_compiler in current_compiler_names:
+                    if current_compiler in optarch:
                         optarch = optarch[current_compiler]
+                        break
+                if optarch == OPTARCH_GENERIC:
+                    use_generic = True
                 # no option for this compiler
-                else:
+                if isinstance(optarch, dict):
                     optarch = None
                     self.log.info("_set_optimal_architecture: no optarch found for compiler %s. Ignoring option.", 
                             current_compiler)

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -291,7 +291,7 @@ class Compiler(Toolchain):
 
             # optarch has been validated as complex string with multiple compilers and converted to a dictionary
             elif isinstance(optarch, dict):
-                # first try module names, than the family in optarch
+                # first try module names, then the family in optarch
                 current_compiler_names = (getattr(self, 'COMPILER_MODULE_NAME', []) +
                                           [getattr(self, 'COMPILER_FAMILY', None)])
                 for current_compiler in current_compiler_names:
@@ -300,7 +300,7 @@ class Compiler(Toolchain):
                         break
                 if optarch == OPTARCH_GENERIC:
                     use_generic = True
-                # no option for this compiler
+                # still a dict: no option for this compiler
                 if isinstance(optarch, dict):
                     optarch = None
                     self.log.info("_set_optimal_architecture: no optarch found for compiler %s. Ignoring option.", 

--- a/easybuild/tools/toolchain/constants.py
+++ b/easybuild/tools/toolchain/constants.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/toolchain/fft.py
+++ b/easybuild/tools/toolchain/fft.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/toolchain/linalg.py
+++ b/easybuild/tools/toolchain/linalg.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/toolchain/mpi.py
+++ b/easybuild/tools/toolchain/mpi.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/toolchain/options.py
+++ b/easybuild/tools/toolchain/options.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -656,7 +656,7 @@ class Toolchain(object):
 
         return (c_comps, fortran_comps)
 
-    def prepare(self, onlymod=None, silent=False, loadmod=True, rpath_filter_dirs=None):
+    def prepare(self, onlymod=None, silent=False, loadmod=True, rpath_filter_dirs=None, rpath_include_dirs=None):
         """
         Prepare a set of environment parameters based on name/version of toolchain
         - load modules for toolchain and dependencies
@@ -668,6 +668,7 @@ class Toolchain(object):
         :param silent: keep quiet, or not (mostly relates to extended dry run output)
         :param loadmod: whether or not to (re)load the toolchain module, and the modules for the dependencies
         :param rpath_filter_dirs: extra directories to include in RPATH filter (e.g. build dir, tmpdir, ...)
+        :param rpath_include_dirs: extra directories to include in RPATH
         """
         if loadmod:
             self._load_modules(silent=silent)
@@ -702,7 +703,7 @@ class Toolchain(object):
 
         if build_option('rpath'):
             if self.options.get('rpath', True):
-                self.prepare_rpath_wrappers()
+                self.prepare_rpath_wrappers(rpath_filter_dirs, rpath_include_dirs)
                 self.use_rpath = True
             else:
                 self.log.info("Not putting RPATH wrappers in place, disabled via 'rpath' toolchain option")
@@ -764,7 +765,7 @@ class Toolchain(object):
         calls_rpath_args = 'rpath_args.py $CMD' in read_file(path)
         return in_rpath_wrappers_dir and calls_rpath_args
 
-    def prepare_rpath_wrappers(self, rpath_filter_dirs=None):
+    def prepare_rpath_wrappers(self, rpath_filter_dirs=None, rpath_include_dirs=None):
         """
         Put RPATH wrapper script in place for compiler and linker commands
 
@@ -796,6 +797,12 @@ class Toolchain(object):
         rpath_filter = ','.join(rpath_filter + ['%s.*' % d for d in rpath_filter_dirs or []])
         self.log.debug("Combined RPATH filter: '%s'", rpath_filter)
 
+        # figure out list of patterns to use in rpath include
+        # rpath_include = build_option('rpath_include')
+        rpath_include = ','.join(['%s' % d for d in rpath_include_dirs or []])
+        self.log.debug("Combined RPATH includes: '%s'", rpath_include)
+
+
         # create wrappers
         for cmd in nub(c_comps + fortran_comps + ['ld', 'ld.gold', 'ld.bfd']):
             orig_cmd = which(cmd)
@@ -824,6 +831,7 @@ class Toolchain(object):
                     'orig_cmd': orig_cmd,
                     'python': sys.executable,
                     'rpath_args_py': rpath_args_py,
+                    'rpath_include': rpath_include,
                     'rpath_filter': rpath_filter,
                     'rpath_wrapper_log': rpath_wrapper_log,
                 }

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -797,11 +797,8 @@ class Toolchain(object):
         rpath_filter = ','.join(rpath_filter + ['%s.*' % d for d in rpath_filter_dirs or []])
         self.log.debug("Combined RPATH filter: '%s'", rpath_filter)
 
-        # figure out list of patterns to use in rpath include
-        # rpath_include = build_option('rpath_include')
-        rpath_include = ','.join(['%s' % d for d in rpath_include_dirs or []])
-        self.log.debug("Combined RPATH includes: '%s'", rpath_include)
-
+        rpath_include = ','.join(rpath_include_dirs or [])
+        self.log.debug("Combined RPATH include paths: '%s'", rpath_include)
 
         # create wrappers
         for cmd in nub(c_comps + fortran_comps + ['ld', 'ld.gold', 'ld.bfd']):
@@ -831,8 +828,8 @@ class Toolchain(object):
                     'orig_cmd': orig_cmd,
                     'python': sys.executable,
                     'rpath_args_py': rpath_args_py,
-                    'rpath_include': rpath_include,
                     'rpath_filter': rpath_filter,
+                    'rpath_include': rpath_include,
                     'rpath_wrapper_log': rpath_wrapper_log,
                 }
                 write_file(cmd_wrapper, cmd_wrapper_txt)

--- a/easybuild/tools/toolchain/toolchainvariables.py
+++ b/easybuild/tools/toolchain/toolchainvariables.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/toolchain/utilities.py
+++ b/easybuild/tools/toolchain/utilities.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/toolchain/variables.py
+++ b/easybuild/tools/toolchain/variables.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/variables.py
+++ b/easybuild/tools/variables.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/version.py
+++ b/easybuild/tools/version.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/tools/version.py
+++ b/easybuild/tools/version.py
@@ -43,7 +43,7 @@ from socket import gethostname
 # recent setuptools versions will *TRANSFORM* something like 'X.Y.Zdev' into 'X.Y.Z.dev0', with a warning like
 #   UserWarning: Normalizing '2.4.0dev' to '2.4.0.dev0'
 # This causes problems further up the dependency chain...
-VERSION = LooseVersion('3.5.1')
+VERSION = LooseVersion('3.5.2.dev0')
 UNKNOWN = 'UNKNOWN'
 
 def get_git_revision():

--- a/easybuild/tools/version.py
+++ b/easybuild/tools/version.py
@@ -43,7 +43,7 @@ from socket import gethostname
 # recent setuptools versions will *TRANSFORM* something like 'X.Y.Zdev' into 'X.Y.Z.dev0', with a warning like
 #   UserWarning: Normalizing '2.4.0dev' to '2.4.0.dev0'
 # This causes problems further up the dependency chain...
-VERSION = LooseVersion('3.5.1.dev0')
+VERSION = LooseVersion('3.5.1')
 UNKNOWN = 'UNKNOWN'
 
 def get_git_revision():

--- a/easybuild/tools/version.py
+++ b/easybuild/tools/version.py
@@ -43,7 +43,7 @@ from socket import gethostname
 # recent setuptools versions will *TRANSFORM* something like 'X.Y.Zdev' into 'X.Y.Z.dev0', with a warning like
 #   UserWarning: Normalizing '2.4.0dev' to '2.4.0.dev0'
 # This causes problems further up the dependency chain...
-VERSION = LooseVersion('3.5.0')
+VERSION = LooseVersion('3.5.1.dev0')
 UNKNOWN = 'UNKNOWN'
 
 def get_git_revision():

--- a/easybuild/tools/version.py
+++ b/easybuild/tools/version.py
@@ -43,7 +43,7 @@ from socket import gethostname
 # recent setuptools versions will *TRANSFORM* something like 'X.Y.Zdev' into 'X.Y.Z.dev0', with a warning like
 #   UserWarning: Normalizing '2.4.0dev' to '2.4.0.dev0'
 # This causes problems further up the dependency chain...
-VERSION = LooseVersion('3.5.0.dev0')
+VERSION = LooseVersion('3.5.0')
 UNKNOWN = 'UNKNOWN'
 
 def get_git_revision():

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/__init__.py
+++ b/test/framework/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/asyncprocess.py
+++ b/test/framework/asyncprocess.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/easyconfigformat.py
+++ b/test/framework/easyconfigformat.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/easyconfigversion.py
+++ b/test/framework/easyconfigversion.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/ebconfigobj.py
+++ b/test/framework/ebconfigobj.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/environment.py
+++ b/test/framework/environment.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/format_convert.py
+++ b/test/framework/format_convert.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/general.py
+++ b/test/framework/general.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/hooks.py
+++ b/test/framework/hooks.py
@@ -138,15 +138,21 @@ class HooksTest(EnhancedTestCase):
             '',
             'def there_is_no_such_hook():',
             '    pass',
+            'def stat_hook(self):',
+            '    pass',
             'def post_source_hook(self):',
             '    pass',
-            'def another_faulty_hook(self):',
+            'def install_hook(self):',
             '    pass',
         ])
 
         write_file(test_broken_hooks_pymod, test_hooks_txt)
 
-        error_msg_pattern = "Found one or more unknown hooks: another_faulty_hook, there_is_no_such_hook \(known hooks:"
+        error_msg_pattern = r"Found one or more unknown hooks:\n"
+        error_msg_pattern += r"\* stat_hook \(did you mean 'start_hook'\?\)\n"
+        error_msg_pattern += r"\* there_is_no_such_hook\n"
+        error_msg_pattern += r"\* install_hook \(did you mean 'pre_install_hook', or 'post_install_hook'\?\)\n\n"
+        error_msg_pattern += r"List of known hooks: .*"
         self.assertErrorRegex(EasyBuildError, error_msg_pattern, load_hooks, test_broken_hooks_pymod)
 
 

--- a/test/framework/hooks.py
+++ b/test/framework/hooks.py
@@ -68,17 +68,17 @@ class HooksTest(EnhancedTestCase):
         hooks = load_hooks(self.test_hooks_pymod)
 
         self.assertEqual(len(hooks), 3)
-        self.assertEqual(sorted(h.__name__ for h in hooks), ['post_configure_hook', 'pre_install_hook', 'start_hook'])
-        self.assertTrue(all(callable(h) for h in hooks))
+        self.assertEqual(sorted(hooks.keys()), ['post_configure_hook', 'pre_install_hook', 'start_hook'])
+        self.assertTrue(all(callable(h) for h in hooks.values()))
 
     def test_find_hook(self):
         """Test for find_hook function."""
 
         hooks = load_hooks(self.test_hooks_pymod)
 
-        post_configure_hook = [h for h in hooks if h.__name__ == 'post_configure_hook'][0]
-        pre_install_hook = [h for h in hooks if h.__name__ == 'pre_install_hook'][0]
-        start_hook = [h for h in hooks if h.__name__ == 'start_hook'][0]
+        post_configure_hook = [hooks[k] for k in hooks if k == 'post_configure_hook'][0]
+        pre_install_hook = [hooks[k] for k in hooks if k == 'pre_install_hook'][0]
+        start_hook = [hooks[k] for k in hooks if k == 'start_hook'][0]
 
         self.assertEqual(find_hook('configure', hooks), None)
         self.assertEqual(find_hook('configure', hooks, pre_step_hook=True), None)

--- a/test/framework/hooks.py
+++ b/test/framework/hooks.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2018-2018 Ghent University
+# Copyright 2017-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/hooks.py
+++ b/test/framework/hooks.py
@@ -152,7 +152,7 @@ class HooksTest(EnhancedTestCase):
         error_msg_pattern += r"\* stat_hook \(did you mean 'start_hook'\?\)\n"
         error_msg_pattern += r"\* there_is_no_such_hook\n"
         error_msg_pattern += r"\* install_hook \(did you mean 'pre_install_hook', or 'post_install_hook'\?\)\n\n"
-        error_msg_pattern += r"List of known hooks: .*"
+        error_msg_pattern += r"Run 'eb --avail-hooks' to get an overview of known hooks"
         self.assertErrorRegex(EasyBuildError, error_msg_pattern, load_hooks, test_broken_hooks_pymod)
 
 

--- a/test/framework/hooks.py
+++ b/test/framework/hooks.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2017-2017 Ghent University
+# Copyright 2018-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/include.py
+++ b/test/framework/include.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/license.py
+++ b/test/framework/license.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -99,7 +99,7 @@ class ModulesTest(EnhancedTestCase):
         ms = self.modtool.available('GCC')
         expected = ['GCC/4.6.3', 'GCC/4.6.4', 'GCC/4.7.2']
         # Tcl-only modules tool does an exact match on module name, Lmod & Tcl/C does prefix matching
-        if not isinstance(self.modtool, EnvironmentModulesTcl) or not isinstance(self.modtool, EnvironmentModules):
+        if not isinstance(self.modtool, EnvironmentModulesTcl) and not isinstance(self.modtool, EnvironmentModules):
             expected.append('GCCcore/6.2.0')
         self.assertEqual(ms, expected)
 

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -98,8 +98,9 @@ class ModulesTest(EnhancedTestCase):
         # test modules include 3 GCC modules and one GCCcore module
         ms = self.modtool.available('GCC')
         expected = ['GCC/4.6.3', 'GCC/4.6.4', 'GCC/4.7.2']
-        # Tcl-only modules tool does an exact match on module name, Lmod & Tcl/C does prefix matching
-        # EnvironmentModules is a subclass of EnvironmentModulesTcl, but Modules 4+ behaves similarly to ModulesC, so also append GCCcore/6.2.0 if we are an instance of EnvironmentModules
+        # Tcl-only modules tool does an exact match on module name, Lmod & Tcl/C do prefix matching
+        # EnvironmentModules is a subclass of EnvironmentModulesTcl, but Modules 4+ behaves similarly to Tcl/C impl.,
+        # so also append GCCcore/6.2.0 if we are an instance of EnvironmentModules
         if not isinstance(self.modtool, EnvironmentModulesTcl) or isinstance(self.modtool, EnvironmentModules):
             expected.append('GCCcore/6.2.0')
         self.assertEqual(ms, expected)
@@ -192,13 +193,19 @@ class ModulesTest(EnhancedTestCase):
 
         # if GCC is loaded again, $EBROOTGCC should be set again, and GCC should be listed last
         self.modtool.load(['GCC/4.6.4'])
-        self.assertTrue(os.environ.get('EBROOTGCC'))
+
+        # environment modules v4.0 does not reload already loaded modules, will be changed in v4.2
+        modtool_ver = StrictVersion(self.modtool.version)
+        if not isinstance(self.modtool, EnvironmentModules) or modtool_ver >= StrictVersion('4.2'):
+            self.assertTrue(os.environ.get('EBROOTGCC'))
+
         if isinstance(self.modtool, Lmod):
             # order of loaded modules only changes with Lmod
             self.assertTrue(self.modtool.loaded_modules()[-1] == 'GCC/4.6.4')
 
         # set things up for checking that GCC does *not* get reloaded when requested
-        del os.environ['EBROOTGCC']
+        if 'EBROOTGCC' in os.environ:
+            del os.environ['EBROOTGCC']
         self.modtool.load(['OpenMPI/1.6.4-GCC-4.6.4'])
         if isinstance(self.modtool, Lmod):
             # order of loaded modules only changes with Lmod

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -99,7 +99,8 @@ class ModulesTest(EnhancedTestCase):
         ms = self.modtool.available('GCC')
         expected = ['GCC/4.6.3', 'GCC/4.6.4', 'GCC/4.7.2']
         # Tcl-only modules tool does an exact match on module name, Lmod & Tcl/C does prefix matching
-        if not isinstance(self.modtool, EnvironmentModulesTcl) and not isinstance(self.modtool, EnvironmentModules):
+        # EnvironmentModules is a subclass of EnvironmentModulesTcl, but Modules 4+ behaves similarly to ModulesC, so also append GCCcore/6.2.0 if we are an instance of EnvironmentModules
+        if not isinstance(self.modtool, EnvironmentModulesTcl) or isinstance(self.modtool, EnvironmentModules):
             expected.append('GCCcore/6.2.0')
         self.assertEqual(ms, expected)
 

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -45,7 +45,7 @@ from easybuild.framework.easyconfig.easyconfig import EasyConfig
 from easybuild.tools import config
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import copy_file, copy_dir, mkdir, read_file, write_file
-from easybuild.tools.modules import EnvironmentModulesTcl, Lmod
+from easybuild.tools.modules import EnvironmentModules, EnvironmentModulesTcl, Lmod
 from easybuild.tools.modules import curr_module_paths, get_software_libdir, get_software_root, get_software_version
 from easybuild.tools.modules import invalidate_module_caches_for, modules_tool, reset_module_caches
 from easybuild.tools.run import run_cmd

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -99,7 +99,7 @@ class ModulesTest(EnhancedTestCase):
         ms = self.modtool.available('GCC')
         expected = ['GCC/4.6.3', 'GCC/4.6.4', 'GCC/4.7.2']
         # Tcl-only modules tool does an exact match on module name, Lmod & Tcl/C does prefix matching
-        if not isinstance(self.modtool, EnvironmentModulesTcl):
+        if not isinstance(self.modtool, EnvironmentModulesTcl) or not isinstance(self.modtool, EnvironmentModules):
             expected.append('GCCcore/6.2.0')
         self.assertEqual(ms, expected)
 

--- a/test/framework/modulestool.py
+++ b/test/framework/modulestool.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2014-2017 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/package.py
+++ b/test/framework/package.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/parallelbuild.py
+++ b/test/framework/parallelbuild.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2014 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/repository.py
+++ b/test/framework/repository.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/easyblocks/f/foo.py
+++ b/test/framework/sandbox/easybuild/easyblocks/f/foo.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/easyblocks/f/foofoo.py
+++ b/test/framework/sandbox/easybuild/easyblocks/f/foofoo.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/easyblocks/g/gcc.py
+++ b/test/framework/sandbox/easybuild/easyblocks/g/gcc.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/easyblocks/generic/bar.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/bar.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/easyblocks/generic/configuremake.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/configuremake.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/easyblocks/generic/dummyextension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/dummyextension.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/easyblocks/generic/toolchain.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toolchain.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/easyblocks/h/hpl.py
+++ b/test/framework/sandbox/easybuild/easyblocks/h/hpl.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/easyblocks/s/scalapack.py
+++ b/test/framework/sandbox/easybuild/easyblocks/s/scalapack.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy_buggy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy_buggy.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/tools/__init__.py
+++ b/test/framework/sandbox/easybuild/tools/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2009-2017 Ghent University
+# Copyright 2009-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/tools/module_naming_scheme/__init__.py
+++ b/test/framework/sandbox/easybuild/tools/module_naming_scheme/__init__.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2011-2017 Ghent University
+# Copyright 2011-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/tools/module_naming_scheme/broken_module_naming_scheme.py
+++ b/test/framework/sandbox/easybuild/tools/module_naming_scheme/broken_module_naming_scheme.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2014 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/tools/module_naming_scheme/test_module_naming_scheme.py
+++ b/test/framework/sandbox/easybuild/tools/module_naming_scheme/test_module_naming_scheme.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/sandbox/easybuild/tools/module_naming_scheme/test_module_naming_scheme_more.py
+++ b/test/framework/sandbox/easybuild/tools/module_naming_scheme/test_module_naming_scheme_more.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/scripts.py
+++ b/test/framework/scripts.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2014 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/style.py
+++ b/test/framework/style.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2016-2017 Ghent University
+# Copyright 2016-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -68,6 +68,7 @@ import test.framework.filetools as f
 import test.framework.format_convert as f_c
 import test.framework.general as gen
 import test.framework.github as g
+import test.framework.hooks as h
 import test.framework.include as i
 import test.framework.license as l
 import test.framework.module_generator as mg
@@ -108,7 +109,7 @@ log = fancylogger.getLogger()
 # call suite() for each module and then run them all
 # note: make sure the options unit tests run first, to avoid running some of them with a readily initialized config
 tests = [gen, bl, o, r, ef, ev, ebco, ep, e, mg, m, mt, f, run, a, robot, b, v, g, tcv, tc, t, c, s, l, f_c, sc,
-         tw, p, i, pkg, d, env, et, y, st]
+         tw, p, i, pkg, d, env, et, y, st, h]
 
 SUITE = unittest.TestSuite([x.suite() for x in tests])
 

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1065,7 +1065,13 @@ class ToolchainTest(EnhancedTestCase):
         """Test rpath_args.py script"""
         script = find_eb_script('rpath_args.py')
 
-        rpath_inc = '%(prefix)s/lib,%(prefix)s/lib64,$ORIGIN' % {'prefix': self.test_prefix}
+        rpath_inc = ','.join([
+            os.path.join(self.test_prefix, 'lib'),
+            os.path.join(self.test_prefix, 'lib64'),
+            '$ORIGIN',
+            '$ORIGIN/../lib',
+            '$ORIGIN/../lib64',
+        ])
 
         # simplest possible compiler command
         out, ec = run_cmd("%s gcc '' '%s' -c foo.c" % (script, rpath_inc), simple=False)
@@ -1074,6 +1080,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
             "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
             "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
             "'-Wl,--disable-new-dtags'",
             "'-c'",
             "'foo.c'",
@@ -1083,15 +1091,12 @@ class ToolchainTest(EnhancedTestCase):
         # linker command, --enable-new-dtags should be replaced with --disable-new-dtags
         out, ec = run_cmd("%s ld '' '%s' --enable-new-dtags foo.o" % (script, rpath_inc), simple=False)
         self.assertEqual(ec, 0)
-        expected = '\n'.join([
-            "CMD_ARGS=('foo.o')",
-            "RPATH_ARGS='--disable-new-dtags -rpath=%(prefix)s/lib -rpath=%(prefix)s/lib64 -rpath=$ORIGIN'" % 
-            {'prefix': self.test_prefix},''
-        ])
         cmd_args = [
             "'-rpath=%s/lib'" % self.test_prefix,
             "'-rpath=%s/lib64'" % self.test_prefix,
             "'-rpath=$ORIGIN'",
+            "'-rpath=$ORIGIN/../lib'",
+            "'-rpath=$ORIGIN/../lib64'",
             "'--disable-new-dtags'",
             "'--disable-new-dtags'",
             "'foo.o'",
@@ -1105,6 +1110,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
             "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
             "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
             "'-Wl,--disable-new-dtags'",
         ]
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
@@ -1116,6 +1123,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-rpath=%s/lib'" % self.test_prefix,
             "'-rpath=%s/lib64'" % self.test_prefix,
             "'-rpath=$ORIGIN'",
+            "'-rpath=$ORIGIN/../lib'",
+            "'-rpath=$ORIGIN/../lib64'",
             "'--disable-new-dtags'",
             "''",
         ]
@@ -1128,6 +1137,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
             "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
             "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
             "'-Wl,--disable-new-dtags'",
             "'-Wl,-rpath=/foo'",
             "'foo.c'",
@@ -1143,6 +1154,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
             "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
             "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
             "'-Wl,--disable-new-dtags'",
             "'foo.c'",
             "'-L../lib'",
@@ -1157,6 +1170,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
             "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
             "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
             "'-Wl,--disable-new-dtags'",
             "'-Wl,-rpath=/foo'",
             "'foo.c'",
@@ -1172,6 +1187,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-rpath=%s/lib'" % self.test_prefix,
             "'-rpath=%s/lib64'" % self.test_prefix,
             "'-rpath=$ORIGIN'",
+            "'-rpath=$ORIGIN/../lib'",
+            "'-rpath=$ORIGIN/../lib64'",
             "'--disable-new-dtags'",
             "'-rpath=/foo'",
             "'-rpath=/lib64'",
@@ -1194,6 +1211,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-rpath=%s/lib'" % self.test_prefix,
             "'-rpath=%s/lib64'" % self.test_prefix,
             "'-rpath=$ORIGIN'",
+            "'-rpath=$ORIGIN/../lib'",
+            "'-rpath=$ORIGIN/../lib64'",
             "'--disable-new-dtags'",
             "'-rpath=/lib64'",
             "'-L/foo'",
@@ -1228,6 +1247,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
             "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
             "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
             "'-Wl,--disable-new-dtags'",
             "'-Wl,-rpath=/icc/lib/intel64'",
             "'-Wl,-rpath=/imkl/lib'",
@@ -1271,6 +1292,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
             "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
             "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
             "'-Wl,--disable-new-dtags'",
             "'-DHAVE_CONFIG_H'",
             "'-I.'",

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1069,8 +1069,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s gcc '' -c foo.c" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-Wl,-rpath=$ORIGIN/../lib'",
-            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             "'-Wl,--disable-new-dtags'",
             "'-c'",
             "'foo.c'",
@@ -1082,12 +1083,13 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(ec, 0)
         expected = '\n'.join([
             "CMD_ARGS=('foo.o')",
-            "RPATH_ARGS='--disable-new-dtags -rpath=$ORIGIN/../lib -rpath=$ORIGIN/../lib64'",
+            "RPATH_ARGS='--disable-new-dtags -rpath=%s/lib -rpath=%s/lib64 -rpath=$ORIGIN'" % (self.test_prefix, self.test_prefix)
             ''
         ])
         cmd_args = [
-            "'-rpath=$ORIGIN/../lib'",
-            "'-rpath=$ORIGIN/../lib64'",
+            "'-rpath=%s/lib'" % self.test_prefix,
+            "'-rpath=%s/lib64'" % self.test_prefix,
+            "'-rpath=$ORIGIN'",
             "'--disable-new-dtags'",
             "'--disable-new-dtags'",
             "'foo.o'",
@@ -1098,8 +1100,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s gcc ''" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-Wl,-rpath=$ORIGIN/../lib'",
-            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             "'-Wl,--disable-new-dtags'",
         ]
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
@@ -1108,8 +1111,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s ld.gold '' ''" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-rpath=$ORIGIN/../lib'",
-            "'-rpath=$ORIGIN/../lib64'",
+            "'-rpath=%s/lib'" % self.test_prefix,
+            "'-rpath=%s/lib64'" % self.test_prefix,
+            "'-rpath=$ORIGIN'",
             "'--disable-new-dtags'",
             "''",
         ]
@@ -1119,8 +1123,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s gcc '' foo.c -L/foo -lfoo" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-Wl,-rpath=$ORIGIN/../lib'",
-            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             "'-Wl,--disable-new-dtags'",
             "'-Wl,-rpath=/foo'",
             "'foo.c'",
@@ -1133,8 +1138,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s gcc '' foo.c -L../lib -lfoo" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-Wl,-rpath=$ORIGIN/../lib'",
-            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             "'-Wl,--disable-new-dtags'",
             "'foo.c'",
             "'-L../lib'",
@@ -1146,8 +1152,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s gcc '' foo.c -L   /foo -lfoo" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-Wl,-rpath=$ORIGIN/../lib'",
-            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             "'-Wl,--disable-new-dtags'",
             "'-Wl,-rpath=/foo'",
             "'foo.c'",
@@ -1160,8 +1167,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s ld '' -L/foo foo.o -L/lib64 -lfoo -lbar -L/usr/lib -L/bar" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-rpath=$ORIGIN/../lib'",
-            "'-rpath=$ORIGIN/../lib64'",
+            "'-rpath=%s/lib'" % self.test_prefix,
+            "'-rpath=%s/lib64'" % self.test_prefix,
+            "'-rpath=$ORIGIN'",
             "'--disable-new-dtags'",
             "'-rpath=/foo'",
             "'-rpath=/lib64'",
@@ -1181,8 +1189,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s ld '/fo.*,/bar.*' -L/foo foo.o -L/lib64 -lfoo -L/bar -lbar" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-rpath=$ORIGIN/../lib'",
-            "'-rpath=$ORIGIN/../lib64'",
+            "'-rpath=%s/lib'" % self.test_prefix,
+            "'-rpath=%s/lib64'" % self.test_prefix,
+            "'-rpath=$ORIGIN'",
             "'--disable-new-dtags'",
             "'-rpath=/lib64'",
             "'-L/foo'",
@@ -1214,8 +1223,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s icc '' %s" % (script, args), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-Wl,-rpath=$ORIGIN/../lib'",
-            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             "'-Wl,--disable-new-dtags'",
             "'-Wl,-rpath=/icc/lib/intel64'",
             "'-Wl,-rpath=/imkl/lib'",
@@ -1256,8 +1266,9 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(ec, 0)
 
         cmd_args = [
-            "'-Wl,-rpath=$ORIGIN/../lib'",
-            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             "'-Wl,--disable-new-dtags'",
             "'-DHAVE_CONFIG_H'",
             "'-I.'",
@@ -1325,8 +1336,9 @@ class ToolchainTest(EnhancedTestCase):
         # no -rpath for /bar because of rpath filter
         out, _ = run_cmd('gcc ${USER}.c -L/foo -L/bar \'$FOO\' -DX="\\"\\""')
         expected = ' '.join([
-            '-Wl,-rpath=$ORIGIN/../lib',
-            '-Wl,-rpath=$ORIGIN/../lib64',
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             '-Wl,--disable-new-dtags',
             '-Wl,-rpath=/foo',
             '%(user)s.c',

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1085,8 +1085,8 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(ec, 0)
         expected = '\n'.join([
             "CMD_ARGS=('foo.o')",
-            "RPATH_ARGS='--disable-new-dtags -rpath=%s/lib -rpath=%s/lib64 -rpath=$ORIGIN'" % (self.test_prefix, self.test_prefix),
-            ''
+            "RPATH_ARGS='--disable-new-dtags -rpath=%(prefix)s/lib -rpath=%(prefix)s/lib64 -rpath=$ORIGIN'" % 
+            {'prefix': self.test_prefix},''
         ])
         cmd_args = [
             "'-rpath=%s/lib'" % self.test_prefix,

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1066,7 +1066,7 @@ class ToolchainTest(EnhancedTestCase):
         script = find_eb_script('rpath_args.py')
 
         # simplest possible compiler command
-        out, ec = run_cmd("%s gcc '' -c foo.c" % script, simple=False)
+        out, ec = run_cmd("%s gcc '' '%s/lib,%s/lib64,$ORIGIN' -c foo.c" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
@@ -1079,7 +1079,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # linker command, --enable-new-dtags should be replaced with --disable-new-dtags
-        out, ec = run_cmd("%s ld '' --enable-new-dtags foo.o" % script, simple=False)
+        out, ec = run_cmd("%s ld '' '%s/lib,%s/lib64,$ORIGIN' --enable-new-dtags foo.o" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         expected = '\n'.join([
             "CMD_ARGS=('foo.o')",
@@ -1097,7 +1097,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # test passing no arguments
-        out, ec = run_cmd("%s gcc ''" % script, simple=False)
+        out, ec = run_cmd("%s gcc '' '%s/lib,%s/lib64,$ORIGIN'" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
@@ -1108,7 +1108,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # test passing a single empty argument
-        out, ec = run_cmd("%s ld.gold '' ''" % script, simple=False)
+        out, ec = run_cmd("%s ld.gold '' '%s/lib,%s/lib64,$ORIGIN' ''" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-rpath=%s/lib'" % self.test_prefix,
@@ -1120,7 +1120,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # single -L argument
-        out, ec = run_cmd("%s gcc '' foo.c -L/foo -lfoo" % script, simple=False)
+        out, ec = run_cmd("%s gcc '' '%s/lib,%s/lib64,$ORIGIN' foo.c -L/foo -lfoo" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
@@ -1135,7 +1135,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # relative paths passed to -L are *not* RPATH'ed in
-        out, ec = run_cmd("%s gcc '' foo.c -L../lib -lfoo" % script, simple=False)
+        out, ec = run_cmd("%s gcc '' '%s/lib,%s/lib64,$ORIGIN' foo.c -L../lib -lfoo" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
@@ -1149,7 +1149,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # single -L argument, with value separated by a space
-        out, ec = run_cmd("%s gcc '' foo.c -L   /foo -lfoo" % script, simple=False)
+        out, ec = run_cmd("%s gcc '' '%s/lib,%s/lib64,$ORIGIN' foo.c -L   /foo -lfoo" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
@@ -1164,7 +1164,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # multiple -L arguments, order should be preserved
-        out, ec = run_cmd("%s ld '' -L/foo foo.o -L/lib64 -lfoo -lbar -L/usr/lib -L/bar" % script, simple=False)
+        out, ec = run_cmd("%s ld '' '%s/lib,%s/lib64,$ORIGIN' -L/foo foo.o -L/lib64 -lfoo -lbar -L/usr/lib -L/bar" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-rpath=%s/lib'" % self.test_prefix,
@@ -1186,7 +1186,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # test specifying of custom rpath filter
-        out, ec = run_cmd("%s ld '/fo.*,/bar.*' -L/foo foo.o -L/lib64 -lfoo -L/bar -lbar" % script, simple=False)
+        out, ec = run_cmd("%s ld '/fo.*,/bar.*' '%s/lib,%s/lib64,$ORIGIN' -L/foo foo.o -L/lib64 -lfoo -L/bar -lbar" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-rpath=%s/lib'" % self.test_prefix,
@@ -1220,7 +1220,7 @@ class ToolchainTest(EnhancedTestCase):
             '-Wl,-rpath',
             '-Wl,/example/software/XZ/5.2.2-intel-2016b/lib',
         ])
-        out, ec = run_cmd("%s icc '' %s" % (script, args), simple=False)
+        out, ec = run_cmd("%s icc '' '%s/lib,%s/lib64,$ORIGIN' %s" % (script, self.test_prefix, self.test_prefix, args), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
@@ -1261,7 +1261,7 @@ class ToolchainTest(EnhancedTestCase):
             '-o build/version.o',
             '../../gcc/version.c',
         ]
-        cmd = "%s g++ '' %s" % (script, ' '.join(args))
+        cmd = "%s g++ '' '%s/lib,%s/lib64,$ORIGIN' %s" % (script, self.test_prefix, self.test_prefix, ' '.join(args))
         out, ec = run_cmd(cmd, simple=False)
         self.assertEqual(ec, 0)
 

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1284,7 +1284,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # verify that no -rpath arguments are injected when command is run in 'version check' mode
-        cmd = "%s g++ '' -v" % script
+        cmd = "%s g++ '' '%s/lib,%s/lib64,$ORIGIN' -v" % (script, self.test_prefix, self.test_prefix)
         out, ec = run_cmd(cmd, simple=False)
         self.assertEqual(ec, 0)
         self.assertEqual(out.strip(), "CMD_ARGS=('-v')")
@@ -1336,9 +1336,6 @@ class ToolchainTest(EnhancedTestCase):
         # no -rpath for /bar because of rpath filter
         out, _ = run_cmd('gcc ${USER}.c -L/foo -L/bar \'$FOO\' -DX="\\"\\""')
         expected = ' '.join([
-            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
-            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
-            "'-Wl,-rpath=$ORIGIN'",
             '-Wl,--disable-new-dtags',
             '-Wl,-rpath=/foo',
             '%(user)s.c',

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -387,16 +387,18 @@ class ToolchainTest(EnhancedTestCase):
         """Test whether specifying optarch on a per compiler basis works."""
         flag_vars = ['CFLAGS', 'CXXFLAGS', 'FCFLAGS', 'FFLAGS', 'F90FLAGS']
         intel_options = [('intelflag', 'intelflag'), ('GENERIC', 'xSSE2'), ('', '')]
-        gcc_options = [('gccflag', 'gccflag'), ('GENERIC', 'march=x86-64 -mtune=generic'), ('', '')]
-        toolchains = [('iccifort', '2011.13.367'), ('GCC', '4.7.2'), ('PGI', '16.7-GCC-5.4.0-2.26')]
+        gcc_options = [('gccflag', 'gccflag'), ('-ftree-vectorize', '-ftree-vectorize'), ('', '')]
+        gcccore_options = [('gcccoreflag', 'gcccoreflag'), ('GENERIC', 'march=x86-64 -mtune=generic'), ('', '')]
+        toolchains = [('iccifort', '2011.13.367'), ('GCC', '4.7.2'), ('GCCcore', '6.2.0'), ('PGI', '16.7-GCC-5.4.0-2.26')]
         enabled = [True, False]
 
-        test_cases = product(intel_options, gcc_options, toolchains, enabled)
+        test_cases = product(intel_options, gcc_options, gcccore_options, toolchains, enabled)
 
-        for (intel_flags, intel_flags_exp), (gcc_flags, gcc_flags_exp), (toolchain, toolchain_ver), enable in test_cases:
+        for (intel_flags, intel_flags_exp), (gcc_flags, gcc_flags_exp), (gcccore_flags, gcccore_flags_exp), (toolchain, toolchain_ver), enable in test_cases:
             optarch_var = {}
             optarch_var['Intel'] = intel_flags
             optarch_var['GCC'] = gcc_flags
+            optarch_var['GCCcore'] = gcccore_flags
             build_options = {'optarch': optarch_var}
             init_config(build_options=build_options)
             tc = self.get_toolchain(toolchain, version=toolchain_ver)
@@ -407,6 +409,8 @@ class ToolchainTest(EnhancedTestCase):
                 flags = intel_flags_exp
             elif toolchain == 'GCC':
                 flags = gcc_flags_exp
+            elif toolchain == 'GCCcore':
+                flags = gcccore_flags_exp
             else: # PGI as an example of compiler not set
                 # default optarch flag, should be the same as the one in
                 # tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(tc.arch,tc.cpu_family)]
@@ -423,6 +427,8 @@ class ToolchainTest(EnhancedTestCase):
                     intel_options[1][1],
                     gcc_options[0][1],
                     gcc_options[1][1],
+                    gcccore_options[0][1],
+                    gcccore_options[1][1],
                     'xHost', # default optimal for Intel
                     'march=native', # default optimal for GCC
                 ]

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1083,7 +1083,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(ec, 0)
         expected = '\n'.join([
             "CMD_ARGS=('foo.o')",
-            "RPATH_ARGS='--disable-new-dtags -rpath=%s/lib -rpath=%s/lib64 -rpath=$ORIGIN'" % (self.test_prefix, self.test_prefix)
+            "RPATH_ARGS='--disable-new-dtags -rpath=%s/lib -rpath=%s/lib64 -rpath=$ORIGIN'" % (self.test_prefix, self.test_prefix),
             ''
         ])
         cmd_args = [

--- a/test/framework/toolchainvariables.py
+++ b/test/framework/toolchainvariables.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2017 Ghent University
+# Copyright 2013-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/tweak.py
+++ b/test/framework/tweak.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2014 Ghent University
+# Copyright 2014-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/type_checking.py
+++ b/test/framework/type_checking.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -1,5 +1,5 @@
 ##
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/variables.py
+++ b/test/framework/variables.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2012-2017 Ghent University
+# Copyright 2012-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/yeb.py
+++ b/test/framework/yeb.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2015-2017 Ghent University
+# Copyright 2015-2018 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),


### PR DESCRIPTION
On systems with multiple architectures sharing a single home directory
for the users there need to be a way to install architecture specific
builds when using the subdir-user-modules extension.