### PR TITLE
stick to autopep8 1.3.4 when testing with Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,10 @@ before_install:
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'paramiko<2.4.0'; else pip install paramiko; fi
     # SQLAlchemy (dep for GC3Pie) 1.2.0 & more recent doesn't work with Python 2.6
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'SQLAlchemy<1.2.0'; else pip install SQLAlchemy; fi
+    # autopep8 1.3.4 is last one to support Python 2.6
+    - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'autopep8<1.3.5'; else pip install autopep8; fi
     # optional Python packages for EasyBuild
-    - pip install autopep8 GC3Pie pycodestyle python-graph-dot python-hglib PyYAML
+    - pip install GC3Pie pycodestyle python-graph-dot python-hglib PyYAML
     # git config is required to make actual git commits (cfr. tests for GitRepository)
     - git config --global user.name "Travis CI"
     - git config --global user.email "travis@travis-ci.org"


### PR DESCRIPTION
without this, tests on Python 2.6 fail with:

```
  File "/home/travis/virtualenv/python2.6.9/lib/python2.6/site-packages/autopep8.py", line 3165
    codes = {result['id'] for result in results
                            ^
SyntaxError: invalid syntax
```