### PR TITLE
skip testing of --preview-pr if no GitHub token is available

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2187,6 +2187,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     def test_preview_pr(self):
         """Test --preview-pr."""
+        if self.github_token is None:
+            print "Skipping test_preview_pr, no GitHub token available?"
+            return
 
         self.mock_stdout(True)
 


### PR DESCRIPTION
This test often fails due to GitHub rate limiting, which is quite annoying, so it should only be run if a GitHub token is available for testing with (just like we already do for tests related to GitHub integration features).