### PR TITLE
install paramiko version < 2.4.0 for Python 2.6 in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ before_install:
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'GitPython<2.0'; else pip install GitPython; fi
     # pydot (dep for python-graph-dot) 1.2.0 and more recent doesn't work with Python 2.6
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install pydot==1.1.0; else pip install pydot; fi
+    # paramiko (dep for GC3Pie) 2.4.0 & more recent doesn't work with Python 2.6
+    - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'paramiko<2.4.0'; else pip install paramiko; fi
     # optional Python packages for EasyBuild
     - pip install autopep8 GC3Pie pycodestyle python-graph-dot python-hglib PyYAML
     # git config is required to make actual git commits (cfr. tests for GitRepository)


### PR DESCRIPTION
See https://github.com/paramiko/paramiko/commit/4f0d5a9e951324f4f2b37c53ce10c9a010154367.

`paramiko` 2.4.0 was released yesterday, one of the tests is broken because of it without this when Python 2.6 is used.