### PR TITLE
support for injecting additional toolchainopts

### DIFF
--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -168,6 +168,13 @@ def tweak_one(src_fn, target_fn, tweaks, targetdir=None):
         tweaks.update({'toolchain': TcDict({'name': toolchain['name'], 'version': toolchain['version']})})
         _log.debug("New toolchain constructed: %s" % tweaks['toolchain'])
 
+    if 'toolchainopts' in keys:
+        tco_regexp = re.compile(r"^\s*toolchainopts\s*=\s*(.*)$", re.M)
+        res = tco_regexp.search(ectxt)
+        toolchainopts = eval(res.group(1))
+        toolchainopts.update(tweaks['toolchainopts'])
+        tweaks.update({'toolchainopts': toolchainopts})
+
     additions = []
 
     # automagically clear out list of checksums if software version is being tweaked 
@@ -176,7 +183,7 @@ def tweak_one(src_fn, target_fn, tweaks, targetdir=None):
         _log.warning("Tweaking version: checksums cleared, verification disabled.")
 
     # we need to treat list values seperately, i.e. we prepend to the current value (if any)
-    for (key, val) in tweaks.items():
+    for (key, val) in tweaks.items():            
 
         if isinstance(val, list):
             # use non-greedy matching for list value using '*?' to avoid including other parameters in match,

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -183,7 +183,7 @@ def tweak_one(src_fn, target_fn, tweaks, targetdir=None):
         _log.warning("Tweaking version: checksums cleared, verification disabled.")
 
     # we need to treat list values seperately, i.e. we prepend to the current value (if any)
-    for (key, val) in tweaks.items():            
+    for (key, val) in tweaks.items():
 
         if isinstance(val, list):
             # use non-greedy matching for list value using '*?' to avoid including other parameters in match,

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -169,10 +169,12 @@ def tweak_one(src_fn, target_fn, tweaks, targetdir=None):
         _log.debug("New toolchain constructed: %s" % tweaks['toolchain'])
 
     if 'toolchainopts' in keys:
+        extra_toolchainopts = tweaks['toolchainopts']
         tco_regexp = re.compile(r"^\s*toolchainopts\s*=\s*(.*)$", re.M)
         res = tco_regexp.search(ectxt)
-        toolchainopts = eval(res.group(1))
-        toolchainopts.update(tweaks['toolchainopts'])
+        toolchainopts = {} if not res else eval(res.group(1))
+        _log.debug("Appending %s toolchainopts to %s" % (extra_toolchainopts, toolchainopts))
+        toolchainopts.update(extra_toolchainopts)
         tweaks.update({'toolchainopts': toolchainopts})
 
     additions = []

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -321,6 +321,7 @@ class EasyBuildOptions(GeneralOption):
 
         opts = OrderedDict({
             'add-dummy-to-minimal-toolchains': ("Include dummy in minimal toolchain searches", None, 'store_true', False),
+            'additional-toolchain-opts': ("List of toolchain options to add", 'strlist', 'store', []),
             'allow-loaded-modules': ("List of software names for which to allow loaded modules in initial environment",
                                      'strlist', 'store', DEFAULT_ALLOW_LOADED_MODULES),
             'allow-modules-tool-mismatch': ("Allow mismatch of modules tool and definition of 'module' function",
@@ -1177,6 +1178,16 @@ def process_software_build_specs(options):
             if ',' in value:
                 value = value.split(',')
             build_specs.update({param: value})
+
+    # process --additional-toolchain-opts
+    if options.additional_toolchain_opts:
+        try_to_generate = True
+
+        toolchainopts = {}
+        for spec in options.additional_toolchain_opts:
+            param, value = spec.split('=')
+            toolchainopts.update({param: value})
+        build_specs.update({'toolchainopts': toolchainopts})
 
     return (try_to_generate, build_specs)
 

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -321,7 +321,6 @@ class EasyBuildOptions(GeneralOption):
 
         opts = OrderedDict({
             'add-dummy-to-minimal-toolchains': ("Include dummy in minimal toolchain searches", None, 'store_true', False),
-            'additional-toolchain-opts': ("List of toolchain options to add", 'strlist', 'store', []),
             'allow-loaded-modules': ("List of software names for which to allow loaded modules in initial environment",
                                      'strlist', 'store', DEFAULT_ALLOW_LOADED_MODULES),
             'allow-modules-tool-mismatch': ("Allow mismatch of modules tool and definition of 'module' function",
@@ -356,6 +355,7 @@ class EasyBuildOptions(GeneralOption):
                              None, 'store_true', False),
             'extra-modules': ("List of extra modules to load after setting up the build environment",
                               'strlist', 'extend', None),
+            'extra-toolchainopts': ("List of toolchain options to add", 'strlist', 'store', []),
             'filter-deps': ("List of dependencies that you do *not* want to install with EasyBuild, "
                             "because equivalent OS packages are installed. (e.g. --filter-deps=zlib,ncurses)",
                             'strlist', 'extend', None),
@@ -1179,12 +1179,12 @@ def process_software_build_specs(options):
                 value = value.split(',')
             build_specs.update({param: value})
 
-    # process --additional-toolchain-opts
-    if options.additional_toolchain_opts:
+    # process --extra-toolchainopts
+    if options.extra_toolchainopts:
         try_to_generate = True
 
         toolchainopts = {}
-        for spec in options.additional_toolchain_opts:
+        for spec in options.extra_toolchainopts:
             param, value = spec.split('=')
             toolchainopts.update({param: value})
         build_specs.update({'toolchainopts': toolchainopts})


### PR DESCRIPTION
this is mostly because --try-amend does not support dictionaries, and supporting it for arbitrary easyconfig parameters would require defining a new (too convoluted?) argument syntax

improvements/alternatives?

