### PR TITLE
consider potential of multiple subtoolchains in get_toolchain_hierarchy 

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -149,14 +149,22 @@ def get_toolchain_hierarchy(parent_toolchain):
     # obtain list of all possible subtoolchains
     _, all_tc_classes = search_toolchain('')
     subtoolchains = dict((tc_class.NAME, getattr(tc_class, 'SUBTOOLCHAIN', None)) for tc_class in all_tc_classes)
-
-    current_tc_name, current_tc_version = parent_toolchain['name'], parent_toolchain['version']
-    subtoolchain_name, subtoolchain_version = subtoolchains[current_tc_name], None
+    optional_toolchains = set(tc_class.NAME for tc_class in all_tc_classes if getattr(tc_class, 'OPTIONAL', False))
 
     # the parent toolchain is at the top of the hierarchy
     toolchain_hierarchy = [parent_toolchain]
+    # use a queue to handle a breadth-first-search of the hierarchy
+    bfs_queue = [parent_toolchain]
+    visited = set()
 
-    while subtoolchain_name:
+    while bfs_queue:
+        current_tc = bfs_queue.pop()
+        current_tc_name, current_tc_version = current_tc['name'], current_tc['version']
+        subtoolchain_names = subtoolchains[current_tc_name]
+        if subtoolchain_names is None:
+            continue
+        if not isinstance(subtoolchain_names, list):
+            subtoolchain_names = [subtoolchain_names]
         # grab the easyconfig of the current toolchain and search the dependencies for a version of the subtoolchain
         path = robot_find_easyconfig(current_tc_name, current_tc_version)
         if path is None:
@@ -196,44 +204,54 @@ def get_toolchain_hierarchy(parent_toolchain):
                 cands.append({'name': depdep['name'], 'version': depdep['version'] + depdep['versionsuffix']})
                 cands.append(depdep['toolchain'])
 
-        # only retain candidates that match subtoolchain name
-        cands = [c for c in cands if c['name'] == subtoolchain_name]
+        # only retain candidates that match subtoolchain names
+        cands = [c for c in cands if c['name'] in subtoolchain_names]
 
-        uniq_subtc_versions = set([subtc['version'] for subtc in cands])
+        for subtoolchain_name in subtoolchain_names:
+            uniq_subtc_versions = set([subtc['version'] for subtc in cands if subtc['name'] == subtoolchain_name])
 
-        if len(uniq_subtc_versions) == 1:
-            subtoolchain_version = cands[0]['version']
+            if len(uniq_subtc_versions) == 1:
+                subtoolchain_version = list(uniq_subtc_versions)[0]
 
-        elif len(uniq_subtc_versions) == 0:
-            # only retain GCCcore as subtoolchain if version was found
-            if subtoolchain_name == GCCcore.NAME:
-                _log.info("No version found for %s; assuming legacy toolchain and skipping it as subtoolchain.",
-                          subtoolchain_name)
-                subtoolchain_name = GCCcore.SUBTOOLCHAIN
-                subtoolchain_version = ''
-            # dummy toolchain: end of the line
-            elif subtoolchain_name == DUMMY_TOOLCHAIN_NAME:
-                subtoolchain_version = ''
+            elif len(uniq_subtc_versions) == 0:
+                # only retain GCCcore as subtoolchain if version was found
+                if subtoolchain_name == GCCcore.NAME:
+                    _log.info("No version found for %s; assuming legacy toolchain and skipping it as subtoolchain.",
+                              subtoolchain_name)
+                    subtoolchain_name = GCCcore.SUBTOOLCHAIN
+                    subtoolchain_version = ''
+                # dummy toolchain: end of the line
+                elif subtoolchain_name == DUMMY_TOOLCHAIN_NAME:
+                    subtoolchain_version = ''
+                elif ((subtoolchain_name in optional_toolchains or current_tc_name in optional_toolchains) and
+                      robot_find_easyconfig(subtoolchain_name, current_tc_version)):
+                    # special case: optionally find e.g. golf/1.4.10 for goolf/1.4.10 even if it is not in
+                    # the module dependencies. This is only allowed for and inside optional subtoolchains.
+                    subtoolchain_version = current_tc_version
+                elif subtoolchain_name in optional_toolchains:
+                    continue
+                else:
+                    raise EasyBuildError("No version found for subtoolchain %s in dependencies of %s",
+                                         subtoolchain_name, current_tc_name)
             else:
-                raise EasyBuildError("No version found for subtoolchain %s in dependencies of %s",
-                                     subtoolchain_name, current_tc_name)
-        else:
-            if subtoolchain_name == DUMMY_TOOLCHAIN_NAME:
-                # Don't care about multiple versions of dummy
-                _log.info("Ignoring multiple versions of %s in toolchain hierarchy", DUMMY_TOOLCHAIN_NAME)
-                subtoolchain_version = ''
-            else:
-                raise EasyBuildError("Multiple versions of %s found in dependencies of toolchain %s: %s",
-                                     subtoolchain_name, current_tc_name, ', '.join(sorted(uniq_subtc_versions)))
+                if subtoolchain_name == DUMMY_TOOLCHAIN_NAME:
+                    # Don't care about multiple versions of dummy
+                    _log.info("Ignoring multiple versions of %s in toolchain hierarchy", DUMMY_TOOLCHAIN_NAME)
+                    subtoolchain_version = ''
+                else:
+                    raise EasyBuildError("Multiple versions of %s found in dependencies of toolchain %s: %s",
+                                         subtoolchain_name, current_tc_name, ', '.join(sorted(uniq_subtc_versions)))
 
-        if subtoolchain_name == DUMMY_TOOLCHAIN_NAME and not build_option('add_dummy_to_minimal_toolchains'):
-            # we're done
-            break
+            if subtoolchain_name == DUMMY_TOOLCHAIN_NAME and not build_option('add_dummy_to_minimal_toolchains'):
+                # we're done
+                continue
 
