### PR TITLE
install SQLAlchemy < 1.2.0 with Python 2.6 in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ before_install:
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install pydot==1.1.0; else pip install pydot; fi
     # paramiko (dep for GC3Pie) 2.4.0 & more recent doesn't work with Python 2.6
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'paramiko<2.4.0'; else pip install paramiko; fi
+    # SQLAlchemy (dep for GC3Pie) 1.2.0 & more recent doesn't work with Python 2.6
+    - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'SQLAlchemy<1.2.0'; else pip install SQLAlchemy; fi
     # optional Python packages for EasyBuild
     - pip install autopep8 GC3Pie pycodestyle python-graph-dot python-hglib PyYAML
     # git config is required to make actual git commits (cfr. tests for GitRepository)


### PR DESCRIPTION
Fix for SQLAlchemy 1.2.0 (released 2 days ago) no longer being compatible with Python 2.6:

```
Exception: SQLAlchemy requires Python 2.7 or higher.
```