### PR TITLE
add Accept header when downloading file

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -459,7 +459,7 @@ def download_file(filename, url, path, forced=False):
     attempt_cnt = 0
 
     # use custom HTTP header
-    url_req = urllib2.Request(url, headers={'User-Agent': 'EasyBuild',  "Accept" : "text/html"})
+    url_req = urllib2.Request(url, headers={'User-Agent': 'EasyBuild',  "Accept" : "*/*"})
 
     while not downloaded and attempt_cnt < max_attempts:
         try:

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -459,7 +459,7 @@ def download_file(filename, url, path, forced=False):
     attempt_cnt = 0
 
     # use custom HTTP header
-    url_req = urllib2.Request(url, headers={'User-Agent': 'EasyBuild'})
+    url_req = urllib2.Request(url, headers={'User-Agent': 'EasyBuild',  "Accept" : "text/html"})
 
     while not downloaded and attempt_cnt < max_attempts:
         try:


### PR DESCRIPTION
when trying to download file with urllib2 adding to the header the field Accept since the absence of such field can lead to some security module to raise a 403 response:
https://serverfault.com/questions/377656/why-does-mod-security-require-an-accept-http-header-field