-        # add to hierarchy and move to next
-        current_tc_name, current_tc_version = subtoolchain_name, subtoolchain_version
-        subtoolchain_name, subtoolchain_version = subtoolchains[current_tc_name], None
-        toolchain_hierarchy.insert(0, {'name': current_tc_name, 'version': current_tc_version})
+            # add to hierarchy and move to next
+            if subtoolchain_name not in visited:
+                tc = {'name': subtoolchain_name, 'version': subtoolchain_version}
+                toolchain_hierarchy.insert(0, tc)
+                bfs_queue.insert(0, tc)
+                visited.add(tc['name'])
 
     _log.info("Found toolchain hierarchy for toolchain %s: %s", parent_toolchain, toolchain_hierarchy)
     return toolchain_hierarchy

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -239,25 +239,25 @@ def get_toolchain_hierarchy(parent_toolchain):
                 # dummy toolchain: bottom of the hierarchy
                 elif subtoolchain_name == DUMMY_TOOLCHAIN_NAME:
                     subtoolchain_version = ''
-                elif ((subtoolchain_name in optional_toolchains or current_tc_name in optional_toolchains) and
-                      robot_find_easyconfig(subtoolchain_name, current_tc_version)):
-                    # special case: optionally find e.g. golf/1.4.10 for goolf/1.4.10 even if it is not in
-                    # the module dependencies. This is only allowed for and inside optional subtoolchains.
-                    subtoolchain_version = current_tc_version
-                elif subtoolchain_name in optional_toolchains:
-                    # consider next subtoolchain in case the current one was optional
-                    continue
                 else:
-                    raise EasyBuildError("No version found for subtoolchain %s in dependencies of %s",
-                                         subtoolchain_name, current_tc_name)
+                    is_optional_tc = subtoolchain_name in optional_toolchains or current_tc_name in optional_toolchains
+                    if is_optional_tc and robot_find_easyconfig(subtoolchain_name, current_tc_version):
+                        # special case: optionally find e.g. golf/1.4.10 for goolf/1.4.10 even if it is not in
+                        # the module dependencies. This is only allowed for and inside optional subtoolchains.
+                        subtoolchain_version = current_tc_version
+                    elif subtoolchain_name in optional_toolchains:
+                        # consider next subtoolchain in case the one considered now is optional
+                        continue
+                    else:
+                        raise EasyBuildError("No version found for subtoolchain %s in dependencies of %s",
+                                             subtoolchain_name, current_tc_name)
+            elif subtoolchain_name == DUMMY_TOOLCHAIN_NAME:
+                # Don't care about multiple versions of dummy
+                _log.info("Ignoring multiple versions of %s in toolchain hierarchy", DUMMY_TOOLCHAIN_NAME)
+                subtoolchain_version = ''
             else:
