### PR TITLE
Allow use of `start_dir` in extensions

### DIFF
--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -32,7 +32,7 @@ from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extension import Extension
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import apply_patch, extract_file
+from easybuild.tools.filetools import apply_patch, change_dir, extract_file
 from easybuild.tools.utilities import remove_unwanted_chars
 
 
@@ -100,6 +100,10 @@ class ExtensionEasyBlock(EasyBlock, Extension):
         if unpack_src:
             targetdir = os.path.join(self.master.builddir, remove_unwanted_chars(self.name))
             self.ext_dir = extract_file("%s" % self.src, targetdir, extra_options=self.unpack_options)
+
+            if self.cfg['start_dir'] and os.path.isdir(self.cfg['start_dir']):
+                self.log.debug("Using start_dir: %s", self.cfg['start_dir'])
+                change_dir(self.cfg['start_dir'])
 
         # patch if needed
         if self.patches:

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -81,8 +81,8 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             # name and version properties of EasyBlock are used, so make sure name and version are correct
             self.cfg['name'] = self.ext.get('name', None)
             self.cfg['version'] = self.ext.get('version', None)
-            # We cannot inherit the start_dir from the easyconfig. It should be specified in the extension
-            # itself or be empty.
+            # We can't inherit the 'start_dir' value from the parent (which will be set, and will most likely be wrong).
+            # It should be specified for the extension specifically, or be empty (so it is auto-derived).
             self.cfg['start_dir'] = self.ext.get('options', {}).get('start_dir', None)
             self.builddir = self.master.builddir
             self.installdir = self.master.installdir

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -81,6 +81,7 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             # name and version properties of EasyBlock are used, so make sure name and version are correct
             self.cfg['name'] = self.ext.get('name', None)
             self.cfg['version'] = self.ext.get('version', None)
+            self.cfg['start_dir'] = self.ext.get('options', {}).get('start_dir', None)
             self.builddir = self.master.builddir
             self.installdir = self.master.installdir
             self.modules_tool = self.master.modules_tool

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -102,9 +102,9 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             targetdir = os.path.join(self.master.builddir, remove_unwanted_chars(self.name))
             self.ext_dir = extract_file("%s" % self.src, targetdir, extra_options=self.unpack_options)
 
-            if self.cfg['start_dir'] and os.path.isdir(self.cfg['start_dir']):
-                self.log.debug("Using start_dir: %s", self.cfg['start_dir'])
-                change_dir(self.cfg['start_dir'])
+            if self.start_dir and os.path.isdir(self.start_dir]):
+                self.log.debug("Using start_dir: %s", self.start_dir)
+                change_dir(self.start_dir)
 
         # patch if needed
         if self.patches:

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -81,6 +81,8 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             # name and version properties of EasyBlock are used, so make sure name and version are correct
             self.cfg['name'] = self.ext.get('name', None)
             self.cfg['version'] = self.ext.get('version', None)
+            # We cannot inherit the start_dir from the easyconfig. It should be specified in the extension
+            # itself or be empty.
             self.cfg['start_dir'] = self.ext.get('options', {}).get('start_dir', None)
             self.builddir = self.master.builddir
             self.installdir = self.master.installdir

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -104,7 +104,7 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             targetdir = os.path.join(self.master.builddir, remove_unwanted_chars(self.name))
             self.ext_dir = extract_file("%s" % self.src, targetdir, extra_options=self.unpack_options)
 
-            if self.start_dir and os.path.isdir(self.start_dir]):
+            if self.start_dir and os.path.isdir(self.start_dir):
                 self.log.debug("Using start_dir: %s", self.start_dir)
                 change_dir(self.start_dir)
 


### PR DESCRIPTION
It's really annoying that symmetric between an `EasyBlock` and `ExtensionEasyBlock` is so broken. Why does an extension use a different extractor method than the general `extractor_step`? It should use the same function so we can use the same parameters (like `start_dir`).

This PR is a dirty hack to fix it.