### PR TITLE
make sure GitHub token is used in test for --preview-pr

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2217,6 +2217,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         eb_file = os.path.join(test_ecs_path, 'b', 'bzip2', 'bzip2-1.0.6-GCC-4.9.2.eb')
         args = [
             '--color=never',
+            '--github-user=%s' % GITHUB_TEST_ACCOUNT,
             '--preview-pr',
             eb_file,
         ]


### PR DESCRIPTION
`test_preview_pr` now fails with `403` for no good reason (due to rate limiting for non-authorised access to GitHub) 