-                if subtoolchain_name == DUMMY_TOOLCHAIN_NAME:
-                    # Don't care about multiple versions of dummy
-                    _log.info("Ignoring multiple versions of %s in toolchain hierarchy", DUMMY_TOOLCHAIN_NAME)
-                    subtoolchain_version = ''
-                else:
-                    raise EasyBuildError("Multiple versions of %s found in dependencies of toolchain %s: %s",
-                                         subtoolchain_name, current_tc_name, ', '.join(sorted(uniq_subtc_versions)))
+                raise EasyBuildError("Multiple versions of %s found in dependencies of toolchain %s: %s",
+                                     subtoolchain_name, current_tc_name, ', '.join(sorted(uniq_subtc_versions)))
 
             if subtoolchain_name == DUMMY_TOOLCHAIN_NAME and not build_option('add_dummy_to_minimal_toolchains'):
                 # skip dummy if add_dummy_to_minimal_toolchains is not set

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -146,6 +146,8 @@ def det_subtoolchain_version(current_tc, subtoolchain_name, optional_toolchains,
     current_tc_name, current_tc_version = current_tc['name'], current_tc['version']
 
     uniq_subtc_versions = set([subtc['version'] for subtc in cands if subtc['name'] == subtoolchain_name])
+    # init with "skipped"
+    subtoolchain_version = None
 
     # dummy toolchain: bottom of the hierarchy
     if subtoolchain_name == DUMMY_TOOLCHAIN_NAME:
@@ -159,19 +161,13 @@ def det_subtoolchain_version(current_tc, subtoolchain_name, optional_toolchains,
             # special case: optionally find e.g. golf/1.4.10 for goolf/1.4.10 even if it is not in
             # the module dependencies. This is only allowed for and inside optional subtoolchains.
             subtoolchain_version = current_tc_version
-        elif subtoolchain_name in optional_toolchains:
-            # skip if the subtoolchain considered now is optional
-            return None
-        else:
+        elif subtoolchain_name not in optional_toolchains:
+            # raise error if the subtoolchain considered now is not optional
             raise EasyBuildError("No version found for subtoolchain %s in dependencies of %s",
                                  subtoolchain_name, current_tc_name)
     else:
         raise EasyBuildError("Multiple versions of %s found in dependencies of toolchain %s: %s",
                              subtoolchain_name, current_tc_name, ', '.join(sorted(uniq_subtc_versions)))
-
-    if subtoolchain_name == DUMMY_TOOLCHAIN_NAME and not build_option('add_dummy_to_minimal_toolchains'):
-        # skip dummy if add_dummy_to_minimal_toolchains is not set
-        return None
 
     return subtoolchain_version
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -143,6 +143,20 @@ def get_toolchain_hierarchy(parent_toolchain):
     The dummy toolchain is considered the most minimal subtoolchain only if the add_dummy_to_minimal_toolchains
     build option is enabled.
 
+    The most complex hierarchy we have now is goolfc which works as follows:
+
+        goolfc
+        /     \
+     gompic    golfc(*)
+          \    /   \      (*)optional toolchains, not compulsory for backwards compatibility
+          gcccuda golf(*)
+              \   /
+               GCC
+                |
+             GCCcore
+                |
+             (dummy: only if enabled)
+
     :param parent_toolchain: dictionary with name/version of parent toolchain
     """
     # obtain list of all possible subtoolchains

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -185,9 +185,9 @@ def get_toolchain_hierarchy(parent_toolchain):
           gcccuda golf(*)
               \   /
                GCC
-                |
-             GCCcore
-                |
+              /  |
+      GCCcore(*) |
+              \  |
              (dummy: only considered if --add-dummy-to-minimal-toolchains configuration option is enabled)
 
     :param parent_toolchain: dictionary with name/version of parent toolchain

--- a/easybuild/toolchains/foss.py
+++ b/easybuild/toolchains/foss.py
@@ -29,12 +29,13 @@ EasyBuild support for foss compiler toolchain (includes GCC, OpenMPI, OpenBLAS, 
 """
 
 from easybuild.toolchains.gompi import Gompi
+from easybuild.toolchains.golf import Golf
 from easybuild.toolchains.fft.fftw import Fftw
 from easybuild.toolchains.linalg.openblas import OpenBLAS
 from easybuild.toolchains.linalg.scalapack import ScaLAPACK
 
+
 class Foss(Gompi, OpenBLAS, ScaLAPACK, Fftw):
     """Compiler toolchain with GCC, OpenMPI, OpenBLAS, ScaLAPACK and FFTW."""
     NAME = 'foss'
-    SUBTOOLCHAIN = Gompi.NAME
-
+    SUBTOOLCHAIN = [Gompi.NAME, Golf.NAME]

--- a/easybuild/toolchains/fosscuda.py
+++ b/easybuild/toolchains/fosscuda.py
@@ -29,6 +29,7 @@ EasyBuild support for fosscuda compiler toolchain (includes GCC+CUDA, OpenMPI, O
 """
 
 from easybuild.toolchains.gompic import Gompic
+from easybuild.toolchains.golfc import Golfc
 from easybuild.toolchains.fft.fftw import Fftw
 from easybuild.toolchains.linalg.openblas import OpenBLAS
 from easybuild.toolchains.linalg.scalapack import ScaLAPACK
@@ -37,4 +38,4 @@ from easybuild.toolchains.linalg.scalapack import ScaLAPACK
 class Fosscuda(Gompic, OpenBLAS, ScaLAPACK, Fftw):
     """Compiler toolchain with GCC+CUDA, OpenMPI, OpenBLAS, ScaLAPACK and FFTW."""
     NAME = 'fosscuda'
-    SUBTOOLCHAIN = Gompic.NAME
+    SUBTOOLCHAIN = [Gompic.NAME, Golfc.NAME]

--- a/easybuild/toolchains/gcc.py
+++ b/easybuild/toolchains/gcc.py
@@ -29,9 +29,11 @@ EasyBuild support for GCC compiler toolchain.
 """
 
 from easybuild.toolchains.gcccore import GCCcore
+from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
 
 class GccToolchain(GCCcore):
     """Simple toolchain with just the GCC compilers."""
     NAME = 'GCC'
     COMPILER_MODULE_NAME = [NAME]
-    SUBTOOLCHAIN = GCCcore.NAME
+    SUBTOOLCHAIN = [GCCcore.NAME, DUMMY_TOOLCHAIN_NAME]
+    OPTIONAL = False

--- a/easybuild/toolchains/gcccore.py
+++ b/easybuild/toolchains/gcccore.py
@@ -37,3 +37,4 @@ class GCCcore(Gcc):
     # Replace the default compiler module name with our own
     COMPILER_MODULE_NAME = [NAME]
     SUBTOOLCHAIN = DUMMY_TOOLCHAIN_NAME
+    OPTIONAL = True

--- a/easybuild/toolchains/gcccore.py
+++ b/easybuild/toolchains/gcccore.py
@@ -37,4 +37,6 @@ class GCCcore(Gcc):
     # Replace the default compiler module name with our own
     COMPILER_MODULE_NAME = [NAME]
     SUBTOOLCHAIN = DUMMY_TOOLCHAIN_NAME
+    # GCCcore is only guaranteed to be present in recent toolchains
+    # for old versions of some toolchains (GCC, intel) it is not part of the hierarchy and hence optional
     OPTIONAL = True

--- a/easybuild/toolchains/gimkl.py
+++ b/easybuild/toolchains/gimkl.py
@@ -31,6 +31,7 @@ Intel Math Kernel Library (MKL) and Intel FFTW wrappers).
 """
 
 from easybuild.toolchains.gimpi import Gimpi
+from easybuild.toolchains.gmkl import Gmkl
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
 
@@ -38,4 +39,4 @@ from easybuild.toolchains.linalg.intelmkl import IntelMKL
 class Gimkl(Gimpi, IntelMKL, IntelFFTW):
     """Compiler toolchain with GCC, Intel MPI, Intel Math Kernel Library (MKL) and Intel FFTW wrappers."""
     NAME = 'gimkl'
-    SUBTOOLCHAIN = Gimpi.NAME
+    SUBTOOLCHAIN = [Gimpi.NAME, Gmkl.NAME]

--- a/easybuild/toolchains/giolf.py
+++ b/easybuild/toolchains/giolf.py
@@ -29,6 +29,7 @@ EasyBuild support for giolf compiler toolchain (includes GCC, IntelMPI, OpenBLAS
 """
 
 from easybuild.toolchains.gimpi import Gimpi
+from easybuild.toolchains.golf import Golf
 from easybuild.toolchains.fft.fftw import Fftw
 from easybuild.toolchains.linalg.openblas import OpenBLAS
 from easybuild.toolchains.linalg.scalapack import ScaLAPACK
@@ -37,4 +38,4 @@ from easybuild.toolchains.linalg.scalapack import ScaLAPACK
 class Giolf(Gimpi, OpenBLAS, ScaLAPACK, Fftw):
     """Compiler toolchain with GCC, IntelMPI, OpenBLAS, ScaLAPACK and FFTW."""
     NAME = 'giolf'
-    SUBTOOLCHAIN = Gimpi.NAME
+    SUBTOOLCHAIN = [Gimpi.NAME, Golf.NAME]

--- a/easybuild/toolchains/giolfc.py
+++ b/easybuild/toolchains/giolfc.py
@@ -30,6 +30,7 @@ EasyBuild support for giolfc compiler toolchain (includes GCC+CUDA, IntelMPI, Op
 """
 
 from easybuild.toolchains.gimpic import Gimpic
+from easybuild.toolchains.golfc import Golfc
 from easybuild.toolchains.fft.fftw import Fftw
 from easybuild.toolchains.linalg.openblas import OpenBLAS
 from easybuild.toolchains.linalg.scalapack import ScaLAPACK
@@ -37,5 +38,5 @@ from easybuild.toolchains.linalg.scalapack import ScaLAPACK
 class Giolfc(Gimpic, OpenBLAS, ScaLAPACK, Fftw):
     """Compiler toolchain with GCC+CUDA, IntelMPI, OpenBLAS, ScaLAPACK and FFTW."""
     NAME = 'giolfc'
-    SUBTOOLCHAIN = Gimpic.NAME
+    SUBTOOLCHAIN = [Gimpic.NAME, Golfc.NAME]
 

--- a/easybuild/toolchains/gmkl.py
+++ b/easybuild/toolchains/gmkl.py
@@ -43,3 +43,4 @@ class Gmkl(GccToolchain, IntelMKL, IntelFFTW):
     """
     NAME = 'gmkl'
     SUBTOOLCHAIN = GccToolchain.NAME
+    OPTIONAL = True

--- a/easybuild/toolchains/gmklc.py
+++ b/easybuild/toolchains/gmklc.py
@@ -33,14 +33,16 @@ Intel Math Kernel Library (MKL), and Intel FFTW wrappers, and CUDA).
 """
 
 from easybuild.toolchains.gcccuda import GccCUDA
+from easybuild.toolchains.gmkl import Gmkl
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
 
 
-class Gmklc(GccCUDA, IntelMKL, IntelFFTW):
+class Gmklc(GccCUDA, Gmkl, IntelMKL, IntelFFTW):
     """
     Compiler toolchain with GCC, Intel Math Kernel Library (MKL)
     and Intel FFTW wrappers and CUDA.
     """
     NAME = 'gmklc'
-    SUBTOOLCHAIN = GccCUDA.NAME
+    SUBTOOLCHAIN = [GccCUDA.NAME, Gmkl.NAME]
+    OPTIONAL = True

--- a/easybuild/toolchains/gmpolf.py
+++ b/easybuild/toolchains/gmpolf.py
@@ -33,6 +33,7 @@ EasyBuild support for gmpolf compiler toolchain (includes GCC, MPICH2, OpenBLAS,
 """
 
 from easybuild.toolchains.gmpich import Gmpich
+from easybuild.toolchains.golf import Golf
 from easybuild.toolchains.fft.fftw import Fftw
 from easybuild.toolchains.linalg.openblas import OpenBLAS
 from easybuild.toolchains.linalg.scalapack import ScaLAPACK
@@ -41,4 +42,4 @@ from easybuild.toolchains.linalg.scalapack import ScaLAPACK
 class Gmpolf(Gmpich, OpenBLAS, ScaLAPACK, Fftw):
     """Compiler toolchain with GCC, MPICH, OpenBLAS, ScaLAPACK and FFTW."""
     NAME = 'gmpolf'
-    SUBTOOLCHAIN = Gmpich.NAME
+    SUBTOOLCHAIN = [Gmpich.NAME, Golf.NAME]

--- a/easybuild/toolchains/gmvolf.py
+++ b/easybuild/toolchains/gmvolf.py
@@ -32,6 +32,7 @@ EasyBuild support for gmvolf compiler toolchain (includes GCC, MVAPICH2, OpenBLA
 """
 
 from easybuild.toolchains.gmvapich2 import Gmvapich2
+from easybuild.toolchains.golf import Golf
 from easybuild.toolchains.fft.fftw import Fftw
 from easybuild.toolchains.linalg.openblas import OpenBLAS
 from easybuild.toolchains.linalg.scalapack import ScaLAPACK
@@ -40,4 +41,4 @@ from easybuild.toolchains.linalg.scalapack import ScaLAPACK
 class Gmvolf(Gmvapich2, OpenBLAS, ScaLAPACK, Fftw):
     """Compiler toolchain with GCC, MVAPICH2, OpenBLAS, ScaLAPACK and FFTW."""
     NAME = 'gmvolf'
-    SUBTOOLCHAIN = Gmvapich2.NAME
+    SUBTOOLCHAIN = [Gmvapich2.NAME, Golf.NAME]

--- a/easybuild/toolchains/golf.py
+++ b/easybuild/toolchains/golf.py
@@ -38,3 +38,4 @@ class Golf(GccToolchain, OpenBLAS, Fftw):
     """Compiler toolchain with GCC, OpenBLAS, and FFTW."""
     NAME = 'golf'
     SUBTOOLCHAIN = GccToolchain.NAME
+    OPTIONAL = True

--- a/easybuild/toolchains/golfc.py
+++ b/easybuild/toolchains/golfc.py
@@ -23,18 +23,19 @@
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 ##
 """
-EasyBuild support for goolfc compiler toolchain (includes GCC+CUDA, OpenMPI, OpenBLAS, LAPACK, ScaLAPACK and FFTW).
+EasyBuild support for golfc compiler toolchain (includes GCC+CUDA, OpenBLAS, LAPACK, and FFTW).
 
 :author: Kenneth Hoste (Ghent University)
+:author: Bart Oldeman (McGill University, Calcul Quebec, Compute Canada)
 """
 
-from easybuild.toolchains.gompic import Gompic
-from easybuild.toolchains.golfc import Golfc
+from easybuild.toolchains.gcccuda import GccCUDA
+from easybuild.toolchains.golf import Golf
 from easybuild.toolchains.fft.fftw import Fftw
 from easybuild.toolchains.linalg.openblas import OpenBLAS
-from easybuild.toolchains.linalg.scalapack import ScaLAPACK
 
-class Goolfc(Gompic, OpenBLAS, ScaLAPACK, Fftw):
-    """Compiler toolchain with GCC+CUDA, OpenMPI, OpenBLAS, ScaLAPACK and FFTW."""
-    NAME = 'goolfc'
-    SUBTOOLCHAIN = [Gompic.NAME, Golfc.NAME]
+class Golfc(GccCUDA, Golf, OpenBLAS, Fftw):
+    """Compiler toolchain with GCC+CUDA, OpenMPI, OpenBLAS, and FFTW."""
+    NAME = 'golfc'
+    SUBTOOLCHAIN = [GccCUDA.NAME, Golf.NAME]
+    OPTIONAL = True

--- a/easybuild/toolchains/golfc.py
+++ b/easybuild/toolchains/golfc.py
@@ -36,7 +36,7 @@ from easybuild.toolchains.linalg.openblas import OpenBLAS
 
 
 class Golfc(GccCUDA, Golf, OpenBLAS, Fftw):
-    """Compiler toolchain with GCC+CUDA, OpenMPI, OpenBLAS, and FFTW."""
+    """Compiler toolchain with GCC+CUDA, OpenBLAS, and FFTW."""
     NAME = 'golfc'
     SUBTOOLCHAIN = [GccCUDA.NAME, Golf.NAME]
     OPTIONAL = True

--- a/easybuild/toolchains/golfc.py
+++ b/easybuild/toolchains/golfc.py
@@ -34,6 +34,7 @@ from easybuild.toolchains.golf import Golf
 from easybuild.toolchains.fft.fftw import Fftw
 from easybuild.toolchains.linalg.openblas import OpenBLAS
 
+
 class Golfc(GccCUDA, Golf, OpenBLAS, Fftw):
     """Compiler toolchain with GCC+CUDA, OpenMPI, OpenBLAS, and FFTW."""
     NAME = 'golfc'

--- a/easybuild/toolchains/gomkl.py
+++ b/easybuild/toolchains/gomkl.py
@@ -32,6 +32,7 @@ Intel Math Kernel Library (MKL) and Intel FFTW wrappers).
 """
 
 from easybuild.toolchains.gompi import Gompi
+from easybuild.toolchains.gmkl import Gmkl
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
 
@@ -39,4 +40,4 @@ from easybuild.toolchains.linalg.intelmkl import IntelMKL
 class Gomkl(Gompi, IntelMKL, IntelFFTW):
     """Compiler toolchain with GCC, OpenMPI, Intel Math Kernel Library (MKL) and Intel FFTW wrappers."""
     NAME = 'gomkl'
-    SUBTOOLCHAIN = Gompi.NAME
+    SUBTOOLCHAIN = [Gompi.NAME, Gmkl.NAME]

--- a/easybuild/toolchains/gomklc.py
+++ b/easybuild/toolchains/gomklc.py
@@ -33,6 +33,7 @@ Intel Math Kernel Library (MKL) and Intel FFTW wrappers).
 """
 
 from easybuild.toolchains.gompic import Gompic
+from easybuild.toolchains.gmklc import Gmklc
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
 
@@ -40,4 +41,4 @@ from easybuild.toolchains.linalg.intelmkl import IntelMKL
 class Gomklc(Gompic, IntelMKL, IntelFFTW):
     """Compiler toolchain with GCC, Open MPI, Intel Math Kernel Library (MKL) and Intel FFTW wrappers and Cuda."""
     NAME = 'gomklc'
-    SUBTOOLCHAIN = Gompic.NAME
+    SUBTOOLCHAIN = [Gompic.NAME, Gmklc.NAME]

--- a/easybuild/toolchains/goolf.py
+++ b/easybuild/toolchains/goolf.py
@@ -29,6 +29,7 @@ EasyBuild support for goolf compiler toolchain (includes GCC, OpenMPI, OpenBLAS,
 """
 
 from easybuild.toolchains.gompi import Gompi
+from easybuild.toolchains.golf import Golf
 from easybuild.toolchains.fft.fftw import Fftw
 from easybuild.toolchains.linalg.openblas import OpenBLAS
 from easybuild.toolchains.linalg.scalapack import ScaLAPACK
@@ -37,4 +38,4 @@ from easybuild.toolchains.linalg.scalapack import ScaLAPACK
 class Goolf(Gompi, OpenBLAS, ScaLAPACK, Fftw):
     """Compiler toolchain with GCC, OpenMPI, OpenBLAS, ScaLAPACK and FFTW."""
     NAME = 'goolf'
-    SUBTOOLCHAIN = Gompi.NAME
+    SUBTOOLCHAIN = [Gompi.NAME, Golf.NAME]

--- a/easybuild/toolchains/gpsolf.py
+++ b/easybuild/toolchains/gpsolf.py
@@ -31,6 +31,7 @@ EasyBuild support for gmpolf compiler toolchain (includes GCC, Parastation MPICH
 """
 
 from easybuild.toolchains.gpsmpi import Gpsmpi
+from easybuild.toolchains.golf import Golf
 from easybuild.toolchains.fft.fftw import Fftw
 from easybuild.toolchains.linalg.openblas import OpenBLAS
 from easybuild.toolchains.linalg.scalapack import ScaLAPACK
@@ -39,4 +40,4 @@ from easybuild.toolchains.linalg.scalapack import ScaLAPACK
 class Gpsolf(Gpsmpi, OpenBLAS, ScaLAPACK, Fftw):
     """Compiler toolchain with GCC, Parastation MPICH, OpenBLAS, ScaLAPACK and FFTW."""
     NAME = 'gpsolf'
-    SUBTOOLCHAIN = Gpsmpi.NAME
+    SUBTOOLCHAIN = [Gpsmpi.NAME, Golf.NAME]

--- a/easybuild/toolchains/gsolf.py
+++ b/easybuild/toolchains/gsolf.py
@@ -30,6 +30,7 @@ EasyBuild support for gsolf compiler toolchain (includes GCC, SpectrumMPI, OpenB
 """
 
 from easybuild.toolchains.gsmpi import Gsmpi
+from easybuild.toolchains.golf import Golf
 from easybuild.toolchains.fft.fftw import Fftw
 from easybuild.toolchains.linalg.openblas import OpenBLAS
 from easybuild.toolchains.linalg.scalapack import ScaLAPACK
@@ -37,4 +38,4 @@ from easybuild.toolchains.linalg.scalapack import ScaLAPACK
 class Gsolf(Gsmpi, OpenBLAS, ScaLAPACK, Fftw):
     """Compiler toolchain with GCC, SpectrumMPI, OpenBLAS, ScaLAPACK and FFTW."""
     NAME = 'gsolf'
-    SUBTOOLCHAIN = Gsmpi.NAME
+    SUBTOOLCHAIN = [Gsmpi.NAME, Golf.NAME]

--- a/easybuild/toolchains/iccifort.py
+++ b/easybuild/toolchains/iccifort.py
@@ -32,10 +32,12 @@ EasyBuild support for Intel compilers toolchain (icc, ifort)
 from easybuild.toolchains.compiler.inteliccifort import IntelIccIfort
 # Need to import the GCCcore class so I can get the name from there
 from easybuild.toolchains.gcccore import GCCcore
+from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
 
 class IccIfort(IntelIccIfort):
     """Compiler toolchain with Intel compilers (icc/ifort)."""
     NAME = 'iccifort'
     # use GCCcore as subtoolchain rather than GCC, since two 'real' compiler-only toolchains don't mix well,
     # in particular in a hierarchical module naming scheme
-    SUBTOOLCHAIN = GCCcore.NAME
+    SUBTOOLCHAIN = [GCCcore.NAME, DUMMY_TOOLCHAIN_NAME]
+    OPTIONAL = False

--- a/easybuild/toolchains/ictce.py
+++ b/easybuild/toolchains/ictce.py
@@ -31,6 +31,7 @@ Intel Math Kernel Library (MKL), and Intel FFTW wrappers).
 """
 
 from easybuild.toolchains.iimpi import Iimpi
+from easybuild.toolchains.iimkl import Iimkl
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
 
@@ -41,4 +42,4 @@ class Ictce(Iimpi, IntelMKL, IntelFFTW):
     Intel Math Kernel Library (MKL) and Intel FFTW wrappers.
     """
     NAME = 'ictce'
-    SUBTOOLCHAIN = Iimpi.NAME
+    SUBTOOLCHAIN = [Iimpi.NAME, Iimkl.NAME]

--- a/easybuild/toolchains/iimkl.py
+++ b/easybuild/toolchains/iimkl.py
@@ -43,3 +43,4 @@ class Iimkl(IccIfort, IntelMKL, IntelFFTW):
     """
     NAME = 'iimkl'
     SUBTOOLCHAIN = IccIfort.NAME
+    OPTIONAL = True

--- a/easybuild/toolchains/iimklc.py
+++ b/easybuild/toolchains/iimklc.py
@@ -33,14 +33,16 @@ CUDA, Intel Math Kernel Library (MKL), and Intel FFTW wrappers.
 """
 
 from easybuild.toolchains.iccifortcuda import IccIfortCUDA
+from easybuild.toolchains.iimkl import Iimkl
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
 
 
-class Iimklc(IccIfortCUDA, IntelMKL, IntelFFTW):
+class Iimklc(IccIfortCUDA, Iimkl, IntelMKL, IntelFFTW):
     """
     Compiler toolchain with Intel compilers (icc/ifort),
     CUDA, Intel Math Kernel Library (MKL) and Intel FFTW wrappers.
     """
     NAME = 'iimklc'
-    SUBTOOLCHAIN = IccIfortCUDA.NAME
+    SUBTOOLCHAIN = [IccIfortCUDA.NAME, Iimkl.NAME]
+    OPTIONAL = True

--- a/easybuild/toolchains/impmkl.py
+++ b/easybuild/toolchains/impmkl.py
@@ -30,6 +30,7 @@ Intel Math Kernel Library (MKL) , and Intel FFTW wrappers.
 """
 
 from easybuild.toolchains.impich import Impich
+from easybuild.toolchains.iimkl import Iimkl
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
 
@@ -39,4 +40,4 @@ class Impmkl(Impich, IntelMKL, IntelFFTW):
     Intel Math Kernel Library (MKL) and Intel FFTW wrappers.
     """
     NAME = 'impmkl'
-    SUBTOOLCHAIN = Impich.NAME
+    SUBTOOLCHAIN = [Impich.NAME, Iimkl.NAME]

--- a/easybuild/toolchains/intel-para.py
+++ b/easybuild/toolchains/intel-para.py
@@ -29,6 +29,7 @@ Intel Math Kernel Library (MKL), and Intel FFTW wrappers).
 """
 
 from easybuild.toolchains.ipsmpi import Ipsmpi
+from easybuild.toolchains.iimkl import Iimkl
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
 
@@ -39,4 +40,4 @@ class IntelPara(Ipsmpi, IntelMKL, IntelFFTW):
     Intel Math Kernel Library (MKL) and Intel FFTW wrappers.
     """
     NAME = 'intel-para'
-    SUBTOOLCHAIN = Ipsmpi.NAME 
+    SUBTOOLCHAIN = [Ipsmpi.NAME, Iimkl]

--- a/easybuild/toolchains/intel.py
+++ b/easybuild/toolchains/intel.py
@@ -31,6 +31,7 @@ Intel Math Kernel Library (MKL), and Intel FFTW wrappers).
 """
 
 from easybuild.toolchains.iimpi import Iimpi
+from easybuild.toolchains.iimkl import Iimkl
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
 
@@ -41,4 +42,4 @@ class Intel(Iimpi, IntelMKL, IntelFFTW):
     Intel Math Kernel Library (MKL) and Intel FFTW wrappers.
     """
     NAME = 'intel'
