### PR TITLE
Add GITHUB_LOWER_SOURCE constant

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -91,6 +91,8 @@ TEMPLATE_CONSTANTS = [
      'http download for gnome ftp server'),
     ('GITHUB_SOURCE', 'https://github.com/%(github_account)s/%(name)s/archive',
      'GitHub source URL (requires github_account easyconfig parameter to be specified)'),
+    ('GITHUB_LOWER_SOURCE', 'https://github.com/%(github_account)s/%(namelower)s/archive',
+     'GitHub source URL (lowercase name, requires github_account easyconfig parameter to be specified)'),
     ('GNU_SAVANNAH_SOURCE', 'http://download-mirror.savannah.gnu.org/releases/%(namelower)s',
      'download.savannah.gnu.org source url'),
     ('GNU_SOURCE', 'http://ftpmirror.gnu.org/gnu/%(namelower)s',


### PR DESCRIPTION
There are several GitHub repositories with lowercase names where the currently available `GITHUB_SOURCE` constant can't be used.