### PR TITLE
avoid fatal error when determining glibc version on non-glibc Linux system (e.g. Alphine Linux)

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -629,6 +629,7 @@ def get_glibc_version():
     """
     Find the version of glibc used on this system
     """
+    glibc_ver = UNKNOWN
     os_type = get_os_type()
 
     if os_type == LINUX:
@@ -637,16 +638,16 @@ def get_glibc_version():
         res = glibc_ver_regex.search(glibc_ver_str)
 
         if res is not None:
-            glibc_version = res.group(1)
-            _log.debug("Found glibc version %s" % glibc_version)
-            return glibc_version
+            glibc_ver = res.group(1)
+            _log.debug("Found glibc version %s" % glibc_ver)
         else:
-            raise EasyBuildError("Failed to determine glibc version from '%s' using pattern '%s'.",
-                                 glibc_ver_str, glibc_ver_regex.pattern)
+            _log.warning("Failed to determine glibc version from '%s' using pattern '%s'.",
+                         glibc_ver_str, glibc_ver_regex.pattern)
     else:
         # no glibc on OS X standard
         _log.debug("No glibc on a non-Linux system, so can't determine version.")
-        return UNKNOWN
+
+    return glibc_ver
 
 
 def get_system_info():

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -342,7 +342,7 @@ class SystemToolsTest(EnhancedTestCase):
         st.get_os_type = self.orig_get_os_type
         st.run_cmd = self.orig_run_cmd
         st.platform.uname = self.orig_platform_uname
-        self.get_tool_version = self.orig_get_tool_version
+        st.get_tool_version = self.orig_get_tool_version
         super(SystemToolsTest, self).tearDown()
 
     def test_avail_core_count_native(self):

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -332,6 +332,7 @@ class SystemToolsTest(EnhancedTestCase):
         self.orig_read_file = st.read_file
         self.orig_run_cmd = st.run_cmd
         self.orig_platform_uname = st.platform.uname
+        self.orig_get_tool_version = st.get_tool_version
 
     def tearDown(self):
         """Cleanup after systemtools test."""
@@ -341,6 +342,7 @@ class SystemToolsTest(EnhancedTestCase):
         st.get_os_type = self.orig_get_os_type
         st.run_cmd = self.orig_run_cmd
         st.platform.uname = self.orig_platform_uname
+        self.get_tool_version = self.orig_get_tool_version
         super(SystemToolsTest, self).tearDown()
 
     def test_avail_core_count_native(self):
@@ -697,6 +699,12 @@ class SystemToolsTest(EnhancedTestCase):
         st.get_os_type = lambda: st.LINUX
         st.run_cmd = mocked_run_cmd
         self.assertEqual(get_glibc_version(), '2.12')
+
+    def test_glibc_version_linux_musl_libc(self):
+        """Test getting glibc version (mocked for Linux)."""
+        st.get_os_type = lambda: st.LINUX
+        st.get_tool_version = lambda _: "musl libc (x86_64); Version 1.1.18; Dynamic Program Loader"
+        self.assertEqual(get_glibc_version(), UNKNOWN)
 
     def test_glibc_version_darwin(self):
         """Test getting glibc version (mocked for Darwin)."""


### PR DESCRIPTION
fix for https://github.com/easybuilders/easybuild/issues/410, replacement for #2397