### PR TITLE
loosen commit message requirements w.r.t. to patches as long as all easyconfigs are new

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -689,9 +689,9 @@ def _easyconfigs_pr_common(paths, ecs, start_branch=None, pr_branch=None, start_
     if commit_msg:
         cnt = len(file_info['paths_in_repo'])
         _log.debug("Using specified commit message for all %d new/modified easyconfigs at once: %s", cnt, commit_msg)
-    elif all(file_info['new']) and not paths['patch_files'] and not paths['files_to_delete']:
+    elif all(file_info['new']) and not paths['files_to_delete']:
         # automagically derive meaningful commit message if all easyconfig files are new
-        commit_msg = "adding easyconfigs: %s" % ', '.join(os.path.basename(p) for p in file_info['paths_in_repo'])
+        commit_msg = "adding easyconfigs: %s" % ', '.join(os.path.basename(p) for p in file_info['paths_in_repo']+paths['patch_files'])
     else:
         raise EasyBuildError("A meaningful commit message must be specified via --pr-commit-msg when "
                              "modifying/deleting easyconfigs and/or specifying patches")

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -696,7 +696,7 @@ def _easyconfigs_pr_common(paths, ecs, start_branch=None, pr_branch=None, start_
             commit_msg += " and patches: %s" % ', '.join(os.path.basename(p) for p in paths['patch_files'])
     else:
         raise EasyBuildError("A meaningful commit message must be specified via --pr-commit-msg when "
-                             "modifying/deleting easyconfigs and/or specifying patches")
+                             "modifying/deleting easyconfigs")
 
     # figure out to which software name patches relate, and copy them to the right place
     if paths['patch_files']:

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -691,7 +691,9 @@ def _easyconfigs_pr_common(paths, ecs, start_branch=None, pr_branch=None, start_
         _log.debug("Using specified commit message for all %d new/modified easyconfigs at once: %s", cnt, commit_msg)
     elif all(file_info['new']) and not paths['files_to_delete']:
         # automagically derive meaningful commit message if all easyconfig files are new
-        commit_msg = "adding easyconfigs: %s" % ', '.join(os.path.basename(p) for p in file_info['paths_in_repo']+paths['patch_files'])
+        commit_msg = "adding easyconfigs: %s" % ', '.join(os.path.basename(p) for p in file_info['paths_in_repo'])
+        if paths['patch_files']:        
+            commit_msg += " and patches: %s" % ', '.join(os.path.basename(p) for p in paths['patch_files'])
     else:
         raise EasyBuildError("A meaningful commit message must be specified via --pr-commit-msg when "
                              "modifying/deleting easyconfigs and/or specifying patches")


### PR DESCRIPTION
It seems to me that as long as all easyconfigs are new, the commit message could still be automatically generated

If a new patch being added applies to an existing easyconfig, that easyconfig would need to be modified so a meaningful commit message is still needed, this change only affects the cases where all easyconfig files are new

do close if I'm missing something