### PR TITLE
Keep the current timestamp when extracting files

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -168,6 +168,7 @@ BUILD_OPTIONS_CMDLINE = {
         'hidden',
         'ignore_checksums',
         'install_latest_eb_release',
+        'keep_current_timestamp',
         'minimal_toolchains',
         'module_only',
         'package',
@@ -408,6 +409,7 @@ def init_build_options(build_options=None, cmdline_options=None):
 def build_option(key, **kwargs):
     """Obtain value specified build option."""
     build_options = BuildOptions()
+    print build_options
     if key in build_options:
         return build_options[key]
     elif 'default' in kwargs:

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -409,7 +409,6 @@ def init_build_options(build_options=None, cmdline_options=None):
 def build_option(key, **kwargs):
     """Obtain value specified build option."""
     build_options = BuildOptions()
-    print build_options
     if key in build_options:
         return build_options[key]
     elif 'default' in kwargs:

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -122,28 +122,28 @@ CHECKSUM_TYPES = sorted(CHECKSUM_FUNCTIONS.keys())
 
 EXTRACT_CMDS = {
     # gzipped or gzipped tarball
-    '.gtgz':    "tar xzf %(filepath)s",
+    '.gtgz':    "tar x%(timestamp_tar)szf %(filepath)s",
     '.gz':      "gunzip -c %(filepath)s > %(target)s",
-    '.tar.gz':  "tar xzf %(filepath)s",
-    '.tgz':     "tar xzf %(filepath)s",
+    '.tar.gz':  "tar x%(timestamp_tar)szf %(filepath)s",
+    '.tgz':     "tar x%(timestamp_tar)szf %(filepath)s",
     # bzipped or bzipped tarball
     '.bz2':     "bunzip2 -c %(filepath)s > %(target)s",
-    '.tar.bz2': "tar xjf %(filepath)s",
-    '.tb2':     "tar xjf %(filepath)s",
-    '.tbz':     "tar xjf %(filepath)s",
-    '.tbz2':    "tar xjf %(filepath)s",
+    '.tar.bz2': "tar x%(timestamp_tar)sjf %(filepath)s",
+    '.tb2':     "tar x%(timestamp_tar)sjf %(filepath)s",
+    '.tbz':     "tar x%(timestamp_tar)sjf %(filepath)s",
+    '.tbz2':    "tar x%(timestamp_tar)sjf %(filepath)s",
     # xzipped or xzipped tarball
-    '.tar.xz':  "unxz %(filepath)s --stdout | tar x",
-    '.txz':     "unxz %(filepath)s --stdout | tar x",
+    '.tar.xz':  "unxz %(filepath)s --stdout | tar x%(timestamp_tar)s",
+    '.txz':     "unxz %(filepath)s --stdout | tar x%(timestamp_tar)s",
     '.xz':      "unxz %(filepath)s",
     # tarball
-    '.tar':     "tar xf %(filepath)s",
+    '.tar':     "tar x%(timestamp_tar)sf %(filepath)s",
     # zip file
-    '.zip':     "unzip -qq %(filepath)s",
+    '.zip':     "unzip -qq %(timestamp_zip)s %(filepath)s",
     # iso file
     '.iso':     "7z x %(filepath)s",
     # tar.Z: using compress (LZW)
-    '.tar.z':   "tar xZf %(filepath)s",
+    '.tar.z':   "tar x%(timestamp_tar)sZf %(filepath)s",
 }
 
 
@@ -768,7 +768,14 @@ def extract_cmd(filepath, overwrite=False):
         if 'unzip -qq' in cmd_tmpl:
             cmd_tmpl = cmd_tmpl.replace('unzip -qq', 'unzip -qq -o')
 
-    return cmd_tmpl % {'filepath': filepath, 'target': target}
+    if build_option('keep_current_timestamp'):
+         ts_tar='m'
+         ts_zip='-DD'
+    else:
+         ts_tar=''
+         ts_zip=''
+
+    return cmd_tmpl % {'filepath': filepath, 'target': target, 'timestamp_tar': ts_tar, 'timestamp_zip': ts_zip}
 
 
 def is_patch_file(path):

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -376,6 +376,7 @@ class EasyBuildOptions(GeneralOption):
             'ignore-checksums': ("Ignore failing checksum verification", None, 'store_true', False),
             'ignore-osdeps': ("Ignore any listed OS dependencies", None, 'store_true', False),
             'install-latest-eb-release': ("Install latest known version of easybuild", None, 'store_true', False),
+            'keep-current-timestamp': ("Keep current timestamp of extracted files", None, 'store_true', False),
             'max-fail-ratio-adjust-permissions': ("Maximum ratio for failures to allow when adjusting permissions",
                                                   'float', 'store', DEFAULT_MAX_FAIL_RATIO_PERMS),
             'minimal-toolchains': ("Use minimal toolchain when resolving dependencies", None, 'store_true', False),

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -87,6 +87,8 @@ class FileToolsTest(EnhancedTestCase):
             cmd = ft.extract_cmd(fn)
             self.assertEqual(expected_cmd, cmd)
 
+        self.assertEqual("unzip -qq -o test.zip", ft.extract_cmd('test.zip', True))
+
         # check whether timestamp option works
         build_options = {
             'keep_current_timestamp': True,
@@ -111,8 +113,6 @@ class FileToolsTest(EnhancedTestCase):
         for (fn, expected_cmd) in tests:
             cmd = ft.extract_cmd(fn)
             self.assertEqual(expected_cmd, cmd)
-
-        self.assertEqual("unzip -qq -o test.zip", ft.extract_cmd('test.zip', True))
 
     def test_find_extension(self):
         """Test find_extension function."""

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -87,6 +87,31 @@ class FileToolsTest(EnhancedTestCase):
             cmd = ft.extract_cmd(fn)
             self.assertEqual(expected_cmd, cmd)
 
+        # check whether timestamp option works
+        build_options = {
+            'keep_current_timestamp': True,
+        }
+        init_config(build_options=build_options)
+
+        tests = [
+            ('test.zip', "unzip -qq -DD test.zip"),
+            ('/some/path/test.tar', "tar xmf /some/path/test.tar"),
+            ('test.tar.gz', "tar xmzf test.tar.gz"),
+            ('test.TAR.GZ', "tar xmzf test.TAR.GZ"),
+            ('test.tgz', "tar xmzf test.tgz"),
+            ('test.gtgz', "tar xmzf test.gtgz"),
+            ('test.tbz', "tar xmjf test.tbz"),
+            ('test.tbz2', "tar xmjf test.tbz2"),
+            ('test.tb2', "tar xmjf test.tb2"),
+            ('test.tar.bz2', "tar xmjf test.tar.bz2"),
+            ('test.tar.xz', "unxz test.tar.xz --stdout | tar xm"),
+            ('test.txz', "unxz test.txz --stdout | tar xm"),
+            ('test.tar.Z', "tar xmZf test.tar.Z"),
+        ]
+        for (fn, expected_cmd) in tests:
+            cmd = ft.extract_cmd(fn)
+            self.assertEqual(expected_cmd, cmd)
+
         self.assertEqual("unzip -qq -o test.zip", ft.extract_cmd('test.zip', True))
 
     def test_find_extension(self):


### PR DESCRIPTION
The code adds an option `--keep-current-timestamp` to extract files without restoring the original timestamp. This is useful on a scratch filesystem that automatically cleans files older than a few weeks.