### PR TITLE
Use absolute paths to lib and lib64 icw $ORIGIN for the RPATH

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -195,6 +195,9 @@ class EasyBlock(object):
         # list of locations to include in RPATH filter used by toolchain
         self.rpath_filter_dirs = []
 
+        # list of locations to include in RPATH used by toolchain
+        self.rpath_include_dirs = []
+
         # logging
         self.log = None
         self.logfile = None
@@ -1734,8 +1737,15 @@ class EasyBlock(object):
         if not self.build_in_installdir:
             self.rpath_filter_dirs.append(self.builddir)
 
+        # always include self.installdir+'/lib' and self.installdir+'/lib64' and $ORIGIN
+        # $ORIGIN will be resolved by the loader to be the full path to the executable or shared object
+        # see also https://linux.die.net/man/8/ld-linux;
+        self.rpath_include_dirs.append(self.installdir+'/lib')
+        self.rpath_include_dirs.append(self.installdir+'/lib64')
+        self.rpath_include_dirs.append('$ORIGIN')
+
         # prepare toolchain: load toolchain module and dependencies, set up build environment
-        self.toolchain.prepare(self.cfg['onlytcmod'], silent=self.silent, rpath_filter_dirs=self.rpath_filter_dirs)
+        self.toolchain.prepare(self.cfg['onlytcmod'], silent=self.silent, rpath_filter_dirs=self.rpath_filter_dirs, rpath_include_dirs=self.rpath_include_dirs)
 
         # handle allowed system dependencies
         for (name, version) in self.cfg['allow_system_deps']:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1745,7 +1745,8 @@ class EasyBlock(object):
         self.rpath_include_dirs.append('$ORIGIN')
 
         # prepare toolchain: load toolchain module and dependencies, set up build environment
-        self.toolchain.prepare(self.cfg['onlytcmod'], silent=self.silent, rpath_filter_dirs=self.rpath_filter_dirs, rpath_include_dirs=self.rpath_include_dirs)
+        self.toolchain.prepare(self.cfg['onlytcmod'], silent=self.silent, rpath_filter_dirs=self.rpath_filter_dirs, 
+                               rpath_include_dirs=self.rpath_include_dirs)
 
         # handle allowed system dependencies
         for (name, version) in self.cfg['allow_system_deps']:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1737,12 +1737,14 @@ class EasyBlock(object):
         if not self.build_in_installdir:
             self.rpath_filter_dirs.append(self.builddir)
 
-        # always include self.installdir+'/lib' and self.installdir+'/lib64' and $ORIGIN
+        # always include '<installdir>/lib', '<installdir>/lib64', $ORIGIN, $ORIGIN/../lib and $ORIGIN/../lib64
         # $ORIGIN will be resolved by the loader to be the full path to the executable or shared object
         # see also https://linux.die.net/man/8/ld-linux;
-        self.rpath_include_dirs.append(self.installdir+'/lib')
-        self.rpath_include_dirs.append(self.installdir+'/lib64')
+        self.rpath_include_dirs.append(os.path.join(self.installdir, 'lib'))
+        self.rpath_include_dirs.append(os.path.join(self.installdir, 'lib64'))
         self.rpath_include_dirs.append('$ORIGIN')
