### PR TITLE
add support for passing custom messages on failing sanity check for extensions

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2202,6 +2202,7 @@ class EasyBlock(object):
 
         # sanity check for extensions
         if not extension:
+            failed_exts = []
             for ext in self.ext_instances:
                 fail_msg = None
                 res = ext.sanity_check_step()
@@ -2218,10 +2219,15 @@ class EasyBlock(object):
                         fail_msg = "sanity check for '%s' extension failed (see log for details)!" % ext.name
 
                 if fail_msg:
-                    self.sanity_check_fail_msgs.append(fail_msg)
+                    failed_exts.append((ext.name, fail_msg))
                     self.log.warning(fail_msg)
                 else:
                     self.log.info("Sanity check for '%s' extension passed!", ext.name)
+
+            if failed_exts:
+                overall_fail_msg = "extensions sanity check failed for %d extensions (see below): " % len(failed_exts)
+                self.sanity_check_fail_msgs.append(overall_fail_msg + ', '.join(x[0] for x in failed_exts))
+                self.sanity_check_fail_msgs.extend(x[1] for x in failed_exts)
 
         # cleanup
         if fake_mod_data:
@@ -2237,7 +2243,7 @@ class EasyBlock(object):
 
         # pass or fail
         if self.sanity_check_fail_msgs:
-            raise EasyBuildError("Sanity check failed: %s", ', '.join(self.sanity_check_fail_msgs))
+            raise EasyBuildError("Sanity check failed: %s", '\n'.join(self.sanity_check_fail_msgs))
         else:
             self.log.debug("Sanity check passed!")
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2204,28 +2204,27 @@ class EasyBlock(object):
         if not extension:
             failed_exts = []
             for ext in self.ext_instances:
-                fail_msg = None
+                success, fail_msg = None, None
                 res = ext.sanity_check_step()
                 # if result is a tuple, we expect a (<bool (success)>, <custom_message>) format
                 if isinstance(res, tuple):
-                    if len(res) == 2:
-                        if not res[0]:
-                            fail_msg = "sanity check for '%s' extension failed: %s" % (ext.name, res[1])
-                    else:
+                    if len(res) != 2:
                         raise EasyBuildError("Wrong sanity check result type for '%s' extension: %s", ext.name, res)
+                    success, fail_msg = res
                 else:
                     # if result of extension sanity check is not a 2-tuple, treat it as a boolean indicating success
-                    if not res:
-                        fail_msg = "sanity check for '%s' extension failed (see log for details)!" % ext.name
+                    success, fail_msg = res, "(see log for details)"
 
-                if fail_msg:
+                if not success:
+                    fail_msg = "failing sanity check for '%s' extension: %s" % (ext.name, fail_msg)
                     failed_exts.append((ext.name, fail_msg))
                     self.log.warning(fail_msg)
                 else:
                     self.log.info("Sanity check for '%s' extension passed!", ext.name)
 
             if failed_exts:
-                overall_fail_msg = "extensions sanity check failed for %d extensions (see below): " % len(failed_exts)
+                overall_fail_msg = "extensions sanity check failed for %d extensions: " % len(failed_exts)
+                self.log.warning(overall_fail_msg)
                 self.sanity_check_fail_msgs.append(overall_fail_msg + ', '.join(x[0] for x in failed_exts))
                 self.sanity_check_fail_msgs.extend(x[1] for x in failed_exts)
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2209,13 +2209,13 @@ class EasyBlock(object):
                 if isinstance(res, tuple):
                     if len(res) == 2:
                         if not res[0]:
-                            fail_msg = "Sanith check for '%s' extension failed: %s" % (ext.name, res[1])
+                            fail_msg = "sanity check for '%s' extension failed: %s" % (ext.name, res[1])
                     else:
                         raise EasyBuildError("Wrong sanity check result type for '%s' extension: %s", ext.name, res)
                 else:
                     # if result of extension sanity check is not a 2-tuple, treat it as a boolean indicating success
                     if not res:
-                        fail_msg = "Sanith check for '%s' extension failed (see log for details)!" % ext.name
+                        fail_msg = "sanity check for '%s' extension failed (see log for details)!" % ext.name
 
                 if fail_msg:
                     self.sanity_check_fail_msgs.append(fail_msg)

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -133,6 +133,7 @@ class Extension(object):
         """
         Sanity check to run after installing extension
         """
+        res = (True, '')
 
         if os.path.isdir(self.installdir):
             change_dir(self.installdir)
@@ -146,7 +147,7 @@ class Extension(object):
             cmd, inp = exts_filter
         else:
             self.log.debug("no exts_filter setting found, skipping sanitycheck")
-            return True
+            cmd = None
 
         if 'modulename' in self.options:
             modname = self.options['modulename']
