### PR TITLE
fix minor issues with --inject-checksums

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3004,10 +3004,13 @@ def inject_checksums(ecs, checksum_type):
 
                     # if any checksums were collected, inject them for this extension
                     if ext_checksums:
-                        exts_list_lines.append("%s'checksums': [" % (INDENT_4SPACES * 2))
-                        for fn, checksum in ext_checksums:
-                            exts_list_lines.append("%s'%s',  # %s" % (INDENT_4SPACES * 3, checksum, fn))
-                        exts_list_lines.append("%s]," % (INDENT_4SPACES * 2))
+                        if len(ext_checksums) == 1:
+                            exts_list_lines.append("%s'checksums': ['%s']," % (INDENT_4SPACES * 2, checksum))
+                        else:
+                            exts_list_lines.append("%s'checksums': [" % (INDENT_4SPACES * 2))
+                            for fn, checksum in ext_checksums:
+                                exts_list_lines.append("%s'%s',  # %s" % (INDENT_4SPACES * 3, checksum, fn))
+                            exts_list_lines.append("%s]," % (INDENT_4SPACES * 2))
 
                     if ext_options or ext_checksums:
                         exts_list_lines.append("%s})," % INDENT_4SPACES)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2957,16 +2957,13 @@ def inject_checksums(ecs, checksum_type):
                     raw[key] = res.group(0).strip() + '\n'
                     ectxt = regex.sub(placeholder, ectxt)
 
-            # this should not happen...
-            if 'sources' not in raw:
-                raise EasyBuildError("Failed to extract raw lines for 'sources' parameter from easyconfig file!")
-
             # inject combination of source_urls/sources/patches/checksums into easyconfig
             # by replacing first occurence of placeholder that was put in place
+            sources_raw = raw.get('sources', '')
             source_urls_raw = raw.get('source_urls', '')
             patches_raw = raw.get('patches', '')
             regex = re.compile(placeholder + '\n', re.M)
-            ectxt = regex.sub(source_urls_raw + raw['sources'] + patches_raw + checksums_txt + '\n', ectxt, count=1)
+            ectxt = regex.sub(source_urls_raw + sources_raw + patches_raw + checksums_txt + '\n', ectxt, count=1)
 
             # get rid of potential remaining placeholders
             ectxt = regex.sub('', ectxt)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2974,10 +2974,21 @@ def inject_checksums(ecs, checksum_type):
 
             exts_list_lines = ['exts_list = [']
             for ext in app.exts:
+                if ext['name'] == app.name:
+                    ext_name = 'name'
+                else:
+                    ext_name = "'%s'" % ext['name']
+
                 # for some extensions, only a name if specified (so no sources/patches)
                 if ext.keys() == ['name']:
-                    exts_list_lines.append("%s'%s'," % (INDENT_4SPACES, ext['name']))
+                    exts_list_lines.append("%s%s," % (INDENT_4SPACES, ext_name))
                 else:
+
+                    if ext['version'] == app.version:
+                        ext_version = 'version'
+                    else:
+                        ext_version = "'%s'" % ext['version']
+
                     ext_options = ext.get('options', {})
 
                     # compute checksums for extension sources & patches
@@ -2993,7 +3004,7 @@ def inject_checksums(ecs, checksum_type):
                         print_msg(" * %s: %s" % (patch_fn, checksum), log=_log)
                         ext_checksums.append((patch_fn, checksum))
 
-                    exts_list_lines.append("%s('%s', '%s'," % (INDENT_4SPACES, ext['name'], ext['version']))
+                    exts_list_lines.append("%s(%s, %s," % (INDENT_4SPACES, ext_name, ext_version))
                     if ext_options or ext_checksums:
                         exts_list_lines[-1] += ' {'
 

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -134,7 +134,8 @@ class Extension(object):
         Sanity check to run after installing extension
         """
 
-        change_dir(self.installdir)
+        if os.path.isdir(self.installdir):
+            change_dir(self.installdir)
 
         # disabling templating is required here to support legacy string templates like name/version
         self.cfg.enable_templating = False

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
@@ -31,7 +31,10 @@ exts_list = [
         'unknowneasyconfigparameterthatshouldbeignored': 'foo',
     }),
     ('barbar', '0.0'),
-    (name, version),
+    (name, version, {
+        'sanity_check_paths': {'files': ['lib/libtoy.a'], 'dirs': []},
+        'exts_filter': ("ls -l lib/libtoy.a", ''),
+    }),
 ]
 
 sanity_check_paths = {

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
@@ -31,6 +31,7 @@ exts_list = [
         'unknowneasyconfigparameterthatshouldbeignored': 'foo',
     }),
     ('barbar', '0.0'),
+    (name, version),
 ]
 
 sanity_check_paths = {

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3361,12 +3361,19 @@ class CommandLineOptionsTest(EnhancedTestCase):
         warning_msg = "WARNING: Found existing checksums in test.eb, overwriting them (due to use of --force)..."
         self.assertEqual(stderr, warning_msg)
 
-        # make sure checksums are only there once...
         ec_txt = read_file(test_ec)
+
+        # some checks on 'raw' easyconfig contents
+        # single-line checksum for barbar extension since there's only one
+        self.assertTrue("'checksums': ['a33100d1837d6d54edff7d19f195056c4bd9a4c8d399e72feaf90f0216c4c91c']," in ec_txt)
+        # name/version of toy should NOT be hardcoded in exts_list, 'name'/'version' parameters should be used
+        self.assertTrue('    (name, version, {' in ec_txt)
+
+        # make sure checksums are only there once...
         # exactly one definition of 'checksums' easyconfig parameter
         self.assertEqual(re.findall('^checksums', ec_txt, re.M), ['checksums'])
-        # exactly two checksum specs for extensions, one list of checksums for each extension
-        self.assertEqual(re.findall("[ ]*'checksums'", ec_txt, re.M), ["        'checksums'", "        'checksums'"])
+        # exactly three checksum specs for extensions, one list of checksums for each extension
+        self.assertEqual(re.findall("[ ]*'checksums'", ec_txt, re.M), ["        'checksums'"] * 3)
 
         # no parse errors for updated easyconfig file...
         ec = EasyConfigParser(test_ec).get_config_dict()

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -32,7 +32,7 @@ import os
 import platform
 import shutil
 
-from easybuild.framework.easyblock import EasyBlock
+from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.environment import setvar
 from easybuild.tools.filetools import mkdir
@@ -40,7 +40,7 @@ from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 
 
-class EB_toy(EasyBlock):
+class EB_toy(ExtensionEasyBlock):
     """Support for building/installing toy."""
 
     def __init__(self, *args, **kwargs):
@@ -98,6 +98,13 @@ class EB_toy(EasyBlock):
         f = open(os.path.join(libdir, 'lib%s.a' % name), 'w')
         f.write(name.upper())
         f.close()
+
+    def run(self):
+        """Install toy as extension."""
+        super(EB_toy, self).run(unpack_src=True)
+        self.configure_step()
+        self.build_step()
+        self.install_step()
 
     def make_module_extra(self):
         """Extra stuff for toy module"""


### PR DESCRIPTION
* fix use of `--inject-checksums` on a `Bundle` easyconfig that has no `sources`
* don't include comment with filename for `checksums` for single-source extensions
* avoid hardcoding name/version of extension that matches parent software name/version