### PR TITLE
Added functionality to skip devel module with naming scheme

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -923,10 +923,6 @@ class EasyBlock(object):
         WARNING: you cannot unload using $EBDEVELNAME (for now: use module unload `basename $EBDEVELNAME`)
         """
 
-        if not ActiveMNS().mns.det_generate_devel_module():
-            self.log.info("Skipping devel module...")
-            return
-
         self.log.info("Making devel module...")
 
         # load fake module
@@ -2328,8 +2324,11 @@ class EasyBlock(object):
             mod_symlink_paths = ActiveMNS().det_module_symlink_paths(self.cfg)
             self.module_generator.create_symlinks(mod_symlink_paths, fake=fake)
 
-            if not fake:
+            if ActiveMNS().mns.det_make_devel_module() and not fake:
                 self.make_devel_module()
+            else:
+                self.log.info("Skipping devel module...")
+
 
         if build_option('set_default_module'):
             self._set_module_as_default()

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -923,6 +923,10 @@ class EasyBlock(object):
         WARNING: you cannot unload using $EBDEVELNAME (for now: use module unload `basename $EBDEVELNAME`)
         """
 
+        if not ActiveMNS().mns.det_generate_devel_module():
+            self.log.info("Skipping devel module...")
+            return
+
         self.log.info("Making devel module...")
 
         # load fake module

--- a/easybuild/tools/module_naming_scheme/mns.py
+++ b/easybuild/tools/module_naming_scheme/mns.py
@@ -164,3 +164,11 @@ class ModuleNamingScheme(object):
                        short_modname, name, modname_regex.pattern, res)
 
         return res
+
+    def det_generate_devel_module(self):
+        """
+        Determine if a devel module should be generated. Can be used to create a separate set of modules with a different naming scheme.
+        Software is already installed beforehand with one naming scheme, including development module.
+        """
+        return True
+

--- a/easybuild/tools/module_naming_scheme/mns.py
+++ b/easybuild/tools/module_naming_scheme/mns.py
@@ -165,9 +165,10 @@ class ModuleNamingScheme(object):
 
         return res
 
-    def det_generate_devel_module(self):
+    def det_make_devel_module(self):
         """
-        Determine if a devel module should be generated. Can be used to create a separate set of modules with a different naming scheme.
+        Determine if a devel module should be generated.
+        Can be used to create a separate set of modules with a different naming scheme.
         Software is already installed beforehand with one naming scheme, including development module.
         """
         return True


### PR DESCRIPTION
So far, we have installed all modules with the default naming scheme. I would like to install a separate set of modules with a lowercase naming scheme (I know about the caveats of using such a scheme). This change allows to install an alternative set of modules that points to the same installation directory, without overwriting the devel module. I also attached the lowercase naming scheme that I used (I had to rename it from `.py` to `.txt`).
[lowercase_easybuild_mns.txt](https://github.com/easybuilders/easybuild-framework/files/1626955/lowercase_easybuild_mns.txt)

