### PR TITLE
fix derive_alt_pypi_url after PyPI switching to sha256 in package URLs + fix broken test for pypi_source_urls + fix bootstrap script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20180412.01 06267c2423de76d49055360e618399fdaebc2e5f3e69e50fabfb6a433ab9744b"
+    - EB_BOOTSTRAP_EXPECTED="20180412.02 d05b0922f83ba7febfeb1dcfca4a854be93cbfefa6cdedcc87cc8c3835aa3fa3"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20180408.01 60b1f1900fb6eb96cdb1206abfd25ab54193ebe2fb71c8402975e843d1aec5ce"
+    - EB_BOOTSTRAP_EXPECTED="20180412.01 06267c2423de76d49055360e618399fdaebc2e5f3e69e50fabfb6a433ab9744b"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -423,16 +423,19 @@ def derive_alt_pypi_url(url):
 
     cand_urls = pypi_source_urls(pkg_name)
 
-    regex = re.compile('.*/%s#md5=[a-f0-9]{32}$' % pkg_source.replace('.', '\\.'), re.M)
+    # md5 for old PyPI, sha256 for new PyPi (Warehouse)
+    regex_md5 = re.compile('.*/%s#md5=[a-f0-9]{32}$' % pkg_source.replace('.', '\\.'), re.M)
+    regex_sha256 = re.compile('.*/%s#sha256=[a-f0-9]{64}$' % pkg_source.replace('.', '\\.'), re.M)
     for cand_url in cand_urls:
-        res = regex.match(cand_url)
+        res = regex_sha256.match(cand_url) or regex_md5.match(cand_url)
         if res:
             # e.g.: https://pypi.python.org/packages/<dir1>/<dir2>/<hash>/easybuild-<version>.tar.gz#md5=<md5>
-            alt_pypi_url = res.group(0).split('#md5')[0]
+            alt_pypi_url = res.group(0).split('#sha256')[0].split('#md5')[0]
             break
 
     if not alt_pypi_url:
-        _log.debug("Failed to extract hash using pattern '%s' from list of URLs: %s", regex.pattern, cand_urls)
+        _log.debug("Failed to extract hash using pattern '%s' or '%s' from list of URLs: %s",
+                   regex_sha256.pattern, regex_md5.pattern, cand_urls)
 
     return alt_pypi_url
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -433,7 +433,7 @@ def derive_alt_pypi_url(url):
             break
 
     if not alt_pypi_url:
-        _log.debug("Failed to extract hash using pattern '%s' or '%s' from list of URLs: %s", regex.pattern, cand_urls)
+        _log.debug("Failed to extract hash using pattern '%s' from list of URLs: %s", regex.pattern, cand_urls)
 
     return alt_pypi_url
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -424,18 +424,16 @@ def derive_alt_pypi_url(url):
     cand_urls = pypi_source_urls(pkg_name)
 
     # md5 for old PyPI, sha256 for new PyPi (Warehouse)
-    regex_md5 = re.compile('.*/%s#md5=[a-f0-9]{32}$' % pkg_source.replace('.', '\\.'), re.M)
-    regex_sha256 = re.compile('.*/%s#sha256=[a-f0-9]{64}$' % pkg_source.replace('.', '\\.'), re.M)
+    regex = re.compile('.*/%s(?:#md5=[a-f0-9]{32}|#sha256=[a-f0-9]{64})$' % pkg_source.replace('.', '\\.'), re.M)
     for cand_url in cand_urls:
-        res = regex_sha256.match(cand_url) or regex_md5.match(cand_url)
+        res = regex.match(cand_url)
         if res:
             # e.g.: https://pypi.python.org/packages/<dir1>/<dir2>/<hash>/easybuild-<version>.tar.gz#md5=<md5>
             alt_pypi_url = res.group(0).split('#sha256')[0].split('#md5')[0]
             break
 
     if not alt_pypi_url:
-        _log.debug("Failed to extract hash using pattern '%s' or '%s' from list of URLs: %s",
-                   regex_sha256.pattern, regex_md5.pattern, cand_urls)
+        _log.debug("Failed to extract hash using pattern '%s' or '%s' from list of URLs: %s", regex.pattern, cand_urls)
 
     return alt_pypi_url
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1114,10 +1114,14 @@ class FileToolsTest(EnhancedTestCase):
         eb340_url += 'easybuild-3.4.0.tar.gz#md5=267a056a77a8f77fccfbf56354364045'
         self.assertTrue(eb340_url, res)
         pattern = '^https://pypi.python.org/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/'
-        pattern += 'easybuild-[0-9rc.]+.tar.gz#md5=[a-f0-9]{32}$'
-        regex = re.compile(pattern)
+        pattern_md5 = pattern + 'easybuild-[0-9rc.]+.tar.gz#md5=[a-f0-9]{32}$'
+        pattern_sha256 = pattern + 'easybuild-[0-9rc.]+.tar.gz#sha256=[a-f0-9]{64}$'
+        regex_md5 = re.compile(pattern_md5)
+        regex_sha256 = re.compile(pattern_sha256)
         for url in res:
-            self.assertTrue(regex.match(url), "Pattern '%s' matches for '%s'" % (regex.pattern, url))
+            error_msg = "Pattern '%s' or '%s' matches for '%s'" % (regex_md5.pattern, regex_sha256.pattern, url)
+            self.assertTrue(regex_md5.match(url) or regex_sha256.match(url), error_msg)
+
         # more than 50 releases at time of writing test, which always stay there
         self.assertTrue(len(res) > 50)
 


### PR DESCRIPTION
Seems like PyPI is switching away from MD5 checksums in favor of SHA256 checksums, probably related to the switch to the new "Warehouse" PyPI.