### PR TITLE
make sure that both 'get_git_revision' and 'this_is_easybuild' return regular strings rather than Unicode strings

### DIFF
--- a/easybuild/tools/version.py
+++ b/easybuild/tools/version.py
@@ -46,6 +46,7 @@ from socket import gethostname
 VERSION = LooseVersion('3.6.0.dev0')
 UNKNOWN = 'UNKNOWN'
 
+
 def get_git_revision():
     """
     Returns the git revision (e.g. aab4afc016b742c6d4b157427e192942d0e131fe),
@@ -60,9 +61,13 @@ def get_git_revision():
     try:
         path = os.path.dirname(__file__)
         gitrepo = git.Git(path)
-        return gitrepo.rev_list("HEAD").splitlines()[0]
+        # 'encode' is required to make sure a regular string is returned rather than a unicode string
+        res = gitrepo.rev_list('HEAD').splitlines()[0].encode('ascii')
     except git.GitCommandError:
-        return UNKNOWN
+        res = UNKNOWN
+
+    return res
+
 
 git_rev = get_git_revision()
 if git_rev == UNKNOWN:
@@ -76,14 +81,15 @@ FRAMEWORK_VERSION = VERBOSE_VERSION
 # EasyBlock version
 try:
     from easybuild.easyblocks import VERBOSE_VERSION as EASYBLOCKS_VERSION
-except:
+except Exception:
     EASYBLOCKS_VERSION = '0.0.UNKNOWN.EASYBLOCKS'  # make sure it is smaller then anything
+
 
 def this_is_easybuild():
     """Standard starting message"""
     top_version = max(FRAMEWORK_VERSION, EASYBLOCKS_VERSION)
     # !!! bootstrap_eb.py script checks hard on the string below, so adjust with sufficient care !!!
-    msg = "This is EasyBuild %s (framework: %s, easyblocks: %s) on host %s." \
-         % (top_version, FRAMEWORK_VERSION, EASYBLOCKS_VERSION, gethostname())
-
-    return msg
+    msg = "This is EasyBuild %s (framework: %s, easyblocks: %s) on host %s."
+    msg = msg % (top_version, FRAMEWORK_VERSION, EASYBLOCKS_VERSION, gethostname())
+    # 'encode' is required to make sure a regular string is returned rather than a unicode string
+    return msg.encode('ascii')

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -46,6 +46,7 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import get_module_syntax
 from easybuild.tools.filetools import copy_file, mkdir, read_file, remove_file, write_file
 from easybuild.tools.modules import modules_tool
+from easybuild.tools.version import get_git_revision, this_is_easybuild
 
 
 class EasyBlockTest(EnhancedTestCase):
@@ -1258,6 +1259,12 @@ class EasyBlockTest(EnhancedTestCase):
         self.mock_stdout(False)
         self.assertEqual(stdout, '')
         self.assertEqual(stderr.strip(), "WARNING: Ignoring failing checksum verification for bar-0.0.tar.gz")
+
+    def test_this_is_easybuild(self):
+        """Test 'this_is_easybuild' function (and get_git_revision function used by it)."""
+        # make sure both return a non-Unicode string
+        self.assertTrue(isinstance(get_git_revision(), str))
+        self.assertTrue(isinstance(this_is_easybuild(), str))
 
 
 def suite():


### PR DESCRIPTION
This fixes the traceback that occurs when a Unicode character slips into the `description` easyconfig parameter and EasyBuild is being run directly from a Git repository:

```
ERROR: Traceback (most recent call last):
  File "/Users/kehoste/work/easybuild-framework/easybuild/main.py", line 128, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env, hooks=hooks)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyblock.py", line 2698, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyblock.py", line 2614, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyblock.py", line 2489, in run_step
    step_method(self)()
  File "/Users/kehoste/work/easybuild-framework/easybuild/framework/easyblock.py", line 2302, in make_module_step
    txt += self.make_module_footer()
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 340: ordinal not in range(128)
```

The problem is that `make_module_footer` includes `VERBOSE_VERSION`, which is a unicode string. This triggers a decoding of `txt` as a unicode string, which fails with the default `ascii` codec because a UTF-8 character is present in the value return by `make_module_description`.

By making sure everything that `VERBOSE_VERSION` is a regular string, this issue can be avoided.

Some additional minor stylistic changes were made to make the `flake8` Python code style checker happy.

cc @migueldiascosta, @vanzod