### PR TITLE
add support for enabling fallback in sanity check to consider lib64 equivalent for seemingly missing libraries

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -169,6 +169,7 @@ BUILD_OPTIONS_CMDLINE = {
         'hidden',
         'ignore_checksums',
         'install_latest_eb_release',
+        'lib64_fallback_sanity_check',
         'minimal_toolchains',
         'module_only',
         'package',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -378,6 +378,8 @@ class EasyBuildOptions(GeneralOption):
             'ignore-checksums': ("Ignore failing checksum verification", None, 'store_true', False),
             'ignore-osdeps': ("Ignore any listed OS dependencies", None, 'store_true', False),
             'install-latest-eb-release': ("Install latest known version of easybuild", None, 'store_true', False),
+            'lib64-fallback-sanity-check': ("Fallback in sanity check to lib64/ equivalent for missing libraries",
+                                            None, 'store_true', False),
             'max-fail-ratio-adjust-permissions': ("Maximum ratio for failures to allow when adjusting permissions",
                                                   'float', 'store', DEFAULT_MAX_FAIL_RATIO_PERMS),
             'minimal-toolchains': ("Use minimal toolchain when resolving dependencies", None, 'store_true', False),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -379,7 +379,7 @@ class EasyBuildOptions(GeneralOption):
             'ignore-osdeps': ("Ignore any listed OS dependencies", None, 'store_true', False),
             'install-latest-eb-release': ("Install latest known version of easybuild", None, 'store_true', False),
             'lib64-fallback-sanity-check': ("Fallback in sanity check to lib64/ equivalent for missing libraries",
-                                            None, 'store_true', False),
+                                            None, 'store_true', True),
             'max-fail-ratio-adjust-permissions': ("Maximum ratio for failures to allow when adjusting permissions",
                                                   'float', 'store', DEFAULT_MAX_FAIL_RATIO_PERMS),
             'minimal-toolchains': ("Use minimal toolchain when resolving dependencies", None, 'store_true', False),

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1574,6 +1574,28 @@ class ToyBuildTest(EnhancedTestCase):
 
         self.assertTrue(os.path.exists(toy_modfile))
 
+    def test_sanity_check_paths_lib64(self):
+        """Test whether fallback in sanity check for lib64/ equivalents of library files works."""
+        test_ecs_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'easyconfigs')
+        ec_file = os.path.join(test_ecs_dir, 'test_ecs', 't', 'toy', 'toy-0.0.eb')
+        ectxt = read_file(ec_file)
+
+        # modify test easyconfig: move lib/libtoy.a to lib64/libtoy.a
+        ectxt = re.sub("\s*'files'.*", "'files': ['bin/toy', 'lib/libtoy.a'],", ectxt)
+        postinstallcmd = "mkdir %(installdir)s/lib64 && mv %(installdir)s/lib/libtoy.a %(installdir)s/lib64/libtoy.a"
+        ectxt = re.sub("postinstallcmds.*", "postinstallcmds = ['%s']" % postinstallcmd, ectxt)
+
+        test_ec = os.path.join(self.test_prefix, 'toy-0.0.eb')
+        write_file(test_ec, ectxt)
+
+        # sanity check fails by default
+        error_pattern = r"Sanity check failed: no file of \('lib/libtoy.a',\)"
+        self.assertErrorRegex(EasyBuildError, error_pattern, self.test_toy_build, ec_file=test_ec,
+                              raise_error=True, verbose=False)
+
+        # all is fine is lib64 fallback check is enabled
+        self.test_toy_build(ec_file=test_ec, extra_args=['--lib64-fallback-sanity-check'], raise_error=True)
+
     def test_toy_dumped_easyconfig(self):
         """ Test dumping of file in eb_filerepo in both .eb and .yeb format """
         filename = 'toy-0.0'

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1588,26 +1588,26 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec = os.path.join(self.test_prefix, 'toy-0.0.eb')
         write_file(test_ec, ectxt)
 
-        # sanity check fails by default
+        # sanity check fails if lib64 fallback in sanity check is disabled
         error_pattern = r"Sanity check failed: no file found at 'lib/libtoy.a' or 'lib/libfoo.a' in "
         self.assertErrorRegex(EasyBuildError, error_pattern, self.test_toy_build, ec_file=test_ec,
-                              raise_error=True, verbose=False)
+                              extra_args=['--disable-lib64-fallback-sanity-check'], raise_error=True, verbose=False)
 
-        # all is fine is lib64 fallback check is enabled
-        self.test_toy_build(ec_file=test_ec, extra_args=['--lib64-fallback-sanity-check'], raise_error=True)
+        # all is fine is lib64 fallback check is enabled (which it is by default)
+        self.test_toy_build(ec_file=test_ec, raise_error=True)
 
         # also check other way around (lib64 -> lib)
         ectxt = read_file(ec_file)
         ectxt = re.sub("\s*'files'.*", "'files': ['bin/toy', 'lib64/libtoy.a'],", ectxt)
         write_file(test_ec, ectxt)
 
-        # sanity check fails by default, lib64/libtoy.a is not there
+        # sanity check fails if lib64 fallback in sanity check is disabled, since lib64/libtoy.a is not there
         error_pattern = r"Sanity check failed: no file found at 'lib64/libtoy.a' in "
         self.assertErrorRegex(EasyBuildError, error_pattern, self.test_toy_build, ec_file=test_ec,
-                              raise_error=True, verbose=False)
+                              extra_args=['--disable-lib64-fallback-sanity-check'], raise_error=True, verbose=False)
 
-        # sanity check passes when lib64 fallback is enabled, since lib/libtoy.a is also considered
-        self.test_toy_build(ec_file=test_ec, extra_args=['--lib64-fallback-sanity-check'], raise_error=True)
+        # sanity check passes when lib64 fallback is enabled (by default), since lib/libtoy.a is also considered
+        self.test_toy_build(ec_file=test_ec, raise_error=True)
 
     def test_toy_dumped_easyconfig(self):
         """ Test dumping of file in eb_filerepo in both .eb and .yeb format """


### PR DESCRIPTION
This is an alternate implementation of the proposed change by @torbjoernk in #1405, as a fix for #1404.

I prefer keeping this optional, since having the fallback enabled by default may result in the sanity check passing where it perhaps shouldn't (although maybe I'm being too careful here, I'm not sure...).

This is fueled by the issues that @pmatousu has been reporting for failing sanity checks on SUSE systems, cfr. https://github.com/easybuilders/easybuild-easyblocks/issues/1400 and https://github.com/easybuilders/easybuild-easyconfigs/issues/6165 .