-    SUBTOOLCHAIN = Iimpi.NAME
+    SUBTOOLCHAIN = [Iimpi.NAME, Iimkl.NAME]

--- a/easybuild/toolchains/intelcuda.py
+++ b/easybuild/toolchains/intelcuda.py
@@ -29,6 +29,7 @@ EasyBuild support for a intel+CUDA compiler toolchain.
 """
 
 from easybuild.toolchains.iimpic import Iimpic
+from easybuild.toolchains.iimklc import Iimklc
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
 
@@ -39,4 +40,4 @@ class Intelcuda(Iimpic, IntelMKL, IntelFFTW):
 
     NAME = 'intelcuda'
 
-    SUBTOOLCHAIN = Iimpic.NAME
+    SUBTOOLCHAIN = [Iimpic.NAME, Iimklc.NAME]

--- a/easybuild/toolchains/iomkl.py
+++ b/easybuild/toolchains/iomkl.py
@@ -31,6 +31,7 @@ Intel Math Kernel Library (MKL), and Intel FFTW wrappers.
 """
 
 from easybuild.toolchains.iompi import Iompi
+from easybuild.toolchains.iimkl import Iimkl
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
 
@@ -41,4 +42,4 @@ class Iomkl(Iompi, IntelMKL, IntelFFTW):
     Intel Math Kernel Library (MKL) and Intel FFTW wrappers.
     """
     NAME = 'iomkl'
-    SUBTOOLCHAIN = Iompi.NAME
+    SUBTOOLCHAIN = [Iompi.NAME, Iimkl.NAME]

--- a/easybuild/toolchains/iomklc.py
+++ b/easybuild/toolchains/iomklc.py
@@ -32,6 +32,7 @@ CUDA, Intel Math Kernel Library (MKL), and Intel FFTW wrappers.
 """
 
 from easybuild.toolchains.iompic import Iompic
