### PR TITLE
disable broken log rotation, avoid duplicate logging of output of executed commands under `--debug`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -266,7 +266,7 @@ class EasyBlock(object):
             return
 
         self.logfile = get_log_filename(self.name, self.version, add_salt=True)
-        fancylogger.logToFile(self.logfile)
+        fancylogger.logToFile(self.logfile, max_bytes=0)
 
         self.log = fancylogger.getLogger(name=self.__class__.__name__, fname=False)
 

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -180,7 +180,7 @@ _init_fancylog = fancylogger.getLogger(fname=False)
 del _init_fancylog.manager.loggerDict[_init_fancylog.name]
 
 # we need to make sure there is a handler
-fancylogger.logToFile(filename=os.devnull)
+fancylogger.logToFile(filename=os.devnull, max_bytes=0)
 
 # EasyBuildLog
 _init_easybuildlog = fancylogger.getLogger(fname=False)
@@ -196,7 +196,7 @@ def init_logging(logfile, logtostdout=False, silent=False, colorize=fancylogger.
             fd, logfile = tempfile.mkstemp(suffix='.log', prefix='easybuild-')
             os.close(fd)
 
-        fancylogger.logToFile(logfile)
+        fancylogger.logToFile(logfile, max_bytes=0)
         print_msg('temporary log file in case of crash %s' % (logfile), log=None, silent=silent)
 
     log = fancylogger.getLogger(fname=False)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -711,7 +711,7 @@ class EasyBuildOptions(GeneralOption):
 
         # log to specified value of --unittest-file
         if self.options.unittest_file:
-            fancylogger.logToFile(self.options.unittest_file)
+            fancylogger.logToFile(self.options.unittest_file, max_bytes=0)
 
         # set tmpdir
         self.tmpdir = set_tmpdir(self.options.tmpdir)

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -475,17 +475,17 @@ def parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp):
     if not regexp:
         use_regexp = False
 
-    _log.debug('cmd "%s" exited with exitcode %s and output:\n%s' % (cmd, ec, stdouterr))
-
     if ec and (log_all or log_ok):
         # We don't want to error if the user doesn't care
         if check_ec:
-            raise EasyBuildError('cmd "%s" exited with exitcode %s and output:\n%s', cmd, ec, stdouterr)
+            raise EasyBuildError('cmd "%s" exited with exit code %s and output:\n%s', cmd, ec, stdouterr)
         else:
-            _log.warn('cmd "%s" exited with exitcode %s and output:\n%s' % (cmd, ec, stdouterr))
+            _log.warn('cmd "%s" exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
     elif not ec:
         if log_all:
-            _log.info('cmd "%s" exited with exitcode %s and output:\n%s' % (cmd, ec, stdouterr))
+            _log.info('cmd "%s" exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
+        else:
+            _log.debug('cmd "%s" exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
 
     # parse the stdout/stderr for errors when strictness dictates this or when regexp is passed in
     if use_regexp or regexp:

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -35,15 +35,15 @@ import re
 import signal
 import stat
 import sys
+import tempfile
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
 from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
 
 import easybuild.tools.utilities
-from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.build_log import EasyBuildError, init_logging, stop_logging
 from easybuild.tools.filetools import adjust_permissions, read_file, write_file
 from easybuild.tools.run import run_cmd, run_cmd_qa, parse_log_for_error
-from easybuild.tools.run import _log as run_log
 
 
 class RunTest(EnhancedTestCase):
@@ -67,6 +67,41 @@ class RunTest(EnhancedTestCase):
         self.assertEqual(out, "hello\n")
         # no reason echo hello could fail
         self.assertEqual(ec, 0)
+
+    def test_run_cmd_log(self):
+        """Test logging of executed commands."""
+        fd, logfile = tempfile.mkstemp(suffix='.log', prefix='eb-test-')
+        os.close(fd)
+
+        regex = re.compile('cmd "echo hello" exited with exit code [0-9]* and output:')
+
+        # command output is not logged by default without debug logging
+        init_logging(logfile, silent=True)
+        self.assertTrue(run_cmd("echo hello"))
+        stop_logging(logfile)
+        self.assertEqual(len(regex.findall(read_file(logfile))), 0)
+        write_file(logfile, '')
+
+        init_logging(logfile, silent=True)
+        self.assertTrue(run_cmd("echo hello", log_all=True))
+        stop_logging(logfile)
+        self.assertEqual(len(regex.findall(read_file(logfile))), 1)
+        write_file(logfile, '')
+
+        # with debugging enabled, exit code and output of command should only get logged once
+        setLogLevelDebug()
+
+        init_logging(logfile, silent=True)
+        self.assertTrue(run_cmd("echo hello"))
+        stop_logging(logfile)
+        self.assertEqual(len(regex.findall(read_file(logfile))), 1)
+        write_file(logfile, '')
+
+        init_logging(logfile, silent=True)
+        self.assertTrue(run_cmd("echo hello", log_all=True))
+        stop_logging(logfile)
+        self.assertEqual(len(regex.findall(read_file(logfile))), 1)
+        write_file(logfile, '')
 
     def test_run_cmd_negative_exit_code(self):
         """Test run_cmd function with command that has negative exit code."""


### PR DESCRIPTION
Log rotation is basically broken (in some circumstances), see #1094 & https://github.com/hpcugent/vsc-base/issues/252.

Avoid to log the output of executed commands when `--debug` is enabled helps significantly in reducing size of (debug) logs.