### PR TITLE
Fix git remote url in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Pull the _develop_ branch from the main easybuild-framework repository:
 
 ```bash
 cd easybuild
-git remote add github_easybuilders git@github.com/easybuilders/easybuild-framework.git
+git remote add github_easybuilders git@github.com:easybuilders/easybuild-framework.git
 git branch develop
 git checkout develop
 git pull github_easybuilders develop


### PR DESCRIPTION
Otherwise `git` fails  when using the remote:

```
$ git pull github_easybuilders develop
fatal: 'git@github.com/easybuilders/easybuild-framework.git' does not appear to be a git repository
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

The url is correct in the other EasyBuild repositories.