+from easybuild.toolchains.iimklc import Iimklc
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
 
@@ -42,4 +43,4 @@ class Iomklc(Iompic, IntelMKL, IntelFFTW):
     CUDA, Intel Math Kernel Library (MKL) and Intel FFTW wrappers.
     """
     NAME = 'iomklc'
-    SUBTOOLCHAIN = Iompic.NAME
+    SUBTOOLCHAIN = [Iompic.NAME, Iimklc.NAME]

--- a/easybuild/toolchains/ismkl.py
+++ b/easybuild/toolchains/ismkl.py
@@ -31,6 +31,7 @@ Intel Math Kernel Library (MKL), and Intel FFTW wrappers.
 """
 
 from easybuild.toolchains.iccifort import IccIfort
+from easybuild.toolchains.iimkl import Iimkl
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.mpi.mpich2 import Mpich2
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
@@ -42,4 +43,4 @@ class Ismkl(IccIfort, Mpich2, IntelMKL, IntelFFTW):
     Intel Math Kernel Library (MKL) and Intel FFTW wrappers.
     """
     NAME = 'ismkl'
-    SUBTOOLCHAIN = IccIfort.NAME
+    SUBTOOLCHAIN = [IccIfort.NAME, Iimkl.NAME]

--- a/easybuild/toolchains/pgi.py
+++ b/easybuild/toolchains/pgi.py
@@ -33,6 +33,7 @@ EasyBuild support for PGI compiler toolchain.
 
 from easybuild.toolchains.compiler.pgi import Pgi
 from easybuild.toolchains.gcccore import GCCcore
+from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
 
 
 class PgiToolchain(Pgi):
@@ -40,4 +41,5 @@ class PgiToolchain(Pgi):
     NAME = 'PGI'
     # use GCCcore as subtoolchain rather than GCC, since two 'real' compiler-only toolchains don't mix well,
     # in particular in a hierarchical module naming scheme
-    SUBTOOLCHAIN = GCCcore.NAME
+    SUBTOOLCHAIN = [GCCcore.NAME, DUMMY_TOOLCHAIN_NAME]
+    OPTIONAL = False

--- a/easybuild/toolchains/pmkl.py
+++ b/easybuild/toolchains/pmkl.py
@@ -43,3 +43,4 @@ class Pmkl(PgiToolchain, IntelMKL, IntelFFTW):
     """
     NAME = 'pmkl'
     SUBTOOLCHAIN = PgiToolchain.NAME
