### PR TITLE
Introduce golf: compiler toolchain with GCC, OpenBLAS, and FFTW.

### DIFF
--- a/easybuild/toolchains/golf.py
+++ b/easybuild/toolchains/golf.py
@@ -1,0 +1,40 @@
+##
+# Copyright 2013-2018 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for golf compiler toolchain (includes GCC, OpenBLAS, LAPACK, and FFTW).
+
+:author: Kenneth Hoste (Ghent University)
+:author: Bart Oldeman (McGill University, Calcul Quebec, Compute Canada)
+"""
+
+from easybuild.toolchains.gcc import GccToolchain
+from easybuild.toolchains.fft.fftw import Fftw
+from easybuild.toolchains.linalg.openblas import OpenBLAS
+
+
+class Golf(GccToolchain, OpenBLAS, Fftw):
+    """Compiler toolchain with GCC, OpenBLAS, and FFTW."""
+    NAME = 'golf'
+    SUBTOOLCHAIN = GccToolchain.NAME

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -412,7 +412,7 @@ class Toolchain(object):
         var_suff = '_MODULE_NAME'
         tc_elems = {}
         for var in dir(self):
-            if var.endswith(var_suff):
+            if var.endswith(var_suff) and getattr(self, var) is not None:
                 tc_elems.update({var[:-len(var_suff)]: getattr(self, var)})
 
         self.log.debug("Toolchain definition for %s: %s", self.as_dict(), tc_elems)


### PR DESCRIPTION
Since BLACS_MODULE_NAME and SCALAPACK_MODULE_NAME are set to None in
this case we need to filter out None for the toolchain definition.