### PR TITLE
Use GCC instead of gompi for OpenBLAS in goolf-1.4.10 test toolchain.

### DIFF
--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -137,7 +137,7 @@ class EasyConfigParserTest(EnhancedTestCase):
             # name, version, versionsuffix, toolchain
             ('GCC', '4.7.2', None, None),
             ('OpenMPI', '1.6.4', None, {'name': 'GCC', 'version': '4.7.2'}),
-            ('OpenBLAS', '0.2.6', '-LAPACK-3.4.2', {'name': 'gompi', 'version': '1.4.10'}),
+            ('OpenBLAS', '0.2.6', '-LAPACK-3.4.2', {'name': 'GCC', 'version': '4.7.2'}),
             ('FFTW', '3.3.3', None, {'name': 'gompi', 'version': '1.4.10'}),
             ('ScaLAPACK', '2.0.2', '-OpenBLAS-0.2.6-LAPACK-3.4.2', {'name': 'gompi', 'version': '1.4.10'}),
         ]

--- a/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.3-GCC-4.7.2-serial.eb
+++ b/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.3-GCC-4.7.2-serial.eb
@@ -17,18 +17,18 @@ source_urls = [homepage]
 common_configopts = "--enable-openmp --with-pic"
 
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
-    common_configopts + " --enable-long-double --enable-mpi",
+    common_configopts + " --enable-single --enable-sse2",
+    common_configopts + " --enable-long-double",
     common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+    common_configopts + " --enable-sse2",  # default as last
 ]
 
 sanity_check_paths = {
     'files': ['bin/fftw%s' % x for x in ['-wisdom', '-wisdom-to-conf', 'f-wisdom', 'l-wisdom', 'q-wisdom']] +
-             ['include/fftw3%s' % x for x in ['-mpi.f03', '-mpi.h', '.f', '.f03',
-                                              '.h', 'l-mpi.f03', 'l.f03', 'q.f03']] +
-             ['lib/libfftw3%s.a' % x for x in ['', '_mpi', '_omp', 'f', 'f_mpi', 'f_omp',
-                                               'l', 'l_mpi', 'l_omp', 'q', 'q_omp']],
+             ['include/fftw3%s' % x for x in ['.f', '.f03',
+                                              '.h', 'l.f03', 'q.f03']] +
+             ['lib/libfftw3%s.a' % x for x in ['', '_omp', 'f', 'f_omp',
+                                               'l', 'l_omp', 'q', 'q_omp']],
     'dirs': ['lib/pkgconfig'],
 }
 

