### PR TITLE
add configuration for houndci + flake8

### DIFF
--- a/.flake8.ini
+++ b/.flake8.ini
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+flake8:
+  enabled: true

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,4 @@
+# configuration for houndci, see https://houndci.com/configuration#python
 flake8:
   enabled: true
+  config_file: .flake8.ini

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -692,7 +692,7 @@ def _easyconfigs_pr_common(paths, ecs, start_branch=None, pr_branch=None, start_
     elif all(file_info['new']) and not paths['files_to_delete']:
         # automagically derive meaningful commit message if all easyconfig files are new
         commit_msg = "adding easyconfigs: %s" % ', '.join(os.path.basename(p) for p in file_info['paths_in_repo'])
-        if paths['patch_files']:        
+        if paths['patch_files']:
             commit_msg += " and patches: %s" % ', '.join(os.path.basename(p) for p in paths['patch_files'])
     else:
         raise EasyBuildError("A meaningful commit message must be specified via --pr-commit-msg when "

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1929,7 +1929,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         test_easyblocks = os.path.dirname(os.path.abspath(__file__))
         path_pattern = os.path.join(test_easyblocks, 'sandbox', 'easybuild', 'easyblocks', 'f', 'foo.py')
-        foo_regex = re.compile(r"^\|-- EB_foo \(easybuild.easyblocks.foo @ %s\)"  % path_pattern, re.M)
+        foo_regex = re.compile(r"^\|-- EB_foo \(easybuild.easyblocks.foo @ %s\)" % path_pattern, re.M)
         self.assertTrue(foo_regex.search(logtxt), "Pattern '%s' found in: %s" % (foo_regex.pattern, logtxt))
 
         # 'undo' import of foo easyblock
@@ -1961,7 +1961,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         logtxt = read_file(self.logfile)
 
         path_pattern = os.path.join(self.test_prefix, '.*', 'included-easyblocks', 'easybuild', 'easyblocks', 'foo.py')
-        foo_regex = re.compile(r"^\|-- EB_foo \(easybuild.easyblocks.foo @ %s\)"  % path_pattern, re.M)
+        foo_regex = re.compile(r"^\|-- EB_foo \(easybuild.easyblocks.foo @ %s\)" % path_pattern, re.M)
         self.assertTrue(foo_regex.search(logtxt), "Pattern '%s' found in: %s" % (foo_regex.pattern, logtxt))
 
         # easyblock is found via get_easyblock_class
@@ -2005,7 +2005,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         path_pattern = os.path.join(self.test_prefix, '.*', 'included-easyblocks', 'easybuild', 'easyblocks',
                                     'generic', 'foobar.py')
-        foo_regex = re.compile(r"^\|-- FooBar \(easybuild.easyblocks.generic.foobar @ %s\)"  % path_pattern, re.M)
+        foo_regex = re.compile(r"^\|-- FooBar \(easybuild.easyblocks.generic.foobar @ %s\)" % path_pattern, re.M)
         self.assertTrue(foo_regex.search(logtxt), "Pattern '%s' found in: %s" % (foo_regex.pattern, logtxt))
 
         klass = get_easyblock_class('FooBar')
@@ -2043,7 +2043,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         mod_pattern = 'easybuild.easyblocks.generic.generictest'
         path_pattern = os.path.join(self.test_prefix, '.*', 'included-easyblocks', 'easybuild', 'easyblocks',
                                     'generic', 'generictest.py')
-        foo_regex = re.compile(r"^\|-- GenericTest \(%s @ %s\)"  % (mod_pattern, path_pattern), re.M)
+        foo_regex = re.compile(r"^\|-- GenericTest \(%s @ %s\)" % (mod_pattern, path_pattern), re.M)
         self.assertTrue(foo_regex.search(logtxt), "Pattern '%s' found in: %s" % (foo_regex.pattern, logtxt))
 
         klass = get_easyblock_class('GenericTest')


### PR DESCRIPTION
(& fix some minor whitespace-related style issues that were introduced recently)

https://houndci.com/ looks like a nice automatic style review CI

With some minimal configuration, it will perform a code style review on pull requests, and add inline comments to indicate the style issues.

A quick test has shown that it works quite well, see https://github.com/boegel/easybuild-framework/pull/30 (before putting configuration for 120 character max line length in place) + https://github.com/boegel/easybuild-framework/pull/31