### PR TITLE
enable caching of $HOME/.cache/pip in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
     - ENV_MOD_VERSION=3.2.10 TEST_EASYBUILD_MODULES_TOOL=EnvironmentModulesC TEST_EASYBUILD_MODULE_SYNTAX=Tcl
     - ENV_MOD_TCL_VERSION=1.147 TEST_EASYBUILD_MODULES_TOOL=EnvironmentModulesTcl TEST_EASYBUILD_MODULE_SYNTAX=Tcl
     - ENV_MOD_VERSION=4.0.0 TEST_EASYBUILD_MODULE_SYNTAX=Tcl TEST_EASYBUILD_MODULES_TOOL=EnvironmentModules
+cache:
+  pip: true
 matrix:
   # mark build as finished as soon as job has failed
   fast_finish: true


### PR DESCRIPTION
During each test run, over 2 minutes is spent installing Python packages through `pip`.

Enabling caching of `$HOME/.cache/pip` speeds this up quite a bit, down to ~10 sec...
cfr. https://docs.travis-ci.com/user/caching#pip-cache