### PR TITLE
make test that verifies that BuildOptions does not support updating a bit more flexible

### DIFF
--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -359,7 +359,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
         self.assertTrue(bo['force'])
 
         # updating is impossible (methods are not even available)
-        self.assertErrorRegex(TypeError, '.*item assignment.*', lambda x: bo.update(x), {'debug': True})
+        self.assertErrorRegex(Exception, '.*(item assignment|no attribute).*', lambda x: bo.update(x), {'debug': True})
         self.assertErrorRegex(AttributeError, '.*no attribute.*', lambda x: bo.__setitem__(*x), ('debug', True))
 
         # only valid keys can be set


### PR DESCRIPTION
This change is needed to avoid that the test starts failing once https://github.com/hpcugent/vsc-base/pull/265 gets merged (since the `TypeError` will change to `AttributeError` because the `update` method is no longer supported, as opposed to simply being non-functional).