+        self.rpath_include_dirs.append('$ORIGIN/../lib')
+        self.rpath_include_dirs.append('$ORIGIN/../lib64')
 
         # prepare toolchain: load toolchain module and dependencies, set up build environment
         self.toolchain.prepare(self.cfg['onlytcmod'], silent=self.silent, rpath_filter_dirs=self.rpath_filter_dirs, 

--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -53,7 +53,10 @@ if rpath_filter:
 else:
     rpath_filter = None
 
-rpath_include = rpath_include.split(',')
+if not rpath_include:
+    rpath_include = []
+else:
+    rpath_include = rpath_include.split(',')
 
 version_mode = False
 cmd_args, cmd_args_rpath = [], []
@@ -110,8 +113,9 @@ while idx < len(args):
 cmd_args = cmd_args_rpath + cmd_args
 
 cmd_args_rpath = []
-for path in rpath_include:
-    cmd_args_rpath.append(flag_prefix + '-rpath=%s' % path)
+if rpath_include:
+    for path in rpath_include:
+        cmd_args_rpath.append(flag_prefix + '-rpath=%s' % path)
 
 
 if not version_mode:

--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -38,7 +38,8 @@ import sys
 
 cmd = sys.argv[1]
 rpath_filter = sys.argv[2]
-args = sys.argv[3:]
+rpath_include = sys.argv[3]
+args = sys.argv[4:]
 
 # wheter or not to use -Wl to pass options to the linker
 if cmd in ['ld', 'ld.gold', 'ld.bfd']:
@@ -51,6 +52,8 @@ if rpath_filter:
     rpath_filter = re.compile('^%s$' % '|'.join(rpath_filter))
 else:
     rpath_filter = None
+
+rpath_include = rpath_include.split(',')
 
 version_mode = False
 cmd_args, cmd_args_rpath = [], []
@@ -106,13 +109,13 @@ while idx < len(args):
 # add -rpath flags in front
 cmd_args = cmd_args_rpath + cmd_args
 
+cmd_args_rpath = []
+for path in rpath_include:
+    cmd_args_rpath.append(flag_prefix + '-rpath=%s' % path)
+
+
 if not version_mode:
-    cmd_args = [
-        # always include '$ORIGIN/../lib' and '$ORIGIN/../lib64'
-        # $ORIGIN will be resolved by the loader to be the full path to the 'executable'
-        # see also https://linux.die.net/man/8/ld-linux;
-        flag_prefix + '-rpath=$ORIGIN/../lib',
-        flag_prefix + '-rpath=$ORIGIN/../lib64',
+    cmd_args = cmd_args_rpath + [
         # try to make sure that RUNPATH is not used by always injecting --disable-new-dtags
         flag_prefix + '--disable-new-dtags',
     ] + cmd_args

--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -53,10 +53,10 @@ if rpath_filter:
 else:
     rpath_filter = None
 
-if not rpath_include:
-    rpath_include = []
-else:
+if rpath_include:
     rpath_include = rpath_include.split(',')
+else:
+    rpath_include = []
 
 version_mode = False
 cmd_args, cmd_args_rpath = [], []
@@ -112,11 +112,7 @@ while idx < len(args):
 # add -rpath flags in front
 cmd_args = cmd_args_rpath + cmd_args
 
-cmd_args_rpath = []
-if rpath_include:
-    for path in rpath_include:
-        cmd_args_rpath.append(flag_prefix + '-rpath=%s' % path)
-
+cmds_args_rpath = [flag_prefix + '-rpath=%s' % inc for inc in rpath_include]
 
 if not version_mode:
     cmd_args = cmd_args_rpath + [

--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -112,7 +112,7 @@ while idx < len(args):
 # add -rpath flags in front
 cmd_args = cmd_args_rpath + cmd_args
 
-cmds_args_rpath = [flag_prefix + '-rpath=%s' % inc for inc in rpath_include]
+cmd_args_rpath = [flag_prefix + '-rpath=%s' % inc for inc in rpath_include]
 
 if not version_mode:
     cmd_args = cmd_args_rpath + [

--- a/easybuild/scripts/rpath_wrapper_template.sh.in
+++ b/easybuild/scripts/rpath_wrapper_template.sh.in
@@ -46,8 +46,8 @@ CMD=`basename $0`
 log "found CMD: $CMD | original command: %(orig_cmd)s | orig args: '$(echo \"$@\")'"
 
 # rpath_args.py script spits out statement that defines $CMD_ARGS
-log "%(python)s -O %(rpath_args_py)s $CMD '%(rpath_filter)s' $(echo \"$@\")'"
-rpath_args_out=$(%(python)s -O %(rpath_args_py)s $CMD '%(rpath_filter)s' "$@")
+log "%(python)s -O %(rpath_args_py)s $CMD '%(rpath_filter)s' '%(rpath_include)s' $(echo \"$@\")'"
+rpath_args_out=$(%(python)s -O %(rpath_args_py)s $CMD '%(rpath_filter)s' '%(rpath_include)s' "$@")
 
 log "rpath_args_out:
 $rpath_args_out"

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -656,7 +656,7 @@ class Toolchain(object):
 
         return (c_comps, fortran_comps)
 
-    def prepare(self, onlymod=None, silent=False, loadmod=True, rpath_filter_dirs=None):
+    def prepare(self, onlymod=None, silent=False, loadmod=True, rpath_filter_dirs=None, rpath_include_dirs=None):
         """
         Prepare a set of environment parameters based on name/version of toolchain
         - load modules for toolchain and dependencies
@@ -668,6 +668,7 @@ class Toolchain(object):
         :param silent: keep quiet, or not (mostly relates to extended dry run output)
         :param loadmod: whether or not to (re)load the toolchain module, and the modules for the dependencies
         :param rpath_filter_dirs: extra directories to include in RPATH filter (e.g. build dir, tmpdir, ...)
+        :param rpath_include_dirs: extra directories to include in RPATH
         """
         if loadmod:
             self._load_modules(silent=silent)
@@ -702,7 +703,7 @@ class Toolchain(object):
 
         if build_option('rpath'):
             if self.options.get('rpath', True):
-                self.prepare_rpath_wrappers()
+                self.prepare_rpath_wrappers(rpath_filter_dirs, rpath_include_dirs)
                 self.use_rpath = True
             else:
                 self.log.info("Not putting RPATH wrappers in place, disabled via 'rpath' toolchain option")
@@ -764,7 +765,7 @@ class Toolchain(object):
         calls_rpath_args = 'rpath_args.py $CMD' in read_file(path)
         return in_rpath_wrappers_dir and calls_rpath_args
 
-    def prepare_rpath_wrappers(self, rpath_filter_dirs=None):
+    def prepare_rpath_wrappers(self, rpath_filter_dirs=None, rpath_include_dirs=None):
         """
         Put RPATH wrapper script in place for compiler and linker commands
 
@@ -796,6 +797,12 @@ class Toolchain(object):
         rpath_filter = ','.join(rpath_filter + ['%s.*' % d for d in rpath_filter_dirs or []])
         self.log.debug("Combined RPATH filter: '%s'", rpath_filter)
 
+        # figure out list of patterns to use in rpath include
+        # rpath_include = build_option('rpath_include')
+        rpath_include = ','.join(['%s' % d for d in rpath_include_dirs or []])
+        self.log.debug("Combined RPATH includes: '%s'", rpath_include)
+
+
         # create wrappers
         for cmd in nub(c_comps + fortran_comps + ['ld', 'ld.gold', 'ld.bfd']):
             orig_cmd = which(cmd)
@@ -824,6 +831,7 @@ class Toolchain(object):
                     'orig_cmd': orig_cmd,
                     'python': sys.executable,
                     'rpath_args_py': rpath_args_py,
+                    'rpath_include': rpath_include,
                     'rpath_filter': rpath_filter,
                     'rpath_wrapper_log': rpath_wrapper_log,
                 }

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -797,11 +797,8 @@ class Toolchain(object):
         rpath_filter = ','.join(rpath_filter + ['%s.*' % d for d in rpath_filter_dirs or []])
         self.log.debug("Combined RPATH filter: '%s'", rpath_filter)
 
-        # figure out list of patterns to use in rpath include
-        # rpath_include = build_option('rpath_include')
-        rpath_include = ','.join(['%s' % d for d in rpath_include_dirs or []])
-        self.log.debug("Combined RPATH includes: '%s'", rpath_include)
-
+        rpath_include = ','.join(rpath_include_dirs or [])
+        self.log.debug("Combined RPATH include paths: '%s'", rpath_include)
 
         # create wrappers
         for cmd in nub(c_comps + fortran_comps + ['ld', 'ld.gold', 'ld.bfd']):
@@ -831,8 +828,8 @@ class Toolchain(object):
                     'orig_cmd': orig_cmd,
                     'python': sys.executable,
                     'rpath_args_py': rpath_args_py,
-                    'rpath_include': rpath_include,
                     'rpath_filter': rpath_filter,
+                    'rpath_include': rpath_include,
                     'rpath_wrapper_log': rpath_wrapper_log,
                 }
                 write_file(cmd_wrapper, cmd_wrapper_txt)

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1065,7 +1065,13 @@ class ToolchainTest(EnhancedTestCase):
         """Test rpath_args.py script"""
         script = find_eb_script('rpath_args.py')
 
-        rpath_inc = '%(prefix)s/lib,%(prefix)s/lib64,$ORIGIN' % {'prefix': self.test_prefix}
+        rpath_inc = ','.join([
+            os.path.join(self.test_prefix, 'lib'),
+            os.path.join(self.test_prefix, 'lib64'),
+            '$ORIGIN',
+            '$ORIGIN/../lib',
+            '$ORIGIN/../lib64',
+        ])
 
         # simplest possible compiler command
         out, ec = run_cmd("%s gcc '' '%s' -c foo.c" % (script, rpath_inc), simple=False)
@@ -1074,6 +1080,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
             "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
             "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
             "'-Wl,--disable-new-dtags'",
             "'-c'",
             "'foo.c'",
@@ -1083,15 +1091,12 @@ class ToolchainTest(EnhancedTestCase):
         # linker command, --enable-new-dtags should be replaced with --disable-new-dtags
         out, ec = run_cmd("%s ld '' '%s' --enable-new-dtags foo.o" % (script, rpath_inc), simple=False)
         self.assertEqual(ec, 0)
-        expected = '\n'.join([
-            "CMD_ARGS=('foo.o')",
-            "RPATH_ARGS='--disable-new-dtags -rpath=%(prefix)s/lib -rpath=%(prefix)s/lib64 -rpath=$ORIGIN'" % 
-            {'prefix': self.test_prefix},''
-        ])
         cmd_args = [
             "'-rpath=%s/lib'" % self.test_prefix,
             "'-rpath=%s/lib64'" % self.test_prefix,
             "'-rpath=$ORIGIN'",
+            "'-rpath=$ORIGIN/../lib'",
+            "'-rpath=$ORIGIN/../lib64'",
             "'--disable-new-dtags'",
             "'--disable-new-dtags'",
             "'foo.o'",
@@ -1105,6 +1110,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
             "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
             "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
             "'-Wl,--disable-new-dtags'",
         ]
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
@@ -1116,6 +1123,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-rpath=%s/lib'" % self.test_prefix,
             "'-rpath=%s/lib64'" % self.test_prefix,
             "'-rpath=$ORIGIN'",
+            "'-rpath=$ORIGIN/../lib'",
+            "'-rpath=$ORIGIN/../lib64'",
             "'--disable-new-dtags'",
             "''",
         ]
@@ -1128,6 +1137,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
             "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
             "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
             "'-Wl,--disable-new-dtags'",
             "'-Wl,-rpath=/foo'",
             "'foo.c'",
@@ -1143,6 +1154,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
             "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
             "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
             "'-Wl,--disable-new-dtags'",
             "'foo.c'",
             "'-L../lib'",
@@ -1157,6 +1170,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
             "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
             "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
             "'-Wl,--disable-new-dtags'",
             "'-Wl,-rpath=/foo'",
             "'foo.c'",
@@ -1172,6 +1187,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-rpath=%s/lib'" % self.test_prefix,
             "'-rpath=%s/lib64'" % self.test_prefix,
             "'-rpath=$ORIGIN'",
+            "'-rpath=$ORIGIN/../lib'",
+            "'-rpath=$ORIGIN/../lib64'",
             "'--disable-new-dtags'",
             "'-rpath=/foo'",
             "'-rpath=/lib64'",
@@ -1194,6 +1211,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-rpath=%s/lib'" % self.test_prefix,
             "'-rpath=%s/lib64'" % self.test_prefix,
             "'-rpath=$ORIGIN'",
+            "'-rpath=$ORIGIN/../lib'",
+            "'-rpath=$ORIGIN/../lib64'",
             "'--disable-new-dtags'",
             "'-rpath=/lib64'",
             "'-L/foo'",
@@ -1228,6 +1247,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
             "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
             "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
             "'-Wl,--disable-new-dtags'",
             "'-Wl,-rpath=/icc/lib/intel64'",
             "'-Wl,-rpath=/imkl/lib'",
@@ -1271,6 +1292,8 @@ class ToolchainTest(EnhancedTestCase):
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
             "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
             "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
             "'-Wl,--disable-new-dtags'",
             "'-DHAVE_CONFIG_H'",
             "'-I.'",

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1069,8 +1069,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s gcc '' -c foo.c" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-Wl,-rpath=$ORIGIN/../lib'",
-            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             "'-Wl,--disable-new-dtags'",
             "'-c'",
             "'foo.c'",
@@ -1082,12 +1083,13 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(ec, 0)
         expected = '\n'.join([
             "CMD_ARGS=('foo.o')",
-            "RPATH_ARGS='--disable-new-dtags -rpath=$ORIGIN/../lib -rpath=$ORIGIN/../lib64'",
+            "RPATH_ARGS='--disable-new-dtags -rpath=%s/lib -rpath=%s/lib64 -rpath=$ORIGIN'" % (self.test_prefix, self.test_prefix)
             ''
         ])
         cmd_args = [
-            "'-rpath=$ORIGIN/../lib'",
-            "'-rpath=$ORIGIN/../lib64'",
+            "'-rpath=%s/lib'" % self.test_prefix,
+            "'-rpath=%s/lib64'" % self.test_prefix,
+            "'-rpath=$ORIGIN'",
             "'--disable-new-dtags'",
             "'--disable-new-dtags'",
             "'foo.o'",
@@ -1098,8 +1100,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s gcc ''" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-Wl,-rpath=$ORIGIN/../lib'",
-            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             "'-Wl,--disable-new-dtags'",
         ]
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
@@ -1108,8 +1111,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s ld.gold '' ''" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-rpath=$ORIGIN/../lib'",
-            "'-rpath=$ORIGIN/../lib64'",
+            "'-rpath=%s/lib'" % self.test_prefix,
+            "'-rpath=%s/lib64'" % self.test_prefix,
+            "'-rpath=$ORIGIN'",
             "'--disable-new-dtags'",
             "''",
         ]
@@ -1119,8 +1123,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s gcc '' foo.c -L/foo -lfoo" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-Wl,-rpath=$ORIGIN/../lib'",
-            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             "'-Wl,--disable-new-dtags'",
             "'-Wl,-rpath=/foo'",
             "'foo.c'",
@@ -1133,8 +1138,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s gcc '' foo.c -L../lib -lfoo" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-Wl,-rpath=$ORIGIN/../lib'",
-            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             "'-Wl,--disable-new-dtags'",
             "'foo.c'",
             "'-L../lib'",
@@ -1146,8 +1152,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s gcc '' foo.c -L   /foo -lfoo" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-Wl,-rpath=$ORIGIN/../lib'",
-            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             "'-Wl,--disable-new-dtags'",
             "'-Wl,-rpath=/foo'",
             "'foo.c'",
@@ -1160,8 +1167,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s ld '' -L/foo foo.o -L/lib64 -lfoo -lbar -L/usr/lib -L/bar" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-rpath=$ORIGIN/../lib'",
-            "'-rpath=$ORIGIN/../lib64'",
+            "'-rpath=%s/lib'" % self.test_prefix,
+            "'-rpath=%s/lib64'" % self.test_prefix,
+            "'-rpath=$ORIGIN'",
             "'--disable-new-dtags'",
             "'-rpath=/foo'",
             "'-rpath=/lib64'",
@@ -1181,8 +1189,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s ld '/fo.*,/bar.*' -L/foo foo.o -L/lib64 -lfoo -L/bar -lbar" % script, simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-rpath=$ORIGIN/../lib'",
-            "'-rpath=$ORIGIN/../lib64'",
+            "'-rpath=%s/lib'" % self.test_prefix,
+            "'-rpath=%s/lib64'" % self.test_prefix,
+            "'-rpath=$ORIGIN'",
             "'--disable-new-dtags'",
             "'-rpath=/lib64'",
             "'-L/foo'",
@@ -1214,8 +1223,9 @@ class ToolchainTest(EnhancedTestCase):
         out, ec = run_cmd("%s icc '' %s" % (script, args), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
-            "'-Wl,-rpath=$ORIGIN/../lib'",
-            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             "'-Wl,--disable-new-dtags'",
             "'-Wl,-rpath=/icc/lib/intel64'",
             "'-Wl,-rpath=/imkl/lib'",
@@ -1256,8 +1266,9 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(ec, 0)
 
         cmd_args = [
-            "'-Wl,-rpath=$ORIGIN/../lib'",
-            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             "'-Wl,--disable-new-dtags'",
             "'-DHAVE_CONFIG_H'",
             "'-I.'",
@@ -1325,8 +1336,9 @@ class ToolchainTest(EnhancedTestCase):
         # no -rpath for /bar because of rpath filter
         out, _ = run_cmd('gcc ${USER}.c -L/foo -L/bar \'$FOO\' -DX="\\"\\""')
         expected = ' '.join([
-            '-Wl,-rpath=$ORIGIN/../lib',
-            '-Wl,-rpath=$ORIGIN/../lib64',
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
             '-Wl,--disable-new-dtags',
             '-Wl,-rpath=/foo',
             '%(user)s.c',

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1085,8 +1085,8 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(ec, 0)
         expected = '\n'.join([
             "CMD_ARGS=('foo.o')",
-            "RPATH_ARGS='--disable-new-dtags -rpath=%s/lib -rpath=%s/lib64 -rpath=$ORIGIN'" % (self.test_prefix, self.test_prefix),
-            ''
+            "RPATH_ARGS='--disable-new-dtags -rpath=%(prefix)s/lib -rpath=%(prefix)s/lib64 -rpath=$ORIGIN'" % 
+            {'prefix': self.test_prefix},''
         ])
         cmd_args = [
             "'-rpath=%s/lib'" % self.test_prefix,

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1066,7 +1066,7 @@ class ToolchainTest(EnhancedTestCase):
         script = find_eb_script('rpath_args.py')
 
         # simplest possible compiler command
-        out, ec = run_cmd("%s gcc '' -c foo.c" % script, simple=False)
+        out, ec = run_cmd("%s gcc '' '%s/lib,%s/lib64,$ORIGIN' -c foo.c" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
@@ -1079,7 +1079,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # linker command, --enable-new-dtags should be replaced with --disable-new-dtags
-        out, ec = run_cmd("%s ld '' --enable-new-dtags foo.o" % script, simple=False)
+        out, ec = run_cmd("%s ld '' '%s/lib,%s/lib64,$ORIGIN' --enable-new-dtags foo.o" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         expected = '\n'.join([
             "CMD_ARGS=('foo.o')",
@@ -1097,7 +1097,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # test passing no arguments
-        out, ec = run_cmd("%s gcc ''" % script, simple=False)
+        out, ec = run_cmd("%s gcc '' '%s/lib,%s/lib64,$ORIGIN'" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
@@ -1108,7 +1108,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # test passing a single empty argument
-        out, ec = run_cmd("%s ld.gold '' ''" % script, simple=False)
+        out, ec = run_cmd("%s ld.gold '' '%s/lib,%s/lib64,$ORIGIN' ''" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-rpath=%s/lib'" % self.test_prefix,
@@ -1120,7 +1120,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # single -L argument
-        out, ec = run_cmd("%s gcc '' foo.c -L/foo -lfoo" % script, simple=False)
+        out, ec = run_cmd("%s gcc '' '%s/lib,%s/lib64,$ORIGIN' foo.c -L/foo -lfoo" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
@@ -1135,7 +1135,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # relative paths passed to -L are *not* RPATH'ed in
-        out, ec = run_cmd("%s gcc '' foo.c -L../lib -lfoo" % script, simple=False)
+        out, ec = run_cmd("%s gcc '' '%s/lib,%s/lib64,$ORIGIN' foo.c -L../lib -lfoo" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
@@ -1149,7 +1149,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # single -L argument, with value separated by a space
-        out, ec = run_cmd("%s gcc '' foo.c -L   /foo -lfoo" % script, simple=False)
+        out, ec = run_cmd("%s gcc '' '%s/lib,%s/lib64,$ORIGIN' foo.c -L   /foo -lfoo" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
@@ -1164,7 +1164,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # multiple -L arguments, order should be preserved
-        out, ec = run_cmd("%s ld '' -L/foo foo.o -L/lib64 -lfoo -lbar -L/usr/lib -L/bar" % script, simple=False)
+        out, ec = run_cmd("%s ld '' '%s/lib,%s/lib64,$ORIGIN' -L/foo foo.o -L/lib64 -lfoo -lbar -L/usr/lib -L/bar" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-rpath=%s/lib'" % self.test_prefix,
@@ -1186,7 +1186,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # test specifying of custom rpath filter
-        out, ec = run_cmd("%s ld '/fo.*,/bar.*' -L/foo foo.o -L/lib64 -lfoo -L/bar -lbar" % script, simple=False)
+        out, ec = run_cmd("%s ld '/fo.*,/bar.*' '%s/lib,%s/lib64,$ORIGIN' -L/foo foo.o -L/lib64 -lfoo -L/bar -lbar" % (script, self.test_prefix, self.test_prefix), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-rpath=%s/lib'" % self.test_prefix,
@@ -1220,7 +1220,7 @@ class ToolchainTest(EnhancedTestCase):
             '-Wl,-rpath',
             '-Wl,/example/software/XZ/5.2.2-intel-2016b/lib',
         ])
-        out, ec = run_cmd("%s icc '' %s" % (script, args), simple=False)
+        out, ec = run_cmd("%s icc '' '%s/lib,%s/lib64,$ORIGIN' %s" % (script, self.test_prefix, self.test_prefix, args), simple=False)
         self.assertEqual(ec, 0)
         cmd_args = [
             "'-Wl,-rpath=%s/lib'" % self.test_prefix,
@@ -1261,7 +1261,7 @@ class ToolchainTest(EnhancedTestCase):
             '-o build/version.o',
             '../../gcc/version.c',
         ]
-        cmd = "%s g++ '' %s" % (script, ' '.join(args))
+        cmd = "%s g++ '' '%s/lib,%s/lib64,$ORIGIN' %s" % (script, self.test_prefix, self.test_prefix, ' '.join(args))
         out, ec = run_cmd(cmd, simple=False)
         self.assertEqual(ec, 0)
 

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1284,7 +1284,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # verify that no -rpath arguments are injected when command is run in 'version check' mode
-        cmd = "%s g++ '' -v" % script
+        cmd = "%s g++ '' '%s/lib,%s/lib64,$ORIGIN' -v" % (script, self.test_prefix, self.test_prefix)
         out, ec = run_cmd(cmd, simple=False)
         self.assertEqual(ec, 0)
         self.assertEqual(out.strip(), "CMD_ARGS=('-v')")
@@ -1336,9 +1336,6 @@ class ToolchainTest(EnhancedTestCase):
         # no -rpath for /bar because of rpath filter
         out, _ = run_cmd('gcc ${USER}.c -L/foo -L/bar \'$FOO\' -DX="\\"\\""')
         expected = ' '.join([
-            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
-            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
-            "'-Wl,-rpath=$ORIGIN'",
             '-Wl,--disable-new-dtags',
             '-Wl,-rpath=/foo',
             '%(user)s.c',

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1083,7 +1083,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(ec, 0)
         expected = '\n'.join([
             "CMD_ARGS=('foo.o')",
-            "RPATH_ARGS='--disable-new-dtags -rpath=%s/lib -rpath=%s/lib64 -rpath=$ORIGIN'" % (self.test_prefix, self.test_prefix)
+            "RPATH_ARGS='--disable-new-dtags -rpath=%s/lib -rpath=%s/lib64 -rpath=$ORIGIN'" % (self.test_prefix, self.test_prefix),
             ''
         ])
         cmd_args = [


### PR DESCRIPTION
Add %installdir/lib, %installdir/lib64 and $ORIGIN to RPATH. This works much better with shared libraries in non-standard locations, esp. python packages. See the discussion in https://github.com/easybuilders/easybuild-framework/issues/2076. This patch has been tested for building Tensorflow+python (using foss-2016b) and VTK (for intel-2016b) from scratch. Works without hacks in the easyconfig.