### PR TITLE
resolve location of singularity command before running 'sudo singularity build'

### DIFF
--- a/easybuild/tools/containers.py
+++ b/easybuild/tools/containers.py
@@ -242,7 +242,10 @@ def build_singularity_image(def_path):
         else:
             raise EasyBuildError("Container image already exists at %s, not overwriting it without --force", img_path)
 
-    cmd = "sudo singularity build %s %s %s" % (cmd_opts, img_path, def_path)
+    # resolve full path to 'singularity' binary, since it may not be available via $PATH under sudo...
+    singularity = which('singularity')
+
+    cmd = "sudo %s build %s %s %s" % (singularity, cmd_opts, img_path, def_path)
     print_msg("Running '%s', you may need to enter your 'sudo' password..." % cmd)
     run_cmd(cmd, stream_output=True)
     print_msg("Singularity image created at %s" % img_path, log=_log)

--- a/test/framework/containers.py
+++ b/test/framework/containers.py
@@ -229,7 +229,7 @@ class ContainersTest(EnhancedTestCase):
             "^== Singularity tool found at %s/bin/singularity" % self.test_prefix,
             "^== Singularity version '2.4.0' is 2.4 or higher ... OK",
             "^== Singularity definition file created at %s/containers/Singularity\.toy-0.0" % self.test_prefix,
-            "^== Running 'sudo singularity build\s*/.* /.*', you may need to enter your 'sudo' password...",
+            "^== Running 'sudo .*/singularity build\s*/.* /.*', you may need to enter your 'sudo' password...",
             "^== Singularity image created at %s/containers/toy-0.0\.simg" % self.test_prefix,
         ]
         self.check_regexs(regexs, stdout)
@@ -246,7 +246,7 @@ class ContainersTest(EnhancedTestCase):
         stdout, stderr = self.run_main(args)
         self.assertFalse(stderr)
         regexs[-3] = "^== Singularity definition file created at %s/containers/Singularity\.foo-bar" % self.test_prefix
-        regexs[-2] = "^== Running 'sudo singularity build --writable /.* /.*', you may need to enter .*"
+        regexs[-2] = "^== Running 'sudo .*/singularity build --writable /.* /.*', you may need to enter .*"
         regexs[-1] = "^== Singularity image created at %s/containers/foo-bar\.img$" % self.test_prefix
         self.check_regexs(regexs, stdout)
 


### PR DESCRIPTION
Without this, we're at the mercy of whatever `$PATH` is set to under `sudo`, which may lead to situations like:

```
== Running 'sudo singularity build /tmp/GCC-6.4.0-2.28.simg /tmp/Singularity.GCC-6.4.0-2.28', you may need to enter your 'sudo' password...
== (streaming) output for command 'sudo singularity build /tmp/GCC-6.4.0-2.28.simg /tmp/Singularity.GCC-6.4.0-2.28':
sudo: singularity: command not found
ERROR: cmd "sudo singularity build  /tmp/GCC-6.4.0-2.28.simg /tmp/Singularity.GCC-6.4.0-2.28" exited with exit code 1 and output:
sudo: singularity: command not found

[boegel@localhost ~]$ which singularity
/usr/local/bin/singularity
```

`/usr/local/bin` is not in `$PATH` under `sudo` for security reasons. We would probably hit the same issue if Singularity is installed in a non-default installation prefix.

Fix is trivial: resolve location of `singularity` command to an absolute path before calling out to it...