+    OPTIONAL = True

--- a/easybuild/toolchains/pomkl.py
+++ b/easybuild/toolchains/pomkl.py
@@ -32,6 +32,7 @@ Intel Math Kernel Library (MKL), and Intel FFTW wrappers).
 """
 
 from easybuild.toolchains.pompi import Pompi
+from easybuild.toolchains.pmkl import Pmkl
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
 
@@ -42,4 +43,4 @@ class Pomkl(Pompi, IntelMKL, IntelFFTW):
     Intel Math Kernel Library (MKL) and Intel FFTW wrappers.
     """
     NAME = 'pomkl'
-    SUBTOOLCHAIN = Pompi.NAME
+    SUBTOOLCHAIN = [Pompi.NAME, Pmkl.NAME]

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -2080,7 +2080,6 @@ class EasyConfigTest(EnhancedTestCase):
         # '%(name)' is not a correct template spec (missing trailing 's')
         self.assertEqual(resolve_template('%(name)', tmpl_dict), '%(name)')
 
-
     def test_det_subtoolchain_version(self):
         """Test det_subtoolchain_version function"""
         _, all_tc_classes = search_toolchain('')
@@ -2124,7 +2123,6 @@ class EasyConfigTest(EnhancedTestCase):
         versions = [det_subtoolchain_version(current_tc, subtoolchain_name, optional_toolchains, cands)
                     for subtoolchain_name in subtoolchains[current_tc['name']]]
         self.assertEqual(versions, ['4.9.3', ''])
