### PR TITLE
strip off .lua extension when backing up modules to ensure Lmod 6.x doesn't pick up on them

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1524,12 +1524,20 @@ class EasyBlock(object):
 
         # create backup of existing module file (if requested)
         if os.path.exists(self.mod_filepath) and build_option('backup_modules'):
+            # strip off .lua extension to ensure that Lmod ignores backed up module file
+            # Lmod 7.x ignores any files not ending in .lua
+            # Lmod 6.x ignores any files that don't have .lua anywhere in the filename
+            strip_fn = None
+            if isinstance(self.module_generator, ModuleGeneratorLua):
+                strip_fn = ModuleGeneratorLua.MODULE_FILE_EXTENSION
+
             # backups of modules in Tcl syntax should be hidden to avoid that they're shown in 'module avail';
             # backups of modules in Lua syntax do not need to be hidden:
-            # since they don't end in .lua (but in .lua.bak_*) Lmod will not pick them up anymore,
+            # since they don't have .lua in the filename Lmod will not pick them up anymore,
             # which is better than hiding them (since --show-hidden still reveals them)
             hidden = isinstance(self.module_generator, ModuleGeneratorTcl)
-            self.mod_file_backup = back_up_file(self.mod_filepath, hidden=hidden)
+
+            self.mod_file_backup = back_up_file(self.mod_filepath, hidden=hidden, strip_fn=strip_fn)
             print_msg("backup of existing module file stored at %s" % self.mod_file_backup, log=self.log)
 
         # check if main install needs to be skipped

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1218,13 +1218,14 @@ def find_backup_name_candidate(src_file):
     return dst_file
 
 
-def back_up_file(src_file, backup_extension='bak', hidden=False):
+def back_up_file(src_file, backup_extension='bak', hidden=False, strip_fn=None):
     """
     Backs up a file appending a backup extension and timestamp to it (if there is already an existing backup).
 
     :param src_file: file to be back up
     :param backup_extension: extension to use for the backup file (can be empty or None)
     :param hidden: make backup hidden (leading dot in filename)
+    :param strip_fn: strip specified trailing substring from filename of backup
     :return: location of backed up file
     """
     fn_prefix, fn_suffix = '', ''
@@ -1234,6 +1235,9 @@ def back_up_file(src_file, backup_extension='bak', hidden=False):
         fn_suffix = '.%s' % backup_extension
 
     src_dir, src_fn = os.path.split(src_file)
+    if strip_fn:
+        src_fn = src_fn.rstrip(strip_fn)
+
     backup_fp = find_backup_name_candidate(os.path.join(src_dir, fn_prefix + src_fn + fn_suffix))
 
     copy_file(src_file, backup_fp)

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -567,10 +567,11 @@ class FileToolsTest(EnhancedTestCase):
         self.assertEqual(sorted(os.listdir(os.path.dirname(fp))), known_files)
 
         # Test simple file backup
-        ft.back_up_file(fp)
+        res = ft.back_up_file(fp)
         test_files = os.listdir(os.path.dirname(fp))
         self.assertEqual(len(test_files), 2)
         new_file = [x for x in test_files if x not in known_files][0]
+        self.assertTrue(os.path.samefile(res, os.path.join(self.test_prefix, 'sandbox', new_file)))
         self.assertTrue(new_file.startswith('test.txt.bak_'))
         first_normal_backup = os.path.join(os.path.dirname(fp), new_file)
         known_files = os.listdir(os.path.dirname(fp))
@@ -679,6 +680,16 @@ class FileToolsTest(EnhancedTestCase):
         self.assertTrue(ft.read_file(first_hidden_bck_backup), txt)
         self.assertEqual(ft.read_file(os.path.join(os.path.dirname(fp), new_file)), new_txt)
         self.assertEqual(ft.read_file(fp), new_txt)
+
+        # check whether strip_fn works as expected
+        fp2 = fp + '.lua'
+        ft.copy_file(fp, fp2)
+        res = ft.back_up_file(fp2)
+        self.assertTrue(fp2.endswith('.lua'))
+        self.assertTrue('.lua' in os.path.basename(res))
+
+        res = ft.back_up_file(fp2, strip_fn='.lua')
+        self.assertFalse('.lua' in os.path.basename(res))
 
     def test_move_logs(self):
         """Test move_logs function."""

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1386,8 +1386,10 @@ class ToyBuildTest(EnhancedTestCase):
         # Test also with lua syntax if Lmod is available. In particular, that the backup is not hidden
         if isinstance(self.modtool, Lmod):
             args = common_args + ['--module-syntax=Lua', '--backup-modules']
-            toy_mod = os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0-deps.lua')
-            toy_mod_dir, toy_mod_fn = os.path.split(toy_mod)
+
+            toy_mod_dir = os.path.join(self.test_installpath, 'modules', 'all', 'toy')
+            toy_mod_fn = '0.0-deps'
+            toy_mod = os.path.join(toy_mod_dir, toy_mod_fn + '.lua')
 
             self.eb_main(args, do_build=True, raise_error=True)
             self.assertTrue(os.path.exists(toy_mod))
@@ -1406,10 +1408,10 @@ class ToyBuildTest(EnhancedTestCase):
             toy_mod_backups = glob.glob(os.path.join(toy_mod_dir, toy_mod_fn + '.bak_*'))
             self.assertEqual(len(toy_mod_backups), 1)
             first_toy_lua_mod_backup = toy_mod_backups[0]
-            self.assertTrue('.lua.bak' in os.path.basename(first_toy_lua_mod_backup))
+            self.assertTrue('.bak_' in os.path.basename(first_toy_lua_mod_backup))
             self.assertFalse(os.path.basename(first_toy_lua_mod_backup).startswith('.'))
 
-            toy_mod_bak = ".*/toy/0\.0-deps\.lua\.bak_[0-9]*"
+            toy_mod_bak = ".*/toy/0\.0-deps\.bak_[0-9]*"
             regex = re.compile("^== backup of existing module file stored at %s" % toy_mod_bak, re.M)
             self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
             regex = re.compile("^== comparing module file with backup %s; no differences found$" % toy_mod_bak, re.M)


### PR DESCRIPTION
fix for #2441