### PR TITLE
Add goolfc-2.6.10 toolchain for test_get_toolchain_hierarchy robot test.

### DIFF
--- a/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.3-GCC-4.8.2-serial.eb
+++ b/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.3-GCC-4.8.2-serial.eb
@@ -1,0 +1,35 @@
+easyblock = 'ConfigureMake'
+
+name = 'FFTW'
+version = '3.3.3'
+versionsuffix = '-serial'
+
+homepage = 'http://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+ in one or more dimensions, of arbitrary input size, and of both real and complex data."""
+
+toolchain = {'name': 'GCC', 'version': '4.7.2'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [homepage]
+
+common_configopts = "--enable-threads --enable-openmp --with-pic"
+
+configopts = [
+    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    common_configopts + " --enable-long-double --enable-mpi",
+    common_configopts + " --enable-quad-precision",
+    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+]
+
+sanity_check_paths = {
+    'files': ['bin/fftw%s' % x for x in ['-wisdom', '-wisdom-to-conf', 'f-wisdom', 'l-wisdom', 'q-wisdom']] +
+             ['include/fftw3%s' % x for x in ['-mpi.f03', '-mpi.h', '.f', '.f03',
+                                              '.h', 'l-mpi.f03', 'l.f03', 'q.f03']] +
+             ['lib/libfftw3%s%s.a' % (x, y) for x in ['', 'f', 'l'] for y in ['', '_mpi', '_omp', '_threads']] +
+             ['lib/libfftw3q.a', 'lib/libfftw3q_omp.a'],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'numlib'

--- a/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.3-gompic-2.6.10.eb
+++ b/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.3-gompic-2.6.10.eb
@@ -1,0 +1,34 @@
+easyblock = 'ConfigureMake'
+
+name = 'FFTW'
+version = '3.3.3'
+
+homepage = 'http://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+ in one or more dimensions, of arbitrary input size, and of both real and complex data."""
+
+toolchain = {'name': 'gompic', 'version': '2.6.10'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [homepage]
+
+common_configopts = "--enable-threads --enable-openmp --with-pic"
+
+configopts = [
+    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    common_configopts + " --enable-long-double --enable-mpi",
+    common_configopts + " --enable-quad-precision",
+    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+]
+
+sanity_check_paths = {
+    'files': ['bin/fftw%s' % x for x in ['-wisdom', '-wisdom-to-conf', 'f-wisdom', 'l-wisdom', 'q-wisdom']] +
+             ['include/fftw3%s' % x for x in ['-mpi.f03', '-mpi.h', '.f', '.f03',
+                                              '.h', 'l-mpi.f03', 'l.f03', 'q.f03']] +
+             ['lib/libfftw3%s%s.a' % (x, y) for x in ['', 'f', 'l'] for y in ['', '_mpi', '_omp', '_threads']] +
+             ['lib/libfftw3q.a', 'lib/libfftw3q_omp.a'],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'numlib'

--- a/test/framework/easyconfigs/test_ecs/g/gcccuda/gcccuda-2.6.10.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gcccuda/gcccuda-2.6.10.eb
@@ -1,0 +1,21 @@
+easyblock = "Toolchain"
+
+name = 'gcccuda'
+version = '2.6.10'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain, along with CUDA toolkit."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+comp_name = 'GCC'
+comp_ver = '4.8.2'
+comp = (comp_name, comp_ver)
+
+# compiler toolchain dependencies
+dependencies = [
+    comp,
+    ('CUDA', '5.5.22', '', comp),
+]
+
+moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/g/golf/golf-2.6.10.eb
+++ b/test/framework/easyconfigs/test_ecs/g/golf/golf-2.6.10.eb
@@ -1,0 +1,27 @@
+easyblock = "Toolchain"
+
+name = 'golf'
+version = '2.6.10'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain, including
+OpenBLAS (BLAS and LAPACK support), and FFTW."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+comp_name = 'GCC'
+comp_ver = '4.8.2'
+comp = (comp_name, comp_ver)
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.8'
+blassuff = '-LAPACK-3.4.2'
+
+# compiler toolchain dependencies
+dependencies = [
+    comp,
+    (blaslib, blasver, blassuff, comp),
+    ('FFTW', '3.3.3', '-serial', comp),
+]
+
+moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/g/golfc/golfc-2.6.10.eb
+++ b/test/framework/easyconfigs/test_ecs/g/golfc/golfc-2.6.10.eb
@@ -1,0 +1,30 @@
+easyblock = "Toolchain"
+
+name = 'golfc'
+version = '2.6.10'
+
+homepage = '(none)'
+description = """GCC based compiler toolchain __with CUDA support__, and including
+ OpenBLAS (BLAS and LAPACK support) and FFTW."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+comp_name = 'GCC'
+comp_ver = '4.8.2'
+comp = (comp_name, comp_ver)
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.8'
+blassuff = '-LAPACK-3.4.2'
+
+# compiler toolchain dependencies
+# we need GCC as explicit dependency instead of golf toolchain
+# because of toolchain preperation functions
+dependencies = [
+    comp, # part of golf and gcccuda
+    ('CUDA', '5.5.22', '', comp),  # part of gcccuda
+    (blaslib, blasver, blassuff, comp),
+    ('FFTW', '3.3.3', '-serial', comp),
+]
+
+moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/g/gompic/gompic-2.6.10.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gompic/gompic-2.6.10.eb
@@ -1,0 +1,23 @@
+easyblock = "Toolchain"
+
+name = 'gompic'
+version = '2.6.10'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain along with CUDA toolkit,
+ including OpenMPI for MPI support with CUDA features enabled."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+comp_name = 'GCC'
+comp_ver = '4.8.2'
+comp = (comp_name, comp_ver)
+
+# compiler toolchain dependencies
+dependencies = [
+    comp,  # part of gcccuda
+    ('CUDA', '5.5.22', '', comp),  # part of gcccuda
+    ('OpenMPI', '1.7.3', '', ('gcccuda', version)),
+]
+
+moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/g/goolfc/goolfc-2.6.10.eb
+++ b/test/framework/easyconfigs/test_ecs/g/goolfc/goolfc-2.6.10.eb
@@ -1,0 +1,38 @@
+easyblock = "Toolchain"
+
+name = 'goolfc'
+version = '2.6.10'
+
+homepage = '(none)'
+description = """GCC based compiler toolchain __with CUDA support__, and including
+ OpenMPI for MPI support, OpenBLAS (BLAS and LAPACK support), FFTW and ScaLAPACK."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+comp_name = 'GCC'
+comp_ver = '4.8.2'
+comp = (comp_name, comp_ver)
+
+# toolchain used to build goolfc dependencies
+comp_mpi_tc_name = 'gompic'
+comp_mpi_tc_ver = version
+comp_mpi_tc = (comp_mpi_tc_name, comp_mpi_tc_ver)
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.8'
+blassuff = '-LAPACK-3.4.2'
+blas = '-%s-%s%s' % (blaslib, blasver, blassuff)
+
+# compiler toolchain dependencies
+# we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
+# because of toolchain preperation functions
+dependencies = [
+    comp,  # part of gompic
+    ('CUDA', '5.5.22', '', comp),  # part of gompic
+    ('OpenMPI', '1.7.3', '', ('gcccuda', version)),  # part of gompic
+    (blaslib, blasver, blassuff, comp),
+    ('FFTW', '3.3.3', '', comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', blas, comp_mpi_tc),
+]
+
+moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/h/hwloc/hwloc-1.8-gcccuda-2.6.10.eb
+++ b/test/framework/easyconfigs/test_ecs/h/hwloc/hwloc-1.8-gcccuda-2.6.10.eb
@@ -1,0 +1,19 @@
+easyblock = 'ConfigureMake'
+
+name = 'hwloc'
+version = "1.8"
+
+homepage = 'http://www.open-mpi.org/projects/hwloc/'
+description = """The Portable Hardware Locality (hwloc) software package provides a portable abstraction
+ (across OS, versions, architectures, ...) of the hierarchical topology of modern architectures, including
+ NUMA memory nodes, sockets, shared caches, cores and simultaneous multithreading. It also gathers various
+ system attributes such as cache and memory information as well as the locality of I/O devices such as
+ network interfaces, InfiniBand HCAs or GPUs. It primarily aims at helping applications with gathering
+ information about modern computing hardware so as to exploit it accordingly and efficiently."""
+
+toolchain = {'name': 'gcccuda', 'version': '2.6.10'}
+
+source_urls = ['http://www.open-mpi.org/software/hwloc/v%(version_major_minor)s/downloads/']
+sources = [SOURCE_TAR_GZ]
+
+moduleclass = 'system'

--- a/test/framework/easyconfigs/test_ecs/o/OpenBLAS/OpenBLAS-0.2.8-GCC-4.8.2-LAPACK-3.4.2.eb
+++ b/test/framework/easyconfigs/test_ecs/o/OpenBLAS/OpenBLAS-0.2.8-GCC-4.8.2-LAPACK-3.4.2.eb
@@ -1,0 +1,53 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenBLAS'
+version = '0.2.8'
+
+lapackver = '3.4.2'
+versionsuffix = '-LAPACK-%s' % lapackver
+
+homepage = 'http://xianyi.github.com/OpenBLAS/'
+description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
+
+toolchain = {'name': 'GCC', 'version': '4.8.2'}
+
+lapack_src = 'lapack-%s.tgz' % lapackver
+large_src = 'large.tgz'
+timing_src = 'timing.tgz'
+sources = [
+    'v%(version)s.tar.gz',
+    lapack_src,
+    large_src,
+    timing_src,
+]
+source_urls = [
+    # order matters, trying to download the LAPACK tarball from GitHub causes trouble
+    "http://www.netlib.org/lapack/",
+    "http://www.netlib.org/lapack/timing/",
+    "https://github.com/xianyi/OpenBLAS/archive/",
+]
+
+patches = [
+    # 'OpenBLAS-%s_Makefile-LAPACK-sources.patch' % version,
+    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    (large_src, '.'),
+    (timing_src, '.'),
+]
+
+skipsteps = ['configure']
+
+threading = 'USE_THREAD=1'
+buildopts = 'BINARY=64 ' + threading + ' CC="$CC" FC="$F77"'
+installopts = threading + " PREFIX=%(installdir)s"
+
+# extensive testing can be enabled by uncommenting the line below
+#runtest = 'PATH=.:$PATH lapack-timing'
+
+sanity_check_paths = {
+    'files': ['include/cblas.h', 'include/f77blas.h', 'include/lapacke_config.h', 'include/lapacke.h',
+              'include/lapacke_mangling.h', 'include/lapacke_utils.h', 'include/openblas_config.h',
+              'lib/libopenblas.a', 'lib/libopenblas.%s' % SHLIB_EXT],
+    'dirs': [],
+}
+
+moduleclass = 'numlib'

--- a/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-1.7.3-gcccuda-2.6.10.eb
+++ b/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-1.7.3-gcccuda-2.6.10.eb
@@ -1,0 +1,42 @@
+easyblock = 'ConfigureMake'
+
+name = 'OpenMPI'
+version = "1.7.3"
+
+homepage = 'http://www.open-mpi.org/'
+description = """The Open MPI Project is an open source MPI-2 implementation."""
+
+toolchain = {'name': 'gcccuda', 'version': '2.6.10'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://www.open-mpi.org/software/ompi/v%(version_major_minor)s/downloads']
+
+patches = [
+    'OpenMPI-%(version)s_common-cuda-lib.patch',
+    'OpenMPI-%(version)s-vt_cupti_events.patch',
+]
+
+builddependencies = [
+    ('Automake', '1.14'),
+    ('Autoconf', '2.69')
+]
+
+dependencies = [('hwloc', '1.8')]
+
+configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '
+configopts += '--enable-mpirun-prefix-by-default '  # suppress failure modes in relation to mpirun path
+configopts += '--with-hwloc=$EBROOTHWLOC '  # hwloc support
+configopts += '--with-cuda=$CUDA_HOME '             # CUDA-aware build; N.B. --disable-dlopen is incompatible
+
+# needed for --with-verbs
+osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
+
+libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
+sanity_check_paths = {
+    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
+             ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
+    'dirs': ["include/openmpi/ompi/mpi/cxx"],
+}
+
+moduleclass = 'mpi'

--- a/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-1.7.3-gcccuda-2.6.10.eb
+++ b/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-1.7.3-gcccuda-2.6.10.eb
@@ -16,11 +16,6 @@ patches = [
     'OpenMPI-%(version)s-vt_cupti_events.patch',
 ]
 
-builddependencies = [
-    ('Automake', '1.14'),
-    ('Autoconf', '2.69')
-]
-
 dependencies = [('hwloc', '1.8')]
 
 configopts = '--with-threads=posix --enable-shared --enable-mpi-thread-multiple --with-verbs '

--- a/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2.6.10-OpenBLAS-0.2.8-LAPACK-3.4.2.eb
+++ b/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2.6.10-OpenBLAS-0.2.8-LAPACK-3.4.2.eb
@@ -1,0 +1,28 @@
+# should be EB_ScaLAPACK, but OK for testing purposes
+easyblock = 'EB_toy'
+
+name = 'ScaLAPACK'
+version = '2.0.2'
+
+homepage = 'http://www.netlib.org/scalapack/'
+description = """The ScaLAPACK (or Scalable LAPACK) library includes a subset of LAPACK routines
+ redesigned for distributed memory MIMD parallel computers."""
+
+toolchain = {'name': 'gompic', 'version': '2.6.10'}
+toolchainopts = {'pic': True}
+
+source_urls = [homepage]
+sources = ['%(namelower)s-%(version)s.tgz']
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.8'
+blassuff = '-LAPACK-3.4.2'
+
+versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
+
+dependencies = [(blaslib, blasver, blassuff)]
+
+# parallel build tends to fail, so disabling it
+parallel = 1
+
+moduleclass = 'numlib'

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1406,15 +1406,17 @@ class FileToolsTest(EnhancedTestCase):
         # check for default semantics, test case-insensitivity
         var_defs, hits = ft.search_file([test_ecs], 'HWLOC', silent=True)
         self.assertEqual(var_defs, [])
-        self.assertEqual(len(hits), 2)
+        self.assertEqual(len(hits), 3)
         self.assertTrue(all(os.path.exists(p) for p in hits))
         self.assertTrue(hits[0].endswith('/hwloc-1.6.2-GCC-4.6.4.eb'))
         self.assertTrue(hits[1].endswith('/hwloc-1.6.2-GCC-4.7.2.eb'))
+        self.assertTrue(hits[2].endswith('/hwloc-1.8-gcccuda-2.6.10.eb'))
 
         # check filename-only mode
         var_defs, hits = ft.search_file([test_ecs], 'HWLOC', silent=True, filename_only=True)
         self.assertEqual(var_defs, [])
-        self.assertEqual(hits, ['hwloc-1.6.2-GCC-4.6.4.eb', 'hwloc-1.6.2-GCC-4.7.2.eb'])
+        self.assertEqual(hits, ['hwloc-1.6.2-GCC-4.6.4.eb', 'hwloc-1.6.2-GCC-4.7.2.eb',
+                                'hwloc-1.8-gcccuda-2.6.10.eb'])
 
         # check specifying of ignored dirs
         var_defs, hits = ft.search_file([test_ecs], 'HWLOC', silent=True, ignore_dirs=['hwloc'])
@@ -1423,7 +1425,8 @@ class FileToolsTest(EnhancedTestCase):
         # check short mode
         var_defs, hits = ft.search_file([test_ecs], 'HWLOC', silent=True, short=True)
         self.assertEqual(var_defs, [('CFGS1', os.path.join(test_ecs, 'h', 'hwloc'))])
-        self.assertEqual(hits, ['$CFGS1/hwloc-1.6.2-GCC-4.6.4.eb', '$CFGS1/hwloc-1.6.2-GCC-4.7.2.eb'])
+        self.assertEqual(hits, ['$CFGS1/hwloc-1.6.2-GCC-4.6.4.eb', '$CFGS1/hwloc-1.6.2-GCC-4.7.2.eb',
+                                '$CFGS1/hwloc-1.8-gcccuda-2.6.10.eb'])
 
         # check terse mode (implies 'silent', overrides 'short')
         var_defs, hits = ft.search_file([test_ecs], 'HWLOC', terse=True, short=True)
@@ -1431,13 +1434,15 @@ class FileToolsTest(EnhancedTestCase):
         expected = [
             os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.6.2-GCC-4.6.4.eb'),
             os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.6.2-GCC-4.7.2.eb'),
+            os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.8-gcccuda-2.6.10.eb'),
         ]
         self.assertEqual(hits, expected)
 
         # check combo of terse and filename-only
         var_defs, hits = ft.search_file([test_ecs], 'HWLOC', terse=True, filename_only=True)
         self.assertEqual(var_defs, [])
-        self.assertEqual(hits, ['hwloc-1.6.2-GCC-4.6.4.eb', 'hwloc-1.6.2-GCC-4.7.2.eb'])
+        self.assertEqual(hits, ['hwloc-1.6.2-GCC-4.6.4.eb', 'hwloc-1.6.2-GCC-4.7.2.eb',
+                                'hwloc-1.8-gcccuda-2.6.10.eb'])
 
     def test_find_eb_script(self):
         """Test find_eb_script function."""

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -688,6 +688,14 @@ class RobotTest(EnhancedTestCase):
             'robot_path': test_easyconfigs,
         })
 
+        goolfc_hierarchy = get_toolchain_hierarchy({'name': 'goolfc', 'version': '2.6.10'})
+        self.assertEqual(goolfc_hierarchy, [
+            {'name': 'GCC', 'version': '4.8.2'},
+            {'name': 'gcccuda', 'version': '2.6.10'},
+            {'name': 'gompic', 'version': '2.6.10'},
+            {'name': 'goolfc', 'version': '2.6.10'},
+        ])
+
         goolf_hierarchy = get_toolchain_hierarchy({'name': 'goolf', 'version': '1.4.10'})
         self.assertEqual(goolf_hierarchy, [
             {'name': 'GCC', 'version': '4.7.2'},

--- a/test/framework/scripts.py
+++ b/test/framework/scripts.py
@@ -85,13 +85,13 @@ class ScriptsTest(EnhancedTestCase):
         out, ec = run_cmd(cmd, simple=False)
 
         # make sure output is kind of what we expect it to be
-        regex = r"Supported Packages \(26 "
+        regex = r"Supported Packages \(31 "
         self.assertTrue(re.search(regex, out), "Pattern '%s' found in output: %s" % (regex, out))
         per_letter = {
             'B': '1',  # bzip2
             'C': '2',  # CrayCCE, CUDA
             'F': '1',  # FFTW
-            'G': '6',  # GCC, GCCcore, gmvapich2, gompi, goolf, gzip
+            'G': '11', # GCC, GCCcore, gcccuda, gmvapich2, golf, golfc, gompic, gompi, goolf, goolfc, gzip
             'H': '1',  # hwloc
             'I': '8',  # icc, iccifort, iccifortcuda, ictce, ifort, iimpi, imkl, impi
             'M': '1',  # MVAPICH2

--- a/test/framework/scripts.py
+++ b/test/framework/scripts.py
@@ -91,7 +91,7 @@ class ScriptsTest(EnhancedTestCase):
             'B': '1',  # bzip2
             'C': '2',  # CrayCCE, CUDA
             'F': '1',  # FFTW
-            'G': '11', # GCC, GCCcore, gcccuda, gmvapich2, golf, golfc, gompic, gompi, goolf, goolfc, gzip
+            'G': '11',  # GCC, GCCcore, gcccuda, gmvapich2, golf, golfc, gompic, gompi, goolf, goolfc, gzip
             'H': '1',  # hwloc
             'I': '8',  # icc, iccifort, iccifortcuda, ictce, ifort, iimpi, imkl, impi
             'M': '1',  # MVAPICH2


### PR DESCRIPTION
goolfc has a more complex subtoolchain hierarchy than goolf/foss so it's useful to test.

I added 2.6.10 because of the existing CUDA test easyconfig, it's all old software but that does not matter really.