### PR TITLE
declare support for RPATH linking stable

### DIFF
--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -771,8 +771,6 @@ class Toolchain(object):
 
         :param rpath_filter_dirs: extra directories to include in RPATH filter (e.g. build dir, tmpdir, ...)
         """
-        self.log.experimental("Using wrapper scripts for compiler/linker commands that enforce RPATH linking")
-
         if get_os_type() == LINUX:
             self.log.info("Putting RPATH wrappers in place...")
         else:


### PR DESCRIPTION
Based on the feedback from @jdonners and @pescobar and the discussion we had during the EasyBuild User Meeting in Amsterdam (cfr. https://github.com/easybuilders/easybuild/wiki/3rd-EasyBuild-User-Meeting), the conclusion was that we can declare the RPATH support as stable.

There are a couple of outstanding issues (cfr. #1992), but none of these seem blockers to me; either they are nice-to-have features, or problems specific to a particular software package that can be handled case-by-case.