-
 
     def test_verify_easyconfig_filename(self):
         """Test verify_easyconfig_filename function"""

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -137,7 +137,7 @@ class EasyConfigParserTest(EnhancedTestCase):
             # name, version, versionsuffix, toolchain
             ('GCC', '4.7.2', None, None),
             ('OpenMPI', '1.6.4', None, {'name': 'GCC', 'version': '4.7.2'}),
-            ('OpenBLAS', '0.2.6', '-LAPACK-3.4.2', {'name': 'gompi', 'version': '1.4.10'}),
+            ('OpenBLAS', '0.2.6', '-LAPACK-3.4.2', {'name': 'GCC', 'version': '4.7.2'}),
             ('FFTW', '3.3.3', None, {'name': 'gompi', 'version': '1.4.10'}),
             ('ScaLAPACK', '2.0.2', '-OpenBLAS-0.2.6-LAPACK-3.4.2', {'name': 'gompi', 'version': '1.4.10'}),
         ]

--- a/test/framework/easyconfigs/v2.0/goolf.eb
+++ b/test/framework/easyconfigs/v2.0/goolf.eb
@@ -25,6 +25,6 @@ toolchains = dummy == dummy
 [DEPENDENCIES]
 GCC = 4.7.2
 OpenMPI = 1.6.4; GCC == 4.7.2
-OpenBLAS = 0.2.6 suffix:-LAPACK-3.4.2; gompi == 1.4.10
+OpenBLAS = 0.2.6 suffix:-LAPACK-3.4.2; GCC == 4.7.2
 FFTW = 3.3.3; gompi == 1.4.10
 ScaLAPACK = 2.0.2 suffix:-OpenBLAS-0.2.6-LAPACK-3.4.2; gompi == 1.4.10

--- a/test/framework/easyconfigs/yeb/goolf-1.4.10.yeb
+++ b/test/framework/easyconfigs/yeb/goolf-1.4.10.yeb
@@ -34,7 +34,7 @@ dependencies:
       toolchain: *comp
     - *blaslib: *blasver
       versionsuffix: *blas_suff
-      toolchain: *comp_mpi_tc
+      toolchain: *comp
     - FFTW: 3.3.3
       toolchain: *comp_mpi_tc
     - ScaLAPACK: 2.0.2

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -832,8 +832,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             # GCC/OpenMPI dependencies are there, but part of toolchain => 'x'
             ("GCC-4.6.4.eb", "GCC/4.6.4", 'x'),
             ("OpenMPI-1.6.4-GCC-4.6.4.eb", "OpenMPI/1.6.4-GCC-4.6.4", 'x'),
-            # OpenBLAS dependency is there, but not listed => 'x'
-            ("OpenBLAS-0.2.6-gompi-1.3.12-LAPACK-3.4.2.eb", "OpenBLAS/0.2.6-gompi-1.3.12-LAPACK-3.4.2", 'x'),
+            # OpenBLAS dependency is listed, but not there => ' '
+            ("OpenBLAS-0.2.6-GCC-4.7.2-LAPACK-3.4.2.eb", "OpenBLAS/0.2.6-GCC-4.7.2-LAPACK-3.4.2", ' '),
             # both FFTW and ScaLAPACK are listed => 'F'
             ("ScaLAPACK-%s.eb" % scalapack_ver, "ScaLAPACK/%s" % scalapack_ver, 'F'),
             ("FFTW-3.3.3-gompi-1.3.12.eb", "FFTW/3.3.3-gompi-1.3.12", 'F'),