@@ -155,10 +156,10 @@ class Extension(object):
             modname = self.name
             self.log.debug("self.name: %s", modname)
 
-        if modname == False:
-            # allow skipping of sanity check by setting module name to False
-            return True
-        else:
+        # allow skipping of sanity check by setting module name to False
+        if modname is False:
+            self.log.info("modulename set to False for '%s' extension, so skipping sanity check", self.name)
+        elif cmd:
             template = {
                         'ext_name': modname,
                         'ext_version': self.version,
@@ -178,9 +179,9 @@ class Extension(object):
             (output, ec) = run_cmd(cmd, log_ok=False, simple=False, regexp=False, inp=stdin)
 
             if ec:
-                msg = "%s failed to install, cmd '%s' (stdin: %s) output: %s" % (self.name, cmd, stdin, output)
-                self.log.warn("Extension: %s" % msg)
-                self.sanity_check_fail_msgs.append(msg)
-                return False
-            else:
-                return True
+                fail_msg = 'command "%s" (stdin: %s) failed; output:\n%s' % (cmd, stdin, output.strip())
+                self.log.warn("Sanity check for '%s' extension failed: %s", self.name, fail_msg)
+                res = (False, fail_msg)
+                self.sanity_check_fail_msgs.append(fail_msg)
+
+        return res

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -179,9 +179,15 @@ class Extension(object):
             (output, ec) = run_cmd(cmd, log_ok=False, simple=False, regexp=False, inp=stdin)
 
             if ec:
-                fail_msg = 'command "%s" (stdin: %s) failed; output:\n%s' % (cmd, stdin, output.strip())
-                self.log.warn("Sanity check for '%s' extension failed: %s", self.name, fail_msg)
+                if stdin:
+                    fail_msg = 'command "%s" (stdin: "%s") failed' % (cmd, stdin)
+                else:
+                    fail_msg = 'command "%s" failed' % cmd
+                fail_msg += "; output:\n%s" % output.strip()
+                self.log.warning("Sanity check for '%s' extension failed: %s", self.name, fail_msg)
                 res = (False, fail_msg)
+                # keep track of all reasons of failure
+                # (only relevant when this extension is installed stand-alone via ExtensionEasyBlock)
                 self.sanity_check_fail_msgs.append(fail_msg)
 
         return res

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -127,8 +127,8 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             # load fake module
             fake_mod_data = self.load_fake_module(purge=True)
 
-        # perform sanity check
-        sanity_check_ok = Extension.sanity_check_step(self)
+        # perform extension sanity check
+        (sanity_check_ok, fail_msg) = Extension.sanity_check_step(self)
 
         if fake_mod_data:
             # unload fake module and clean up
@@ -140,21 +140,19 @@ class ExtensionEasyBlock(EasyBlock, Extension):
                                                               extension=self.is_extension)
 
         # pass or fail sanity check
-        if not sanity_check_ok:
-            msg = "Sanity check for %s failed: %s" % (self.name, '; '.join(self.sanity_check_fail_msgs))
-            if self.is_extension:
-                self.log.warning(msg)
-            else:
-                raise EasyBuildError(msg)
-            return False
+        if sanity_check_ok:
+            self.log.info("Sanity check for %s successful!", self.name)
         else:
-            self.log.info("Sanity check for %s successful!" % self.name)
-            return True
+            if not self.is_extension:
+                msg = "Sanity check for %s failed: %s" % (self.name, '; '.join(self.sanity_check_fail_msgs))
+                raise EasyBuildError(msg)
+
+        return (sanity_check_ok, '; '.join(self.sanity_check_fail_msgs))
 
     def make_module_extra(self, extra=None):
         """Add custom entries to module."""
 
         txt = EasyBlock.make_module_extra(self)
-        if not extra is None:
+        if extra is not None:
             txt += extra
         return txt

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1090,15 +1090,29 @@ class EasyBlockTest(EnhancedTestCase):
     def test_extensions_sanity_check(self):
         """Test sanity check aspect of extensions."""
         test_ecs_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'easyconfigs', 'test_ecs')
-        toy_ec = EasyConfig(os.path.join(test_ecs_dir, 't', 'toy', 'toy-0.0-gompi-1.3.12-test.eb'))
+        toy_ec_fn = os.path.join(test_ecs_dir, 't', 'toy', 'toy-0.0-gompi-1.3.12-test.eb')
+
+        # this import only works here, since EB_toy is a test easyblock
+        from easybuild.easyblocks.toy import EB_toy
+
+        # purposely inject failing custom extension filter for last extension
+        toy_ec = EasyConfig(toy_ec_fn)
+        toy_ec.enable_templating = False
+        exts_list = toy_ec['exts_list']
+        exts_list[-1][2]['exts_filter'] = ("thisshouldfail", '')
+        toy_ec['exts_list'] = exts_list
+        toy_ec.enable_templating = True
+
+        eb = EB_toy(toy_ec)
+        eb.silent = True
+        error_pattern = r"Sanity check failed: Sanith check for 'toy' extension failed \(see log for details\)\!"
+        self.assertErrorRegex(EasyBuildError, error_pattern, eb.run_all_steps, True)
 
         # purposely put sanity check command in place that breaks the build,
         # to check whether sanity check is only run once;
         # sanity check commands are checked after checking sanity check paths, so this should work
