### PR TITLE
make EB logs more syntax highlighting friendly

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1385,7 +1385,7 @@ def invalidate_module_caches_for(path):
     if not os.path.exists(path):
         raise EasyBuildError("Non-existing path specified to invalidate module caches: %s", path)
 
-    _log.debug("Invallidating module cache entries for path '%s'", path)
+    _log.debug("Invalidating module cache entries for path: %s", path)
     for cache, subcmd in [(MODULE_AVAIL_CACHE, 'avail'), (MODULE_SHOW_CACHE, 'show')]:
         for key in cache.keys():
             paths_in_key = '='.join(key[0].split('=')[1:]).split(os.pathsep)

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1389,10 +1389,10 @@ def invalidate_module_caches_for(path):
     for cache, subcmd in [(MODULE_AVAIL_CACHE, 'avail'), (MODULE_SHOW_CACHE, 'show')]:
         for key in cache.keys():
             paths_in_key = '='.join(key[0].split('=')[1:]).split(os.pathsep)
-            _log.debug("Paths for 'module %s' key '%s': %s", subcmd, key, paths_in_key)
+            _log.debug("Paths for 'module %s' key (%s): %s", subcmd, key, paths_in_key)
             for path_in_key in paths_in_key:
                 if path == path_in_key or (os.path.exists(path_in_key) and os.path.samefile(path, path_in_key)):
-                    _log.debug("Entry '%s' in 'module %s' cache is evicted, marked as invalid via path '%s': %s",
+                    _log.debug("Entry '%s' in 'module %s' cache is evicted, marked as invalid via path (%s): %s",
                                key, subcmd, path, cache[key])
                     del cache[key]
                     break

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1392,7 +1392,7 @@ def invalidate_module_caches_for(path):
             _log.debug("Paths for 'module %s' key (%s): %s", subcmd, key, paths_in_key)
             for path_in_key in paths_in_key:
                 if path == path_in_key or (os.path.exists(path_in_key) and os.path.samefile(path, path_in_key)):
-                    _log.debug("Entry '%s' in 'module %s' cache is evicted, marked as invalid via path (%s): %s",
+                    _log.debug("Entry (%s) in 'module %s' cache is evicted, marked as invalid via path (%s): %s",
                                key, subcmd, path, cache[key])
                     del cache[key]
                     break

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -132,7 +132,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
             cmd_log = open(cmd_log_fn, 'w')
         except IOError as err:
             raise EasyBuildError("Failed to open temporary log file for output of command: %s", err)
-        _log.debug('run_cmd: Output of "%s" will be logged to %s' % (cmd, cmd_log_fn))
+        _log.debug('run_cmd: Output of (%s) will be logged to %s' % (cmd, cmd_log_fn))
     else:
         cmd_log_fn, cmd_log = None, None
 

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -498,14 +498,14 @@ def parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp):
     if ec and (log_all or log_ok):
         # We don't want to error if the user doesn't care
         if check_ec:
-            raise EasyBuildError('cmd "%s" exited with exit code %s and output:\n%s', cmd, ec, stdouterr)
+            raise EasyBuildError('cmd (%s) exited with exit code %s and output:\n%s', cmd, ec, stdouterr)
         else:
-            _log.warn('cmd "%s" exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
+            _log.warn('cmd (%s) exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
     elif not ec:
         if log_all:
-            _log.info('cmd "%s" exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
+            _log.info('cmd (%s) exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
         else:
-            _log.debug('cmd "%s" exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
+            _log.debug('cmd (%s) exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
 
     # parse the stdout/stderr for errors when strictness dictates this or when regexp is passed in
     if use_regexp or regexp:

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -81,7 +81,7 @@ def run_cmd_cache(func):
         key = (cmd, kwargs.get('inp', None))
         # fetch from cache if available, cache it if it's not, but only on cmd strings
         if isinstance(cmd, basestring) and key in cache:
-            _log.debug("Using cached value for command '%s': %s", cmd, cache[key])
+            _log.debug("Using cached value for command (%s): %s", cmd, cache[key])
             return cache[key]
         else:
             res = func(cmd, *args, **kwargs)
@@ -265,7 +265,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
             cmd_log = open(cmd_log_fn, 'w')
         except IOError as err:
             raise EasyBuildError("Failed to open temporary log file for output of interactive command: %s", err)
-        _log.debug('run_cmd_qa: Output of "%s" will be logged to %s' % (cmd, cmd_log_fn))
+        _log.debug('run_cmd_qa: Output of (%s) will be logged to %s' % (cmd, cmd_log_fn))
     else:
         cmd_log_fn, cmd_log = None, None
 


### PR DESCRIPTION
i am trying to make custom syntax highlighting for EB log files to make debugging a bit more eye-friendly.
however, getting syntax highlighting right for strings with multiple nested quotes is quite hard.
removing the outer quotes from `key`, `cmd` and `path` improves things a lot.
