### PR TITLE
add support for 'exts_default_options' easyconfig parameter

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -470,14 +470,19 @@ class EasyBlock(object):
                     exts_sources.append({'name': ext_name})
                 else:
                     ext_version = ext[1]
-                    ext_options = {}
+
+                    # make sure we grab *raw* dict of default options for extension,
+                    # since it may use template values like %(name)s & %(version)s
+                    self.cfg.enable_templating = False
+                    ext_options = copy.deepcopy(self.cfg['exts_default_options'])
+                    self.cfg.enable_templating = True
 
                     def_src_tmpl = "%(name)s-%(version)s.tar.gz"
 
                     if len(ext) == 3:
-                        ext_options = ext[2]
-
-                        if not isinstance(ext_options, dict):
+                        if isinstance(ext_options, dict):
+                            ext_options.update(ext[2])
+                        else:
                             raise EasyBuildError("Unexpected type (non-dict) for 3rd element of %s", ext)
                     elif len(ext) > 3:
                         raise EasyBuildError('Extension specified in unknown format (list/tuple too long)')

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -153,6 +153,7 @@ DEFAULT_CONFIG = {
     # EXTENSIONS easyconfig parameters
     'exts_classmap': [{}, "Map of extension name to class for handling build and installation.", EXTENSIONS],
     'exts_defaultclass': [None, "List of module for and name of the default extension class", EXTENSIONS],
+    'exts_default_options': [{}, "List of default options for extensions", EXTENSIONS],
     'exts_filter': [None, ("Extension filter details: template for cmd and input to cmd "
                            "(templates for name, version and src)."), EXTENSIONS],
     'exts_list': [[], 'List with extensions added to the base installation', EXTENSIONS],

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -310,13 +310,13 @@ class EasyConfigTest(EnhancedTestCase):
             'homepage = "http://example.com"',
             'description = "test easyconfig"',
             'toolchain = {"name": "dummy", "version": "dummy"}',
+            'exts_default_options = {',
+            '    "source_tmpl": "gzip-1.4.eb",',  # dummy source template to avoid downloading fail
+            '    "source_urls": ["http://example.com/"]',
+            '}',
             'exts_list = [',
-            '   ("ext1", "ext_ver1", {',
-            '       "source_tmpl": "gzip-1.4.eb",',  # dummy source template to avoid downloading fail
-            '       "source_urls": ["http://example.com/"]',
-            '   }),',
-            '   ("ext2", "ext_ver2", {',
-            '       "source_tmpl": "gzip-1.4.eb",',  # dummy source template to avoid downloading fail
+            '   ("ext1", "1.0"),',
+            '   ("ext2", "2.0", {',
             '       "source_urls": [("http://example.com", "suffix")],'
             '       "patches": ["toy-0.0.eb"],',  # dummy patch to avoid downloading fail
             '       "checksums": [',
@@ -333,9 +333,26 @@ class EasyConfigTest(EnhancedTestCase):
         eb = EasyBlock(ec)
         exts_sources = eb.fetch_extension_sources()
 
+        self.assertEqual(len(exts_sources), 2)
+        self.assertEqual(exts_sources[0]['name'], 'ext1')
+        self.assertEqual(exts_sources[0]['version'], '1.0')
+        self.assertEqual(exts_sources[0]['options'], {
+            'source_tmpl': 'gzip-1.4.eb',
+            'source_urls': ['http://example.com/'],
+        })
+        self.assertEqual(exts_sources[1]['name'], 'ext2')
+        self.assertEqual(exts_sources[1]['version'], '2.0')
+        self.assertEqual(exts_sources[1]['options'], {
+            'checksums': ['6f281b6d7a3965476324a23b9d80232bd4ffe3967da85e4b7c01d9d81d649a09',
+                          '044e300a051120defb01c14c7c06e9aa4bca40c5d589828df360e2684dcc9074'],
+            'patches': ['toy-0.0.eb'],
+            'source_tmpl': 'gzip-1.4.eb',
+            'source_urls': [('http://example.com', 'suffix')],
+        })
+
         modfile = os.path.join(eb.make_module_step(), 'pi', '3.14' + eb.module_generator.MODULE_FILE_EXTENSION)
         modtxt = read_file(modfile)
-        regex = re.compile('EBEXTSLISTPI.*ext1-ext_ver1,ext2-ext_ver2')
+        regex = re.compile('EBEXTSLISTPI.*ext1-1.0,ext2-2.0')
         self.assertTrue(regex.search(modtxt), "Pattern '%s' found in: %s" % (regex.pattern, modtxt))
 
     def test_suggestions(self):

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -312,7 +312,7 @@ class EasyConfigTest(EnhancedTestCase):
             'toolchain = {"name": "dummy", "version": "dummy"}',
             'exts_default_options = {',
             '    "source_tmpl": "gzip-1.4.eb",',  # dummy source template to avoid downloading fail
-            '    "source_urls": ["http://example.com/"]',
+            '    "source_urls": ["http://example.com/%(name)s/%(version)s"]',
             '}',
             'exts_list = [',
             '   ("ext1", "1.0"),',
@@ -338,7 +338,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(exts_sources[0]['version'], '1.0')
         self.assertEqual(exts_sources[0]['options'], {
             'source_tmpl': 'gzip-1.4.eb',
-            'source_urls': ['http://example.com/'],
+            'source_urls': ['http://example.com/%(name)s/%(version)s'],
         })
         self.assertEqual(exts_sources[1]['name'], 'ext2')
         self.assertEqual(exts_sources[1]['version'], '2.0')

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
@@ -20,12 +20,16 @@ checksums = [[
 ]]
 patches = ['toy-0.0_typo.patch']
 
+exts_default_options = {
+    'source_urls': ['http://example.com'],
+}
+
 exts_list = [
     ('bar', '0.0', {
         'buildopts': " && gcc bar.c -o anotherbar",
         'checksums': ['f3676716b610545a4e8035087f5be0a0248adee0abb3930d3edb76d498ae91e7'],  # checksum for 
         # custom extension filter to verify use of stdin value being passed to filter command
-        'exts_filter': ("cat | grep '^bar$'", '%(name)s'),
+    'exts_filter': ("cat | grep '^bar$'", '%(name)s'),
         'patches': ['bar-0.0_typo.patch'],
         'toy_ext_param': "mv anotherbar bar_bis",
         'unknowneasyconfigparameterthatshouldbeignored': 'foo',

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3406,11 +3406,13 @@ class CommandLineOptionsTest(EnhancedTestCase):
             ],
             'exts_filter': ("cat | grep '^bar$'", '%(name)s'),
             'patches': ['bar-0.0_typo.patch'],
+            'source_urls': ['http://example.com'],
             'toy_ext_param': "mv anotherbar bar_bis",
             'unknowneasyconfigparameterthatshouldbeignored': 'foo',
         }))
         self.assertEqual(ec['exts_list'][1], ('barbar', '0.0', {
-            'checksums': ['a33100d1837d6d54edff7d19f195056c4bd9a4c8d399e72feaf90f0216c4c91c']
+            'checksums': ['a33100d1837d6d54edff7d19f195056c4bd9a4c8d399e72feaf90f0216c4c91c'],
+            'source_urls': ['http://example.com'],
         }))
 
         # backup of easyconfig was created


### PR DESCRIPTION
We currently use something like this in some easyconfig that have a long list of extensions (e.g. `R`):

```python
ext_options = { ... }

exts_list = [
    ('<name1>', '<version1>', ext_options),
    ...,
]
```

(where `ext_options` is just a local variable in the easyconfig file, EasyBuild itself ignores it when parsing)

In places where we need to list additional options, we do ugly things like:

```python
    ('<name2>', '<version2>', dict(ext_options.items() + [('patches', ['example.patch'])])),
```

This change adds support for `exts_default_options`, which cleans up this mess thoroughly, as follows:

```python
exts_default_options = { ... }

exts_lists = [
    ('<name1>', '<version1>'),
    ('<name2>', '<version2>', {
        'patches': ['example.patch'],
    }),
```

This is particularly useful when we want to enforce having checksums for all extensions...