@@ -865,8 +865,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             ("hwloc-1.6.2-GCC-4.7.2.eb", "Compiler/GCC/4.7.2", "hwloc/1.6.2", 'x'),
             ("OpenMPI-1.6.4-GCC-4.7.2.eb", "Compiler/GCC/4.7.2", "OpenMPI/1.6.4", 'F'),  # already present and listed, so 'F'
             ("gompi-1.4.10.eb", "Core", "gompi/1.4.10", 'x'),
-            ("OpenBLAS-0.2.6-gompi-1.4.10-LAPACK-3.4.2.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4",
-             "OpenBLAS/0.2.6-LAPACK-3.4.2", 'x'),
+            ("OpenBLAS-0.2.6-GCC-4.7.2-LAPACK-3.4.2.eb", "Compiler/GCC/4.7.2",
+             "OpenBLAS/0.2.6-LAPACK-3.4.2", ' '),
             ("FFTW-3.3.3-gompi-1.4.10.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4", "FFTW/3.3.3", 'x'),
             ("ScaLAPACK-2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4",
              "ScaLAPACK/2.0.2-OpenBLAS-0.2.6-LAPACK-3.4.2", 'x'),
@@ -904,8 +904,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             ("hwloc-1.6.2-GCC-4.7.2.eb", "Compiler/GCC/4.7.2/system", "hwloc/1.6.2", 'x'),
             ("OpenMPI-1.6.4-GCC-4.7.2.eb", "Compiler/GCC/4.7.2/mpi", "OpenMPI/1.6.4", 'F'),  # already present and listed, so 'F'
             ("gompi-1.4.10.eb", "Core/toolchain", "gompi/1.4.10", 'x'),
-            ("OpenBLAS-0.2.6-gompi-1.4.10-LAPACK-3.4.2.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4/numlib",
-             "OpenBLAS/0.2.6-LAPACK-3.4.2", 'x'),
+            ("OpenBLAS-0.2.6-GCC-4.7.2-LAPACK-3.4.2.eb", "Compiler/GCC/4.7.2/numlib",
+             "OpenBLAS/0.2.6-LAPACK-3.4.2", ' '),
             ("FFTW-3.3.3-gompi-1.4.10.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4/numlib", "FFTW/3.3.3", 'x'),
             ("ScaLAPACK-2.0.2-gompi-1.4.10-OpenBLAS-0.2.6-LAPACK-3.4.2.eb", "MPI/GCC/4.7.2/OpenMPI/1.6.4/numlib",
              "ScaLAPACK/2.0.2-OpenBLAS-0.2.6-LAPACK-3.4.2", 'x'),
@@ -1595,7 +1595,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
         self.assertTrue(re.search('module: GCC/4.7.2', outtxt))
         self.assertTrue(re.search('module: OpenMPI/1.6.4-GCC-4.7.2', outtxt))
-        self.assertTrue(re.search('module: OpenBLAS/0.2.6-gompi-1.4.10-LAPACK-3.4.2', outtxt))
+        self.assertTrue(re.search('module: OpenBLAS/0.2.6-GCC-4.7.2-LAPACK-3.4.2', outtxt))
         self.assertTrue(re.search('module: FFTW/3.3.3-gompi', outtxt))
         self.assertTrue(re.search('module: ScaLAPACK/2.0.2-gompi', outtxt))
         # zlib is not a dep at all
@@ -1609,7 +1609,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
         self.assertTrue(re.search('module: GCC/4.7.2', outtxt))
         self.assertTrue(re.search('module: OpenMPI/1.6.4-GCC-4.7.2', outtxt))
-        self.assertTrue(re.search('module: OpenBLAS/0.2.6-gompi-1.4.10-LAPACK-3.4.2', outtxt))
+        self.assertTrue(re.search('module: OpenBLAS/0.2.6-GCC-4.7.2-LAPACK-3.4.2', outtxt))
         self.assertFalse(re.search(r'module: FFTW/3\.3\.3-gompi', outtxt))
         self.assertTrue(re.search(r'module: FFTW/\.3\.3\.3-gompi', outtxt))
         self.assertFalse(re.search(r'module: ScaLAPACK/2\.0\.2-gompi', outtxt))

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -691,7 +691,9 @@ class RobotTest(EnhancedTestCase):
         goolfc_hierarchy = get_toolchain_hierarchy({'name': 'goolfc', 'version': '2.6.10'})
         self.assertEqual(goolfc_hierarchy, [
             {'name': 'GCC', 'version': '4.8.2'},
+            {'name': 'golf', 'version': '2.6.10'},
             {'name': 'gcccuda', 'version': '2.6.10'},
+            {'name': 'golfc', 'version': '2.6.10'},
             {'name': 'gompic', 'version': '2.6.10'},
             {'name': 'goolfc', 'version': '2.6.10'},
         ])
@@ -699,6 +701,7 @@ class RobotTest(EnhancedTestCase):
         goolf_hierarchy = get_toolchain_hierarchy({'name': 'goolf', 'version': '1.4.10'})
         self.assertEqual(goolf_hierarchy, [
             {'name': 'GCC', 'version': '4.7.2'},
+            {'name': 'golf', 'version': '1.4.10'},
             {'name': 'gompi', 'version': '1.4.10'},
             {'name': 'goolf', 'version': '1.4.10'},
         ])


### PR DESCRIPTION
This PR replaces #2234, and depends on ~~#2464~~ and ~~#2465~~.
subtoolchains are now searched using a breadth-first-search, which
allows multiple subtoolchains per toolchain.

Some subtoolchains such as golf and golfc are now marked OPTIONAL
since they do not have to exist as modules, and can be skipped.

Since those optional subtoolchains cannot usually be found via a
dependency search (as toolchain easyconfigs do not typically have
subtoolchains as dependencies)
try to search for subtoolchain/version with the same version as
the parent. E.g. goolfc/2.6.10 searches for golfc/2.6.10, and
golfc/2.6.10 searches for golf/2.6.10 and gcccuda/2.6.10.