### PR TITLE
Allow basic compiler modulenames to be specified as keys in optarch.

### DIFF
--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -291,14 +291,17 @@ class Compiler(Toolchain):
 
             # optarch has been validated as complex string with multiple compilers and converted to a dictionary
             elif isinstance(optarch, dict):
-                current_compiler = getattr(self, 'COMPILER_FAMILY', None)
-                if current_compiler in optarch:
-                    if optarch[current_compiler] == OPTARCH_GENERIC:
-                        use_generic = True
-                    else:
+                # first try module names, than the family in optarch
+                current_compiler_names = (getattr(self, 'COMPILER_MODULE_NAME', []) +
+                                          [getattr(self, 'COMPILER_FAMILY', None)])
+                for current_compiler in current_compiler_names:
+                    if current_compiler in optarch:
                         optarch = optarch[current_compiler]
+                        break
+                if optarch == OPTARCH_GENERIC:
+                    use_generic = True
                 # no option for this compiler
-                else:
+                if isinstance(optarch, dict):
                     optarch = None
                     self.log.info("_set_optimal_architecture: no optarch found for compiler %s. Ignoring option.", 
                             current_compiler)

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -291,7 +291,7 @@ class Compiler(Toolchain):
 
             # optarch has been validated as complex string with multiple compilers and converted to a dictionary
             elif isinstance(optarch, dict):
-                # first try module names, than the family in optarch
+                # first try module names, then the family in optarch
                 current_compiler_names = (getattr(self, 'COMPILER_MODULE_NAME', []) +
                                           [getattr(self, 'COMPILER_FAMILY', None)])
                 for current_compiler in current_compiler_names:
@@ -300,7 +300,7 @@ class Compiler(Toolchain):
                         break
                 if optarch == OPTARCH_GENERIC:
                     use_generic = True
-                # no option for this compiler
+                # still a dict: no option for this compiler
                 if isinstance(optarch, dict):
                     optarch = None
                     self.log.info("_set_optimal_architecture: no optarch found for compiler %s. Ignoring option.", 

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -387,16 +387,18 @@ class ToolchainTest(EnhancedTestCase):
         """Test whether specifying optarch on a per compiler basis works."""
         flag_vars = ['CFLAGS', 'CXXFLAGS', 'FCFLAGS', 'FFLAGS', 'F90FLAGS']
         intel_options = [('intelflag', 'intelflag'), ('GENERIC', 'xSSE2'), ('', '')]
-        gcc_options = [('gccflag', 'gccflag'), ('GENERIC', 'march=x86-64 -mtune=generic'), ('', '')]
-        toolchains = [('iccifort', '2011.13.367'), ('GCC', '4.7.2'), ('PGI', '16.7-GCC-5.4.0-2.26')]
+        gcc_options = [('gccflag', 'gccflag'), ('-ftree-vectorize', '-ftree-vectorize'), ('', '')]
+        gcccore_options = [('gcccoreflag', 'gcccoreflag'), ('GENERIC', 'march=x86-64 -mtune=generic'), ('', '')]
+        toolchains = [('iccifort', '2011.13.367'), ('GCC', '4.7.2'), ('GCCcore', '6.2.0'), ('PGI', '16.7-GCC-5.4.0-2.26')]
         enabled = [True, False]
 
-        test_cases = product(intel_options, gcc_options, toolchains, enabled)
+        test_cases = product(intel_options, gcc_options, gcccore_options, toolchains, enabled)
 
-        for (intel_flags, intel_flags_exp), (gcc_flags, gcc_flags_exp), (toolchain, toolchain_ver), enable in test_cases:
+        for (intel_flags, intel_flags_exp), (gcc_flags, gcc_flags_exp), (gcccore_flags, gcccore_flags_exp), (toolchain, toolchain_ver), enable in test_cases:
             optarch_var = {}
             optarch_var['Intel'] = intel_flags
             optarch_var['GCC'] = gcc_flags
+            optarch_var['GCCcore'] = gcccore_flags
             build_options = {'optarch': optarch_var}
             init_config(build_options=build_options)
             tc = self.get_toolchain(toolchain, version=toolchain_ver)
@@ -407,6 +409,8 @@ class ToolchainTest(EnhancedTestCase):
                 flags = intel_flags_exp
             elif toolchain == 'GCC':
                 flags = gcc_flags_exp
+            elif toolchain == 'GCCcore':
+                flags = gcccore_flags_exp
             else: # PGI as an example of compiler not set
                 # default optarch flag, should be the same as the one in
                 # tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(tc.arch,tc.cpu_family)]
@@ -423,6 +427,8 @@ class ToolchainTest(EnhancedTestCase):
                     intel_options[1][1],
                     gcc_options[0][1],
                     gcc_options[1][1],
+                    gcccore_options[0][1],
+                    gcccore_options[1][1],
                     'xHost', # default optimal for Intel
                     'march=native', # default optimal for GCC
                 ]


### PR DESCRIPTION
Examples: 'GCCcore', 'icc', 'ifort'. They will be considered before
the compiler family ('Intel', etc).