### PR TITLE
prepend location for temporary module file to $MODULEPATH with high priority + mark it as default in load_fake_module method

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1305,7 +1305,7 @@ class EasyBlock(object):
         fake_mod_path = self.make_module_step(fake=True)
 
         # load fake module
-        self.modules_tool.prepend_module_path(os.path.join(fake_mod_path, self.mod_subdir))
+        self.modules_tool.prepend_module_path(os.path.join(fake_mod_path, self.mod_subdir), priority=10000)
         self.load_module(purge=purge)
 
         return (fake_mod_path, env)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2291,17 +2291,17 @@ class EasyBlock(object):
         else:
             self.log.debug("Sanity check passed!")
 
-    def _set_module_as_default(self):
+    def _set_module_as_default(self, fake=False):
         """
-        Defining default module Version
+        Sets the default module version except if we are in dry run
 
-        sets the default module version except if we are in dry run.
+        :param fake: set default for 'fake' module in temporary location
         """
         version = self.full_mod_name.split('/')[-1]
         if self.dry_run:
             dry_run_msg("Marked %s v%s as default version" % (self.name, version))
         else:
-            mod_folderpath = os.path.dirname(self.module_generator.get_module_filepath())
+            mod_folderpath = os.path.dirname(self.module_generator.get_module_filepath(fake=fake))
             self.module_generator.set_as_default(mod_folderpath, version)
 
     def cleanup_step(self):
@@ -2409,8 +2409,10 @@ class EasyBlock(object):
             else:
                 self.log.info("Skipping devel module...")
 
-        if build_option('set_default_module'):
-            self._set_module_as_default()
+        # always set default for temporary module file,
+        # to avoid that it gets overruled by an existing module file that is set as default
+        if fake or build_option('set_default_module'):
+            self._set_module_as_default(fake=fake)
 
         return modpath
 

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -333,7 +333,8 @@ class ModulesTool(object):
         :param priority: priority for this path in $MODULEPATH (Lmod-specific)
         """
         if priority:
-            self.log.info("Ignoring specified priority '%s' when running 'module use %s'", priority, path)
+            self.log.info("Ignoring specified priority '%s' when running 'module use %s' (Lmod-specific)",
+                          priority, path)
 
         # make sure path exists before we add it
         mkdir(path, parents=True)
@@ -379,7 +380,8 @@ class ModulesTool(object):
         :param priority: priority for this path in $MODULEPATH (Lmod-specific)
         """
         if priority:
-            self.log.info("Ignoring specified priority '%s' when prepending %s to $MODULEPATH", priority, path)
+            self.log.info("Ignoring specified priority '%s' when prepending %s to $MODULEPATH (Lmod-specific)",
+                          priority, path)
 
         # generic approach: remove the path first (if it's there), then add it again (to the front)
         modulepath = curr_module_paths()

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -333,7 +333,7 @@ class ModulesTool(object):
         :param priority: priority for this path in $MODULEPATH (Lmod-specific)
         """
         if priority:
-            self.log.info("Ignoring specified priority '%s' when prepending %s to $MODULEPATH", priority, path)
+            self.log.info("Ignoring specified priority '%s' when running 'module use %s'", priority, path)
 
         # make sure path exists before we add it
         mkdir(path, parents=True)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -218,6 +218,21 @@ class EasyBlockTest(EnhancedTestCase):
         eb = EasyBlock(EasyConfig(self.eb_file))
         eb.installdir = config.build_path()
         fake_mod_data = eb.load_fake_module()
+
+        pi_modfile = os.path.join(fake_mod_data[0], 'pi', '3.14')
+        if get_module_syntax() == 'Lua':
+            pi_modfile += '.lua'
+
+        self.assertTrue(os.path.exists(pi_modfile))
+
+        # check whether temporary module file is marked as default
+        if get_module_syntax() == 'Lua':
+            default_symlink = os.path.join(fake_mod_data[0], 'pi', 'default')
+            self.assertTrue(os.path.samefile(default_symlink, pi_modfile))
+        else:
+            dot_version_txt = read_file(os.path.join(fake_mod_data[0], 'pi', '.version'))
+            self.assertTrue("set ModulesVersion 3.14" in dot_version_txt)
+
         eb.clean_up_fake_module(fake_mod_data)
 
         # cleanup

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -41,8 +41,6 @@ from unittest import TextTestRunner
 
 import easybuild.tools.modules as mod
 from easybuild.framework.easyblock import EasyBlock
-from easybuild.framework.easyconfig.easyconfig import EasyConfig
-from easybuild.tools import config
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import copy_file, copy_dir, mkdir, read_file, write_file
 from easybuild.tools.modules import EnvironmentModules, EnvironmentModulesTcl, Lmod, NoModulesTool
@@ -239,6 +237,19 @@ class ModulesTest(EnhancedTestCase):
         os.symlink(modulepath[0], symlink_path)
         self.modtool.prepend_module_path(symlink_path)
         self.assertEqual(modulepath, curr_module_paths())
+
+        # test prepending with high priority
+        test_path_bis = tempfile.mkdtemp(prefix=self.test_prefix)
+        test_path_tris = tempfile.mkdtemp(prefix=self.test_prefix)
+        self.modtool.prepend_module_path(test_path_bis, priority=10000)
+        self.assertEqual(test_path_bis, curr_module_paths()[0])
+
+        # check whether prepend with priority actually works (only for Lmod)
+        if isinstance(self.modtool, Lmod):
+            self.modtool.prepend_module_path(test_path_tris)
+            modulepath = curr_module_paths()
+            self.assertEqual(test_path_bis, modulepath[0])
+            self.assertEqual(test_path_tris, modulepath[1])
 
     def test_ld_library_path(self):
         """Make sure LD_LIBRARY_PATH is what it should be when loaded multiple modules."""
@@ -757,6 +768,25 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(mod.MODULE_AVAIL_CACHE, {})
         self.assertEqual(mod.MODULE_SHOW_CACHE, {})
 
+    def test_module_use(self):
+        """Test 'module use'."""
+        test_dir1 = os.path.join(self.test_prefix, 'one')
+        test_dir2 = os.path.join(self.test_prefix, 'two')
+        test_dir3 = os.path.join(self.test_prefix, 'three')
+
+        self.assertFalse(test_dir1 in os.environ.get('MODULEPATH', ''))
+        self.modtool.use(test_dir1)
+        self.assertTrue(os.environ.get('MODULEPATH', '').startswith('%s:' % test_dir1))
+
+        # also test use with high priority
+        self.modtool.use(test_dir2, priority=10000)
+        self.assertTrue(os.environ['MODULEPATH'].startswith('%s:' % test_dir2))
+
+        # check whether prepend with priority actually works (only for Lmod)
+        if isinstance(self.modtool, Lmod):
+            self.modtool.use(test_dir3)
+            self.assertTrue(os.environ['MODULEPATH'].startswith('%s:%s:' % (test_dir2, test_dir3)))
+
     def test_module_use_bash(self):
         """Test whether effect of 'module use' is preserved when a new bash session is started."""
         # this test is here as check for a nasty bug in how the modules tool is deployed
@@ -813,6 +843,21 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(os.environ['EBROOTGCC'], '/tmp/software/Core/GCC/4.7.2')
         self.modtool.load(['hwloc/1.6.2'])
         self.assertEqual(os.environ['EBROOTHWLOC'], '/tmp/software/Compiler/GCC/4.7.2/hwloc/1.6.2')
+
+        # also test whether correct temporary module is loaded even though same module file already exists elsewhere
+        # with Lmod, this requires prepending the temporary module path to $MODULEPATH with high priority
+        tmp_moddir = os.path.join(self.test_prefix, 'tmp_modules')
+        hwloc_mod = os.path.join(tmp_moddir, 'hwloc', '1.6.2')
+        hwloc_mod_txt = '\n'.join([
+            '#%Module',
+            "module load GCC/4.7.2",
+            "setenv EBROOTHWLOC /path/to/tmp/hwloc-1.6.2",
+        ])
+        write_file(hwloc_mod, hwloc_mod_txt)
+        self.modtool.purge()
+        self.modtool.use(tmp_moddir, priority=10000)
+        self.modtool.load(['hwloc/1.6.2'])
+        self.assertTrue(os.environ['EBROOTHWLOC'], "/path/to/tmp/hwloc-1.6.2")
 
     def test_exit_code_check(self):
         """Verify that EasyBuild checks exit code of executed module commands"""


### PR DESCRIPTION
fix for #2499 reported by @mboisson based on suggestion by @ocaisa 