### PR TITLE
fix running --containerize --container-build-image with --extended-dry-run

### DIFF
--- a/easybuild/tools/containers.py
+++ b/easybuild/tools/containers.py
@@ -257,7 +257,7 @@ def check_singularity():
         path_to_singularity_cmd = which('singularity')
         if path_to_singularity_cmd:
             print_msg("Singularity tool found at %s" % path_to_singularity_cmd)
-            out, ec = run_cmd("singularity --version", simple=False, trace=False)
+            out, ec = run_cmd("singularity --version", simple=False, trace=False, force_in_dry_run=True)
             if ec:
                 raise EasyBuildError("Failed to determine Singularity version: %s" % out)
             else:


### PR DESCRIPTION
`singularity --version` always need to be run, to avoid this crash:

```
Traceback (most recent call last):
  File "/example/easybuild-framework/test/framework/containers.py", line 260, in test_end2end_singularity_image
    stdout, stderr = self.run_main(args)
  File "/example/easybuild-framework/test/framework/containers.py", line 84, in run_main
    self.eb_main(args, raise_error=True, verbose=True, do_build=True)
  File "/example/easybuild-framework/test/framework/utilities.py", line 295, in eb_main
    raise myerr
AttributeError: LooseVersion instance has no attribute 'version'
```

cc @shahzebsiddiqui 