+        toy_ec = EasyConfig(toy_ec_fn)
         toy_ec.update('sanity_check_commands', [("%(installdir)s/bin/toy && rm %(installdir)s/bin/toy", '')])
-
-        # this import only works here, since EB_toy is a test easyblock
-        from easybuild.easyblocks.toy import EB_toy
         eb = EB_toy(toy_ec)
         eb.silent = True
         eb.run_all_steps(True)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1105,9 +1105,10 @@ class EasyBlockTest(EnhancedTestCase):
 
         eb = EB_toy(toy_ec)
         eb.silent = True
-        error_pattern = r"Sanity check failed: sanity check for 'toy' extension failed: "
-        error_pattern += r'command "thisshouldfail" \(stdin: None\) failed; '
-        error_pattern += r"output:\n/bin/bash: thisshouldfail: command not found"
+        error_pattern = "Sanity check failed: extensions sanity check failed for 1 extensions \(see below\): toy\n"
+        error_pattern += "sanity check for 'toy' extension failed: "
+        error_pattern += 'command "thisshouldfail" \(stdin: None\) failed; output:\n'
+        error_pattern += "/bin/bash: thisshouldfail: command not found"
         self.assertErrorRegex(EasyBuildError, error_pattern, eb.run_all_steps, True)
 
         # purposely put sanity check command in place that breaks the build,

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1105,10 +1105,9 @@ class EasyBlockTest(EnhancedTestCase):
 
         eb = EB_toy(toy_ec)
         eb.silent = True
-        error_pattern = "Sanity check failed: extensions sanity check failed for 1 extensions \(see below\): toy\n"
-        error_pattern += "sanity check for 'toy' extension failed: "
-        error_pattern += 'command "thisshouldfail" \(stdin: None\) failed; output:\n'
-        error_pattern += "/bin/bash: thisshouldfail: command not found"
+        error_pattern = r"Sanity check failed: extensions sanity check failed for 1 extensions: toy\n"
+        error_pattern += r"failing sanity check for 'toy' extension: "
+        error_pattern += r'command "thisshouldfail" failed; output:\n/bin/bash: thisshouldfail: command not found'
         self.assertErrorRegex(EasyBuildError, error_pattern, eb.run_all_steps, True)
 
         # purposely put sanity check command in place that breaks the build,

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1105,7 +1105,9 @@ class EasyBlockTest(EnhancedTestCase):
 
         eb = EB_toy(toy_ec)
         eb.silent = True
-        error_pattern = r"Sanity check failed: Sanith check for 'toy' extension failed \(see log for details\)\!"
+        error_pattern = r"Sanity check failed: sanity check for 'toy' extension failed: "
+        error_pattern += r'command "thisshouldfail" \(stdin: None\) failed; '
+        error_pattern += r"output:\n/bin/bash: thisshouldfail: command not found"
         self.assertErrorRegex(EasyBuildError, error_pattern, eb.run_all_steps, True)
 
         # purposely put sanity check command in place that breaks the build,


### PR DESCRIPTION
This is motivated by a suggestion by @akesandgren in the context of https://github.com/easybuilders/easybuild-easyblocks/pull/1377, to postpone raising of errors at the end, which helps with limiting a lot of back & forth when the same type of problems arise for multiple extensions.

One issue with moving the download check in https://github.com/easybuilders/easybuild-easyblocks/pull/1377 to the sanity check step is error reporting: the actual cause of the failing sanity check for an extension is hidden higher up in the log.
This is fixed by the (backwards-compatible) changes made in this PR.

For example, with current `develop` you would get an error message like:

```
Sanity check failed: sanity checks for ['ipython', 'pyzmq'] extensions failed!
```

(and then you had to go back in the log to figure out the actual problem)

With these changes, you'll see:

```
Sanity check failed: extensions sanity check failed for 2 extensions: ipython, pyzmq
failing sanity check for 'ipython' extension: command "python -c 'import ipython'" failed; output:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'ipython'
failing sanity check for 'pyzmq' extension: command "python -c 'import pyzmq'" failed; output:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'pyzmq'
```

cc @vanzod, @wpoely86