--- a/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.3-GCC-4.7.2-serial.eb
+++ b/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.3-GCC-4.7.2-serial.eb
@@ -1,0 +1,35 @@
+easyblock = 'ConfigureMake'
+
+name = 'FFTW'
+version = '3.3.3'
+versionsuffix = '-serial'
+
+homepage = 'http://www.fftw.org'
+description = """FFTW is a C subroutine library for computing the discrete Fourier transform (DFT)
+ in one or more dimensions, of arbitrary input size, and of both real and complex data."""
+
+toolchain = {'name': 'GCC', 'version': '4.7.2'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [homepage]
+
+common_configopts = "--enable-openmp --with-pic"
+
+configopts = [
+    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    common_configopts + " --enable-long-double --enable-mpi",
+    common_configopts + " --enable-quad-precision",
+    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+]
+
+sanity_check_paths = {
+    'files': ['bin/fftw%s' % x for x in ['-wisdom', '-wisdom-to-conf', 'f-wisdom', 'l-wisdom', 'q-wisdom']] +
+             ['include/fftw3%s' % x for x in ['-mpi.f03', '-mpi.h', '.f', '.f03',
+                                              '.h', 'l-mpi.f03', 'l.f03', 'q.f03']] +
+             ['lib/libfftw3%s.a' % x for x in ['', '_mpi', '_omp', 'f', 'f_mpi', 'f_omp',
+                                               'l', 'l_mpi', 'l_omp', 'q', 'q_omp']],
+    'dirs': ['lib/pkgconfig'],
+}
+
+moduleclass = 'numlib'

--- a/test/framework/easyconfigs/test_ecs/g/golf/golf-1.4.10.eb
+++ b/test/framework/easyconfigs/test_ecs/g/golf/golf-1.4.10.eb
@@ -1,0 +1,27 @@
+easyblock = "Toolchain"
+
+name = 'golf'
+version = '1.4.10'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain, including
+OpenBLAS (BLAS and LAPACK support), and FFTW."""
+
+toolchain = {'name': 'dummy', 'version': 'dummy'}
+
+comp_name = 'GCC'
+comp_version = '4.7.2'
+comp = (comp_name, comp_version)
+
+blaslib = 'OpenBLAS'
+blasver = '0.2.6'
+blas_suff = '-LAPACK-3.4.2'
+
+# compiler toolchain dependencies
+dependencies = [
+    comp,
+    (blaslib, blasver, blas_suff, comp),
+    ('FFTW', '3.3.3', '-serial', comp),
+]
+
+moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/g/goolf/goolf-1.4.10.eb
+++ b/test/framework/easyconfigs/test_ecs/g/goolf/goolf-1.4.10.eb
@@ -29,7 +29,7 @@ comp_mpi_tc = (comp_mpi_tc_name, comp_mpi_tc_ver)
 dependencies = [
     comp,
     ('OpenMPI', '1.6.4', '', comp),  # part of gompi-1.4.10
-    (blaslib, blasver, blas_suff, comp_mpi_tc),
+    (blaslib, blasver, blas_suff, comp),
     ('FFTW', '3.3.3', '', comp_mpi_tc),
     ('ScaLAPACK', '2.0.2', '-%s%s' % (blas, blas_suff), comp_mpi_tc)
 ]

--- a/test/framework/easyconfigs/test_ecs/o/OpenBLAS/OpenBLAS-0.2.6-GCC-4.7.2-LAPACK-3.4.2.eb
+++ b/test/framework/easyconfigs/test_ecs/o/OpenBLAS/OpenBLAS-0.2.6-GCC-4.7.2-LAPACK-3.4.2.eb
@@ -9,7 +9,7 @@ versionsuffix = '-LAPACK-%s' % lapackver
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
-toolchain = {'name': 'gompi', 'version': '1.4.10'}
+toolchain = {'name': 'GCC', 'version': '4.7.2'}
 
 lapack_src = 'lapack-%s.tgz' % lapackver
 large_src = 'large.tgz'

--- a/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2.eb
+++ b/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2.eb
@@ -20,7 +20,7 @@ blassuff = '-LAPACK-3.4.2'
 
 versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
 
-dependencies = [(blaslib, blasver, blassuff)]
+dependencies = [(blaslib, blasver, blassuff, ('GCC', '4.7.2'))]
 
 # parallel build tends to fail, so disabling it
 parallel = 1

--- a/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2.eb
+++ b/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2.eb
@@ -20,7 +20,7 @@ blassuff = '-LAPACK-3.4.2'
 
 versionsuffix = "-%s-%s%s" % (blaslib, blasver, blassuff)
 
-dependencies = [(blaslib, blasver, blassuff, ('GCC', '4.7.2'))]
+dependencies = [(blaslib, blasver, blassuff)]
 
 # parallel build tends to fail, so disabling it
 parallel = 1

--- a/test/framework/easyconfigs/v2.0/goolf.eb
+++ b/test/framework/easyconfigs/v2.0/goolf.eb
@@ -25,6 +25,6 @@ toolchains = dummy == dummy
 [DEPENDENCIES]
 GCC = 4.7.2
 OpenMPI = 1.6.4; GCC == 4.7.2
-OpenBLAS = 0.2.6 suffix:-LAPACK-3.4.2; gompi == 1.4.10
+OpenBLAS = 0.2.6 suffix:-LAPACK-3.4.2; GCC == 4.7.2
 FFTW = 3.3.3; gompi == 1.4.10
 ScaLAPACK = 2.0.2 suffix:-OpenBLAS-0.2.6-LAPACK-3.4.2; gompi == 1.4.10

--- a/test/framework/easyconfigs/yeb/goolf-1.4.10.yeb
+++ b/test/framework/easyconfigs/yeb/goolf-1.4.10.yeb
@@ -34,7 +34,7 @@ dependencies:
       toolchain: *comp
     - *blaslib: *blasver
       versionsuffix: *blas_suff
-      toolchain: *comp_mpi_tc
+      toolchain: *comp
     - FFTW: 3.3.3
       toolchain: *comp_mpi_tc
     - ScaLAPACK: 2.0.2

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -832,8 +832,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             # GCC/OpenMPI dependencies are there, but part of toolchain => 'x'
             ("GCC-4.6.4.eb", "GCC/4.6.4", 'x'),
             ("OpenMPI-1.6.4-GCC-4.6.4.eb", "OpenMPI/1.6.4-GCC-4.6.4", 'x'),
-            # OpenBLAS dependency is there, but not listed => 'x'
-            ("OpenBLAS-0.2.6-gompi-1.3.12-LAPACK-3.4.2.eb", "OpenBLAS/0.2.6-gompi-1.3.12-LAPACK-3.4.2", 'x'),
+            # OpenBLAS dependency is listed, but not there => ' '
+            ("OpenBLAS-0.2.6-GCC-4.7.2-LAPACK-3.4.2.eb", "OpenBLAS/0.2.6-GCC-4.7.2-LAPACK-3.4.2", ' '),
             # both FFTW and ScaLAPACK are listed => 'F'
             ("ScaLAPACK-%s.eb" % scalapack_ver, "ScaLAPACK/%s" % scalapack_ver, 'F'),
             ("FFTW-3.3.3-gompi-1.3.12.eb", "FFTW/3.3.3-gompi-1.3.12", 'F'),
@@ -865,8 +865,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             ("hwloc-1.6.2-GCC-4.7.2.eb", "Compiler/GCC/4.7.2", "hwloc/1.6.2", 'x'),
             ("OpenMPI-1.6.4-GCC-4.7.2.eb", "Compiler/GCC/4.7.2", "OpenMPI/1.6.4", 'F'),  # already present and listed, so 'F'
             ("gompi-1.4.10.eb", "Core", "gompi/1.4.10", 'x'),
-            ("OpenBLAS-0.2.6-gompi-1.4.10-LAPACK-3.4.2.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4",
-             "OpenBLAS/0.2.6-LAPACK-3.4.2", 'x'),
+            ("OpenBLAS-0.2.6-GCC-4.7.2-LAPACK-3.4.2.eb", "Compiler/GCC/4.7.2",
+             "OpenBLAS/0.2.6-LAPACK-3.4.2", ' '),
             ("FFTW-3.3.3-gompi-1.4.10.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4", "FFTW/3.3.3", 'x'),
             ("ScaLAPACK-2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4",
              "ScaLAPACK/2.0.2-OpenBLAS-0.2.6-LAPACK-3.4.2", 'x'),
@@ -904,8 +904,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             ("hwloc-1.6.2-GCC-4.7.2.eb", "Compiler/GCC/4.7.2/system", "hwloc/1.6.2", 'x'),
             ("OpenMPI-1.6.4-GCC-4.7.2.eb", "Compiler/GCC/4.7.2/mpi", "OpenMPI/1.6.4", 'F'),  # already present and listed, so 'F'
             ("gompi-1.4.10.eb", "Core/toolchain", "gompi/1.4.10", 'x'),
-            ("OpenBLAS-0.2.6-gompi-1.4.10-LAPACK-3.4.2.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4/numlib",
-             "OpenBLAS/0.2.6-LAPACK-3.4.2", 'x'),
+            ("OpenBLAS-0.2.6-GCC-4.7.2-LAPACK-3.4.2.eb", "Compiler/GCC/4.7.2/numlib",
+             "OpenBLAS/0.2.6-LAPACK-3.4.2", ' '),
             ("FFTW-3.3.3-gompi-1.4.10.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4/numlib", "FFTW/3.3.3", 'x'),
             ("ScaLAPACK-2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4/numlib",
              "ScaLAPACK/2.0.2-OpenBLAS-0.2.6-LAPACK-3.4.2", 'x'),
@@ -1595,7 +1595,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
         self.assertTrue(re.search('module: GCC/4.7.2', outtxt))
         self.assertTrue(re.search('module: OpenMPI/1.6.4-GCC-4.7.2', outtxt))
-        self.assertTrue(re.search('module: OpenBLAS/0.2.6-gompi-1.4.10-LAPACK-3.4.2', outtxt))
+        self.assertTrue(re.search('module: OpenBLAS/0.2.6-GCC-4.7.2-LAPACK-3.4.2', outtxt))
         self.assertTrue(re.search('module: FFTW/3.3.3-gompi', outtxt))
         self.assertTrue(re.search('module: ScaLAPACK/2.0.2-gompi', outtxt))
         # zlib is not a dep at all
@@ -1609,7 +1609,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
         self.assertTrue(re.search('module: GCC/4.7.2', outtxt))
         self.assertTrue(re.search('module: OpenMPI/1.6.4-GCC-4.7.2', outtxt))
-        self.assertTrue(re.search('module: OpenBLAS/0.2.6-gompi-1.4.10-LAPACK-3.4.2', outtxt))
+        self.assertTrue(re.search('module: OpenBLAS/0.2.6-GCC-4.7.2-LAPACK-3.4.2', outtxt))
         self.assertFalse(re.search(r'module: FFTW/3\.3\.3-gompi', outtxt))
         self.assertTrue(re.search(r'module: FFTW/\.3\.3\.3-gompi', outtxt))
         self.assertFalse(re.search(r'module: ScaLAPACK/2\.0\.2-gompi', outtxt))

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -249,7 +249,7 @@ class RobotTest(EnhancedTestCase):
         MockModule.avail_modules = [
             'GCC/4.7.2',
             'OpenMPI/1.6.4-GCC-4.7.2',
-            'OpenBLAS/0.2.6-gompi-1.4.10-LAPACK-3.4.2',
+            'OpenBLAS/0.2.6-GCC-4.7.2-LAPACK-3.4.2',
             'FFTW/3.3.3-gompi-1.4.10',
             'ScaLAPACK/2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2',
         ]
@@ -331,7 +331,7 @@ class RobotTest(EnhancedTestCase):
         # there should only be two retained builds, i.e. the software itself and the goolf toolchain as dep
         self.assertEqual(len(res), 4)
         # goolf should be first, the software itself second
-        self.assertEqual('OpenBLAS/0.2.6-gompi-1.4.10-LAPACK-3.4.2', res[0]['full_mod_name'])
+        self.assertEqual('OpenBLAS/0.2.6-GCC-4.7.2-LAPACK-3.4.2', res[0]['full_mod_name'])
         self.assertEqual('ScaLAPACK/2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2', res[1]['full_mod_name'])
         self.assertEqual('goolf/1.4.10', res[2]['full_mod_name'])
         self.assertEqual('foo/1.2.3', res[3]['full_mod_name'])
@@ -442,12 +442,12 @@ class RobotTest(EnhancedTestCase):
         # all modules in the dep graph, in order
         all_mods_ordered = [
             'GCC/4.7.2',
+            'OpenBLAS/0.2.6-GCC-4.7.2-LAPACK-3.4.2',
             'hwloc/1.6.2-GCC-4.7.2',
             'OpenMPI/1.6.4-GCC-4.7.2',
-            'gompi/1.4.10',
-            'OpenBLAS/0.2.6-gompi-1.4.10-LAPACK-3.4.2',
-            'ScaLAPACK/2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2',
             'SQLite/3.8.10.2-GCC-4.7.2',
+            'gompi/1.4.10',
+            'ScaLAPACK/2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2',
             'FFTW/3.3.3-gompi-1.4.10',
             'goolf/1.4.10',
             'bar/1.2.3-goolf-1.4.10',
@@ -464,7 +464,7 @@ class RobotTest(EnhancedTestCase):
             'gompi/1.4.10',
             'goolf/1.4.10',
             'OpenMPI/1.6.4-GCC-4.7.2',
-            'OpenBLAS/0.2.6-gompi-1.4.10-LAPACK-3.4.2',
+            'OpenBLAS/0.2.6-GCC-4.7.2-LAPACK-3.4.2',
             'ScaLAPACK/2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2',
             'SQLite/3.8.10.2-GCC-4.7.2',
         ]
@@ -992,7 +992,7 @@ class RobotTest(EnhancedTestCase):
 
         expected_dep_versions = [
             '1.6.4-GCC-4.7.2',
-            '0.2.6-gompi-1.4.10-LAPACK-3.4.2',
+            '0.2.6-GCC-4.7.2-LAPACK-3.4.2',
             '2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2',
             '3.8.10.2-goolf-1.4.10',
         ]

--- a/test/framework/scripts.py
+++ b/test/framework/scripts.py
@@ -85,13 +85,13 @@ class ScriptsTest(EnhancedTestCase):
         out, ec = run_cmd(cmd, simple=False)
 
         # make sure output is kind of what we expect it to be
-        regex = r"Supported Packages \(26 "
+        regex = r"Supported Packages \(27 "
         self.assertTrue(re.search(regex, out), "Pattern '%s' found in output: %s" % (regex, out))
         per_letter = {
             'B': '1',  # bzip2
             'C': '2',  # CrayCCE, CUDA
             'F': '1',  # FFTW
-            'G': '6',  # GCC, GCCcore, gmvapich2, gompi, goolf, gzip
+            'G': '7',  # GCC, GCCcore, gmvapich2, golf, gompi, goolf, gzip
             'H': '1',  # hwloc
             'I': '8',  # icc, iccifort, iccifortcuda, ictce, ifort, iimpi, imkl, impi
             'M': '1',  # MVAPICH2


### PR DESCRIPTION
This allows to use the golf toolchain within goolf-1.4.10, also added.