### PR TITLE
perform early 'raw' parse of provided easyconfig file to check for syntax error or faulty inputs

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -274,6 +274,12 @@ class EasyConfig(object):
             self.rawtxt = rawtxt
             self.log.debug("Supplied raw easyconfig contents: %s" % self.rawtxt)
 
+        # constructing easyconfig parser object includes a "raw" parse,
+        # which serves as a check to see whether supplied easyconfig file is an actual easyconfig...
+        self.log.info("Performing quick parse to check for valid easyconfig file...")
+        self.parser = EasyConfigParser(filename=self.path, rawcontent=self.rawtxt,
+                                       auto_convert_value_types=auto_convert_value_types)
+
         self.modules_tool = modules_tool()
 
         # use legacy module classes as default
@@ -318,8 +324,6 @@ class EasyConfig(object):
 
         # parse easyconfig file
         self.build_specs = build_specs
-        self.parser = EasyConfigParser(filename=self.path, rawcontent=self.rawtxt,
-                                       auto_convert_value_types=auto_convert_value_types)
         self.parse()
 
         # perform validations

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -297,7 +297,7 @@ class FormatOneZero(EasyConfigFormatConfigObj):
         rawlines = rawtxt.split('\n')
 
         # extract header first
-        while rawlines[0].startswith('#'):
+        while rawlines and rawlines[0].startswith('#'):
             self.comments['header'].append(rawlines.pop(0))
 
         parsed_ec = self.get_config_dict()

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -2171,6 +2171,16 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(get_module_path('RPackage'), 'easybuild.easyblocks.generic.rpackage')
         self.assertEqual(get_module_path('RPackage', generic=True), 'easybuild.easyblocks.generic.rpackage')
 
+    def test_not_an_easyconfig(self):
+        """Test error reporting when a file that's not actually an easyconfig file is provided."""
+        test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs',)
+        # run test on an easyconfig file that was downloaded using wget using a non-raw GitHub URL
+        # cfr. https://github.com/easybuilders/easybuild-framework/issues/2383
+        not_an_ec = os.path.join(os.path.dirname(test_ecs_dir), 'sandbox', 'not_an_easyconfig.eb')
+
+        error_pattern = "Parsing easyconfig file failed: invalid syntax"
+        self.assertErrorRegex(EasyBuildError, error_pattern, EasyConfig, not_an_ec)
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/sandbox/not_an_easyconfig.eb
+++ b/test/framework/sandbox/not_an_easyconfig.eb
@@ -1,0 +1,8584 @@
+
+
+
+
+
+
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+  <link rel="dns-prefetch" href="https://assets-cdn.github.com">
+  <link rel="dns-prefetch" href="https://avatars0.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://avatars1.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://avatars2.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://avatars3.githubusercontent.com">
+  <link rel="dns-prefetch" href="https://github-cloud.s3.amazonaws.com">
+  <link rel="dns-prefetch" href="https://user-images.githubusercontent.com/">
+
+
+
+  <link crossorigin="anonymous" media="all" integrity="sha512-pCRDtdb3GlUU48h+oRJVA8f0GddrLnU97wB7mHQ7q6c40vMbMMZsFdk0IMhkUFRqw1M/y4EkWxtaKwfeFezOkQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/frameworks-73f533b7cc08a9d040e601cfd38fa585.css" />
+  <link crossorigin="anonymous" media="all" integrity="sha512-2FkDpuTRv4jHbgwoBH0elwdCYjJh2+wfEVrcV57xnSwlDd3o0HFhCjOiOphKdW2j9WrisyqThYS5ewxCeA/AkA==" rel="stylesheet" href="https://assets-cdn.github.com/assets/github-27937b62110f7615d6f14a9e5939f7c8.css" />
+  
+  
+  <link crossorigin="anonymous" media="all" integrity="sha512-YBQhG++AtbZ1OJfwAkSqS9GCbbYzicxNDYKdMaLTV49eF0Lks0Bs9Egbu46uQi62AyUInQS8Cx6GGkK6uZnqFQ==" rel="stylesheet" href="https://assets-cdn.github.com/assets/site-14cf418638c848dd5bbac72b6f77dfa2.css" />
+  
+
+  <meta name="viewport" content="width=device-width">
+  
+  <title>easybuild-easyconfigs/R-3.4.4-foss-2018a-X11-20180131.eb at master · easybuilders/easybuild-easyconfigs · GitHub</title>
+    <meta name="description" content="GitHub is where people build software. More than 28 million people use GitHub to discover, fork, and contribute to over 85 million projects.">
+    <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
+  <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
+  <meta property="fb:app_id" content="1401488693436528">
+
+    
+    <meta property="og:image" content="https://avatars3.githubusercontent.com/u/29568382?s=400&amp;v=4" /><meta property="og:site_name" content="GitHub" /><meta property="og:type" content="object" /><meta property="og:title" content="easybuilders/easybuild-easyconfigs" /><meta property="og:url" content="https://github.com/easybuilders/easybuild-easyconfigs" /><meta property="og:description" content="easybuild-easyconfigs - A collection of easyconfig files that describe which software to build using which build options with EasyBuild." />
+
+  <link rel="assets" href="https://assets-cdn.github.com/">
+  
+  <meta name="pjax-timeout" content="1000">
+  
+  <meta name="request-id" content="D250:4BE8:88CDC0D:D5E21DE:5B33AD22" data-pjax-transient>
+
+
+  
+
+  <meta name="selected-link" value="repo_source" data-pjax-transient>
+
+    <meta name="google-site-verification" content="KT5gs8h0wvaagLKAVWq8bbeNwnZZK1r1XQysX3xurLU">
+  <meta name="google-site-verification" content="ZzhVyEFwb7w3e0-uOTltm8Jsck2F5StVihD0exw2fsA">
+  <meta name="google-site-verification" content="GXs5KoUUkNCoaAZn7wPN-t01Pywp9M3sEjnt_3_ZWPc">
+    <meta name="google-analytics" content="UA-3769691-2">
+
+<meta name="octolytics-host" content="collector.githubapp.com" /><meta name="octolytics-app-id" content="github" /><meta name="octolytics-event-url" content="https://collector.githubapp.com/github-external/browser_event" /><meta name="octolytics-dimension-request_id" content="D250:4BE8:88CDC0D:D5E21DE:5B33AD22" /><meta name="octolytics-dimension-region_edge" content="iad" /><meta name="octolytics-dimension-region_render" content="iad" />
+<meta name="analytics-location" content="/&lt;user-name&gt;/&lt;repo-name&gt;/blob/show" data-pjax-transient="true" />
+
+
+
+
+<meta class="js-ga-set" name="dimension1" content="Logged Out">
+
+
+  
+
+      <meta name="hostname" content="github.com">
+    <meta name="user-login" content="">
+
+      <meta name="expected-hostname" content="github.com">
+    <meta name="js-proxy-site-detection-payload" content="N2Q1YTc4ODA3ZmQ0MWYyM2YwNDU0N2E5ZjI1ODIzNWI3N2U3MmI5NzFjZWRhODY4MzkxMGM2ZmYxMjU2OTRlM3x7InJlbW90ZV9hZGRyZXNzIjoiMTU3LjE5My4xNi45IiwicmVxdWVzdF9pZCI6IkQyNTA6NEJFODo4OENEQzBEOkQ1RTIxREU6NUIzM0FEMjIiLCJ0aW1lc3RhbXAiOjE1MzAxMTMzMTUsImhvc3QiOiJnaXRodWIuY29tIn0=">
+
+    <meta name="enabled-features" content="UNIVERSE_BANNER,FREE_TRIALS,MARKETPLACE_INSIGHTS,MARKETPLACE_INSIGHTS_CONVERSION_PERCENTAGES">
+
+  <meta name="html-safe-nonce" content="6f7094124e5b98be9171bc2f6152b271c488ce9d">
+
+  <meta http-equiv="x-pjax-version" content="fbb8cc35809bad500c75e8d63d6908fe">
+  
+
+      <link href="https://github.com/easybuilders/easybuild-easyconfigs/commits/master.atom" rel="alternate" title="Recent Commits to easybuild-easyconfigs:master" type="application/atom+xml">
+
+  <meta name="description" content="easybuild-easyconfigs - A collection of easyconfig files that describe which software to build using which build options with EasyBuild.">
+  <meta name="go-import" content="github.com/easybuilders/easybuild-easyconfigs git https://github.com/easybuilders/easybuild-easyconfigs.git">
+
+  <meta name="octolytics-dimension-user_id" content="29568382" /><meta name="octolytics-dimension-user_login" content="easybuilders" /><meta name="octolytics-dimension-repository_id" content="6228403" /><meta name="octolytics-dimension-repository_nwo" content="easybuilders/easybuild-easyconfigs" /><meta name="octolytics-dimension-repository_public" content="true" /><meta name="octolytics-dimension-repository_is_fork" content="false" /><meta name="octolytics-dimension-repository_network_root_id" content="6228403" /><meta name="octolytics-dimension-repository_network_root_nwo" content="easybuilders/easybuild-easyconfigs" /><meta name="octolytics-dimension-repository_explore_github_marketplace_ci_cta_shown" content="false" />
+
+
+    <link rel="canonical" href="https://github.com/easybuilders/easybuild-easyconfigs/blob/master/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb" data-pjax-transient>
+
+
+  <meta name="browser-stats-url" content="https://api.github.com/_private/browser/stats">
+
+  <meta name="browser-errors-url" content="https://api.github.com/_private/browser/errors">
+
+  <link rel="mask-icon" href="https://assets-cdn.github.com/pinned-octocat.svg" color="#000000">
+  <link rel="icon" type="image/x-icon" class="js-site-favicon" href="https://assets-cdn.github.com/favicon.ico">
+
+<meta name="theme-color" content="#1e2327">
+
+
+
+<link rel="manifest" href="/manifest.json" crossOrigin="use-credentials">
+
+  </head>
+
+  <body class="logged-out env-production page-blob">
+    
+
+  <div class="position-relative js-header-wrapper ">
+    <a href="#start-of-content" tabindex="1" class="px-2 py-4 bg-blue text-white show-on-focus js-skip-to-content">Skip to content</a>
+    <div id="js-pjax-loader-bar" class="pjax-loader-bar"><div class="progress"></div></div>
+
+    
+    
+    
+
+
+
+        <header class="Header header-logged-out  position-relative f4 py-3" role="banner">
+  <div class="container-lg d-flex px-3">
+    <div class="d-flex flex-justify-between flex-items-center">
+      <a class="header-logo-invertocat my-0" href="https://github.com/" aria-label="Homepage" data-ga-click="(Logged out) Header, go to homepage, icon:logo-wordmark">
+        <svg height="32" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="32" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+      </a>
+
+    </div>
+
+    <div class="HeaderMenu HeaderMenu--bright d-flex flex-justify-between flex-auto">
+        <nav class="mt-0">
+          <ul class="d-flex list-style-none">
+              <li class="ml-2">
+                <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:features" data-selected-links="/features /features/project-management /features/code-review /features/project-management /features/integrations /features" href="/features">
+                  Features
+</a>              </li>
+              <li class="ml-4">
+                <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:business" data-selected-links="/business /business/security /business/customers /business" href="/business">
+                  Business
+</a>              </li>
+
+              <li class="ml-4">
+                <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:explore" data-selected-links="/explore /trending /trending/developers /integrations /integrations/feature/code /integrations/feature/collaborate /integrations/feature/ship showcases showcases_search showcases_landing /explore" href="/explore">
+                  Explore
+</a>              </li>
+
+              <li class="ml-4">
+                    <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:marketplace" data-selected-links=" /marketplace" href="/marketplace">
+                      Marketplace
+</a>              </li>
+              <li class="ml-4">
+                <a class="js-selected-navigation-item HeaderNavlink px-0 py-2 m-0" data-ga-click="Header, click, Nav menu - item:pricing" data-selected-links="/pricing /pricing/developer /pricing/team /pricing/business-hosted /pricing/business-enterprise /pricing" href="/pricing">
+                  Pricing
+</a>              </li>
+          </ul>
+        </nav>
+
+      <div class="d-flex">
+          <div class="d-lg-flex flex-items-center mr-3">
+            <div class="header-search scoped-search site-scoped-search js-site-search position-relative js-jump-to"
+  role="search combobox"
+  aria-owns="jump-to-results"
+  aria-label="Search or jump to"
+  aria-haspopup="listbox"
+  aria-expanded="true"
+>
+  <div class="position-relative">
+    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-site-search-form" data-scope-type="Repository" data-scope-id="6228403" data-scoped-search-url="/easybuilders/easybuild-easyconfigs/search" data-unscoped-search-url="/search" action="/easybuilders/easybuild-easyconfigs/search" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+      <label class="form-control header-search-wrapper header-search-wrapper-jump-to position-relative d-flex flex-justify-between flex-items-center js-chromeless-input-container">
+        <input type="text"
+          class="form-control header-search-input jump-to-field js-jump-to-field js-site-search-focus js-site-search-field is-clearable"
+          data-hotkey="s,/"
+          name="q"
+          value=""
+          placeholder="Search"
+          data-unscoped-placeholder="Search GitHub"
+          data-scoped-placeholder="Search"
+          autocapitalize="off"
+          aria-autocomplete="list"
+          aria-controls="jump-to-results"
+          data-jump-to-suggestions-path="/_graphql/GetSuggestedNavigationDestinations#csrf-token=uzcEw5/7Z7neh+/zjguuEU16RqPn+Y8Go7LWQ/Qbj6SsTr5UItTLLmdD1194slYGFym0MlO6hbMfDpXNPQ3vTQ=="
+          spellcheck="false"
+          autocomplete="off"
+          >
+          <input type="hidden" class="js-site-search-type-field" name="type" >
+            <img src="https://assets-cdn.github.com/images/search-shortcut-hint.svg" alt="" class="mr-2 header-search-key-slash">
+
+            <div class="Box position-absolute overflow-hidden d-none jump-to-suggestions js-jump-to-suggestions-container">
+              <ul class="d-none js-jump-to-suggestions-template-container">
+                <li class="d-flex flex-justify-start flex-items-center p-0 f5 navigation-item js-navigation-item">
+                  <a tabindex="-1" class="no-underline d-flex flex-auto flex-items-center p-2 jump-to-suggestions-path js-jump-to-suggestion-path js-navigation-open" href="">
+                    <div class="jump-to-octicon js-jump-to-octicon mr-2 text-center d-none"></div>
+                    <img class="avatar mr-2 flex-shrink-0 js-jump-to-suggestion-avatar" alt="" aria-label="Team" src="" width="28" height="28">
+
+                    <div class="jump-to-suggestion-name js-jump-to-suggestion-name flex-auto overflow-hidden no-wrap css-truncate css-truncate-target">
+                    </div>
+
+                    <div class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none js-jump-to-badge-search">
+                      <span class="js-jump-to-badge-search-text-default d-none" aria-label="in this repository">
+                        In this repository
+                      </span>
+                      <span class="js-jump-to-badge-search-text-global d-none" aria-label="in all of GitHub">
+                        All GitHub
+                      </span>
+                      <span aria-hidden="true" class="d-inline-block ml-1 v-align-middle">↵</span>
+                    </div>
+
+                    <div aria-hidden="true" class="border rounded-1 flex-shrink-0 bg-gray px-1 text-gray-light ml-1 f6 d-none d-on-nav-focus js-jump-to-badge-jump">
+                      Jump to
+                      <span class="d-inline-block ml-1 v-align-middle">↵</span>
+                    </div>
+                  </a>
+                </li>
+                <svg height="16" width="16" class="octicon octicon-repo flex-shrink-0 js-jump-to-repo-octicon-template" title="Repository" aria-label="Repository" viewBox="0 0 12 16" version="1.1" role="img"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+                <svg height="16" width="16" class="octicon octicon-project flex-shrink-0 js-jump-to-project-octicon-template" title="Project" aria-label="Project" viewBox="0 0 15 16" version="1.1" role="img"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+                <svg height="16" width="16" class="octicon octicon-search flex-shrink-0 js-jump-to-search-octicon-template" title="Search" aria-label="Search" viewBox="0 0 16 16" version="1.1" role="img"><path fill-rule="evenodd" d="M15.7 13.3l-3.81-3.83A5.93 5.93 0 0 0 13 6c0-3.31-2.69-6-6-6S1 2.69 1 6s2.69 6 6 6c1.3 0 2.48-.41 3.47-1.11l3.83 3.81c.19.2.45.3.7.3.25 0 .52-.09.7-.3a.996.996 0 0 0 0-1.41v.01zM7 10.7c-2.59 0-4.7-2.11-4.7-4.7 0-2.59 2.11-4.7 4.7-4.7 2.59 0 4.7 2.11 4.7 4.7 0 2.59-2.11 4.7-4.7 4.7z"/></svg>
+              </ul>
+              <ul class="d-none js-jump-to-no-results-template-container">
+                <li class="d-flex flex-justify-center flex-items-center p-3 f5 d-none">
+                  <span class="text-gray">No suggested jump to results</span>
+                </li>
+              </ul>
+
+              <ul id="jump-to-results" class="js-navigation-container jump-to-suggestions-results-container js-jump-to-suggestions-results-container" >
+                <li class="d-flex flex-justify-center flex-items-center p-0 f5">
+                  <img src="https://assets-cdn.github.com/images/spinners/octocat-spinner-128.gif" alt="Octocat Spinner Icon" class="m-2" width="28">
+                </li>
+              </ul>
+            </div>
+      </label>
+</form>  </div>
+</div>
+
+          </div>
+
+        <span class="d-inline-block">
+            <div class="HeaderNavlink px-0 py-2 m-0">
+              <a class="text-bold text-white no-underline" href="/login?return_to=%2Feasybuilders%2Feasybuild-easyconfigs%2Fblob%2Fmaster%2Feasybuild%2Feasyconfigs%2Fr%2FR%2FR-3.4.4-foss-2018a-X11-20180131.eb" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign in</a>
+                <span class="text-gray">or</span>
+                <a class="text-bold text-white no-underline" href="/join?source=header-repo" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">Sign up</a>
+            </div>
+        </span>
+      </div>
+    </div>
+  </div>
+</header>
+
+  </div>
+
+  <div id="start-of-content" class="show-on-focus"></div>
+
+    <div id="js-flash-container">
+</div>
+
+
+
+  <div role="main" class="application-main ">
+        <div itemscope itemtype="http://schema.org/SoftwareSourceCode" class="">
+    <div id="js-repo-pjax-container" data-pjax-container >
+      
+
+
+
+
+
+  
+
+
+
+  <div class="pagehead repohead instapaper_ignore readability-menu experiment-repo-nav  ">
+    <div class="repohead-details-container clearfix container">
+
+      <ul class="pagehead-actions">
+  <li>
+      <a href="/login?return_to=%2Feasybuilders%2Feasybuild-easyconfigs"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    aria-label="You must be signed in to watch a repository" rel="nofollow">
+    <svg class="octicon octicon-eye" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.06 2C3 2 0 8 0 8s3 6 8.06 6C13 14 16 8 16 8s-3-6-7.94-6zM8 12c-2.2 0-4-1.78-4-4 0-2.2 1.8-4 4-4 2.22 0 4 1.8 4 4 0 2.22-1.78 4-4 4zm2-4c0 1.11-.89 2-2 2-1.11 0-2-.89-2-2 0-1.11.89-2 2-2 1.11 0 2 .89 2 2z"/></svg>
+    Watch
+  </a>
+  <a class="social-count" href="/easybuilders/easybuild-easyconfigs/watchers"
+     aria-label="32 users are watching this repository">
+    32
+  </a>
+
+  </li>
+
+  <li>
+      <a href="/login?return_to=%2Feasybuilders%2Feasybuild-easyconfigs"
+    class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+    aria-label="You must be signed in to star a repository" rel="nofollow">
+    <svg class="octicon octicon-star" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M14 6l-4.9-.64L7 1 4.9 5.36 0 6l3.6 3.26L2.67 14 7 11.67 11.33 14l-.93-4.74L14 6z"/></svg>
+    Star
+  </a>
+
+    <a class="social-count js-social-count" href="/easybuilders/easybuild-easyconfigs/stargazers"
+      aria-label="109 users starred this repository">
+      109
+    </a>
+
+  </li>
+
+  <li>
+      <a href="/login?return_to=%2Feasybuilders%2Feasybuild-easyconfigs"
+        class="btn btn-sm btn-with-count tooltipped tooltipped-n"
+        aria-label="You must be signed in to fork a repository" rel="nofollow">
+        <svg class="octicon octicon-repo-forked" viewBox="0 0 10 16" version="1.1" width="10" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8 1a1.993 1.993 0 0 0-1 3.72V6L5 8 3 6V4.72A1.993 1.993 0 0 0 2 1a1.993 1.993 0 0 0-1 3.72V6.5l3 3v1.78A1.993 1.993 0 0 0 5 15a1.993 1.993 0 0 0 1-3.72V9.5l3-3V4.72A1.993 1.993 0 0 0 8 1zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3 10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zm3-10c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
+        Fork
+      </a>
+
+    <a href="/easybuilders/easybuild-easyconfigs/network" class="social-count"
+       aria-label="314 users forked this repository">
+      314
+    </a>
+  </li>
+</ul>
+
+      <h1 class="public ">
+  <svg class="octicon octicon-repo" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M4 9H3V8h1v1zm0-3H3v1h1V6zm0-2H3v1h1V4zm0-2H3v1h1V2zm8-1v12c0 .55-.45 1-1 1H6v2l-1.5-1.5L3 16v-2H1c-.55 0-1-.45-1-1V1c0-.55.45-1 1-1h10c.55 0 1 .45 1 1zm-1 10H1v2h2v-1h3v1h5v-2zm0-10H2v9h9V1z"/></svg>
+  <span class="author" itemprop="author"><a class="url fn" rel="author" href="/easybuilders">easybuilders</a></span><!--
+--><span class="path-divider">/</span><!--
+--><strong itemprop="name"><a data-pjax="#js-repo-pjax-container" href="/easybuilders/easybuild-easyconfigs">easybuild-easyconfigs</a></strong>
+
+</h1>
+
+    </div>
+    
+<nav class="reponav js-repo-nav js-sidenav-container-pjax container"
+     itemscope
+     itemtype="http://schema.org/BreadcrumbList"
+     role="navigation"
+     data-pjax="#js-repo-pjax-container">
+
+  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+    <a class="js-selected-navigation-item selected reponav-item" itemprop="url" data-hotkey="g c" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches repo_packages /easybuilders/easybuild-easyconfigs" href="/easybuilders/easybuild-easyconfigs">
+      <svg class="octicon octicon-code" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M9.5 3L8 4.5 11.5 8 8 11.5 9.5 13 14 8 9.5 3zm-5 0L0 8l4.5 5L6 11.5 2.5 8 6 4.5 4.5 3z"/></svg>
+      <span itemprop="name">Code</span>
+      <meta itemprop="position" content="1">
+</a>  </span>
+
+    <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+      <a itemprop="url" data-hotkey="g i" class="js-selected-navigation-item reponav-item" data-selected-links="repo_issues repo_labels repo_milestones /easybuilders/easybuild-easyconfigs/issues" href="/easybuilders/easybuild-easyconfigs/issues">
+        <svg class="octicon octicon-issue-opened" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"/></svg>
+        <span itemprop="name">Issues</span>
+        <span class="Counter">247</span>
+        <meta itemprop="position" content="2">
+</a>    </span>
+
+  <span itemscope itemtype="http://schema.org/ListItem" itemprop="itemListElement">
+    <a data-hotkey="g p" itemprop="url" class="js-selected-navigation-item reponav-item" data-selected-links="repo_pulls checks /easybuilders/easybuild-easyconfigs/pulls" href="/easybuilders/easybuild-easyconfigs/pulls">
+      <svg class="octicon octicon-git-pull-request" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 11.28V5c-.03-.78-.34-1.47-.94-2.06C9.46 2.35 8.78 2.03 8 2H7V0L4 3l3 3V4h1c.27.02.48.11.69.31.21.2.3.42.31.69v6.28A1.993 1.993 0 0 0 10 15a1.993 1.993 0 0 0 1-3.72zm-1 2.92c-.66 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2zM4 3c0-1.11-.89-2-2-2a1.993 1.993 0 0 0-1 3.72v6.56A1.993 1.993 0 0 0 2 15a1.993 1.993 0 0 0 1-3.72V4.72c.59-.34 1-.98 1-1.72zm-.8 10c0 .66-.55 1.2-1.2 1.2-.65 0-1.2-.55-1.2-1.2 0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2zM2 4.2C1.34 4.2.8 3.65.8 3c0-.65.55-1.2 1.2-1.2.65 0 1.2.55 1.2 1.2 0 .65-.55 1.2-1.2 1.2z"/></svg>
+      <span itemprop="name">Pull requests</span>
+      <span class="Counter">444</span>
+      <meta itemprop="position" content="3">
+</a>  </span>
+
+    <a data-hotkey="g b" class="js-selected-navigation-item reponav-item" data-selected-links="repo_projects new_repo_project repo_project /easybuilders/easybuild-easyconfigs/projects" href="/easybuilders/easybuild-easyconfigs/projects">
+      <svg class="octicon octicon-project" viewBox="0 0 15 16" version="1.1" width="15" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M10 12h3V2h-3v10zm-4-2h3V2H6v8zm-4 4h3V2H2v12zm-1 1h13V1H1v14zM14 0H1a1 1 0 0 0-1 1v14a1 1 0 0 0 1 1h13a1 1 0 0 0 1-1V1a1 1 0 0 0-1-1z"/></svg>
+      Projects
+      <span class="Counter" >0</span>
+</a>
+
+
+  <a class="js-selected-navigation-item reponav-item" data-selected-links="repo_graphs repo_contributors dependency_graph pulse /easybuilders/easybuild-easyconfigs/pulse" href="/easybuilders/easybuild-easyconfigs/pulse">
+    <svg class="octicon octicon-graph" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M16 14v1H0V0h1v14h15zM5 13H3V8h2v5zm4 0H7V3h2v10zm4 0h-2V6h2v7z"/></svg>
+    Insights
+</a>
+
+</nav>
+
+
+  </div>
+
+<div class="container new-discussion-timeline experiment-repo-nav  ">
+  <div class="repository-content ">
+
+    
+  <a class="d-none js-permalink-shortcut" data-hotkey="y" href="/easybuilders/easybuild-easyconfigs/blob/96d4f7857072ade7e058ed0f83b53791ef6b6b12/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb">Permalink</a>
+
+  <!-- blob contrib key: blob_contributors:v21:cee06142eb7f1f98109a12f1c48e7438 -->
+
+      <div class="signup-prompt-bg rounded-1">
+      <div class="signup-prompt p-4 text-center mb-4 rounded-1">
+        <div class="position-relative">
+          <!-- '"` --><!-- </textarea></xmp> --></option></form><form action="/site/dismiss_signup_prompt" accept-charset="UTF-8" method="post"><input name="utf8" type="hidden" value="&#x2713;" /><input type="hidden" name="authenticity_token" value="p5PBEW44kt7+BQmHrRsbOYtDy6rlE634qgjzYnj75QS5jy9wtpmiYsXh+JnjghZVJwgfI4n7NrekBWSaNDoMhw==" />
+            <button type="submit" class="position-absolute top-0 right-0 btn-link link-gray" data-ga-click="(Logged out) Sign up prompt, clicked Dismiss, text:dismiss">
+              Dismiss
+            </button>
+</form>          <h3 class="pt-2">Join GitHub today</h3>
+          <p class="col-6 mx-auto">GitHub is home to over 28 million developers working together to host and review code, manage projects, and build software together.</p>
+          <a class="btn btn-primary" href="/join?source=prompt-blob-show" data-ga-click="(Logged out) Sign up prompt, clicked Sign up, text:sign-up">Sign up</a>
+        </div>
+      </div>
+    </div>
+
+
+  <div class="file-navigation">
+    
+<div class="select-menu branch-select-menu js-menu-container js-select-menu float-left">
+  <button class=" btn btn-sm select-menu-button js-menu-target css-truncate" data-hotkey="w"
+    
+    type="button" aria-label="Switch branches or tags" aria-expanded="false" aria-haspopup="true">
+      <i>Branch:</i>
+      <span class="js-select-button css-truncate-target">master</span>
+  </button>
+
+  <div class="select-menu-modal-holder js-menu-content js-navigation-container" data-pjax>
+
+    <div class="select-menu-modal">
+      <div class="select-menu-header">
+        <svg class="octicon octicon-x js-menu-close" role="img" aria-label="Close" viewBox="0 0 12 16" version="1.1" width="12" height="16"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+        <span class="select-menu-title">Switch branches/tags</span>
+      </div>
+
+      <div class="select-menu-filters">
+        <div class="select-menu-text-filter">
+          <input type="text" aria-label="Filter branches/tags" id="context-commitish-filter-field" class="form-control js-filterable-field js-navigation-enable" placeholder="Filter branches/tags">
+        </div>
+        <div class="select-menu-tabs">
+          <ul>
+            <li class="select-menu-tab">
+              <a href="#" data-tab-filter="branches" data-filter-placeholder="Filter branches/tags" class="js-select-menu-tab" role="tab">Branches</a>
+            </li>
+            <li class="select-menu-tab">
+              <a href="#" data-tab-filter="tags" data-filter-placeholder="Find a tag…" class="js-select-menu-tab" role="tab">Tags</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="select-menu-list select-menu-tab-bucket js-select-menu-tab-bucket" data-tab-filter="branches" role="menu">
+
+        <div data-filterable-for="context-commitish-filter-field" data-filterable-type="substring">
+
+
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+               href="/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+               data-name="develop"
+               data-skip-pjax="true"
+               rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text">
+                develop
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open selected"
+               href="/easybuilders/easybuild-easyconfigs/blob/master/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+               data-name="master"
+               data-skip-pjax="true"
+               rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target js-select-menu-filter-text">
+                master
+              </span>
+            </a>
+        </div>
+
+          <div class="select-menu-no-results">Nothing to show</div>
+      </div>
+
+      <div class="select-menu-list select-menu-tab-bucket js-select-menu-tab-bucket" data-tab-filter="tags">
+        <div data-filterable-for="context-commitish-filter-field" data-filterable-type="substring">
+
+
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.11.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.11.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.11.0.0">
+                v1.11.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.10.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.10.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.10.0.0">
+                v1.10.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.9.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.9.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.9.0.0">
+                v1.9.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.8.2.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.8.2.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.8.2.0">
+                v1.8.2.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.8.1.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.8.1.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.8.1.0">
+                v1.8.1.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.8.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.8.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.8.0.0">
+                v1.8.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.7.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.7.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.7.0.0">
+                v1.7.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.6.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.6.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.6.0.0">
+                v1.6.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.6.0.0rc1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.6.0.0rc1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.6.0.0rc1">
+                v1.6.0.0rc1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.5.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.5.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.5.0.0">
+                v1.5.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.5.0.0rc2/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.5.0.0rc2"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.5.0.0rc2">
+                v1.5.0.0rc2
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.5.0.0rc1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.5.0.0rc1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.5.0.0rc1">
+                v1.5.0.0rc1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.4.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.4.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.4.0.0">
+                v1.4.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.4.0.0rc1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.4.0.0rc1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.4.0.0rc1">
+                v1.4.0.0rc1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.3.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.3.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.3.0.0">
+                v1.3.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.3.0.0rc2/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.3.0.0rc2"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.3.0.0rc2">
+                v1.3.0.0rc2
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.2.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.2.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.2.0.0">
+                v1.2.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.2.0.0rc1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.2.0.0rc1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.2.0.0rc1">
+                v1.2.0.0rc1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.1.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.1.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.1.0.0">
+                v1.1.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.0.0.1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.0.0.1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.0.0.1">
+                v1.0.0.1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.0.0">
+                v1.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/v1.0.0-rc1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="v1.0.0-rc1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="v1.0.0-rc1">
+                v1.0.0-rc1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.6.1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.6.1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.6.1">
+                easybuild-easyconfigs-v3.6.1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.6.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.6.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.6.0">
+                easybuild-easyconfigs-v3.6.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.5.3/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.5.3"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.5.3">
+                easybuild-easyconfigs-v3.5.3
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.5.2/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.5.2"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.5.2">
+                easybuild-easyconfigs-v3.5.2
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.5.1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.5.1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.5.1">
+                easybuild-easyconfigs-v3.5.1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.5.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.5.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.5.0">
+                easybuild-easyconfigs-v3.5.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.4.1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.4.1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.4.1">
+                easybuild-easyconfigs-v3.4.1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.4.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.4.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.4.0">
+                easybuild-easyconfigs-v3.4.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.3.1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.3.1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.3.1">
+                easybuild-easyconfigs-v3.3.1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.3.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.3.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.3.0">
+                easybuild-easyconfigs-v3.3.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.2.1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.2.1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.2.1">
+                easybuild-easyconfigs-v3.2.1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.2.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.2.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.2.0">
+                easybuild-easyconfigs-v3.2.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.1.2/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.1.2"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.1.2">
+                easybuild-easyconfigs-v3.1.2
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.1.1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.1.1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.1.1">
+                easybuild-easyconfigs-v3.1.1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.1.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.1.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.1.0">
+                easybuild-easyconfigs-v3.1.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.0.2/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.0.2"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.0.2">
+                easybuild-easyconfigs-v3.0.2
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.0.1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.0.1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.0.1">
+                easybuild-easyconfigs-v3.0.1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v3.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v3.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v3.0.0">
+                easybuild-easyconfigs-v3.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v2.9.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v2.9.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v2.9.0">
+                easybuild-easyconfigs-v2.9.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v2.8.2/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v2.8.2"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v2.8.2">
+                easybuild-easyconfigs-v2.8.2
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v2.8.1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v2.8.1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v2.8.1">
+                easybuild-easyconfigs-v2.8.1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v2.8.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v2.8.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v2.8.0">
+                easybuild-easyconfigs-v2.8.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v2.7.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v2.7.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v2.7.0">
+                easybuild-easyconfigs-v2.7.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v2.6.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v2.6.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v2.6.0">
+                easybuild-easyconfigs-v2.6.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v2.5.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v2.5.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v2.5.0">
+                easybuild-easyconfigs-v2.5.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v2.4.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v2.4.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v2.4.0">
+                easybuild-easyconfigs-v2.4.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v2.3.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v2.3.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v2.3.0">
+                easybuild-easyconfigs-v2.3.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v2.2.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v2.2.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v2.2.0">
+                easybuild-easyconfigs-v2.2.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v2.1.1/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v2.1.1"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v2.1.1">
+                easybuild-easyconfigs-v2.1.1
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v2.1.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v2.1.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v2.1.0">
+                easybuild-easyconfigs-v2.1.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v2.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v2.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v2.0.0">
+                easybuild-easyconfigs-v2.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v1.16.2.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v1.16.2.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v1.16.2.0">
+                easybuild-easyconfigs-v1.16.2.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v1.16.1.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v1.16.1.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v1.16.1.0">
+                easybuild-easyconfigs-v1.16.1.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v1.16.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v1.16.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v1.16.0.0">
+                easybuild-easyconfigs-v1.16.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v1.15.2.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v1.15.2.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v1.15.2.0">
+                easybuild-easyconfigs-v1.15.2.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v1.15.1.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v1.15.1.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v1.15.1.0">
+                easybuild-easyconfigs-v1.15.1.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v1.15.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v1.15.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v1.15.0.0">
+                easybuild-easyconfigs-v1.15.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v1.14.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v1.14.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v1.14.0.0">
+                easybuild-easyconfigs-v1.14.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v1.13.0.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v1.13.0.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v1.13.0.0">
+                easybuild-easyconfigs-v1.13.0.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v1.12.1.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v1.12.1.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v1.12.1.0">
+                easybuild-easyconfigs-v1.12.1.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v1.12.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v1.12.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v1.12.0">
+                easybuild-easyconfigs-v1.12.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/easybuild-easyconfigs-v1.11.1.0/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="easybuild-easyconfigs-v1.11.1.0"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="easybuild-easyconfigs-v1.11.1.0">
+                easybuild-easyconfigs-v1.11.1.0
+              </span>
+            </a>
+            <a class="select-menu-item js-navigation-item js-navigation-open "
+              href="/easybuilders/easybuild-easyconfigs/tree/1.0.0-rc2/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb"
+              data-name="1.0.0-rc2"
+              data-skip-pjax="true"
+              rel="nofollow">
+              <svg class="octicon octicon-check select-menu-item-icon" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M12 5l-8 8-4-4 1.5-1.5L4 10l6.5-6.5L12 5z"/></svg>
+              <span class="select-menu-item-text css-truncate-target" title="1.0.0-rc2">
+                1.0.0-rc2
+              </span>
+            </a>
+        </div>
+
+        <div class="select-menu-no-results">Nothing to show</div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+    <div class="BtnGroup float-right">
+      <a href="/easybuilders/easybuild-easyconfigs/find/master"
+            class="js-pjax-capture-input btn btn-sm BtnGroup-item"
+            data-pjax
+            data-hotkey="t">
+        Find file
+      </a>
+      <clipboard-copy for="blob-path" class="btn btn-sm BtnGroup-item">
+        Copy path
+      </clipboard-copy>
+    </div>
+    <div id="blob-path" class="breadcrumb">
+      <span class="repo-root js-repo-root"><span class="js-path-segment"><a data-pjax="true" href="/easybuilders/easybuild-easyconfigs"><span>easybuild-easyconfigs</span></a></span></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" href="/easybuilders/easybuild-easyconfigs/tree/master/easybuild"><span>easybuild</span></a></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" href="/easybuilders/easybuild-easyconfigs/tree/master/easybuild/easyconfigs"><span>easyconfigs</span></a></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" href="/easybuilders/easybuild-easyconfigs/tree/master/easybuild/easyconfigs/r"><span>r</span></a></span><span class="separator">/</span><span class="js-path-segment"><a data-pjax="true" href="/easybuilders/easybuild-easyconfigs/tree/master/easybuild/easyconfigs/r/R"><span>R</span></a></span><span class="separator">/</span><strong class="final-path">R-3.4.4-foss-2018a-X11-20180131.eb</strong>
+    </div>
+  </div>
+
+
+  
+  <div class="commit-tease">
+      <span class="float-right">
+        <a class="commit-tease-sha" href="/easybuilders/easybuild-easyconfigs/commit/930bddf14ab7e4131c694aeda809112c23df6dc2" data-pjax>
+          930bddf
+        </a>
+        <relative-time datetime="2018-05-24T13:16:48Z">May 24, 2018</relative-time>
+      </span>
+      <div>
+        <a rel="contributor" data-skip-pjax="true" data-hovercard-user-id="620876" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boegel"><img class="avatar" src="https://avatars2.githubusercontent.com/u/620876?s=40&amp;v=4" width="20" height="20" alt="@boegel" /></a>
+        <a class="user-mention" rel="contributor" data-hovercard-user-id="620876" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boegel">boegel</a>
+          <a data-pjax="true" title="include ICU as dependency in recent R easyconfigs (v3.4.3 &amp; v3.4.4), required for rJava (and gdsfmt in Bioconductor bundle)" class="message" href="/easybuilders/easybuild-easyconfigs/commit/930bddf14ab7e4131c694aeda809112c23df6dc2">include ICU as dependency in recent R easyconfigs (v3.4.3 &amp; v3.4.4), …</a>
+      </div>
+
+    <div class="commit-tease-contributors">
+      <button type="button" class="btn-link muted-link contributors-toggle" data-facebox="#blob_contributors_box">
+        <strong>2</strong>
+         contributors
+      </button>
+          <a class="avatar-link" data-hovercard-user-id="16937134" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/easybuilders/easybuild-easyconfigs/commits/master/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb?author=RvDijk">
+      <img class="avatar" src="https://avatars2.githubusercontent.com/u/16937134?s=40&amp;v=4" width="20" height="20" alt="@RvDijk" /> 
+</a>    <a class="avatar-link" data-hovercard-user-id="620876" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/easybuilders/easybuild-easyconfigs/commits/master/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb?author=boegel">
+      <img class="avatar" src="https://avatars2.githubusercontent.com/u/620876?s=40&amp;v=4" width="20" height="20" alt="@boegel" /> 
+</a>
+
+    </div>
+
+    <div id="blob_contributors_box" style="display:none">
+      <h2 class="facebox-header" data-facebox-id="facebox-header">Users who have contributed to this file</h2>
+      <ul class="facebox-user-list" data-facebox-id="facebox-description">
+          <li class="facebox-user-list-item">
+            <a class="d-inline-block" data-hovercard-user-id="16937134" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/RvDijk"><img src="https://avatars3.githubusercontent.com/u/16937134?s=48&amp;v=4" width="24" height="24" alt="@RvDijk" /></a>
+            <a data-hovercard-user-id="16937134" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/RvDijk">RvDijk</a>
+          </li>
+          <li class="facebox-user-list-item">
+            <a class="d-inline-block" data-hovercard-user-id="620876" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boegel"><img src="https://avatars3.githubusercontent.com/u/620876?s=48&amp;v=4" width="24" height="24" alt="@boegel" /></a>
+            <a data-hovercard-user-id="620876" data-octo-click="hovercard-link-click" data-octo-dimensions="link_type:self" href="/boegel">boegel</a>
+          </li>
+      </ul>
+    </div>
+  </div>
+
+
+
+  <div class="file">
+    <div class="file-header">
+  <div class="file-actions">
+
+    <div class="BtnGroup">
+      <a id="raw-url" class="btn btn-sm BtnGroup-item" href="/easybuilders/easybuild-easyconfigs/raw/master/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb">Raw</a>
+        <a class="btn btn-sm js-update-url-with-hash BtnGroup-item" data-hotkey="b" href="/easybuilders/easybuild-easyconfigs/blame/master/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb">Blame</a>
+      <a rel="nofollow" class="btn btn-sm BtnGroup-item" href="/easybuilders/easybuild-easyconfigs/commits/master/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb">History</a>
+    </div>
+
+
+        <button type="button" class="btn-octicon disabled tooltipped tooltipped-nw"
+          aria-label="You must be signed in to make or propose changes">
+          <svg class="octicon octicon-pencil" viewBox="0 0 14 16" version="1.1" width="14" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M0 12v3h3l8-8-3-3-8 8zm3 2H1v-2h1v1h1v1zm10.3-9.3L12 6 9 3l1.3-1.3a.996.996 0 0 1 1.41 0l1.59 1.59c.39.39.39 1.02 0 1.41z"/></svg>
+        </button>
+        <button type="button" class="btn-octicon btn-octicon-danger disabled tooltipped tooltipped-nw"
+          aria-label="You must be signed in to make or propose changes">
+          <svg class="octicon octicon-trashcan" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M11 2H9c0-.55-.45-1-1-1H5c-.55 0-1 .45-1 1H2c-.55 0-1 .45-1 1v1c0 .55.45 1 1 1v9c0 .55.45 1 1 1h7c.55 0 1-.45 1-1V5c.55 0 1-.45 1-1V3c0-.55-.45-1-1-1zm-1 12H3V5h1v8h1V5h1v8h1V5h1v8h1V5h1v9zm1-10H2V3h9v1z"/></svg>
+        </button>
+  </div>
+
+  <div class="file-info">
+      1813 lines (1802 sloc)
+      <span class="file-info-divider"></span>
+    73.4 KB
+  </div>
+</div>
+
+    
+
+  <div itemprop="text" class="blob-wrapper data type-easybuild">
+      <table class="highlight tab-size js-file-line-container" data-tab-size="8">
+      <tr>
+        <td id="L1" class="blob-num js-line-number" data-line-number="1"></td>
+        <td id="LC1" class="blob-code blob-code-inner js-file-line">name <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>R<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L2" class="blob-num js-line-number" data-line-number="2"></td>
+        <td id="LC2" class="blob-code blob-code-inner js-file-line">version <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>3.4.4<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L3" class="blob-num js-line-number" data-line-number="3"></td>
+        <td id="LC3" class="blob-code blob-code-inner js-file-line">x11ver <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>20180131<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L4" class="blob-num js-line-number" data-line-number="4"></td>
+        <td id="LC4" class="blob-code blob-code-inner js-file-line">versionsuffix <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>-X11-<span class="pl-c1">%s</span><span class="pl-pds">&#39;</span></span> <span class="pl-k">%</span> x11ver</td>
+      </tr>
+      <tr>
+        <td id="L5" class="blob-num js-line-number" data-line-number="5"></td>
+        <td id="LC5" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L6" class="blob-num js-line-number" data-line-number="6"></td>
+        <td id="LC6" class="blob-code blob-code-inner js-file-line">homepage <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>http://www.r-project.org/<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L7" class="blob-num js-line-number" data-line-number="7"></td>
+        <td id="LC7" class="blob-code blob-code-inner js-file-line">description <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&quot;&quot;&quot;</span>R is a free software environment for statistical computing and graphics.<span class="pl-pds">&quot;&quot;&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L8" class="blob-num js-line-number" data-line-number="8"></td>
+        <td id="LC8" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L9" class="blob-num js-line-number" data-line-number="9"></td>
+        <td id="LC9" class="blob-code blob-code-inner js-file-line">toolchain <span class="pl-k">=</span> {<span class="pl-s"><span class="pl-pds">&#39;</span>name<span class="pl-pds">&#39;</span></span>: <span class="pl-s"><span class="pl-pds">&#39;</span>foss<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>version<span class="pl-pds">&#39;</span></span>: <span class="pl-s"><span class="pl-pds">&#39;</span>2018a<span class="pl-pds">&#39;</span></span>}</td>
+      </tr>
+      <tr>
+        <td id="L10" class="blob-num js-line-number" data-line-number="10"></td>
+        <td id="LC10" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L11" class="blob-num js-line-number" data-line-number="11"></td>
+        <td id="LC11" class="blob-code blob-code-inner js-file-line">sources <span class="pl-k">=</span> [<span class="pl-c1">SOURCE_TAR_GZ</span>]</td>
+      </tr>
+      <tr>
+        <td id="L12" class="blob-num js-line-number" data-line-number="12"></td>
+        <td id="LC12" class="blob-code blob-code-inner js-file-line">source_urls <span class="pl-k">=</span> [<span class="pl-s"><span class="pl-pds">&#39;</span>https://cloud.r-project.org/src/base/R-<span class="pl-c1">%(version_major)s</span><span class="pl-pds">&#39;</span></span>]</td>
+      </tr>
+      <tr>
+        <td id="L13" class="blob-num js-line-number" data-line-number="13"></td>
+        <td id="LC13" class="blob-code blob-code-inner js-file-line">checksums <span class="pl-k">=</span> [<span class="pl-s"><span class="pl-pds">&#39;</span>b3e97d2fab7256d1c655c4075934725ba1cd7cb9237240a11bb22ccdad960337<span class="pl-pds">&#39;</span></span>]</td>
+      </tr>
+      <tr>
+        <td id="L14" class="blob-num js-line-number" data-line-number="14"></td>
+        <td id="LC14" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L15" class="blob-num js-line-number" data-line-number="15"></td>
+        <td id="LC15" class="blob-code blob-code-inner js-file-line">builddependencies <span class="pl-k">=</span> [</td>
+      </tr>
+      <tr>
+        <td id="L16" class="blob-num js-line-number" data-line-number="16"></td>
+        <td id="LC16" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pkg-config<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.29.2<span class="pl-pds">&#39;</span></span>),</td>
+      </tr>
+      <tr>
+        <td id="L17" class="blob-num js-line-number" data-line-number="17"></td>
+        <td id="LC17" class="blob-code blob-code-inner js-file-line">]</td>
+      </tr>
+      <tr>
+        <td id="L18" class="blob-num js-line-number" data-line-number="18"></td>
+        <td id="LC18" class="blob-code blob-code-inner js-file-line">dependencies <span class="pl-k">=</span> [</td>
+      </tr>
+      <tr>
+        <td id="L19" class="blob-num js-line-number" data-line-number="19"></td>
+        <td id="LC19" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>X11<span class="pl-pds">&#39;</span></span>, x11ver),</td>
+      </tr>
+      <tr>
+        <td id="L20" class="blob-num js-line-number" data-line-number="20"></td>
+        <td id="LC20" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Mesa<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>17.3.6<span class="pl-pds">&#39;</span></span>),</td>
+      </tr>
+      <tr>
+        <td id="L21" class="blob-num js-line-number" data-line-number="21"></td>
+        <td id="LC21" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>libGLU<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>9.0.0<span class="pl-pds">&#39;</span></span>),</td>
+      </tr>
+      <tr>
+        <td id="L22" class="blob-num js-line-number" data-line-number="22"></td>
+        <td id="LC22" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>cairo<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.14.12<span class="pl-pds">&#39;</span></span>),</td>
+      </tr>
+      <tr>
+        <td id="L23" class="blob-num js-line-number" data-line-number="23"></td>
+        <td id="LC23" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>libreadline<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>7.0<span class="pl-pds">&#39;</span></span>),</td>
+      </tr>
+      <tr>
+        <td id="L24" class="blob-num js-line-number" data-line-number="24"></td>
+        <td id="LC24" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ncurses<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>6.0<span class="pl-pds">&#39;</span></span>),</td>
+      </tr>
+      <tr>
+        <td id="L25" class="blob-num js-line-number" data-line-number="25"></td>
+        <td id="LC25" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bzip2<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.6<span class="pl-pds">&#39;</span></span>),</td>
+      </tr>
+      <tr>
+        <td id="L26" class="blob-num js-line-number" data-line-number="26"></td>
+        <td id="LC26" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>XZ<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>5.2.3<span class="pl-pds">&#39;</span></span>),</td>
+      </tr>
+      <tr>
+        <td id="L27" class="blob-num js-line-number" data-line-number="27"></td>
+        <td id="LC27" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>zlib<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.11<span class="pl-pds">&#39;</span></span>),</td>
+      </tr>
+      <tr>
+        <td id="L28" class="blob-num js-line-number" data-line-number="28"></td>
+        <td id="LC28" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>SQLite<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.21.0<span class="pl-pds">&#39;</span></span>),</td>
+      </tr>
+      <tr>
+        <td id="L29" class="blob-num js-line-number" data-line-number="29"></td>
+        <td id="LC29" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>PCRE<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>8.41<span class="pl-pds">&#39;</span></span>),</td>
+      </tr>
+      <tr>
+        <td id="L30" class="blob-num js-line-number" data-line-number="30"></td>
+        <td id="LC30" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>libpng<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.6.34<span class="pl-pds">&#39;</span></span>),  <span class="pl-c"><span class="pl-c">#</span> for plotting in R</span></td>
+      </tr>
+      <tr>
+        <td id="L31" class="blob-num js-line-number" data-line-number="31"></td>
+        <td id="LC31" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>libjpeg-turbo<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5.3<span class="pl-pds">&#39;</span></span>),  <span class="pl-c"><span class="pl-c">#</span> for plottting in R</span></td>
+      </tr>
+      <tr>
+        <td id="L32" class="blob-num js-line-number" data-line-number="32"></td>
+        <td id="LC32" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>LibTIFF<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>4.0.9<span class="pl-pds">&#39;</span></span>),</td>
+      </tr>
+      <tr>
+        <td id="L33" class="blob-num js-line-number" data-line-number="33"></td>
+        <td id="LC33" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Java<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.8.0_162<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-pds">&#39;</span></span>, <span class="pl-c1">True</span>),  <span class="pl-c"><span class="pl-c">#</span> Java bindings are built if Java is found, might as well provide it</span></td>
+      </tr>
+      <tr>
+        <td id="L34" class="blob-num js-line-number" data-line-number="34"></td>
+        <td id="LC34" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Tcl<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>8.6.8<span class="pl-pds">&#39;</span></span>),  <span class="pl-c"><span class="pl-c">#</span> for tcltk</span></td>
+      </tr>
+      <tr>
+        <td id="L35" class="blob-num js-line-number" data-line-number="35"></td>
+        <td id="LC35" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Tk<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>8.6.8<span class="pl-pds">&#39;</span></span>),  <span class="pl-c"><span class="pl-c">#</span> for tcltk</span></td>
+      </tr>
+      <tr>
+        <td id="L36" class="blob-num js-line-number" data-line-number="36"></td>
+        <td id="LC36" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>cURL<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>7.58.0<span class="pl-pds">&#39;</span></span>),  <span class="pl-c"><span class="pl-c">#</span> for RCurl</span></td>
+      </tr>
+      <tr>
+        <td id="L37" class="blob-num js-line-number" data-line-number="37"></td>
+        <td id="LC37" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>libxml2<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.9.7<span class="pl-pds">&#39;</span></span>),  <span class="pl-c"><span class="pl-c">#</span> for XML</span></td>
+      </tr>
+      <tr>
+        <td id="L38" class="blob-num js-line-number" data-line-number="38"></td>
+        <td id="LC38" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>GDAL<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.2.3<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>-Python-3.6.4<span class="pl-pds">&#39;</span></span>),  <span class="pl-c"><span class="pl-c">#</span> for rgdal</span></td>
+      </tr>
+      <tr>
+        <td id="L39" class="blob-num js-line-number" data-line-number="39"></td>
+        <td id="LC39" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>PROJ<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>5.0.0<span class="pl-pds">&#39;</span></span>),  <span class="pl-c"><span class="pl-c">#</span> for rgdal</span></td>
+      </tr>
+      <tr>
+        <td id="L40" class="blob-num js-line-number" data-line-number="40"></td>
+        <td id="LC40" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>GMP<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>6.1.2<span class="pl-pds">&#39;</span></span>),  <span class="pl-c"><span class="pl-c">#</span> for igraph</span></td>
+      </tr>
+      <tr>
+        <td id="L41" class="blob-num js-line-number" data-line-number="41"></td>
+        <td id="LC41" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>NLopt<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.4.2<span class="pl-pds">&#39;</span></span>),  <span class="pl-c"><span class="pl-c">#</span> for nloptr</span></td>
+      </tr>
+      <tr>
+        <td id="L42" class="blob-num js-line-number" data-line-number="42"></td>
+        <td id="LC42" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>FFTW<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.3.7<span class="pl-pds">&#39;</span></span>),  <span class="pl-c"><span class="pl-c">#</span> for fftw</span></td>
+      </tr>
+      <tr>
+        <td id="L43" class="blob-num js-line-number" data-line-number="43"></td>
+        <td id="LC43" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>libsndfile<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.28<span class="pl-pds">&#39;</span></span>),  <span class="pl-c"><span class="pl-c">#</span> for seewave</span></td>
+      </tr>
+      <tr>
+        <td id="L44" class="blob-num js-line-number" data-line-number="44"></td>
+        <td id="LC44" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ICU<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>61.1<span class="pl-pds">&#39;</span></span>),  <span class="pl-c"><span class="pl-c">#</span> for rJava &amp; gdsfmt</span></td>
+      </tr>
+      <tr>
+        <td id="L45" class="blob-num js-line-number" data-line-number="45"></td>
+        <td id="LC45" class="blob-code blob-code-inner js-file-line">    <span class="pl-c"><span class="pl-c">#</span> OS dependency should be preferred if the os version is more recent then this version,</span></td>
+      </tr>
+      <tr>
+        <td id="L46" class="blob-num js-line-number" data-line-number="46"></td>
+        <td id="LC46" class="blob-code blob-code-inner js-file-line">    <span class="pl-c"><span class="pl-c">#</span> it&#39;s nice to have an up to date openssl for security reasons</span></td>
+      </tr>
+      <tr>
+        <td id="L47" class="blob-num js-line-number" data-line-number="47"></td>
+        <td id="LC47" class="blob-code blob-code-inner js-file-line">    <span class="pl-c"><span class="pl-c">#</span> (&#39;OpenSSL&#39;, &#39;1.0.2h&#39;),</span></td>
+      </tr>
+      <tr>
+        <td id="L48" class="blob-num js-line-number" data-line-number="48"></td>
+        <td id="LC48" class="blob-code blob-code-inner js-file-line">]</td>
+      </tr>
+      <tr>
+        <td id="L49" class="blob-num js-line-number" data-line-number="49"></td>
+        <td id="LC49" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L50" class="blob-num js-line-number" data-line-number="50"></td>
+        <td id="LC50" class="blob-code blob-code-inner js-file-line">osdependencies <span class="pl-k">=</span> [(<span class="pl-s"><span class="pl-pds">&#39;</span>openssl-devel<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>libssl-dev<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>libopenssl-devel<span class="pl-pds">&#39;</span></span>)]</td>
+      </tr>
+      <tr>
+        <td id="L51" class="blob-num js-line-number" data-line-number="51"></td>
+        <td id="LC51" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L52" class="blob-num js-line-number" data-line-number="52"></td>
+        <td id="LC52" class="blob-code blob-code-inner js-file-line">configopts <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&quot;</span>--with-pic --enable-threads --enable-R-shlib<span class="pl-pds">&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L53" class="blob-num js-line-number" data-line-number="53"></td>
+        <td id="LC53" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> some recommended packages may fail in a parallel build (e.g. Matrix), and we&#39;re installing them anyway below</span></td>
+      </tr>
+      <tr>
+        <td id="L54" class="blob-num js-line-number" data-line-number="54"></td>
+        <td id="LC54" class="blob-code blob-code-inner js-file-line">configopts <span class="pl-k">+=</span> <span class="pl-s"><span class="pl-pds">&quot;</span> --with-recommended-packages=no<span class="pl-pds">&quot;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L55" class="blob-num js-line-number" data-line-number="55"></td>
+        <td id="LC55" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L56" class="blob-num js-line-number" data-line-number="56"></td>
+        <td id="LC56" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> specify that at least EasyBuild v3.5.0 is required,</span></td>
+      </tr>
+      <tr>
+        <td id="L57" class="blob-num js-line-number" data-line-number="57"></td>
+        <td id="LC57" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> since we rely on the updated easyblock for R to configure correctly w.r.t. BLAS/LAPACK</span></td>
+      </tr>
+      <tr>
+        <td id="L58" class="blob-num js-line-number" data-line-number="58"></td>
+        <td id="LC58" class="blob-code blob-code-inner js-file-line">easybuild_version <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>3.5.0<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+      <tr>
+        <td id="L59" class="blob-num js-line-number" data-line-number="59"></td>
+        <td id="LC59" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L60" class="blob-num js-line-number" data-line-number="60"></td>
+        <td id="LC60" class="blob-code blob-code-inner js-file-line">exts_default_options <span class="pl-k">=</span> {</td>
+      </tr>
+      <tr>
+        <td id="L61" class="blob-num js-line-number" data-line-number="61"></td>
+        <td id="LC61" class="blob-code blob-code-inner js-file-line">    <span class="pl-s"><span class="pl-pds">&#39;</span>source_urls<span class="pl-pds">&#39;</span></span>: [</td>
+      </tr>
+      <tr>
+        <td id="L62" class="blob-num js-line-number" data-line-number="62"></td>
+        <td id="LC62" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>http://cran.r-project.org/src/contrib/Archive/<span class="pl-c1">%(name)s</span><span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> package archive</span></td>
+      </tr>
+      <tr>
+        <td id="L63" class="blob-num js-line-number" data-line-number="63"></td>
+        <td id="LC63" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>http://cran.r-project.org/src/contrib/<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> current version of packages</span></td>
+      </tr>
+      <tr>
+        <td id="L64" class="blob-num js-line-number" data-line-number="64"></td>
+        <td id="LC64" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>http://cran.freestatistics.org/src/contrib<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> mirror alternative for current packages</span></td>
+      </tr>
+      <tr>
+        <td id="L65" class="blob-num js-line-number" data-line-number="65"></td>
+        <td id="LC65" class="blob-code blob-code-inner js-file-line">    ],</td>
+      </tr>
+      <tr>
+        <td id="L66" class="blob-num js-line-number" data-line-number="66"></td>
+        <td id="LC66" class="blob-code blob-code-inner js-file-line">    <span class="pl-s"><span class="pl-pds">&#39;</span>source_tmpl<span class="pl-pds">&#39;</span></span>: <span class="pl-s"><span class="pl-pds">&#39;</span><span class="pl-c1">%(name)s</span>_<span class="pl-c1">%(version)s</span>.tar.gz<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L67" class="blob-num js-line-number" data-line-number="67"></td>
+        <td id="LC67" class="blob-code blob-code-inner js-file-line">}</td>
+      </tr>
+      <tr>
+        <td id="L68" class="blob-num js-line-number" data-line-number="68"></td>
+        <td id="LC68" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L69" class="blob-num js-line-number" data-line-number="69"></td>
+        <td id="LC69" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> !! order of packages is important !!</span></td>
+      </tr>
+      <tr>
+        <td id="L70" class="blob-num js-line-number" data-line-number="70"></td>
+        <td id="LC70" class="blob-code blob-code-inner js-file-line"><span class="pl-c"><span class="pl-c">#</span> packages updated on Mar 15 2018</span></td>
+      </tr>
+      <tr>
+        <td id="L71" class="blob-num js-line-number" data-line-number="71"></td>
+        <td id="LC71" class="blob-code blob-code-inner js-file-line">exts_list <span class="pl-k">=</span> [</td>
+      </tr>
+      <tr>
+        <td id="L72" class="blob-num js-line-number" data-line-number="72"></td>
+        <td id="LC72" class="blob-code blob-code-inner js-file-line">    <span class="pl-s"><span class="pl-pds">&#39;</span>base<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L73" class="blob-num js-line-number" data-line-number="73"></td>
+        <td id="LC73" class="blob-code blob-code-inner js-file-line">    <span class="pl-s"><span class="pl-pds">&#39;</span>datasets<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L74" class="blob-num js-line-number" data-line-number="74"></td>
+        <td id="LC74" class="blob-code blob-code-inner js-file-line">    <span class="pl-s"><span class="pl-pds">&#39;</span>graphics<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L75" class="blob-num js-line-number" data-line-number="75"></td>
+        <td id="LC75" class="blob-code blob-code-inner js-file-line">    <span class="pl-s"><span class="pl-pds">&#39;</span>grDevices<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L76" class="blob-num js-line-number" data-line-number="76"></td>
+        <td id="LC76" class="blob-code blob-code-inner js-file-line">    <span class="pl-s"><span class="pl-pds">&#39;</span>grid<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L77" class="blob-num js-line-number" data-line-number="77"></td>
+        <td id="LC77" class="blob-code blob-code-inner js-file-line">    <span class="pl-s"><span class="pl-pds">&#39;</span>methods<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L78" class="blob-num js-line-number" data-line-number="78"></td>
+        <td id="LC78" class="blob-code blob-code-inner js-file-line">    <span class="pl-s"><span class="pl-pds">&#39;</span>splines<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L79" class="blob-num js-line-number" data-line-number="79"></td>
+        <td id="LC79" class="blob-code blob-code-inner js-file-line">    <span class="pl-s"><span class="pl-pds">&#39;</span>stats<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L80" class="blob-num js-line-number" data-line-number="80"></td>
+        <td id="LC80" class="blob-code blob-code-inner js-file-line">    <span class="pl-s"><span class="pl-pds">&#39;</span>stats4<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L81" class="blob-num js-line-number" data-line-number="81"></td>
+        <td id="LC81" class="blob-code blob-code-inner js-file-line">    <span class="pl-s"><span class="pl-pds">&#39;</span>tools<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L82" class="blob-num js-line-number" data-line-number="82"></td>
+        <td id="LC82" class="blob-code blob-code-inner js-file-line">    <span class="pl-s"><span class="pl-pds">&#39;</span>utils<span class="pl-pds">&#39;</span></span>,</td>
+      </tr>
+      <tr>
+        <td id="L83" class="blob-num js-line-number" data-line-number="83"></td>
+        <td id="LC83" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Rmpi<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6-6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L84" class="blob-num js-line-number" data-line-number="84"></td>
+        <td id="LC84" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>patches<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>Rmpi-0.6-5_impi5.patch<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L85" class="blob-num js-line-number" data-line-number="85"></td>
+        <td id="LC85" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [</td>
+      </tr>
+      <tr>
+        <td id="L86" class="blob-num js-line-number" data-line-number="86"></td>
+        <td id="LC86" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>d8fc09ad38264697caa86079885a7a1098921a3116d5a77a62022b9508f8a63a<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> Rmpi_0.6-6.tar.gz</span></td>
+      </tr>
+      <tr>
+        <td id="L87" class="blob-num js-line-number" data-line-number="87"></td>
+        <td id="LC87" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>f753f0b6434295be70fe29d36edb2047c091e465b7ff0cab56b93d55883c8dd3<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> Rmpi-0.6-5_impi5.patch</span></td>
+      </tr>
+      <tr>
+        <td id="L88" class="blob-num js-line-number" data-line-number="88"></td>
+        <td id="LC88" class="blob-code blob-code-inner js-file-line">        ],</td>
+      </tr>
+      <tr>
+        <td id="L89" class="blob-num js-line-number" data-line-number="89"></td>
+        <td id="LC89" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L90" class="blob-num js-line-number" data-line-number="90"></td>
+        <td id="LC90" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>abind<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4-5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L91" class="blob-num js-line-number" data-line-number="91"></td>
+        <td id="LC91" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3a3ace5afbcb86e56889efcebf3bf5c3bb042a282ba7cc4412d450bb246a3f2c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L92" class="blob-num js-line-number" data-line-number="92"></td>
+        <td id="LC92" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L93" class="blob-num js-line-number" data-line-number="93"></td>
+        <td id="LC93" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>magic<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5-8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L94" class="blob-num js-line-number" data-line-number="94"></td>
+        <td id="LC94" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7f8bc26e05003168e9d2dadf64eb9a34b51bc41beba482208874803dee7d6c20<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L95" class="blob-num js-line-number" data-line-number="95"></td>
+        <td id="LC95" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L96" class="blob-num js-line-number" data-line-number="96"></td>
+        <td id="LC96" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>geometry<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3-6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L97" class="blob-num js-line-number" data-line-number="97"></td>
+        <td id="LC97" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>patches<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>geometry-0.3-4-icc.patch<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L98" class="blob-num js-line-number" data-line-number="98"></td>
+        <td id="LC98" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [</td>
+      </tr>
+      <tr>
+        <td id="L99" class="blob-num js-line-number" data-line-number="99"></td>
+        <td id="LC99" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>2be231ac99171367635cd957f27da77705329df97520ab86f655839c41dc0968<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> geometry_0.3-6.tar.gz</span></td>
+      </tr>
+      <tr>
+        <td id="L100" class="blob-num js-line-number" data-line-number="100"></td>
+        <td id="LC100" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>df0ea118e597f31561093e01d50698dac3345d40d082eee05360bb4f94378377<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> geometry-0.3-4-icc.patch</span></td>
+      </tr>
+      <tr>
+        <td id="L101" class="blob-num js-line-number" data-line-number="101"></td>
+        <td id="LC101" class="blob-code blob-code-inner js-file-line">        ],</td>
+      </tr>
+      <tr>
+        <td id="L102" class="blob-num js-line-number" data-line-number="102"></td>
+        <td id="LC102" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L103" class="blob-num js-line-number" data-line-number="103"></td>
+        <td id="LC103" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bit<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1-12<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L104" class="blob-num js-line-number" data-line-number="104"></td>
+        <td id="LC104" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ce281c87fb7602bf1a599e72f3e25f9ff7a13e390c124a4506087f69ad79d128<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L105" class="blob-num js-line-number" data-line-number="105"></td>
+        <td id="LC105" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L106" class="blob-num js-line-number" data-line-number="106"></td>
+        <td id="LC106" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>filehash<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.4-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L107" class="blob-num js-line-number" data-line-number="107"></td>
+        <td id="LC107" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d0e087d338d89372c251c18fc93b53fb24b1750ea154833216ff16aff3b1eaf4<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L108" class="blob-num js-line-number" data-line-number="108"></td>
+        <td id="LC108" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L109" class="blob-num js-line-number" data-line-number="109"></td>
+        <td id="LC109" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ff<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.2-13<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L110" class="blob-num js-line-number" data-line-number="110"></td>
+        <td id="LC110" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>8bfb08afe0651ef3c23aaad49208146d5f929af5af12a25262fe7743fa346ddb<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L111" class="blob-num js-line-number" data-line-number="111"></td>
+        <td id="LC111" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L112" class="blob-num js-line-number" data-line-number="112"></td>
+        <td id="LC112" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bnlearn<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>4.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L113" class="blob-num js-line-number" data-line-number="113"></td>
+        <td id="LC113" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>78bb1d45977801ffa64f04f4319fa6e1fe9b5268f42b197d33aac074dc46f787<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L114" class="blob-num js-line-number" data-line-number="114"></td>
+        <td id="LC114" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L115" class="blob-num js-line-number" data-line-number="115"></td>
+        <td id="LC115" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bootstrap<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2017.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L116" class="blob-num js-line-number" data-line-number="116"></td>
+        <td id="LC116" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>44f118c90ee226730175c467a16ac8d5b3169d610424e613da4f73348fd79522<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L117" class="blob-num js-line-number" data-line-number="117"></td>
+        <td id="LC117" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L118" class="blob-num js-line-number" data-line-number="118"></td>
+        <td id="LC118" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>combinat<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.0-8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L119" class="blob-num js-line-number" data-line-number="119"></td>
+        <td id="LC119" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1513cf6b6ed74865bfdd9f8ca58feae12b62f38965d1a32c6130bef810ca30c1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L120" class="blob-num js-line-number" data-line-number="120"></td>
+        <td id="LC120" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L121" class="blob-num js-line-number" data-line-number="121"></td>
+        <td id="LC121" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>deal<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-37<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L122" class="blob-num js-line-number" data-line-number="122"></td>
+        <td id="LC122" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>aadfadfd85792b129063d02d5604dbd1afa5aacd2a6ec7eff7458edf2b5dc2da<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L123" class="blob-num js-line-number" data-line-number="123"></td>
+        <td id="LC123" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L124" class="blob-num js-line-number" data-line-number="124"></td>
+        <td id="LC124" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>fdrtool<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.15<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L125" class="blob-num js-line-number" data-line-number="125"></td>
+        <td id="LC125" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>65f964aa768d0703ceb7a199adc5e79ca79a6d29d7bc053a262eb533697686c0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L126" class="blob-num js-line-number" data-line-number="126"></td>
+        <td id="LC126" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L127" class="blob-num js-line-number" data-line-number="127"></td>
+        <td id="LC127" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>formatR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L128" class="blob-num js-line-number" data-line-number="128"></td>
+        <td id="LC128" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>874c197ae3720ec11b44984a055655b99a698e1912104eb9034c11fdf6104da7<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L129" class="blob-num js-line-number" data-line-number="129"></td>
+        <td id="LC129" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L130" class="blob-num js-line-number" data-line-number="130"></td>
+        <td id="LC130" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gtools<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.5.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L131" class="blob-num js-line-number" data-line-number="131"></td>
+        <td id="LC131" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>86b6a51a92ddb3c78095e0c5dc20414c67f6e28f915bf0ee11406adad3e476f6<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L132" class="blob-num js-line-number" data-line-number="132"></td>
+        <td id="LC132" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L133" class="blob-num js-line-number" data-line-number="133"></td>
+        <td id="LC133" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gdata<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.18.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L134" class="blob-num js-line-number" data-line-number="134"></td>
+        <td id="LC134" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>4b287f59f5bbf5fcbf18db16477852faac4a605b10c5284c46b93fa6e9918d7f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L135" class="blob-num js-line-number" data-line-number="135"></td>
+        <td id="LC135" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L136" class="blob-num js-line-number" data-line-number="136"></td>
+        <td id="LC136" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>GSA<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.03<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L137" class="blob-num js-line-number" data-line-number="137"></td>
+        <td id="LC137" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>dfb84f92508765c74b170bb5bb2b206a11d10fdb4a74473821b0e51cec5d3ac0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L138" class="blob-num js-line-number" data-line-number="138"></td>
+        <td id="LC138" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L139" class="blob-num js-line-number" data-line-number="139"></td>
+        <td id="LC139" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>highr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L140" class="blob-num js-line-number" data-line-number="140"></td>
+        <td id="LC140" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>43e152b2dea596df6e14c44398c74fcd438ece15eaae5bdb84aef8d61b213b59<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L141" class="blob-num js-line-number" data-line-number="141"></td>
+        <td id="LC141" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L142" class="blob-num js-line-number" data-line-number="142"></td>
+        <td id="LC142" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>infotheo<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L143" class="blob-num js-line-number" data-line-number="143"></td>
+        <td id="LC143" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9b47ebc3db5708c88dc014b4ffec6734053a9c255a9241fcede30fec3e63aaa3<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L144" class="blob-num js-line-number" data-line-number="144"></td>
+        <td id="LC144" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L145" class="blob-num js-line-number" data-line-number="145"></td>
+        <td id="LC145" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>lars<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L146" class="blob-num js-line-number" data-line-number="146"></td>
+        <td id="LC146" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>64745b568f20b2cfdae3dad02fba92ebf78ffee466a71aaaafd4f48c3921922e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L147" class="blob-num js-line-number" data-line-number="147"></td>
+        <td id="LC147" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L148" class="blob-num js-line-number" data-line-number="148"></td>
+        <td id="LC148" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>lazy<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-15<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L149" class="blob-num js-line-number" data-line-number="149"></td>
+        <td id="LC149" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7a4a33ad77ad5dc973413745b5626856485c1c63a984f2182ccf5d0cec7eb8dd<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L150" class="blob-num js-line-number" data-line-number="150"></td>
+        <td id="LC150" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L151" class="blob-num js-line-number" data-line-number="151"></td>
+        <td id="LC151" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>kernlab<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.9-25<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L152" class="blob-num js-line-number" data-line-number="152"></td>
+        <td id="LC152" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b9de072754bb03c02c4d6a5ca20f2290fd090de328b55ab334ac0b397ac2ca62<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L153" class="blob-num js-line-number" data-line-number="153"></td>
+        <td id="LC153" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L154" class="blob-num js-line-number" data-line-number="154"></td>
+        <td id="LC154" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>mime<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L155" class="blob-num js-line-number" data-line-number="155"></td>
+        <td id="LC155" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fcc72115afb0eb43237da872754464f37ae9ae097f332ec7984149b5e3a82145<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L156" class="blob-num js-line-number" data-line-number="156"></td>
+        <td id="LC156" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L157" class="blob-num js-line-number" data-line-number="157"></td>
+        <td id="LC157" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>markdown<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L158" class="blob-num js-line-number" data-line-number="158"></td>
+        <td id="LC158" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>538fd912b2220f2df344c6cca58304ce11e0960de7bd7bd573b3385105d48fed<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L159" class="blob-num js-line-number" data-line-number="159"></td>
+        <td id="LC159" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L160" class="blob-num js-line-number" data-line-number="160"></td>
+        <td id="LC160" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>mlbench<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L161" class="blob-num js-line-number" data-line-number="161"></td>
+        <td id="LC161" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>748141d56531a39dc4d37cf0a5165a40b653a04c507e916854053ed77119e0e6<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L162" class="blob-num js-line-number" data-line-number="162"></td>
+        <td id="LC162" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L163" class="blob-num js-line-number" data-line-number="163"></td>
+        <td id="LC163" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>NLP<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-11<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L164" class="blob-num js-line-number" data-line-number="164"></td>
+        <td id="LC164" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>580551a463c14d7186f62e029504f2e95dd9cbbaaef3f979221ddffafb036597<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L165" class="blob-num js-line-number" data-line-number="165"></td>
+        <td id="LC165" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L166" class="blob-num js-line-number" data-line-number="166"></td>
+        <td id="LC166" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>mclust<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>5.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L167" class="blob-num js-line-number" data-line-number="167"></td>
+        <td id="LC167" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7363057845272a1c2b97c77c89704d9d21f3b4eb9b41b95d1c54018c110e7bc4<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L168" class="blob-num js-line-number" data-line-number="168"></td>
+        <td id="LC168" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L169" class="blob-num js-line-number" data-line-number="169"></td>
+        <td id="LC169" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RANN<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.5.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L170" class="blob-num js-line-number" data-line-number="170"></td>
+        <td id="LC170" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>75277e5d8a13ca01ff387f99d403268a8077862d4e95b076b74fb1b5538a8546<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L171" class="blob-num js-line-number" data-line-number="171"></td>
+        <td id="LC171" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L172" class="blob-num js-line-number" data-line-number="172"></td>
+        <td id="LC172" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rmeta<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.16<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L173" class="blob-num js-line-number" data-line-number="173"></td>
+        <td id="LC173" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9efb9e4f1847b59d9cbc46c793c528cf1b79d961ab1e6636daad81390b0a76e8<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L174" class="blob-num js-line-number" data-line-number="174"></td>
+        <td id="LC174" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L175" class="blob-num js-line-number" data-line-number="175"></td>
+        <td id="LC175" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>segmented<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.5-3.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L176" class="blob-num js-line-number" data-line-number="176"></td>
+        <td id="LC176" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>98f2f0c23693d49527b43e7b6eb0746f2be7cb25715d2679e43015ec5d99315b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L177" class="blob-num js-line-number" data-line-number="177"></td>
+        <td id="LC177" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L178" class="blob-num js-line-number" data-line-number="178"></td>
+        <td id="LC178" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>som<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3-5.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L179" class="blob-num js-line-number" data-line-number="179"></td>
+        <td id="LC179" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a6f4c0e5b36656b7a8ea144b057e3d7642a8b71972da387a7133f3dd65507fb9<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L180" class="blob-num js-line-number" data-line-number="180"></td>
+        <td id="LC180" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L181" class="blob-num js-line-number" data-line-number="181"></td>
+        <td id="LC181" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>SuppDists<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1-9.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L182" class="blob-num js-line-number" data-line-number="182"></td>
+        <td id="LC182" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fcb571150af66b95dcf0627298c54f7813671d60521a00ed157f63fc2247ddb9<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L183" class="blob-num js-line-number" data-line-number="183"></td>
+        <td id="LC183" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L184" class="blob-num js-line-number" data-line-number="184"></td>
+        <td id="LC184" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>stabledist<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.7-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L185" class="blob-num js-line-number" data-line-number="185"></td>
+        <td id="LC185" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>06c5704d3a3c179fa389675c537c39a006867bc6e4f23dd7e406476ed2c88a69<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L186" class="blob-num js-line-number" data-line-number="186"></td>
+        <td id="LC186" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L187" class="blob-num js-line-number" data-line-number="187"></td>
+        <td id="LC187" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>survivalROC<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L188" class="blob-num js-line-number" data-line-number="188"></td>
+        <td id="LC188" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1449e7038e048e6ad4d3f7767983c0873c9c7a7637ffa03a4cc7f0e25c31cd72<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L189" class="blob-num js-line-number" data-line-number="189"></td>
+        <td id="LC189" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L190" class="blob-num js-line-number" data-line-number="190"></td>
+        <td id="LC190" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pspline<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0-18<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L191" class="blob-num js-line-number" data-line-number="191"></td>
+        <td id="LC191" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f71cf293bd5462e510ac5ad16c4a96eda18891a0bfa6447dd881c65845e19ac7<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L192" class="blob-num js-line-number" data-line-number="192"></td>
+        <td id="LC192" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L193" class="blob-num js-line-number" data-line-number="193"></td>
+        <td id="LC193" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>timeDate<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3043.102<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L194" class="blob-num js-line-number" data-line-number="194"></td>
+        <td id="LC194" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>377cba03cddab8c6992e31d0683c1db3a73afa9834eee3e95b3b0723f02d7473<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L195" class="blob-num js-line-number" data-line-number="195"></td>
+        <td id="LC195" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L196" class="blob-num js-line-number" data-line-number="196"></td>
+        <td id="LC196" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>longmemo<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L197" class="blob-num js-line-number" data-line-number="197"></td>
+        <td id="LC197" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>acfd7c55389ebce52c7805c55a4b3161102b534c9a50aec891dc77ee6c99ccca<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L198" class="blob-num js-line-number" data-line-number="198"></td>
+        <td id="LC198" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L199" class="blob-num js-line-number" data-line-number="199"></td>
+        <td id="LC199" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ADGofTest<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L200" class="blob-num js-line-number" data-line-number="200"></td>
+        <td id="LC200" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9cd9313954f6ecd82480d373f6c5371ca84ab33e3f5c39d972d35cfcf1096846<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L201" class="blob-num js-line-number" data-line-number="201"></td>
+        <td id="LC201" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L202" class="blob-num js-line-number" data-line-number="202"></td>
+        <td id="LC202" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>MASS<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>7.3-49<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L203" class="blob-num js-line-number" data-line-number="203"></td>
+        <td id="LC203" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1a33f77d5571e97daae22d1b764f3696f088bd2b18a9c709e21b7c7283b44bfa<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L204" class="blob-num js-line-number" data-line-number="204"></td>
+        <td id="LC204" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L205" class="blob-num js-line-number" data-line-number="205"></td>
+        <td id="LC205" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ade4<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.7-10<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L206" class="blob-num js-line-number" data-line-number="206"></td>
+        <td id="LC206" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>865157b21d5c0db96504d36f4361640c81d66de0fe5f09985f0f0ceb410f687e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L207" class="blob-num js-line-number" data-line-number="207"></td>
+        <td id="LC207" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L208" class="blob-num js-line-number" data-line-number="208"></td>
+        <td id="LC208" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>AlgDesign<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1-7.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L209" class="blob-num js-line-number" data-line-number="209"></td>
+        <td id="LC209" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>df0d56111401474b7f06eaf9ce7145a1cb73b3c5ec4817bad06f56db48af872e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L210" class="blob-num js-line-number" data-line-number="210"></td>
+        <td id="LC210" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L211" class="blob-num js-line-number" data-line-number="211"></td>
+        <td id="LC211" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>base64enc<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L212" class="blob-num js-line-number" data-line-number="212"></td>
+        <td id="LC212" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6d856d8a364bcdc499a0bf38bfd283b7c743d08f0b288174fba7dbf0a04b688d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L213" class="blob-num js-line-number" data-line-number="213"></td>
+        <td id="LC213" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L214" class="blob-num js-line-number" data-line-number="214"></td>
+        <td id="LC214" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>BH<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.66.0-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L215" class="blob-num js-line-number" data-line-number="215"></td>
+        <td id="LC215" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>17d9eb5512d74aa7dd02ec98953408422e728b01ce63493a6a473070b9596a92<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L216" class="blob-num js-line-number" data-line-number="216"></td>
+        <td id="LC216" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L217" class="blob-num js-line-number" data-line-number="217"></td>
+        <td id="LC217" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>brew<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0-6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L218" class="blob-num js-line-number" data-line-number="218"></td>
+        <td id="LC218" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d70d1a9a01cf4a923b4f11e4374ffd887ad3ff964f35c6f9dc0f29c8d657f0ed<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L219" class="blob-num js-line-number" data-line-number="219"></td>
+        <td id="LC219" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L220" class="blob-num js-line-number" data-line-number="220"></td>
+        <td id="LC220" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Brobdingnag<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L221" class="blob-num js-line-number" data-line-number="221"></td>
+        <td id="LC221" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6ab8afd7fb0751c6d24c9cfad9b986dfbf397e29da03be43284e0c2712515de9<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L222" class="blob-num js-line-number" data-line-number="222"></td>
+        <td id="LC222" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L223" class="blob-num js-line-number" data-line-number="223"></td>
+        <td id="LC223" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>corpcor<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.6.9<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L224" class="blob-num js-line-number" data-line-number="224"></td>
+        <td id="LC224" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2e4fabd1d3936fecea67fa365233590147ca50bb45cf80efb53a10345a8a23c2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L225" class="blob-num js-line-number" data-line-number="225"></td>
+        <td id="LC225" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L226" class="blob-num js-line-number" data-line-number="226"></td>
+        <td id="LC226" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>longitudinal<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.12<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L227" class="blob-num js-line-number" data-line-number="227"></td>
+        <td id="LC227" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d4f894c38373ba105b1bdc89e3e7c1b215838e2fb6b4470b9f23768b84e603b5<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L228" class="blob-num js-line-number" data-line-number="228"></td>
+        <td id="LC228" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L229" class="blob-num js-line-number" data-line-number="229"></td>
+        <td id="LC229" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>backports<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L230" class="blob-num js-line-number" data-line-number="230"></td>
+        <td id="LC230" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e85b93675c6703e1da790dce1f8fb61f27b87e92722c7f0909273ed5074cb456<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L231" class="blob-num js-line-number" data-line-number="231"></td>
+        <td id="LC231" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L232" class="blob-num js-line-number" data-line-number="232"></td>
+        <td id="LC232" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>checkmate<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.8.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L233" class="blob-num js-line-number" data-line-number="233"></td>
+        <td id="LC233" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e94d2a3971908ce2a8252a9320ae7e030e0364b0ecd5385ab98e600aca7cd1e0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L234" class="blob-num js-line-number" data-line-number="234"></td>
+        <td id="LC234" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L235" class="blob-num js-line-number" data-line-number="235"></td>
+        <td id="LC235" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Rcpp<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.12.16<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L236" class="blob-num js-line-number" data-line-number="236"></td>
+        <td id="LC236" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d4e1636e53e2b656e173b49085b7abbb627981787cd63d63df325c713c83a8e6<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L237" class="blob-num js-line-number" data-line-number="237"></td>
+        <td id="LC237" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L238" class="blob-num js-line-number" data-line-number="238"></td>
+        <td id="LC238" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>cubature<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3-11<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L239" class="blob-num js-line-number" data-line-number="239"></td>
+        <td id="LC239" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9398fae6e0f5fa62a06f41f4ed3a8b86941909fcbb439301ba629cb5b67ec619<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L240" class="blob-num js-line-number" data-line-number="240"></td>
+        <td id="LC240" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L241" class="blob-num js-line-number" data-line-number="241"></td>
+        <td id="LC241" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>DEoptimR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0-8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L242" class="blob-num js-line-number" data-line-number="242"></td>
+        <td id="LC242" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>846911c1b2561a9fae73a8c60a21a5680963ebb0050af3c1f1147ae9a121e5ef<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L243" class="blob-num js-line-number" data-line-number="243"></td>
+        <td id="LC243" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L244" class="blob-num js-line-number" data-line-number="244"></td>
+        <td id="LC244" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>digest<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6.15<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L245" class="blob-num js-line-number" data-line-number="245"></td>
+        <td id="LC245" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>882e74bb4f0722260bd912fd7f8a0fcefcf44c558f43ac8a03d63e53d25444c5<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L246" class="blob-num js-line-number" data-line-number="246"></td>
+        <td id="LC246" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L247" class="blob-num js-line-number" data-line-number="247"></td>
+        <td id="LC247" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>fastmatch<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L248" class="blob-num js-line-number" data-line-number="248"></td>
+        <td id="LC248" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>20b51aa4838dbe829e11e951444a9c77257dcaf85130807508f6d7e76797007d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L249" class="blob-num js-line-number" data-line-number="249"></td>
+        <td id="LC249" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L250" class="blob-num js-line-number" data-line-number="250"></td>
+        <td id="LC250" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ffbase<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.12.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L251" class="blob-num js-line-number" data-line-number="251"></td>
+        <td id="LC251" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a52998ec589c2b519034757919565473273f8b73486d8333ba7ff6deec3ae9db<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L252" class="blob-num js-line-number" data-line-number="252"></td>
+        <td id="LC252" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L253" class="blob-num js-line-number" data-line-number="253"></td>
+        <td id="LC253" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>iterators<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.9<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L254" class="blob-num js-line-number" data-line-number="254"></td>
+        <td id="LC254" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>de001e063805fdd124953b571ccb0ed2838c55e40cca2e9d283d8a90b0645e9b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L255" class="blob-num js-line-number" data-line-number="255"></td>
+        <td id="LC255" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L256" class="blob-num js-line-number" data-line-number="256"></td>
+        <td id="LC256" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>maps<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.2.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L257" class="blob-num js-line-number" data-line-number="257"></td>
+        <td id="LC257" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>437abeb4fa4ad4a36af6165d319634b89bfc6bf2b1827ca86c478d56d670e714<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L258" class="blob-num js-line-number" data-line-number="258"></td>
+        <td id="LC258" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L259" class="blob-num js-line-number" data-line-number="259"></td>
+        <td id="LC259" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>nnls<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L260" class="blob-num js-line-number" data-line-number="260"></td>
+        <td id="LC260" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>0e5d77abae12bc50639d34354f96a8e079408c9d7138a360743b73bd7bce6c1f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L261" class="blob-num js-line-number" data-line-number="261"></td>
+        <td id="LC261" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L262" class="blob-num js-line-number" data-line-number="262"></td>
+        <td id="LC262" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>sendmailR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L263" class="blob-num js-line-number" data-line-number="263"></td>
+        <td id="LC263" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>04feb08c6c763d9c58b2db24b1222febe01e28974eac4fe87670be6fb9bff17c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L264" class="blob-num js-line-number" data-line-number="264"></td>
+        <td id="LC264" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L265" class="blob-num js-line-number" data-line-number="265"></td>
+        <td id="LC265" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>dotCall64<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.9-5.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L266" class="blob-num js-line-number" data-line-number="266"></td>
+        <td id="LC266" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>738809d87ff13d1fa06ebe903645989b72fca24e3117016b943bda92b89f80cb<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L267" class="blob-num js-line-number" data-line-number="267"></td>
+        <td id="LC267" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L268" class="blob-num js-line-number" data-line-number="268"></td>
+        <td id="LC268" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>spam<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L269" class="blob-num js-line-number" data-line-number="269"></td>
+        <td id="LC269" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c2ef16eb239ffdd50003d423ab91954c14cfa2c1ee295ccc92984828a85a8219<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L270" class="blob-num js-line-number" data-line-number="270"></td>
+        <td id="LC270" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L271" class="blob-num js-line-number" data-line-number="271"></td>
+        <td id="LC271" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>subplex<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L272" class="blob-num js-line-number" data-line-number="272"></td>
+        <td id="LC272" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6f8c3ccadf1ccd7f11f3eae28cec16eed3695f14e351b864d807dbaba6cd3ded<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L273" class="blob-num js-line-number" data-line-number="273"></td>
+        <td id="LC273" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L274" class="blob-num js-line-number" data-line-number="274"></td>
+        <td id="LC274" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>stringi<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L275" class="blob-num js-line-number" data-line-number="275"></td>
+        <td id="LC275" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b475a8549fbaf8ee0e625a7cead9b3b478cd73864c785582cdb3d217850e9359<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L276" class="blob-num js-line-number" data-line-number="276"></td>
+        <td id="LC276" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L277" class="blob-num js-line-number" data-line-number="277"></td>
+        <td id="LC277" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>magrittr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L278" class="blob-num js-line-number" data-line-number="278"></td>
+        <td id="LC278" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>05c45943ada9443134caa0ab24db4a962b629f00b755ccf039a2a2a7b2c92ae8<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L279" class="blob-num js-line-number" data-line-number="279"></td>
+        <td id="LC279" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L280" class="blob-num js-line-number" data-line-number="280"></td>
+        <td id="LC280" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>glue<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L281" class="blob-num js-line-number" data-line-number="281"></td>
+        <td id="LC281" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>19275b34ee6a1bcad05360b7eb996cebaa1402f189a5dfb084e695d423f2296e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L282" class="blob-num js-line-number" data-line-number="282"></td>
+        <td id="LC282" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L283" class="blob-num js-line-number" data-line-number="283"></td>
+        <td id="LC283" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>stringr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L284" class="blob-num js-line-number" data-line-number="284"></td>
+        <td id="LC284" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>23b048d2344cafa10a3480f8d52ab818525c6fdf7210290635f3a10de772bb1d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L285" class="blob-num js-line-number" data-line-number="285"></td>
+        <td id="LC285" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L286" class="blob-num js-line-number" data-line-number="286"></td>
+        <td id="LC286" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>evaluate<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.10.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L287" class="blob-num js-line-number" data-line-number="287"></td>
+        <td id="LC287" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c9a763895d3f460dbf87c43a6469e4b41a251a74477df8c5d7e7d2b66cdd1b1c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L288" class="blob-num js-line-number" data-line-number="288"></td>
+        <td id="LC288" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L289" class="blob-num js-line-number" data-line-number="289"></td>
+        <td id="LC289" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>logspline<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1.9<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L290" class="blob-num js-line-number" data-line-number="290"></td>
+        <td id="LC290" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7c9b051f5bf7f64fb7ab7923f60e14fde4496b59eb74989aa192adae58cca7cd<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L291" class="blob-num js-line-number" data-line-number="291"></td>
+        <td id="LC291" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L292" class="blob-num js-line-number" data-line-number="292"></td>
+        <td id="LC292" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ncbit<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2013.03.29<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L293" class="blob-num js-line-number" data-line-number="293"></td>
+        <td id="LC293" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>4480271f14953615c8ddc2e0666866bb1d0964398ba0fab6cc29046436820738<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L294" class="blob-num js-line-number" data-line-number="294"></td>
+        <td id="LC294" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L295" class="blob-num js-line-number" data-line-number="295"></td>
+        <td id="LC295" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>permute<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.9-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L296" class="blob-num js-line-number" data-line-number="296"></td>
+        <td id="LC296" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a541a5f5636ddd67fd856d3e11224f15bc068e96e23aabe3e607a7e7c2fc1cf1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L297" class="blob-num js-line-number" data-line-number="297"></td>
+        <td id="LC297" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L298" class="blob-num js-line-number" data-line-number="298"></td>
+        <td id="LC298" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>plotrix<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L299" class="blob-num js-line-number" data-line-number="299"></td>
+        <td id="LC299" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3e5f232546b05cbb92242ad595842389f94c57918ebd4bd60051b471930d8867<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L300" class="blob-num js-line-number" data-line-number="300"></td>
+        <td id="LC300" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L301" class="blob-num js-line-number" data-line-number="301"></td>
+        <td id="LC301" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>randomForest<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>4.6-12<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L302" class="blob-num js-line-number" data-line-number="302"></td>
+        <td id="LC302" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6e512f8f88a51c01a918360acba61f1f39432f6e690bc231b7864218558b83c4<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L303" class="blob-num js-line-number" data-line-number="303"></td>
+        <td id="LC303" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L304" class="blob-num js-line-number" data-line-number="304"></td>
+        <td id="LC304" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>scatterplot3d<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3-41<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L305" class="blob-num js-line-number" data-line-number="305"></td>
+        <td id="LC305" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>4c8326b70a3b2d37126ca806771d71e5e9fe1201cfbe5b0d5a0a83c3d2c75d94<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L306" class="blob-num js-line-number" data-line-number="306"></td>
+        <td id="LC306" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L307" class="blob-num js-line-number" data-line-number="307"></td>
+        <td id="LC307" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>SparseM<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.77<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L308" class="blob-num js-line-number" data-line-number="308"></td>
+        <td id="LC308" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a9329fef14ae4fc646df1f4f6e57efb0211811599d015f7bc04c04285495d45c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L309" class="blob-num js-line-number" data-line-number="309"></td>
+        <td id="LC309" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L310" class="blob-num js-line-number" data-line-number="310"></td>
+        <td id="LC310" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tripack<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3-8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L311" class="blob-num js-line-number" data-line-number="311"></td>
+        <td id="LC311" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6bb340292a9629a41a0e0664335ddd97be3ad46bca225034db5dfb6efe01c75d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L312" class="blob-num js-line-number" data-line-number="312"></td>
+        <td id="LC312" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L313" class="blob-num js-line-number" data-line-number="313"></td>
+        <td id="LC313" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>irace<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L314" class="blob-num js-line-number" data-line-number="314"></td>
+        <td id="LC314" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>64cecf6fd0807dacea55a4f029677de127e105807de8dc026e3203cc2479bf1f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L315" class="blob-num js-line-number" data-line-number="315"></td>
+        <td id="LC315" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L316" class="blob-num js-line-number" data-line-number="316"></td>
+        <td id="LC316" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rJava<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.9-9<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L317" class="blob-num js-line-number" data-line-number="317"></td>
+        <td id="LC317" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>932b153f2b5c546d614bb5ac4124df3d103c9f8e09a608a14fd036dfe15e9146<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L318" class="blob-num js-line-number" data-line-number="318"></td>
+        <td id="LC318" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L319" class="blob-num js-line-number" data-line-number="319"></td>
+        <td id="LC319" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>lattice<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.20-35<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L320" class="blob-num js-line-number" data-line-number="320"></td>
+        <td id="LC320" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>0829ab0f4dec55aac6a73bc3411af68441ddb1b5b078d680a7c2643abeaa965d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L321" class="blob-num js-line-number" data-line-number="321"></td>
+        <td id="LC321" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L322" class="blob-num js-line-number" data-line-number="322"></td>
+        <td id="LC322" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RColorBrewer<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L323" class="blob-num js-line-number" data-line-number="323"></td>
+        <td id="LC323" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f3e9781e84e114b7a88eb099825936cc5ae7276bbba5af94d35adb1b3ea2ccdd<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L324" class="blob-num js-line-number" data-line-number="324"></td>
+        <td id="LC324" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L325" class="blob-num js-line-number" data-line-number="325"></td>
+        <td id="LC325" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>latticeExtra<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6-28<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L326" class="blob-num js-line-number" data-line-number="326"></td>
+        <td id="LC326" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>780695323dfadac108fb27000011c734e2927b1e0f069f247d65d27994c67ec2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L327" class="blob-num js-line-number" data-line-number="327"></td>
+        <td id="LC327" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L328" class="blob-num js-line-number" data-line-number="328"></td>
+        <td id="LC328" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Matrix<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-12<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L329" class="blob-num js-line-number" data-line-number="329"></td>
+        <td id="LC329" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>0d0e36e9742ea86355b2611ed94552946093b027e5eca2b8656abb4401838291<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L330" class="blob-num js-line-number" data-line-number="330"></td>
+        <td id="LC330" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L331" class="blob-num js-line-number" data-line-number="331"></td>
+        <td id="LC331" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>png<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L332" class="blob-num js-line-number" data-line-number="332"></td>
+        <td id="LC332" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e269ff968f04384fc9421d17cfc7c10cf7756b11c2d6d126e9776f5aca65553c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L333" class="blob-num js-line-number" data-line-number="333"></td>
+        <td id="LC333" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L334" class="blob-num js-line-number" data-line-number="334"></td>
+        <td id="LC334" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RcppArmadillo<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.8.400.0.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L335" class="blob-num js-line-number" data-line-number="335"></td>
+        <td id="LC335" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d917b66aa36779bb7ba6be8fd138ef181febfcd7e0cc093e73867f439c9ec287<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L336" class="blob-num js-line-number" data-line-number="336"></td>
+        <td id="LC336" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L337" class="blob-num js-line-number" data-line-number="337"></td>
+        <td id="LC337" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>plyr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.8.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L338" class="blob-num js-line-number" data-line-number="338"></td>
+        <td id="LC338" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>60b522d75961007658c9806f8394db27989f1154727cb0bb970062c96ec9eac5<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L339" class="blob-num js-line-number" data-line-number="339"></td>
+        <td id="LC339" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L340" class="blob-num js-line-number" data-line-number="340"></td>
+        <td id="LC340" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gtable<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L341" class="blob-num js-line-number" data-line-number="341"></td>
+        <td id="LC341" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>801e4869830ff3da1d38e41f5a2296a54fc10a7419c6ffb108582850c701e76f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L342" class="blob-num js-line-number" data-line-number="342"></td>
+        <td id="LC342" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L343" class="blob-num js-line-number" data-line-number="343"></td>
+        <td id="LC343" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>reshape2<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L344" class="blob-num js-line-number" data-line-number="344"></td>
+        <td id="LC344" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>8aff94c935e75032344b52407593392ddd4e16a88bb206984340c816d42c710e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L345" class="blob-num js-line-number" data-line-number="345"></td>
+        <td id="LC345" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L346" class="blob-num js-line-number" data-line-number="346"></td>
+        <td id="LC346" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>dichromat<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L347" class="blob-num js-line-number" data-line-number="347"></td>
+        <td id="LC347" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>31151eaf36f70bdc1172da5ff5088ee51cc0a3db4ead59c7c38c25316d580dd1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L348" class="blob-num js-line-number" data-line-number="348"></td>
+        <td id="LC348" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L349" class="blob-num js-line-number" data-line-number="349"></td>
+        <td id="LC349" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>colorspace<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L350" class="blob-num js-line-number" data-line-number="350"></td>
+        <td id="LC350" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>dd9fd2342b650456901d014e7ff6d2e201f8bec0b555be63b1a878d2e1513e34<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L351" class="blob-num js-line-number" data-line-number="351"></td>
+        <td id="LC351" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L352" class="blob-num js-line-number" data-line-number="352"></td>
+        <td id="LC352" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>munsell<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L353" class="blob-num js-line-number" data-line-number="353"></td>
+        <td id="LC353" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>397c3c90af966f48eebe8f5d9e40c41b17541f0baaa102eec3ea4faae5a2bd49<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L354" class="blob-num js-line-number" data-line-number="354"></td>
+        <td id="LC354" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L355" class="blob-num js-line-number" data-line-number="355"></td>
+        <td id="LC355" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>labeling<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L356" class="blob-num js-line-number" data-line-number="356"></td>
+        <td id="LC356" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>0d8069eb48e91f6f6d6a9148f4e2dc5026cabead15dd15fc343eff9cf33f538f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L357" class="blob-num js-line-number" data-line-number="357"></td>
+        <td id="LC357" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L358" class="blob-num js-line-number" data-line-number="358"></td>
+        <td id="LC358" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>R6<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.2.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L359" class="blob-num js-line-number" data-line-number="359"></td>
+        <td id="LC359" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>087756f471884c3b3ead80215a7cc5636a78b8a956e91675acfe2896426eae8f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L360" class="blob-num js-line-number" data-line-number="360"></td>
+        <td id="LC360" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L361" class="blob-num js-line-number" data-line-number="361"></td>
+        <td id="LC361" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>viridisLite<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L362" class="blob-num js-line-number" data-line-number="362"></td>
+        <td id="LC362" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>780ea12e7c4024d5ba9029f3a107321c74b8d6d9165262f6e64b79e00aa0c2af<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L363" class="blob-num js-line-number" data-line-number="363"></td>
+        <td id="LC363" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L364" class="blob-num js-line-number" data-line-number="364"></td>
+        <td id="LC364" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>scales<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.5.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L365" class="blob-num js-line-number" data-line-number="365"></td>
+        <td id="LC365" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>dbfcc0817c4ab8b8777ec7d68ebfe220177c193cfb5bd0e8ba5d365dbfe3e97d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L366" class="blob-num js-line-number" data-line-number="366"></td>
+        <td id="LC366" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L367" class="blob-num js-line-number" data-line-number="367"></td>
+        <td id="LC367" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rlang<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L368" class="blob-num js-line-number" data-line-number="368"></td>
+        <td id="LC368" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>4872a7d1b8e1e1a64a851dac707efb0c1dcbef69f6dadee417dac85b38740739<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L369" class="blob-num js-line-number" data-line-number="369"></td>
+        <td id="LC369" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L370" class="blob-num js-line-number" data-line-number="370"></td>
+        <td id="LC370" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>assertthat<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L371" class="blob-num js-line-number" data-line-number="371"></td>
+        <td id="LC371" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d73ef79b1e75293ed889a99571b237a95829c099f7da094d4763f83ea6fde5f2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L372" class="blob-num js-line-number" data-line-number="372"></td>
+        <td id="LC372" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L373" class="blob-num js-line-number" data-line-number="373"></td>
+        <td id="LC373" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>crayon<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L374" class="blob-num js-line-number" data-line-number="374"></td>
+        <td id="LC374" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fc6e9bf990e9532c4fcf1a3d2ce22d8cf12d25a95e4779adfa17713ed836fa68<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L375" class="blob-num js-line-number" data-line-number="375"></td>
+        <td id="LC375" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L376" class="blob-num js-line-number" data-line-number="376"></td>
+        <td id="LC376" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>cli<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L377" class="blob-num js-line-number" data-line-number="377"></td>
+        <td id="LC377" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>8fa3dbfc954ca61b8510f767ede9e8a365dac2ef95fe87c715a0f37d721b5a1d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L378" class="blob-num js-line-number" data-line-number="378"></td>
+        <td id="LC378" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L379" class="blob-num js-line-number" data-line-number="379"></td>
+        <td id="LC379" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>utf8<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L380" class="blob-num js-line-number" data-line-number="380"></td>
+        <td id="LC380" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>43b394c3274ba0f66719d28dc4a7babeb87187e766de8d8ca716e0548091440f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L381" class="blob-num js-line-number" data-line-number="381"></td>
+        <td id="LC381" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L382" class="blob-num js-line-number" data-line-number="382"></td>
+        <td id="LC382" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pillar<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L383" class="blob-num js-line-number" data-line-number="383"></td>
+        <td id="LC383" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6de997a43416f436039f2b8b47c46ea08d2508f8ad341e0e1fd878704a3dcde7<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L384" class="blob-num js-line-number" data-line-number="384"></td>
+        <td id="LC384" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L385" class="blob-num js-line-number" data-line-number="385"></td>
+        <td id="LC385" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tibble<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L386" class="blob-num js-line-number" data-line-number="386"></td>
+        <td id="LC386" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>11670353ff7059a55066dd075d1534d6a27bc5c3583fb9bc291bf750a75c5b17<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L387" class="blob-num js-line-number" data-line-number="387"></td>
+        <td id="LC387" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L388" class="blob-num js-line-number" data-line-number="388"></td>
+        <td id="LC388" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>lazyeval<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L389" class="blob-num js-line-number" data-line-number="389"></td>
+        <td id="LC389" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>83b3a43e94c40fe7977e43eb607be0a3cd64c02800eae4f2774e7866d1e93f61<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L390" class="blob-num js-line-number" data-line-number="390"></td>
+        <td id="LC390" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L391" class="blob-num js-line-number" data-line-number="391"></td>
+        <td id="LC391" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ggplot2<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.2.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L392" class="blob-num js-line-number" data-line-number="392"></td>
+        <td id="LC392" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5fbc89fec3160ad14ba90bd545b151c7a2e7baad021c0ab4b950ecd6043a8314<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L393" class="blob-num js-line-number" data-line-number="393"></td>
+        <td id="LC393" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L394" class="blob-num js-line-number" data-line-number="394"></td>
+        <td id="LC394" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pROC<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.10.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L395" class="blob-num js-line-number" data-line-number="395"></td>
+        <td id="LC395" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>4039fb71e531b1fcff319fc656657813465bf818476535d02a16f7271c44a066<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L396" class="blob-num js-line-number" data-line-number="396"></td>
+        <td id="LC396" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L397" class="blob-num js-line-number" data-line-number="397"></td>
+        <td id="LC397" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>quadprog<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5-5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L398" class="blob-num js-line-number" data-line-number="398"></td>
+        <td id="LC398" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d999620688354c283de5bb305203f5db70271b4dfdc23577cae8c2ba94c9e349<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L399" class="blob-num js-line-number" data-line-number="399"></td>
+        <td id="LC399" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L400" class="blob-num js-line-number" data-line-number="400"></td>
+        <td id="LC400" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>BB<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2014.10-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L401" class="blob-num js-line-number" data-line-number="401"></td>
+        <td id="LC401" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a09f67e3a6ef36db660e4dc92832dfad4a7591ae9fadc2a265c8770ffb1e2fd2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L402" class="blob-num js-line-number" data-line-number="402"></td>
+        <td id="LC402" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L403" class="blob-num js-line-number" data-line-number="403"></td>
+        <td id="LC403" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>BBmisc<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.11<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L404" class="blob-num js-line-number" data-line-number="404"></td>
+        <td id="LC404" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1ea48c281825349d8642a661bb447e23bfd651db3599bf72593bfebe17b101d2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L405" class="blob-num js-line-number" data-line-number="405"></td>
+        <td id="LC405" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L406" class="blob-num js-line-number" data-line-number="406"></td>
+        <td id="LC406" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>fail<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L407" class="blob-num js-line-number" data-line-number="407"></td>
+        <td id="LC407" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ede8aa2a9f2371aff5874cd030ac625adb35c33954835b54ab4abf7aeb34d56d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L408" class="blob-num js-line-number" data-line-number="408"></td>
+        <td id="LC408" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L409" class="blob-num js-line-number" data-line-number="409"></td>
+        <td id="LC409" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rlecuyer<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L410" class="blob-num js-line-number" data-line-number="410"></td>
+        <td id="LC410" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c7378f1134e99abc9dfbde7906da430b34333e11aa98a03f87b638637f63b534<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L411" class="blob-num js-line-number" data-line-number="411"></td>
+        <td id="LC411" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L412" class="blob-num js-line-number" data-line-number="412"></td>
+        <td id="LC412" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>snow<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L413" class="blob-num js-line-number" data-line-number="413"></td>
+        <td id="LC413" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ee070187aea3607c9ca6235399b3db3e181348692405d038e962e06aefccabd7<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L414" class="blob-num js-line-number" data-line-number="414"></td>
+        <td id="LC414" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L415" class="blob-num js-line-number" data-line-number="415"></td>
+        <td id="LC415" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tree<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0-38<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L416" class="blob-num js-line-number" data-line-number="416"></td>
+        <td id="LC416" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fa0b9258261f1dadfb2baaf798bed8d758a02c8a12092c28383710b131d1fafd<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L417" class="blob-num js-line-number" data-line-number="417"></td>
+        <td id="LC417" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L418" class="blob-num js-line-number" data-line-number="418"></td>
+        <td id="LC418" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pls<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.6-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L419" class="blob-num js-line-number" data-line-number="419"></td>
+        <td id="LC419" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3d8708fb7f45863d3861fd231e06955e6750bcbe717e1ccfcc6d66d0cb4d4596<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L420" class="blob-num js-line-number" data-line-number="420"></td>
+        <td id="LC420" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L421" class="blob-num js-line-number" data-line-number="421"></td>
+        <td id="LC421" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>class<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>7.3-14<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L422" class="blob-num js-line-number" data-line-number="422"></td>
+        <td id="LC422" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>18b876dbc18bebe6a00890eab7d04ef72b903ba0049d5ce50731406a82426b9c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L423" class="blob-num js-line-number" data-line-number="423"></td>
+        <td id="LC423" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L424" class="blob-num js-line-number" data-line-number="424"></td>
+        <td id="LC424" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>e1071<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.6-8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L425" class="blob-num js-line-number" data-line-number="425"></td>
+        <td id="LC425" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f68601743b9b49e1d1f8b9ec9963d6500d66158417c53f65bf7232678d88c622<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L426" class="blob-num js-line-number" data-line-number="426"></td>
+        <td id="LC426" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L427" class="blob-num js-line-number" data-line-number="427"></td>
+        <td id="LC427" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>nnet<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>7.3-12<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L428" class="blob-num js-line-number" data-line-number="428"></td>
+        <td id="LC428" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2723523e8581cc0e2215435ac773033577a16087a3f41d111757dd96b8c5559d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L429" class="blob-num js-line-number" data-line-number="429"></td>
+        <td id="LC429" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L430" class="blob-num js-line-number" data-line-number="430"></td>
+        <td id="LC430" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>nlme<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.1-131.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L431" class="blob-num js-line-number" data-line-number="431"></td>
+        <td id="LC431" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1e3c2d147df34d83b0f3ab50ac065371035f5d676a763c45595f26058e894ef5<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L432" class="blob-num js-line-number" data-line-number="432"></td>
+        <td id="LC432" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L433" class="blob-num js-line-number" data-line-number="433"></td>
+        <td id="LC433" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>minqa<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L434" class="blob-num js-line-number" data-line-number="434"></td>
+        <td id="LC434" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>cfa193a4a9c55cb08f3faf4ab09c11b70412523767f19894e4eafc6e94cccd0c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L435" class="blob-num js-line-number" data-line-number="435"></td>
+        <td id="LC435" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L436" class="blob-num js-line-number" data-line-number="436"></td>
+        <td id="LC436" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RcppEigen<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3.3.4.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L437" class="blob-num js-line-number" data-line-number="437"></td>
+        <td id="LC437" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>11020c567b299b1eac95e8a4d57abf0315931286907823dc7b66c44d0dd6dad4<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L438" class="blob-num js-line-number" data-line-number="438"></td>
+        <td id="LC438" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L439" class="blob-num js-line-number" data-line-number="439"></td>
+        <td id="LC439" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>MatrixModels<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L440" class="blob-num js-line-number" data-line-number="440"></td>
+        <td id="LC440" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fe878e401e697992a480cd146421c3a10fa331f6b37a51bac83b5c1119dcce33<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L441" class="blob-num js-line-number" data-line-number="441"></td>
+        <td id="LC441" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L442" class="blob-num js-line-number" data-line-number="442"></td>
+        <td id="LC442" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>quantreg<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>5.35<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L443" class="blob-num js-line-number" data-line-number="443"></td>
+        <td id="LC443" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f57c75d3ab15cc1cb6a819200fa9239c976b2bfa5a7f580aae78051976c7c3a1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L444" class="blob-num js-line-number" data-line-number="444"></td>
+        <td id="LC444" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L445" class="blob-num js-line-number" data-line-number="445"></td>
+        <td id="LC445" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>mgcv<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.8-23<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L446" class="blob-num js-line-number" data-line-number="446"></td>
+        <td id="LC446" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7771ac5581542904d569388e2e498d3e3b8b65f7a81737acbb45d8ef838359d3<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L447" class="blob-num js-line-number" data-line-number="447"></td>
+        <td id="LC447" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L448" class="blob-num js-line-number" data-line-number="448"></td>
+        <td id="LC448" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>robustbase<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.92-8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L449" class="blob-num js-line-number" data-line-number="449"></td>
+        <td id="LC449" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>bcbf894c7d3916fc92064f0f9152f6347560c9b98ec81d57b5705f8421b31e20<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L450" class="blob-num js-line-number" data-line-number="450"></td>
+        <td id="LC450" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L451" class="blob-num js-line-number" data-line-number="451"></td>
+        <td id="LC451" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>sp<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L452" class="blob-num js-line-number" data-line-number="452"></td>
+        <td id="LC452" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6d60e03e1abd30a7d4afe547d157ce3dd7a8c166fc5e407fd6d62ae99ff30460<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L453" class="blob-num js-line-number" data-line-number="453"></td>
+        <td id="LC453" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L454" class="blob-num js-line-number" data-line-number="454"></td>
+        <td id="LC454" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>zoo<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.8-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L455" class="blob-num js-line-number" data-line-number="455"></td>
+        <td id="LC455" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d93d88500374fce7f5c047f25240ac60483bcfd6fadf81df4eb2b879ad2ccc9a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L456" class="blob-num js-line-number" data-line-number="456"></td>
+        <td id="LC456" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L457" class="blob-num js-line-number" data-line-number="457"></td>
+        <td id="LC457" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>lmtest<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.9-35<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L458" class="blob-num js-line-number" data-line-number="458"></td>
+        <td id="LC458" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2f4982f1b6cd133ef36fe9718f4ff2f4fa5c20716100fdd5ee5c947b68c8eb80<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L459" class="blob-num js-line-number" data-line-number="459"></td>
+        <td id="LC459" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L460" class="blob-num js-line-number" data-line-number="460"></td>
+        <td id="LC460" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>vcd<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L461" class="blob-num js-line-number" data-line-number="461"></td>
+        <td id="LC461" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a561adf120b5ce41b66e0c0c321542fcddc772eb12b3d7020d86e9cd014ce9d2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L462" class="blob-num js-line-number" data-line-number="462"></td>
+        <td id="LC462" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L463" class="blob-num js-line-number" data-line-number="463"></td>
+        <td id="LC463" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>snowfall<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.84-6.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L464" class="blob-num js-line-number" data-line-number="464"></td>
+        <td id="LC464" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5c446df3a931e522a8b138cf1fb7ca5815cc82fcf486dbac964dcbc0690e248d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L465" class="blob-num js-line-number" data-line-number="465"></td>
+        <td id="LC465" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L466" class="blob-num js-line-number" data-line-number="466"></td>
+        <td id="LC466" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rpart<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>4.1-13<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L467" class="blob-num js-line-number" data-line-number="467"></td>
+        <td id="LC467" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>8e11a6552224e0fbe23a85aba95acd21a0889a3fe48277f3d345de3147c7494c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L468" class="blob-num js-line-number" data-line-number="468"></td>
+        <td id="LC468" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L469" class="blob-num js-line-number" data-line-number="469"></td>
+        <td id="LC469" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>survival<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.41-3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L470" class="blob-num js-line-number" data-line-number="470"></td>
+        <td id="LC470" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f3797c344de93abd2ba8c89568770a13524a8b2694144ae55adec46921c8961d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L471" class="blob-num js-line-number" data-line-number="471"></td>
+        <td id="LC471" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L472" class="blob-num js-line-number" data-line-number="472"></td>
+        <td id="LC472" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>mice<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.46.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L473" class="blob-num js-line-number" data-line-number="473"></td>
+        <td id="LC473" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5d3109ab3e9a84cb9ba60b0ab477d4e3ed9326fe4831fd99bbf1ed7fcca45bbe<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L474" class="blob-num js-line-number" data-line-number="474"></td>
+        <td id="LC474" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L475" class="blob-num js-line-number" data-line-number="475"></td>
+        <td id="LC475" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>urca<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L476" class="blob-num js-line-number" data-line-number="476"></td>
+        <td id="LC476" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>621cc82398e25b58b4a16edf000ed0a1484d9a0bc458f734e97b6f371cc76aaa<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L477" class="blob-num js-line-number" data-line-number="477"></td>
+        <td id="LC477" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L478" class="blob-num js-line-number" data-line-number="478"></td>
+        <td id="LC478" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>fracdiff<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L479" class="blob-num js-line-number" data-line-number="479"></td>
+        <td id="LC479" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>983781cedc2b4e3ba9fa020213957d5133ae9cd6710bc61d6225728e2f6e850e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L480" class="blob-num js-line-number" data-line-number="480"></td>
+        <td id="LC480" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L481" class="blob-num js-line-number" data-line-number="481"></td>
+        <td id="LC481" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>logistf<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.22<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L482" class="blob-num js-line-number" data-line-number="482"></td>
+        <td id="LC482" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e866f02b1b40332e6e57c932201993725742e464f362e0053776bb8ce8c2fc5a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L483" class="blob-num js-line-number" data-line-number="483"></td>
+        <td id="LC483" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L484" class="blob-num js-line-number" data-line-number="484"></td>
+        <td id="LC484" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>akima<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L485" class="blob-num js-line-number" data-line-number="485"></td>
+        <td id="LC485" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>61da3e556553eea6d1f8db7c92218254441da31e365bdef82dfe5da188cc97ce<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L486" class="blob-num js-line-number" data-line-number="486"></td>
+        <td id="LC486" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L487" class="blob-num js-line-number" data-line-number="487"></td>
+        <td id="LC487" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bitops<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0-6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L488" class="blob-num js-line-number" data-line-number="488"></td>
+        <td id="LC488" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9b731397b7166dd54941fb0d2eac6df60c7a483b2e790f7eb15b4d7b79c9d69c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L489" class="blob-num js-line-number" data-line-number="489"></td>
+        <td id="LC489" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L490" class="blob-num js-line-number" data-line-number="490"></td>
+        <td id="LC490" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>boot<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3-20<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L491" class="blob-num js-line-number" data-line-number="491"></td>
+        <td id="LC491" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>adcb90b72409705e3f9c69ea6c15673dcb649b464fed06723fe0930beac5212a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L492" class="blob-num js-line-number" data-line-number="492"></td>
+        <td id="LC492" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L493" class="blob-num js-line-number" data-line-number="493"></td>
+        <td id="LC493" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>mixtools<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L494" class="blob-num js-line-number" data-line-number="494"></td>
+        <td id="LC494" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>543fd8d8dc8d4b6079ebf491cf97f27d6225e1a6e65d8fd48553ada23ba88d8f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L495" class="blob-num js-line-number" data-line-number="495"></td>
+        <td id="LC495" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L496" class="blob-num js-line-number" data-line-number="496"></td>
+        <td id="LC496" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>cluster<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L497" class="blob-num js-line-number" data-line-number="497"></td>
+        <td id="LC497" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b53bb0eed64b79767a6e0d203fdc82f9fdb5c9692f30316fbe1c5b196a62fd81<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L498" class="blob-num js-line-number" data-line-number="498"></td>
+        <td id="LC498" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L499" class="blob-num js-line-number" data-line-number="499"></td>
+        <td id="LC499" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gclus<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L500" class="blob-num js-line-number" data-line-number="500"></td>
+        <td id="LC500" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d6994ee264b464503db005450153973d75eba502e4caaaa6ff99cb95e4376a09<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L501" class="blob-num js-line-number" data-line-number="501"></td>
+        <td id="LC501" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L502" class="blob-num js-line-number" data-line-number="502"></td>
+        <td id="LC502" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>coda<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.19-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L503" class="blob-num js-line-number" data-line-number="503"></td>
+        <td id="LC503" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d41ff5731da6805170769dba75dd011ab33f916d15b2336001f279e21a524491<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L504" class="blob-num js-line-number" data-line-number="504"></td>
+        <td id="LC504" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L505" class="blob-num js-line-number" data-line-number="505"></td>
+        <td id="LC505" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>codetools<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2-15<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L506" class="blob-num js-line-number" data-line-number="506"></td>
+        <td id="LC506" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>4e0798ed79281a614f8cdd199e25f2c1bd8f35ecec902b03016544bd7795fa40<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L507" class="blob-num js-line-number" data-line-number="507"></td>
+        <td id="LC507" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L508" class="blob-num js-line-number" data-line-number="508"></td>
+        <td id="LC508" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>foreach<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L509" class="blob-num js-line-number" data-line-number="509"></td>
+        <td id="LC509" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c0a71090d5b70b9a95a6936091dabae9c26e1fc6b9609bfe5fb6346033905e48<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L510" class="blob-num js-line-number" data-line-number="510"></td>
+        <td id="LC510" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L511" class="blob-num js-line-number" data-line-number="511"></td>
+        <td id="LC511" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>doMC<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L512" class="blob-num js-line-number" data-line-number="512"></td>
+        <td id="LC512" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>792254596babd8cc074bb3c83c18672dd07a0c3246b4ebab08d8ebedf6f4d9ed<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L513" class="blob-num js-line-number" data-line-number="513"></td>
+        <td id="LC513" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L514" class="blob-num js-line-number" data-line-number="514"></td>
+        <td id="LC514" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>DBI<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L515" class="blob-num js-line-number" data-line-number="515"></td>
+        <td id="LC515" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d52b9e04b3291f9bda8a88c174678f520ddffc5f2edf9b3dfa6d97dca943ce9a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L516" class="blob-num js-line-number" data-line-number="516"></td>
+        <td id="LC516" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L517" class="blob-num js-line-number" data-line-number="517"></td>
+        <td id="LC517" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>foreign<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.8-69<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L518" class="blob-num js-line-number" data-line-number="518"></td>
+        <td id="LC518" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>13689f5ec1ab09e8973be81c7f1799b7de4313176072887a9fa0b5825aed3468<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L519" class="blob-num js-line-number" data-line-number="519"></td>
+        <td id="LC519" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L520" class="blob-num js-line-number" data-line-number="520"></td>
+        <td id="LC520" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gam<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.15<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L521" class="blob-num js-line-number" data-line-number="521"></td>
+        <td id="LC521" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1e365f9f328e018955140b4d842a30a499f4877291cb88cb9f147be79b62d1f0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L522" class="blob-num js-line-number" data-line-number="522"></td>
+        <td id="LC522" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L523" class="blob-num js-line-number" data-line-number="523"></td>
+        <td id="LC523" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gamlss.data<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>5.0-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L524" class="blob-num js-line-number" data-line-number="524"></td>
+        <td id="LC524" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3abc373d43698275361bfc3d61f5646e8ddf59019886bfd248bdea19493d1fd7<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L525" class="blob-num js-line-number" data-line-number="525"></td>
+        <td id="LC525" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L526" class="blob-num js-line-number" data-line-number="526"></td>
+        <td id="LC526" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gamlss.dist<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>5.0-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L527" class="blob-num js-line-number" data-line-number="527"></td>
+        <td id="LC527" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2d1221db92be90b88f50e01e284c7e2218d35bb72af488e351b3d3ec4ca1b498<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L528" class="blob-num js-line-number" data-line-number="528"></td>
+        <td id="LC528" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L529" class="blob-num js-line-number" data-line-number="529"></td>
+        <td id="LC529" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>hwriter<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L530" class="blob-num js-line-number" data-line-number="530"></td>
+        <td id="LC530" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6b3531d2e7a239be9d6e3a1aa3256b2745eb68aa0bdffd2076d36552d0d7322b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L531" class="blob-num js-line-number" data-line-number="531"></td>
+        <td id="LC531" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L532" class="blob-num js-line-number" data-line-number="532"></td>
+        <td id="LC532" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>KernSmooth<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.23-15<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L533" class="blob-num js-line-number" data-line-number="533"></td>
+        <td id="LC533" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>8b72d23ed121a54af188b2cda4441e3ce2646359309885f6455b82c0275210f6<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L534" class="blob-num js-line-number" data-line-number="534"></td>
+        <td id="LC534" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L535" class="blob-num js-line-number" data-line-number="535"></td>
+        <td id="LC535" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>xts<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.10-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L536" class="blob-num js-line-number" data-line-number="536"></td>
+        <td id="LC536" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>8155888319c38e874ed87300decd65570e77ea4a7575136f4690123d3f7321c4<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L537" class="blob-num js-line-number" data-line-number="537"></td>
+        <td id="LC537" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L538" class="blob-num js-line-number" data-line-number="538"></td>
+        <td id="LC538" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>curl<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L539" class="blob-num js-line-number" data-line-number="539"></td>
+        <td id="LC539" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>270f2596be50a11fe43fe63bcacbf4a4aa9c75cc6ebc0d619ac2e52e9497cb95<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L540" class="blob-num js-line-number" data-line-number="540"></td>
+        <td id="LC540" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L541" class="blob-num js-line-number" data-line-number="541"></td>
+        <td id="LC541" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>TTR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.23-3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L542" class="blob-num js-line-number" data-line-number="542"></td>
+        <td id="LC542" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2136032c7a2cd2a82518a4412fc655ecb16597b123dbdebe5684caef9f15261f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L543" class="blob-num js-line-number" data-line-number="543"></td>
+        <td id="LC543" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L544" class="blob-num js-line-number" data-line-number="544"></td>
+        <td id="LC544" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>quantmod<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4-12<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L545" class="blob-num js-line-number" data-line-number="545"></td>
+        <td id="LC545" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>18d61d869180670cd5e97bc6cc12ab2939b8b63ae720c89c6e1b041d2680ef78<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L546" class="blob-num js-line-number" data-line-number="546"></td>
+        <td id="LC546" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L547" class="blob-num js-line-number" data-line-number="547"></td>
+        <td id="LC547" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>mnormt<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5-5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L548" class="blob-num js-line-number" data-line-number="548"></td>
+        <td id="LC548" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ff78d5f935278935f1814a69e5a913d93d6dd2ac1b5681ba86b30c6773ef64ac<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L549" class="blob-num js-line-number" data-line-number="549"></td>
+        <td id="LC549" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L550" class="blob-num js-line-number" data-line-number="550"></td>
+        <td id="LC550" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>mvtnorm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0-7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L551" class="blob-num js-line-number" data-line-number="551"></td>
+        <td id="LC551" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d063b0dec57c2f588da4ac35fcd479dc2ab83cb473e4a6fee6cbb6e7a9fbf038<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L552" class="blob-num js-line-number" data-line-number="552"></td>
+        <td id="LC552" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L553" class="blob-num js-line-number" data-line-number="553"></td>
+        <td id="LC553" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pcaPP<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.9-73<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L554" class="blob-num js-line-number" data-line-number="554"></td>
+        <td id="LC554" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ca4566b0babfbe83ef9418283b08a12b3420dc362f93c6562f265df7926b53fc<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L555" class="blob-num js-line-number" data-line-number="555"></td>
+        <td id="LC555" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L556" class="blob-num js-line-number" data-line-number="556"></td>
+        <td id="LC556" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>numDeriv<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2016.8-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L557" class="blob-num js-line-number" data-line-number="557"></td>
+        <td id="LC557" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1b681d273697dc780a3ac5bedabb4a257785732d9ca4ef68e4e4aac8b328d11e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L558" class="blob-num js-line-number" data-line-number="558"></td>
+        <td id="LC558" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L559" class="blob-num js-line-number" data-line-number="559"></td>
+        <td id="LC559" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>SQUAREM<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2017.10-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L560" class="blob-num js-line-number" data-line-number="560"></td>
+        <td id="LC560" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9b89905b436f1cf3faa9e3dabc585a76299e729e85ca659bfddb4b7cba11b283<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L561" class="blob-num js-line-number" data-line-number="561"></td>
+        <td id="LC561" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L562" class="blob-num js-line-number" data-line-number="562"></td>
+        <td id="LC562" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>lava<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L563" class="blob-num js-line-number" data-line-number="563"></td>
+        <td id="LC563" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>bf05dafeeeac86b7d64ea7c2a0986fb727f139019efb82ed4b5f6564522bae0b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L564" class="blob-num js-line-number" data-line-number="564"></td>
+        <td id="LC564" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L565" class="blob-num js-line-number" data-line-number="565"></td>
+        <td id="LC565" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>prodlim<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.6.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L566" class="blob-num js-line-number" data-line-number="566"></td>
+        <td id="LC566" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3f2665257118a3db8682731a500b1ae4d669af344672dc2037f987bee3cca154<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L567" class="blob-num js-line-number" data-line-number="567"></td>
+        <td id="LC567" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L568" class="blob-num js-line-number" data-line-number="568"></td>
+        <td id="LC568" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pscl<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L569" class="blob-num js-line-number" data-line-number="569"></td>
+        <td id="LC569" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2c9fe648485c6b54c6f95a54b6e00ffe3cf06fa8c5c68f1d669664a7b91a0ede<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L570" class="blob-num js-line-number" data-line-number="570"></td>
+        <td id="LC570" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L571" class="blob-num js-line-number" data-line-number="571"></td>
+        <td id="LC571" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>memoise<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L572" class="blob-num js-line-number" data-line-number="572"></td>
+        <td id="LC572" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b276f9452a26aeb79e12dd7227fcc8712832781a42f92d70e86040da0573980c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L573" class="blob-num js-line-number" data-line-number="573"></td>
+        <td id="LC573" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L574" class="blob-num js-line-number" data-line-number="574"></td>
+        <td id="LC574" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>plogr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L575" class="blob-num js-line-number" data-line-number="575"></td>
+        <td id="LC575" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>22755c93c76c26252841f43195df31681ea865e91aa89726010bd1b9288ef48f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L576" class="blob-num js-line-number" data-line-number="576"></td>
+        <td id="LC576" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L577" class="blob-num js-line-number" data-line-number="577"></td>
+        <td id="LC577" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bit64<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.9-7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L578" class="blob-num js-line-number" data-line-number="578"></td>
+        <td id="LC578" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7b9aaa7f971198728c3629f9ba1a1b24d53db5c7e459498b0fdf86bbd3dff61f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L579" class="blob-num js-line-number" data-line-number="579"></td>
+        <td id="LC579" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L580" class="blob-num js-line-number" data-line-number="580"></td>
+        <td id="LC580" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>blob<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L581" class="blob-num js-line-number" data-line-number="581"></td>
+        <td id="LC581" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>16d6603df3ddba177f0ac4d9469c938f89131c4bf8834345db838defd9ffea16<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L582" class="blob-num js-line-number" data-line-number="582"></td>
+        <td id="LC582" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L583" class="blob-num js-line-number" data-line-number="583"></td>
+        <td id="LC583" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pkgconfig<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L584" class="blob-num js-line-number" data-line-number="584"></td>
+        <td id="LC584" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ab02b2a4b639ba94dcba882a059fe9cddae5498a4309841f764b62ec46ba5a40<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L585" class="blob-num js-line-number" data-line-number="585"></td>
+        <td id="LC585" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L586" class="blob-num js-line-number" data-line-number="586"></td>
+        <td id="LC586" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RSQLite<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L587" class="blob-num js-line-number" data-line-number="587"></td>
+        <td id="LC587" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>patches<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>RSQLite-2.0-icc.patch<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L588" class="blob-num js-line-number" data-line-number="588"></td>
+        <td id="LC588" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [</td>
+      </tr>
+      <tr>
+        <td id="L589" class="blob-num js-line-number" data-line-number="589"></td>
+        <td id="LC589" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>7f0fe629f34641c6af1e8a34412f3089ee2d184853843209d97ffe29430ceff6<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> RSQLite_2.0.tar.gz</span></td>
+      </tr>
+      <tr>
+        <td id="L590" class="blob-num js-line-number" data-line-number="590"></td>
+        <td id="LC590" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>828dd9aeb4f8aaff7bccb8671bee757b8001e049ed349d655044e9c916d1860d<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> RSQLite-2.0-icc.patch</span></td>
+      </tr>
+      <tr>
+        <td id="L591" class="blob-num js-line-number" data-line-number="591"></td>
+        <td id="LC591" class="blob-code blob-code-inner js-file-line">        ],</td>
+      </tr>
+      <tr>
+        <td id="L592" class="blob-num js-line-number" data-line-number="592"></td>
+        <td id="LC592" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L593" class="blob-num js-line-number" data-line-number="593"></td>
+        <td id="LC593" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>data.table<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.10.4-3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L594" class="blob-num js-line-number" data-line-number="594"></td>
+        <td id="LC594" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ba8b4f1b96b16e7f9765fc49c5028f21ef2210fc46cf962f4f7ea7901f9d8a89<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L595" class="blob-num js-line-number" data-line-number="595"></td>
+        <td id="LC595" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L596" class="blob-num js-line-number" data-line-number="596"></td>
+        <td id="LC596" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>BatchJobs<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L597" class="blob-num js-line-number" data-line-number="597"></td>
+        <td id="LC597" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>49ef69adfb42f085c7ed143a80d78566d55d794ee9a1e1c83d85dbac2a2aa60c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L598" class="blob-num js-line-number" data-line-number="598"></td>
+        <td id="LC598" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L599" class="blob-num js-line-number" data-line-number="599"></td>
+        <td id="LC599" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>sandwich<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.4-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L600" class="blob-num js-line-number" data-line-number="600"></td>
+        <td id="LC600" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>34315b9ced76a3ed109aead7b8f77eea6398a6eb2e1ad71515a48bed9808ccc0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L601" class="blob-num js-line-number" data-line-number="601"></td>
+        <td id="LC601" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L602" class="blob-num js-line-number" data-line-number="602"></td>
+        <td id="LC602" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>sfsmisc<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L603" class="blob-num js-line-number" data-line-number="603"></td>
+        <td id="LC603" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>808734644863d102263134634b89dc856dbaadc4d54c32ae697f3e1b0214f831<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L604" class="blob-num js-line-number" data-line-number="604"></td>
+        <td id="LC604" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L605" class="blob-num js-line-number" data-line-number="605"></td>
+        <td id="LC605" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>spatial<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>7.3-11<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L606" class="blob-num js-line-number" data-line-number="606"></td>
+        <td id="LC606" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>624448d2ac22e1798097d09fc5dc4605908a33f490b8ec971fc6ea318a445c11<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L607" class="blob-num js-line-number" data-line-number="607"></td>
+        <td id="LC607" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L608" class="blob-num js-line-number" data-line-number="608"></td>
+        <td id="LC608" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>VGAM<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0-5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L609" class="blob-num js-line-number" data-line-number="609"></td>
+        <td id="LC609" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>01acf530b011b8f04e1698742c51ea0682d7c9fcdf814fc65ba44869b6e76346<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L610" class="blob-num js-line-number" data-line-number="610"></td>
+        <td id="LC610" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L611" class="blob-num js-line-number" data-line-number="611"></td>
+        <td id="LC611" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>waveslim<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.7.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L612" class="blob-num js-line-number" data-line-number="612"></td>
+        <td id="LC612" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>31b698f7b19aadcdc02068ee69bf7676cd9dea2913420ce3caa7e507e3a41a53<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L613" class="blob-num js-line-number" data-line-number="613"></td>
+        <td id="LC613" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L614" class="blob-num js-line-number" data-line-number="614"></td>
+        <td id="LC614" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>xtable<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.8-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L615" class="blob-num js-line-number" data-line-number="615"></td>
+        <td id="LC615" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1623a1cde2e130fedb46f98840c3a882f1cbb167b292ef2bd86d70baefc4280d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L616" class="blob-num js-line-number" data-line-number="616"></td>
+        <td id="LC616" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L617" class="blob-num js-line-number" data-line-number="617"></td>
+        <td id="LC617" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>profileModel<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.5-9<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L618" class="blob-num js-line-number" data-line-number="618"></td>
+        <td id="LC618" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c94f25d222521867ddc86021bd0b9a6b9f7b055212985652a8511054b24c2bdd<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L619" class="blob-num js-line-number" data-line-number="619"></td>
+        <td id="LC619" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L620" class="blob-num js-line-number" data-line-number="620"></td>
+        <td id="LC620" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>brglm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L621" class="blob-num js-line-number" data-line-number="621"></td>
+        <td id="LC621" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b786db50edc703b1b6a986b1ce13d31aab76fd3c672a6540161b25f5cd57239f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L622" class="blob-num js-line-number" data-line-number="622"></td>
+        <td id="LC622" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L623" class="blob-num js-line-number" data-line-number="623"></td>
+        <td id="LC623" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>deSolve<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.20<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L624" class="blob-num js-line-number" data-line-number="624"></td>
+        <td id="LC624" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>56e945835b0c66d36ebc4ec8b55197b616e387d990788a2e52e924ce551ddda2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L625" class="blob-num js-line-number" data-line-number="625"></td>
+        <td id="LC625" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L626" class="blob-num js-line-number" data-line-number="626"></td>
+        <td id="LC626" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tseriesChaos<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-13<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L627" class="blob-num js-line-number" data-line-number="627"></td>
+        <td id="LC627" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>efabf9c59548e2d22aa9763b340789d8e46e88c741ed4a831e52b1ed3bf35038<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L628" class="blob-num js-line-number" data-line-number="628"></td>
+        <td id="LC628" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L629" class="blob-num js-line-number" data-line-number="629"></td>
+        <td id="LC629" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tseries<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.10-43<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L630" class="blob-num js-line-number" data-line-number="630"></td>
+        <td id="LC630" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c27912f45d6bbd723c8055b345936a3c96ccdc7bd919fad9cf57dc408f845dfa<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L631" class="blob-num js-line-number" data-line-number="631"></td>
+        <td id="LC631" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L632" class="blob-num js-line-number" data-line-number="632"></td>
+        <td id="LC632" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>fastICA<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L633" class="blob-num js-line-number" data-line-number="633"></td>
+        <td id="LC633" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6f2997dd766a544be3a3de2780df48ca67242ac7790a4a2882c417bfaa171f81<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L634" class="blob-num js-line-number" data-line-number="634"></td>
+        <td id="LC634" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L635" class="blob-num js-line-number" data-line-number="635"></td>
+        <td id="LC635" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>R.methodsS3<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.7.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L636" class="blob-num js-line-number" data-line-number="636"></td>
+        <td id="LC636" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>44b840399266cd27f8f9157777b4d9d85ab7bd31bfdc143b3fc45079a2d8e687<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L637" class="blob-num js-line-number" data-line-number="637"></td>
+        <td id="LC637" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L638" class="blob-num js-line-number" data-line-number="638"></td>
+        <td id="LC638" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>R.oo<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.21.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L639" class="blob-num js-line-number" data-line-number="639"></td>
+        <td id="LC639" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>645ceec2f815ed39650ca72db87fb4ece7357857875a4ec73e18bfaf647f431c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L640" class="blob-num js-line-number" data-line-number="640"></td>
+        <td id="LC640" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L641" class="blob-num js-line-number" data-line-number="641"></td>
+        <td id="LC641" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>cgdsr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.10<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L642" class="blob-num js-line-number" data-line-number="642"></td>
+        <td id="LC642" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>43bc02fb33c371464f9407d5e5e6419527e9360e3e394343862cca0aebe1d0f7<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L643" class="blob-num js-line-number" data-line-number="643"></td>
+        <td id="LC643" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L644" class="blob-num js-line-number" data-line-number="644"></td>
+        <td id="LC644" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>R.utils<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.6.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L645" class="blob-num js-line-number" data-line-number="645"></td>
+        <td id="LC645" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5d64993d1209b512a4e97f2edecdbc185f4a369ee5fa2e334ed2cf017486470e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L646" class="blob-num js-line-number" data-line-number="646"></td>
+        <td id="LC646" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L647" class="blob-num js-line-number" data-line-number="647"></td>
+        <td id="LC647" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>R.matlab<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.6.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L648" class="blob-num js-line-number" data-line-number="648"></td>
+        <td id="LC648" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1032579fd152d419eaf1f69bf6035fba7a71ef26e76136c48a6fc619e3887804<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L649" class="blob-num js-line-number" data-line-number="649"></td>
+        <td id="LC649" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L650" class="blob-num js-line-number" data-line-number="650"></td>
+        <td id="LC650" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gbm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L651" class="blob-num js-line-number" data-line-number="651"></td>
+        <td id="LC651" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>eaf24be931d762f1ccca4f90e15997719d01005f152160a3d20d858a0bbed92b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L652" class="blob-num js-line-number" data-line-number="652"></td>
+        <td id="LC652" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L653" class="blob-num js-line-number" data-line-number="653"></td>
+        <td id="LC653" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Formula<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L654" class="blob-num js-line-number" data-line-number="654"></td>
+        <td id="LC654" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>8def4600fb7457d38db8083733477501b54528974aa216e4adf8871bff4aa429<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L655" class="blob-num js-line-number" data-line-number="655"></td>
+        <td id="LC655" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L656" class="blob-num js-line-number" data-line-number="656"></td>
+        <td id="LC656" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>acepack<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L657" class="blob-num js-line-number" data-line-number="657"></td>
+        <td id="LC657" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>82750507926f02a696f6cc03693e8d4a5ee7e92500c8c15a16a9c12addcd28b9<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L658" class="blob-num js-line-number" data-line-number="658"></td>
+        <td id="LC658" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L659" class="blob-num js-line-number" data-line-number="659"></td>
+        <td id="LC659" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>proto<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L660" class="blob-num js-line-number" data-line-number="660"></td>
+        <td id="LC660" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9294d9a3b2b680bb6fac17000bfc97453d77c87ef68cfd609b4c4eb6d11d04d1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L661" class="blob-num js-line-number" data-line-number="661"></td>
+        <td id="LC661" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L662" class="blob-num js-line-number" data-line-number="662"></td>
+        <td id="LC662" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gridExtra<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L663" class="blob-num js-line-number" data-line-number="663"></td>
+        <td id="LC663" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>81b60ce6f237ec308555471ae0119158b115463df696d2eca9b177ded8988e3b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L664" class="blob-num js-line-number" data-line-number="664"></td>
+        <td id="LC664" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L665" class="blob-num js-line-number" data-line-number="665"></td>
+        <td id="LC665" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>chron<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.3-52<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L666" class="blob-num js-line-number" data-line-number="666"></td>
+        <td id="LC666" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c47fcf4abb635babe6337604c876d4853d8a24639a98b71523746c56ce75b4a0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L667" class="blob-num js-line-number" data-line-number="667"></td>
+        <td id="LC667" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L668" class="blob-num js-line-number" data-line-number="668"></td>
+        <td id="LC668" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>viridis<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.5.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L669" class="blob-num js-line-number" data-line-number="669"></td>
+        <td id="LC669" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fea477172c1e11be40554545260b36d6ddff3fe6bc3bbed87813ffb77c5546cd<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L670" class="blob-num js-line-number" data-line-number="670"></td>
+        <td id="LC670" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L671" class="blob-num js-line-number" data-line-number="671"></td>
+        <td id="LC671" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>yaml<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1.18<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L672" class="blob-num js-line-number" data-line-number="672"></td>
+        <td id="LC672" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1bb54d5f28f0adc24a5f3cfbf5cda4a71ca2ad7922a687f756e0619767c1a496<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L673" class="blob-num js-line-number" data-line-number="673"></td>
+        <td id="LC673" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L674" class="blob-num js-line-number" data-line-number="674"></td>
+        <td id="LC674" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>jsonlite<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L675" class="blob-num js-line-number" data-line-number="675"></td>
+        <td id="LC675" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6490371082a387cb1834048ad8cdecacb8b6b6643751b50298c741490c798e02<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L676" class="blob-num js-line-number" data-line-number="676"></td>
+        <td id="LC676" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L677" class="blob-num js-line-number" data-line-number="677"></td>
+        <td id="LC677" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>htmltools<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L678" class="blob-num js-line-number" data-line-number="678"></td>
+        <td id="LC678" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>44affb82f9c2fd76c9e2b58f9229adb003217932b68c3fdbf1327c8d74c868a2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L679" class="blob-num js-line-number" data-line-number="679"></td>
+        <td id="LC679" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L680" class="blob-num js-line-number" data-line-number="680"></td>
+        <td id="LC680" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>htmlwidgets<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L681" class="blob-num js-line-number" data-line-number="681"></td>
+        <td id="LC681" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9973fe7a0271d1f39317fad58edee818eae8df26d037f0341024d032e0af9326<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L682" class="blob-num js-line-number" data-line-number="682"></td>
+        <td id="LC682" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L683" class="blob-num js-line-number" data-line-number="683"></td>
+        <td id="LC683" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>knitr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.20<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L684" class="blob-num js-line-number" data-line-number="684"></td>
+        <td id="LC684" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7b2409056af001970d1ed502a25fd84536aca4a21039479998507556446d0890<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L685" class="blob-num js-line-number" data-line-number="685"></td>
+        <td id="LC685" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L686" class="blob-num js-line-number" data-line-number="686"></td>
+        <td id="LC686" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rstudioapi<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L687" class="blob-num js-line-number" data-line-number="687"></td>
+        <td id="LC687" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a541bc76ef082d2c27e42fd683f8262cb195b1497af3509178d2642870397a8c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L688" class="blob-num js-line-number" data-line-number="688"></td>
+        <td id="LC688" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L689" class="blob-num js-line-number" data-line-number="689"></td>
+        <td id="LC689" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bindr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L690" class="blob-num js-line-number" data-line-number="690"></td>
+        <td id="LC690" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7c785ca77ceb3ab9282148bcecf64d1857d35f5b800531d49483622fe67505d0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L691" class="blob-num js-line-number" data-line-number="691"></td>
+        <td id="LC691" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L692" class="blob-num js-line-number" data-line-number="692"></td>
+        <td id="LC692" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bindrcpp<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L693" class="blob-num js-line-number" data-line-number="693"></td>
+        <td id="LC693" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d0efa1313cb8148880f7902a4267de1dcedae916f28d9a0ef5911f44bf103450<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L694" class="blob-num js-line-number" data-line-number="694"></td>
+        <td id="LC694" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L695" class="blob-num js-line-number" data-line-number="695"></td>
+        <td id="LC695" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>dplyr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.7.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L696" class="blob-num js-line-number" data-line-number="696"></td>
+        <td id="LC696" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7b1fc90750fbb46483423da6721832c545d37b157f4f3355784a65e50fada8c2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L697" class="blob-num js-line-number" data-line-number="697"></td>
+        <td id="LC697" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L698" class="blob-num js-line-number" data-line-number="698"></td>
+        <td id="LC698" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>purrr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L699" class="blob-num js-line-number" data-line-number="699"></td>
+        <td id="LC699" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ed8d0f69d29b95c2289ae52be08a0e65f8171abb6d2587de7b57328bf3b2eb71<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L700" class="blob-num js-line-number" data-line-number="700"></td>
+        <td id="LC700" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L701" class="blob-num js-line-number" data-line-number="701"></td>
+        <td id="LC701" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tidyselect<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L702" class="blob-num js-line-number" data-line-number="702"></td>
+        <td id="LC702" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5cb30e56ad5c1ac59786969edc8d542a7a1735a129a474f585a141aefe6a2295<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L703" class="blob-num js-line-number" data-line-number="703"></td>
+        <td id="LC703" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L704" class="blob-num js-line-number" data-line-number="704"></td>
+        <td id="LC704" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tidyr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.8.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L705" class="blob-num js-line-number" data-line-number="705"></td>
+        <td id="LC705" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>0b7fb3e4ee7c6c8bb9894825c7f16db967abb57aceac0609b7866fa1825c57e2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L706" class="blob-num js-line-number" data-line-number="706"></td>
+        <td id="LC706" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L707" class="blob-num js-line-number" data-line-number="707"></td>
+        <td id="LC707" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>htmlTable<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.11.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L708" class="blob-num js-line-number" data-line-number="708"></td>
+        <td id="LC708" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>64a273b1cdf07a7c57b9031315ca665f95d78e70b4320d020f64a139278877d1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L709" class="blob-num js-line-number" data-line-number="709"></td>
+        <td id="LC709" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L710" class="blob-num js-line-number" data-line-number="710"></td>
+        <td id="LC710" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Hmisc<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>4.1-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L711" class="blob-num js-line-number" data-line-number="711"></td>
+        <td id="LC711" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>991db21cdf73ffbf5b0239a4876b2e76fd243ea33528afd88dc968792f281498<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L712" class="blob-num js-line-number" data-line-number="712"></td>
+        <td id="LC712" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L713" class="blob-num js-line-number" data-line-number="713"></td>
+        <td id="LC713" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>fastcluster<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.24<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L714" class="blob-num js-line-number" data-line-number="714"></td>
+        <td id="LC714" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>82c939b79dbaf00c79b01f19b09a8fadb9a949397b8f65bc861c552e0485b995<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L715" class="blob-num js-line-number" data-line-number="715"></td>
+        <td id="LC715" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L716" class="blob-num js-line-number" data-line-number="716"></td>
+        <td id="LC716" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>registry<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L717" class="blob-num js-line-number" data-line-number="717"></td>
+        <td id="LC717" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5d8be59ba791987b2400e9e8eaaac614cd544c1aece785ec4782ea6d5ea00efb<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L718" class="blob-num js-line-number" data-line-number="718"></td>
+        <td id="LC718" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L719" class="blob-num js-line-number" data-line-number="719"></td>
+        <td id="LC719" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pkgmaker<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.22<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L720" class="blob-num js-line-number" data-line-number="720"></td>
+        <td id="LC720" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>19ad78c16bd5757333e7abbd5eebcec081deb494c9a4b6eec6919a3747b3386f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L721" class="blob-num js-line-number" data-line-number="721"></td>
+        <td id="LC721" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L722" class="blob-num js-line-number" data-line-number="722"></td>
+        <td id="LC722" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rngtools<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L723" class="blob-num js-line-number" data-line-number="723"></td>
+        <td id="LC723" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>27019835b750f470b13dbb7fecd3b839a61b52774e23fffa191f919533768fb9<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L724" class="blob-num js-line-number" data-line-number="724"></td>
+        <td id="LC724" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L725" class="blob-num js-line-number" data-line-number="725"></td>
+        <td id="LC725" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>doParallel<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.11<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L726" class="blob-num js-line-number" data-line-number="726"></td>
+        <td id="LC726" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>4ccbd2eb46d3e4f5251b0c3de4d93d9168b02bb0be493656d6aea236667ff76a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L727" class="blob-num js-line-number" data-line-number="727"></td>
+        <td id="LC727" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L728" class="blob-num js-line-number" data-line-number="728"></td>
+        <td id="LC728" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gridBase<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4-7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L729" class="blob-num js-line-number" data-line-number="729"></td>
+        <td id="LC729" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>be8718d24cd10f6e323dce91b15fc40ed88bccaa26acf3192d5e38fe33e15f26<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L730" class="blob-num js-line-number" data-line-number="730"></td>
+        <td id="LC730" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L731" class="blob-num js-line-number" data-line-number="731"></td>
+        <td id="LC731" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>NMF<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.21.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L732" class="blob-num js-line-number" data-line-number="732"></td>
+        <td id="LC732" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3b30c81c66066fab4a63c5611a0313418b840d8b63414db31ef0e932872d02e3<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L733" class="blob-num js-line-number" data-line-number="733"></td>
+        <td id="LC733" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L734" class="blob-num js-line-number" data-line-number="734"></td>
+        <td id="LC734" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>irlba<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.3.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L735" class="blob-num js-line-number" data-line-number="735"></td>
+        <td id="LC735" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3fdf2d8fefa6ab14cd0992740de7958f9f501c71aca93229f5eb03c54558fc38<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L736" class="blob-num js-line-number" data-line-number="736"></td>
+        <td id="LC736" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L737" class="blob-num js-line-number" data-line-number="737"></td>
+        <td id="LC737" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>igraph<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L738" class="blob-num js-line-number" data-line-number="738"></td>
+        <td id="LC738" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>55341848f85a436c32d60f59a4db485238d535f2e8afe0d5a360804fc33299c1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L739" class="blob-num js-line-number" data-line-number="739"></td>
+        <td id="LC739" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L740" class="blob-num js-line-number" data-line-number="740"></td>
+        <td id="LC740" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>GeneNet<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.13<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L741" class="blob-num js-line-number" data-line-number="741"></td>
+        <td id="LC741" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3798caac3bef7dc87f97b3628eb29eb12365d571ce0837b5b6285b0be655a270<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L742" class="blob-num js-line-number" data-line-number="742"></td>
+        <td id="LC742" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L743" class="blob-num js-line-number" data-line-number="743"></td>
+        <td id="LC743" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ape<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>5.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L744" class="blob-num js-line-number" data-line-number="744"></td>
+        <td id="LC744" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c32ed22e350b3d7c7ef3de9334155ab1f3086922b5ec9a1643897cae7abda960<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L745" class="blob-num js-line-number" data-line-number="745"></td>
+        <td id="LC745" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L746" class="blob-num js-line-number" data-line-number="746"></td>
+        <td id="LC746" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RJSONIO<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L747" class="blob-num js-line-number" data-line-number="747"></td>
+        <td id="LC747" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>119334b7761c6c1c3cec52fa17dbc1b72eaebb520c53e68d873dea147cf48fb7<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L748" class="blob-num js-line-number" data-line-number="748"></td>
+        <td id="LC748" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L749" class="blob-num js-line-number" data-line-number="749"></td>
+        <td id="LC749" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>caTools<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.17.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L750" class="blob-num js-line-number" data-line-number="750"></td>
+        <td id="LC750" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d32a73febf00930355cc00f3e4e71357412e0f163faae6a4bf7f552cacfe9af4<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L751" class="blob-num js-line-number" data-line-number="751"></td>
+        <td id="LC751" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L752" class="blob-num js-line-number" data-line-number="752"></td>
+        <td id="LC752" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gplots<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.0.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L753" class="blob-num js-line-number" data-line-number="753"></td>
+        <td id="LC753" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>343df84327ac3d03494992e79ee3afc78ba3bdc08af9a305ee3fb0a38745cb0a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L754" class="blob-num js-line-number" data-line-number="754"></td>
+        <td id="LC754" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L755" class="blob-num js-line-number" data-line-number="755"></td>
+        <td id="LC755" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ROCR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0-7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L756" class="blob-num js-line-number" data-line-number="756"></td>
+        <td id="LC756" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e7ef710f847e441a48b20fdc781dbc1377f5a060a5ee635234053f7a2a435ec9<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L757" class="blob-num js-line-number" data-line-number="757"></td>
+        <td id="LC757" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L758" class="blob-num js-line-number" data-line-number="758"></td>
+        <td id="LC758" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>httpuv<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3.6.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L759" class="blob-num js-line-number" data-line-number="759"></td>
+        <td id="LC759" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>8e8ca2f15529089846695abdab229cbc9812f0b2710855fb0a41ac720a9f7040<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L760" class="blob-num js-line-number" data-line-number="760"></td>
+        <td id="LC760" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L761" class="blob-num js-line-number" data-line-number="761"></td>
+        <td id="LC761" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rjson<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.15<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L762" class="blob-num js-line-number" data-line-number="762"></td>
+        <td id="LC762" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>77d00d8f6a1c936329b46f3b8b0be79a165f8c5f1989497f942ecc53dcf6f2ef<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L763" class="blob-num js-line-number" data-line-number="763"></td>
+        <td id="LC763" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L764" class="blob-num js-line-number" data-line-number="764"></td>
+        <td id="LC764" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>sourcetools<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L765" class="blob-num js-line-number" data-line-number="765"></td>
+        <td id="LC765" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c9f48d2f0b7f7ed0e7fecdf8e730b0b80c4d567f0e1e880d118b0944b1330c51<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L766" class="blob-num js-line-number" data-line-number="766"></td>
+        <td id="LC766" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L767" class="blob-num js-line-number" data-line-number="767"></td>
+        <td id="LC767" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>shiny<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L768" class="blob-num js-line-number" data-line-number="768"></td>
+        <td id="LC768" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>20e25f3f72f3608a2151663f7836f2e0c6da32683a555d7541063ae7a935fa42<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L769" class="blob-num js-line-number" data-line-number="769"></td>
+        <td id="LC769" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L770" class="blob-num js-line-number" data-line-number="770"></td>
+        <td id="LC770" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>seqinr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.4-5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L771" class="blob-num js-line-number" data-line-number="771"></td>
+        <td id="LC771" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>162a347495fd52cbb62e8187a4692e7c50b9fa62123c5ef98f2744c98a05fb9f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L772" class="blob-num js-line-number" data-line-number="772"></td>
+        <td id="LC772" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L773" class="blob-num js-line-number" data-line-number="773"></td>
+        <td id="LC773" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>LearnBayes<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.15<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L774" class="blob-num js-line-number" data-line-number="774"></td>
+        <td id="LC774" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>45c91114b4aaa0314feeb4311dbe78f5b75a3b76bb2d1ca0f8adb2e0f1cbe233<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L775" class="blob-num js-line-number" data-line-number="775"></td>
+        <td id="LC775" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L776" class="blob-num js-line-number" data-line-number="776"></td>
+        <td id="LC776" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>deldir<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-14<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L777" class="blob-num js-line-number" data-line-number="777"></td>
+        <td id="LC777" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>89d365a980ef8589971e5d311c6bd59fe32c48dbac8000a880b9655032c99289<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L778" class="blob-num js-line-number" data-line-number="778"></td>
+        <td id="LC778" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L779" class="blob-num js-line-number" data-line-number="779"></td>
+        <td id="LC779" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gmodels<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.16.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L780" class="blob-num js-line-number" data-line-number="780"></td>
+        <td id="LC780" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ab018894bdb376c5bd6bc4fbc4fe6e86590f4106795a586ef196fbb6699ec47d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L781" class="blob-num js-line-number" data-line-number="781"></td>
+        <td id="LC781" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L782" class="blob-num js-line-number" data-line-number="782"></td>
+        <td id="LC782" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>expm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.999-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L783" class="blob-num js-line-number" data-line-number="783"></td>
+        <td id="LC783" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>38f1e5bfa90f794486789695d0d9e49158c7eb9445dc171dd83dec3d8fa130d6<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L784" class="blob-num js-line-number" data-line-number="784"></td>
+        <td id="LC784" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L785" class="blob-num js-line-number" data-line-number="785"></td>
+        <td id="LC785" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>spData<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.8.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L786" class="blob-num js-line-number" data-line-number="786"></td>
+        <td id="LC786" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>64e389474bd45f39b2cdf4ba8e5bf872a6f52cbf83deca10111df1000e7b7951<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L787" class="blob-num js-line-number" data-line-number="787"></td>
+        <td id="LC787" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L788" class="blob-num js-line-number" data-line-number="788"></td>
+        <td id="LC788" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>spdep<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.7-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L789" class="blob-num js-line-number" data-line-number="789"></td>
+        <td id="LC789" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9643f1e509e0107c8f8d949b0a6cbb6a274c7ca1e9ba4d474ce42235696653c7<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L790" class="blob-num js-line-number" data-line-number="790"></td>
+        <td id="LC790" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L791" class="blob-num js-line-number" data-line-number="791"></td>
+        <td id="LC791" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>vegan<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.4-6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L792" class="blob-num js-line-number" data-line-number="792"></td>
+        <td id="LC792" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>dc9c1b0832835e1dd9e0ed3d9066e0834f4b15f2330f771f4abed72a48c6b59c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L793" class="blob-num js-line-number" data-line-number="793"></td>
+        <td id="LC793" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L794" class="blob-num js-line-number" data-line-number="794"></td>
+        <td id="LC794" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>adegenet<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L795" class="blob-num js-line-number" data-line-number="795"></td>
+        <td id="LC795" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3043fe5d731a38ff0e266f090dcda448640c3d0fd61934c76da32d082e5dce7a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L796" class="blob-num js-line-number" data-line-number="796"></td>
+        <td id="LC796" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L797" class="blob-num js-line-number" data-line-number="797"></td>
+        <td id="LC797" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>prettyunits<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L798" class="blob-num js-line-number" data-line-number="798"></td>
+        <td id="LC798" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>35a4980586c20650538ae1e4fed4d80fdde3f212b98546fc3c7d9469a1207f5c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L799" class="blob-num js-line-number" data-line-number="799"></td>
+        <td id="LC799" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L800" class="blob-num js-line-number" data-line-number="800"></td>
+        <td id="LC800" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>progress<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L801" class="blob-num js-line-number" data-line-number="801"></td>
+        <td id="LC801" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a9f4abfd9579b80967cd681041643fe9dfcc4eb3beeba45391bb64e9209baabb<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L802" class="blob-num js-line-number" data-line-number="802"></td>
+        <td id="LC802" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L803" class="blob-num js-line-number" data-line-number="803"></td>
+        <td id="LC803" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rncl<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.8.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L804" class="blob-num js-line-number" data-line-number="804"></td>
+        <td id="LC804" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>80e1aa00cab4af0093198d0d902c973eb31dbdf4628e229ee9c136a9cc9c369e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L805" class="blob-num js-line-number" data-line-number="805"></td>
+        <td id="LC805" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L806" class="blob-num js-line-number" data-line-number="806"></td>
+        <td id="LC806" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>XML<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.98-1.10<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L807" class="blob-num js-line-number" data-line-number="807"></td>
+        <td id="LC807" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a19e04178e420c0cbf8a2d55513ea568c7c13aa53a6c1f1c3de652ba56525fb9<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L808" class="blob-num js-line-number" data-line-number="808"></td>
+        <td id="LC808" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L809" class="blob-num js-line-number" data-line-number="809"></td>
+        <td id="LC809" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>praise<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L810" class="blob-num js-line-number" data-line-number="810"></td>
+        <td id="LC810" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5c035e74fd05dfa59b03afe0d5f4c53fbf34144e175e90c53d09c6baedf5debd<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L811" class="blob-num js-line-number" data-line-number="811"></td>
+        <td id="LC811" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L812" class="blob-num js-line-number" data-line-number="812"></td>
+        <td id="LC812" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>withr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L813" class="blob-num js-line-number" data-line-number="813"></td>
+        <td id="LC813" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>bd5fae3846b8f89081a0991375402266dccf49bfa5d614690deea1b03ba5eb9e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L814" class="blob-num js-line-number" data-line-number="814"></td>
+        <td id="LC814" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L815" class="blob-num js-line-number" data-line-number="815"></td>
+        <td id="LC815" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>testthat<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L816" class="blob-num js-line-number" data-line-number="816"></td>
+        <td id="LC816" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3bc047ad1c4522104023d4fbbfc9aceed14d316fdb16865a514f26b3e628b494<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L817" class="blob-num js-line-number" data-line-number="817"></td>
+        <td id="LC817" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L818" class="blob-num js-line-number" data-line-number="818"></td>
+        <td id="LC818" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rprojroot<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L819" class="blob-num js-line-number" data-line-number="819"></td>
+        <td id="LC819" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>df5665834941d8b0e377a8810a04f98552201678300f168de5f58a587b73238b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L820" class="blob-num js-line-number" data-line-number="820"></td>
+        <td id="LC820" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L821" class="blob-num js-line-number" data-line-number="821"></td>
+        <td id="LC821" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rmarkdown<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.9<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L822" class="blob-num js-line-number" data-line-number="822"></td>
+        <td id="LC822" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>cbb7da80b514c148b48b8d4b6d497ec8edf6d2f6be3c483c836eec99e19a0673<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L823" class="blob-num js-line-number" data-line-number="823"></td>
+        <td id="LC823" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L824" class="blob-num js-line-number" data-line-number="824"></td>
+        <td id="LC824" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>openssl<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L825" class="blob-num js-line-number" data-line-number="825"></td>
+        <td id="LC825" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>605c05868e26c5d3cbea9748d400371612bcf082322b1cea5c08397e5fa1d8e3<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L826" class="blob-num js-line-number" data-line-number="826"></td>
+        <td id="LC826" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L827" class="blob-num js-line-number" data-line-number="827"></td>
+        <td id="LC827" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>httr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L828" class="blob-num js-line-number" data-line-number="828"></td>
+        <td id="LC828" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>22134d7426b2eba37f0cc34b99285499b8bac9fe75a7bc3222fbad179bf8f258<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L829" class="blob-num js-line-number" data-line-number="829"></td>
+        <td id="LC829" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L830" class="blob-num js-line-number" data-line-number="830"></td>
+        <td id="LC830" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>reshape<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.8.7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L831" class="blob-num js-line-number" data-line-number="831"></td>
+        <td id="LC831" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2fa6c87d1e89f182e51bc5a4fcda3d42d83b8fb4474ca525fa7a8db5081f3992<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L832" class="blob-num js-line-number" data-line-number="832"></td>
+        <td id="LC832" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L833" class="blob-num js-line-number" data-line-number="833"></td>
+        <td id="LC833" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>xml2<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L834" class="blob-num js-line-number" data-line-number="834"></td>
+        <td id="LC834" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>0a7a916fe9c5da9ac45aeb4c6b6b25d33c07652d422b9f2bb570f2e8f4ac9494<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L835" class="blob-num js-line-number" data-line-number="835"></td>
+        <td id="LC835" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L836" class="blob-num js-line-number" data-line-number="836"></td>
+        <td id="LC836" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>triebeard<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L837" class="blob-num js-line-number" data-line-number="837"></td>
+        <td id="LC837" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>bf1dd6209cea1aab24e21a85375ca473ad11c2eff400d65c6202c0fb4ef91ec3<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L838" class="blob-num js-line-number" data-line-number="838"></td>
+        <td id="LC838" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L839" class="blob-num js-line-number" data-line-number="839"></td>
+        <td id="LC839" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>urltools<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.7.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L840" class="blob-num js-line-number" data-line-number="840"></td>
+        <td id="LC840" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b4272fce4de28c6abb15ff6c192a889cf99d96a777fcb19de712b94c2429bb4f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L841" class="blob-num js-line-number" data-line-number="841"></td>
+        <td id="LC841" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L842" class="blob-num js-line-number" data-line-number="842"></td>
+        <td id="LC842" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>httpcode<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L843" class="blob-num js-line-number" data-line-number="843"></td>
+        <td id="LC843" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fbc1853db742a2cc1df11285cf27ce2ea43bc0ba5f7d393ee96c7e0ee328681a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L844" class="blob-num js-line-number" data-line-number="844"></td>
+        <td id="LC844" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L845" class="blob-num js-line-number" data-line-number="845"></td>
+        <td id="LC845" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>crul<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.5.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L846" class="blob-num js-line-number" data-line-number="846"></td>
+        <td id="LC846" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e01b25606dd113941537a9399d90370fa8de133ae7b2d8c82aa8979525dad269<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L847" class="blob-num js-line-number" data-line-number="847"></td>
+        <td id="LC847" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L848" class="blob-num js-line-number" data-line-number="848"></td>
+        <td id="LC848" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bold<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.5.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L849" class="blob-num js-line-number" data-line-number="849"></td>
+        <td id="LC849" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f40963b847667cf8d69ba7ba3bd479bc117e1bc4df8bd1482a975dadff58b53d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L850" class="blob-num js-line-number" data-line-number="850"></td>
+        <td id="LC850" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L851" class="blob-num js-line-number" data-line-number="851"></td>
+        <td id="LC851" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rredlist<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L852" class="blob-num js-line-number" data-line-number="852"></td>
+        <td id="LC852" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9e59d3c5830322ed85762bbb3273b59befe59c3feabfe7d2f32de96fc4525048<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L853" class="blob-num js-line-number" data-line-number="853"></td>
+        <td id="LC853" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L854" class="blob-num js-line-number" data-line-number="854"></td>
+        <td id="LC854" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rentrez<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L855" class="blob-num js-line-number" data-line-number="855"></td>
+        <td id="LC855" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>74cf6dbe1b229518c25221534b20437b53cb663f1473cf9df5a59ca76b76ae84<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L856" class="blob-num js-line-number" data-line-number="856"></td>
+        <td id="LC856" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L857" class="blob-num js-line-number" data-line-number="857"></td>
+        <td id="LC857" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rotl<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.0.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L858" class="blob-num js-line-number" data-line-number="858"></td>
+        <td id="LC858" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>049a417ee10203339b3543fd97116b59de467344493f234d0d01c4b6ad7fd75d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L859" class="blob-num js-line-number" data-line-number="859"></td>
+        <td id="LC859" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L860" class="blob-num js-line-number" data-line-number="860"></td>
+        <td id="LC860" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>solrium<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L861" class="blob-num js-line-number" data-line-number="861"></td>
+        <td id="LC861" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>0e362d4f3b700997bc417ea3ca21301ddbd7978ab3394affbe6861eb27308ee6<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L862" class="blob-num js-line-number" data-line-number="862"></td>
+        <td id="LC862" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L863" class="blob-num js-line-number" data-line-number="863"></td>
+        <td id="LC863" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ritis<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.7.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L864" class="blob-num js-line-number" data-line-number="864"></td>
+        <td id="LC864" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>bb3a3243f83083e7dd874624e8dfb57953c8aea38df16b3e5c0163857e875d38<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L865" class="blob-num js-line-number" data-line-number="865"></td>
+        <td id="LC865" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L866" class="blob-num js-line-number" data-line-number="866"></td>
+        <td id="LC866" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>worrms<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L867" class="blob-num js-line-number" data-line-number="867"></td>
+        <td id="LC867" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>66f6238988b3deeecc1dee628979727c98b3db072b046e316ff8962192141bd7<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L868" class="blob-num js-line-number" data-line-number="868"></td>
+        <td id="LC868" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L869" class="blob-num js-line-number" data-line-number="869"></td>
+        <td id="LC869" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>natserv<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L870" class="blob-num js-line-number" data-line-number="870"></td>
+        <td id="LC870" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>07501608a2e79b20940cd0e22aca9db6150942eed5b6dad184ec957e153d8e63<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L871" class="blob-num js-line-number" data-line-number="871"></td>
+        <td id="LC871" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L872" class="blob-num js-line-number" data-line-number="872"></td>
+        <td id="LC872" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>WikipediR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L873" class="blob-num js-line-number" data-line-number="873"></td>
+        <td id="LC873" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f8d0e6f04fb65f7ad9c1c068852a6a8b699ffe8d39edf1f3fa07d32d087e8ff0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L874" class="blob-num js-line-number" data-line-number="874"></td>
+        <td id="LC874" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L875" class="blob-num js-line-number" data-line-number="875"></td>
+        <td id="LC875" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>WikidataR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L876" class="blob-num js-line-number" data-line-number="876"></td>
+        <td id="LC876" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>64b1d53d7023249b73a77a7146adc3a8957b7bf3d808ebd6734795e9f58f4b2a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L877" class="blob-num js-line-number" data-line-number="877"></td>
+        <td id="LC877" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L878" class="blob-num js-line-number" data-line-number="878"></td>
+        <td id="LC878" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>wikitaxa<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L879" class="blob-num js-line-number" data-line-number="879"></td>
+        <td id="LC879" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>944523717b2571af02a6bf15a58100dfb69530f702ab919f1c5fd3d263588c19<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L880" class="blob-num js-line-number" data-line-number="880"></td>
+        <td id="LC880" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L881" class="blob-num js-line-number" data-line-number="881"></td>
+        <td id="LC881" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>taxize<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.9.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L882" class="blob-num js-line-number" data-line-number="882"></td>
+        <td id="LC882" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>15aacbdd61a77b27a6faa8e0c6fd05b2e96cba51eb94cefd623f29428c4cbb97<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L883" class="blob-num js-line-number" data-line-number="883"></td>
+        <td id="LC883" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L884" class="blob-num js-line-number" data-line-number="884"></td>
+        <td id="LC884" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>uuid<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L885" class="blob-num js-line-number" data-line-number="885"></td>
+        <td id="LC885" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>dd71704dc336b0857981b92a75ed9877d4ca47780b1682def28839304cd3b1be<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L886" class="blob-num js-line-number" data-line-number="886"></td>
+        <td id="LC886" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L887" class="blob-num js-line-number" data-line-number="887"></td>
+        <td id="LC887" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RNeXML<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0.8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L888" class="blob-num js-line-number" data-line-number="888"></td>
+        <td id="LC888" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b2bc118a3982866d12aa880823a17e0247915a0fa265163a383bc26981d96d46<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L889" class="blob-num js-line-number" data-line-number="889"></td>
+        <td id="LC889" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L890" class="blob-num js-line-number" data-line-number="890"></td>
+        <td id="LC890" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>phylobase<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.8.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L891" class="blob-num js-line-number" data-line-number="891"></td>
+        <td id="LC891" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d7c1a972c266ffe80345c7150608a85e6e2def4a3f079ac964ad9dbce2281002<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L892" class="blob-num js-line-number" data-line-number="892"></td>
+        <td id="LC892" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L893" class="blob-num js-line-number" data-line-number="893"></td>
+        <td id="LC893" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>adephylo<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1-11<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L894" class="blob-num js-line-number" data-line-number="894"></td>
+        <td id="LC894" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>154bf2645eac4493b85877933b9445442524ca4891aefe4e80c294c398cff61a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L895" class="blob-num js-line-number" data-line-number="895"></td>
+        <td id="LC895" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L896" class="blob-num js-line-number" data-line-number="896"></td>
+        <td id="LC896" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>animation<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L897" class="blob-num js-line-number" data-line-number="897"></td>
+        <td id="LC897" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b232fef1b318c79710e5e1923d87baba4c85ffe2c77ddb188130e0911d8cb55f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L898" class="blob-num js-line-number" data-line-number="898"></td>
+        <td id="LC898" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L899" class="blob-num js-line-number" data-line-number="899"></td>
+        <td id="LC899" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bigmemory.sri<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L900" class="blob-num js-line-number" data-line-number="900"></td>
+        <td id="LC900" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>55403252d8bae9627476d1f553236ea5dc7aa6e54da6980526a6cdc66924e155<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L901" class="blob-num js-line-number" data-line-number="901"></td>
+        <td id="LC901" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L902" class="blob-num js-line-number" data-line-number="902"></td>
+        <td id="LC902" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bigmemory<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>4.5.33<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L903" class="blob-num js-line-number" data-line-number="903"></td>
+        <td id="LC903" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [</td>
+      </tr>
+      <tr>
+        <td id="L904" class="blob-num js-line-number" data-line-number="904"></td>
+        <td id="LC904" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>7237d9785d8ce3eab4e36ad3ce2c95cbae926326031661b4f237b7517f4b9479<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> bigmemory_4.5.33.tar.gz</span></td>
+      </tr>
+      <tr>
+        <td id="L905" class="blob-num js-line-number" data-line-number="905"></td>
+        <td id="LC905" class="blob-code blob-code-inner js-file-line">        ],</td>
+      </tr>
+      <tr>
+        <td id="L906" class="blob-num js-line-number" data-line-number="906"></td>
+        <td id="LC906" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L907" class="blob-num js-line-number" data-line-number="907"></td>
+        <td id="LC907" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>calibrate<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.7.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L908" class="blob-num js-line-number" data-line-number="908"></td>
+        <td id="LC908" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>78066a564f57f2110f1752d681d6b97915cf73135134330587fff8b46c581604<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L909" class="blob-num js-line-number" data-line-number="909"></td>
+        <td id="LC909" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L910" class="blob-num js-line-number" data-line-number="910"></td>
+        <td id="LC910" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>clusterGeneration<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L911" class="blob-num js-line-number" data-line-number="911"></td>
+        <td id="LC911" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7c591ad95a8a9d7fb0e4d5d80dfd78f7d6a63cf7d11eb53dd3c98fdfb5b868aa<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L912" class="blob-num js-line-number" data-line-number="912"></td>
+        <td id="LC912" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L913" class="blob-num js-line-number" data-line-number="913"></td>
+        <td id="LC913" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>raster<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.6-7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L914" class="blob-num js-line-number" data-line-number="914"></td>
+        <td id="LC914" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fb91804fd465a4a6d9d9858e29fd05f41a99b8efdcc5cf4370ea253b68e42b01<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L915" class="blob-num js-line-number" data-line-number="915"></td>
+        <td id="LC915" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L916" class="blob-num js-line-number" data-line-number="916"></td>
+        <td id="LC916" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>dismo<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L917" class="blob-num js-line-number" data-line-number="917"></td>
+        <td id="LC917" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f2110f716cd9e4cca5fd2b22130c6954658aaf61361d2fe688ba22bbfdfa97c8<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L918" class="blob-num js-line-number" data-line-number="918"></td>
+        <td id="LC918" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L919" class="blob-num js-line-number" data-line-number="919"></td>
+        <td id="LC919" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>extrafontdb<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L920" class="blob-num js-line-number" data-line-number="920"></td>
+        <td id="LC920" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>faa1bafee5d4fbc24d03ed237f29f1179964ebac6e3a46ac25b0eceda020b684<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L921" class="blob-num js-line-number" data-line-number="921"></td>
+        <td id="LC921" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L922" class="blob-num js-line-number" data-line-number="922"></td>
+        <td id="LC922" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Rttf2pt1<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L923" class="blob-num js-line-number" data-line-number="923"></td>
+        <td id="LC923" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>4eb1f3e0e5bcb11f8e2f6fa7d5ecb3410287291ba538f615872ab78fac20f1a2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L924" class="blob-num js-line-number" data-line-number="924"></td>
+        <td id="LC924" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L925" class="blob-num js-line-number" data-line-number="925"></td>
+        <td id="LC925" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>extrafont<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.17<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L926" class="blob-num js-line-number" data-line-number="926"></td>
+        <td id="LC926" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2f6d7d79a890424b56ddbdced361f8b9ddede5edd33e090b816b88a99315332d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L927" class="blob-num js-line-number" data-line-number="927"></td>
+        <td id="LC927" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L928" class="blob-num js-line-number" data-line-number="928"></td>
+        <td id="LC928" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>fields<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>9.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L929" class="blob-num js-line-number" data-line-number="929"></td>
+        <td id="LC929" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>410424d74861ad0ba16f26e2b44bd63a9b590a190cc98c048dac55891422ffec<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L930" class="blob-num js-line-number" data-line-number="930"></td>
+        <td id="LC930" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L931" class="blob-num js-line-number" data-line-number="931"></td>
+        <td id="LC931" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>shapefiles<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L932" class="blob-num js-line-number" data-line-number="932"></td>
+        <td id="LC932" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>eeb18ea4165119519a978d4a2ba1ecbb47649deb96a7f617f5b3100d63b3f021<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L933" class="blob-num js-line-number" data-line-number="933"></td>
+        <td id="LC933" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L934" class="blob-num js-line-number" data-line-number="934"></td>
+        <td id="LC934" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>fossil<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3.7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L935" class="blob-num js-line-number" data-line-number="935"></td>
+        <td id="LC935" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3feba6ceecaa6f2f68fdc1ceb0019395ccfadb0cf033e1709dddb690c7f210a1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L936" class="blob-num js-line-number" data-line-number="936"></td>
+        <td id="LC936" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L937" class="blob-num js-line-number" data-line-number="937"></td>
+        <td id="LC937" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>geiger<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L938" class="blob-num js-line-number" data-line-number="938"></td>
+        <td id="LC938" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e13b2c526378eaf9356b00bbe21b3c2c956327f8062fed638ccc1f49591c3eff<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L939" class="blob-num js-line-number" data-line-number="939"></td>
+        <td id="LC939" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L940" class="blob-num js-line-number" data-line-number="940"></td>
+        <td id="LC940" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>glmnet<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0-13<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L941" class="blob-num js-line-number" data-line-number="941"></td>
+        <td id="LC941" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f3288dcaddb2f7014d42b755bede6563f73c17bc87f8292c2ef7776cb9b9b8fd<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L942" class="blob-num js-line-number" data-line-number="942"></td>
+        <td id="LC942" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L943" class="blob-num js-line-number" data-line-number="943"></td>
+        <td id="LC943" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>crosstalk<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L944" class="blob-num js-line-number" data-line-number="944"></td>
+        <td id="LC944" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b31eada24cac26f24c9763d9a8cbe0adfd87b264cf57f8725027fe0c7742ca51<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L945" class="blob-num js-line-number" data-line-number="945"></td>
+        <td id="LC945" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L946" class="blob-num js-line-number" data-line-number="946"></td>
+        <td id="LC946" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rgl<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.99.9<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L947" class="blob-num js-line-number" data-line-number="947"></td>
+        <td id="LC947" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b5bdc24ba7f86b940158ad72ac9069e7b80067f103493fc916a6af3a007e64e7<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L948" class="blob-num js-line-number" data-line-number="948"></td>
+        <td id="LC948" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L949" class="blob-num js-line-number" data-line-number="949"></td>
+        <td id="LC949" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>labdsv<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.8-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L950" class="blob-num js-line-number" data-line-number="950"></td>
+        <td id="LC950" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>dfaeb03a6e1bab6cfd384c00671235b22f2b4254cac1129b24a348cb353b6e65<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L951" class="blob-num js-line-number" data-line-number="951"></td>
+        <td id="LC951" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L952" class="blob-num js-line-number" data-line-number="952"></td>
+        <td id="LC952" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>stabs<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6-3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L953" class="blob-num js-line-number" data-line-number="953"></td>
+        <td id="LC953" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e961ae21d45babc1162b6eeda874c4e3677fc286fd06f5427f071ad7a5064a9f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L954" class="blob-num js-line-number" data-line-number="954"></td>
+        <td id="LC954" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L955" class="blob-num js-line-number" data-line-number="955"></td>
+        <td id="LC955" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>modeltools<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2-21<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L956" class="blob-num js-line-number" data-line-number="956"></td>
+        <td id="LC956" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>07b331475625674ab00e6ddfc479cbdbf0b22d5d237e8c25d83ddf3e0ad1cd7a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L957" class="blob-num js-line-number" data-line-number="957"></td>
+        <td id="LC957" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L958" class="blob-num js-line-number" data-line-number="958"></td>
+        <td id="LC958" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>strucchange<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L959" class="blob-num js-line-number" data-line-number="959"></td>
+        <td id="LC959" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>740e2e20477b9fceeef767ae1002adc5ec397cb0f7daba5289a2c23b0dddaf31<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L960" class="blob-num js-line-number" data-line-number="960"></td>
+        <td id="LC960" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L961" class="blob-num js-line-number" data-line-number="961"></td>
+        <td id="LC961" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>TH.data<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0-8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L962" class="blob-num js-line-number" data-line-number="962"></td>
+        <td id="LC962" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>478f109fcc1226500ead8e3bd6e047cecde2294fde4df8ec216d38313db79a9d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L963" class="blob-num js-line-number" data-line-number="963"></td>
+        <td id="LC963" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L964" class="blob-num js-line-number" data-line-number="964"></td>
+        <td id="LC964" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>multcomp<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4-8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L965" class="blob-num js-line-number" data-line-number="965"></td>
+        <td id="LC965" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a20876619312310e9523d67e9090af501383ce49dc6113c6b4ca30f9c943a73a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L966" class="blob-num js-line-number" data-line-number="966"></td>
+        <td id="LC966" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L967" class="blob-num js-line-number" data-line-number="967"></td>
+        <td id="LC967" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>coin<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L968" class="blob-num js-line-number" data-line-number="968"></td>
+        <td id="LC968" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d518065d3e1eb00121cb4e0200e1e4ae6b68eca6e249afc38bbffa35d24105bb<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L969" class="blob-num js-line-number" data-line-number="969"></td>
+        <td id="LC969" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L970" class="blob-num js-line-number" data-line-number="970"></td>
+        <td id="LC970" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>party<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L971" class="blob-num js-line-number" data-line-number="971"></td>
+        <td id="LC971" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6c1d3ee9ce6f1ce8e33eefc3d28a504406be6470cac4da6dd4aab09166ff2182<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L972" class="blob-num js-line-number" data-line-number="972"></td>
+        <td id="LC972" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L973" class="blob-num js-line-number" data-line-number="973"></td>
+        <td id="LC973" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>mboost<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.8-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L974" class="blob-num js-line-number" data-line-number="974"></td>
+        <td id="LC974" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>96a8b7daf5c6bc9240ad2e398867834ec18918c6cbdf64804ddc100a9b717798<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L975" class="blob-num js-line-number" data-line-number="975"></td>
+        <td id="LC975" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L976" class="blob-num js-line-number" data-line-number="976"></td>
+        <td id="LC976" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>msm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.6.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L977" class="blob-num js-line-number" data-line-number="977"></td>
+        <td id="LC977" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fd12512d3cdca5fab634bf6222d896482bd1876192939da475f251b3a873a71a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L978" class="blob-num js-line-number" data-line-number="978"></td>
+        <td id="LC978" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L979" class="blob-num js-line-number" data-line-number="979"></td>
+        <td id="LC979" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>nor1mix<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L980" class="blob-num js-line-number" data-line-number="980"></td>
+        <td id="LC980" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>435e6519e832ef5229c51ccb2619640e6b50dfc7470f70f0c938d18a114273af<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L981" class="blob-num js-line-number" data-line-number="981"></td>
+        <td id="LC981" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L982" class="blob-num js-line-number" data-line-number="982"></td>
+        <td id="LC982" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>np<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.60-6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L983" class="blob-num js-line-number" data-line-number="983"></td>
+        <td id="LC983" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>59c37424161cfac331d1c8b6feec747010445f18f3c72e3c7bac269964e9e2f8<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L984" class="blob-num js-line-number" data-line-number="984"></td>
+        <td id="LC984" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L985" class="blob-num js-line-number" data-line-number="985"></td>
+        <td id="LC985" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>polynom<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3-9<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L986" class="blob-num js-line-number" data-line-number="986"></td>
+        <td id="LC986" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d35a50925cc5552a6aac0816a91dbc03e9fd77da47e06d27572fde9dcbee9de8<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L987" class="blob-num js-line-number" data-line-number="987"></td>
+        <td id="LC987" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L988" class="blob-num js-line-number" data-line-number="988"></td>
+        <td id="LC988" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>polspline<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.12<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L989" class="blob-num js-line-number" data-line-number="989"></td>
+        <td id="LC989" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fc6bd2e0cca8c13cf099c54fe1e740730e26bb9793d439c395cf16ec8c2b0f32<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L990" class="blob-num js-line-number" data-line-number="990"></td>
+        <td id="LC990" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L991" class="blob-num js-line-number" data-line-number="991"></td>
+        <td id="LC991" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rms<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>5.1-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L992" class="blob-num js-line-number" data-line-number="992"></td>
+        <td id="LC992" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f1cfeef466ac436105756679353a3468027d97a600e3be755b819aef30ed9207<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L993" class="blob-num js-line-number" data-line-number="993"></td>
+        <td id="LC993" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L994" class="blob-num js-line-number" data-line-number="994"></td>
+        <td id="LC994" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RWekajars<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.9.2-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L995" class="blob-num js-line-number" data-line-number="995"></td>
+        <td id="LC995" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>0e6c00ea2a0798dec828a3a3eb61fbcf43da305f1664f62774fbdb8e473dd600<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L996" class="blob-num js-line-number" data-line-number="996"></td>
+        <td id="LC996" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L997" class="blob-num js-line-number" data-line-number="997"></td>
+        <td id="LC997" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RWeka<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4-37<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L998" class="blob-num js-line-number" data-line-number="998"></td>
+        <td id="LC998" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fc0a3bb09b9d4dfefd7c3ada038d5d6b03c5091e1206e88ef7f045c18f8f19e0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L999" class="blob-num js-line-number" data-line-number="999"></td>
+        <td id="LC999" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1000" class="blob-num js-line-number" data-line-number="1000"></td>
+        <td id="LC1000" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>slam<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-42<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1001" class="blob-num js-line-number" data-line-number="1001"></td>
+        <td id="LC1001" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7206b0189544c9878b83005f80f89626cc2c53cfe3e640aeaa9c3da1f07675df<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1002" class="blob-num js-line-number" data-line-number="1002"></td>
+        <td id="LC1002" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1003" class="blob-num js-line-number" data-line-number="1003"></td>
+        <td id="LC1003" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.7-3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1004" class="blob-num js-line-number" data-line-number="1004"></td>
+        <td id="LC1004" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f3c3e151e621ffb0c82048b5bf9c2a34c8fb34cf5d2943544979b4fcc2cc1c11<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1005" class="blob-num js-line-number" data-line-number="1005"></td>
+        <td id="LC1005" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1006" class="blob-num js-line-number" data-line-number="1006"></td>
+        <td id="LC1006" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>TraMineR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0-8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1007" class="blob-num js-line-number" data-line-number="1007"></td>
+        <td id="LC1007" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>394d4481707dfd8a4b0e28681097948ab36934dbe4084cf0917ae5f3e0bb9774<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1008" class="blob-num js-line-number" data-line-number="1008"></td>
+        <td id="LC1008" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1009" class="blob-num js-line-number" data-line-number="1009"></td>
+        <td id="LC1009" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>chemometrics<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1010" class="blob-num js-line-number" data-line-number="1010"></td>
+        <td id="LC1010" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b705832fa167dc24b52b642f571ed1efd24c5f53ba60d02c7797986481b6186a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1011" class="blob-num js-line-number" data-line-number="1011"></td>
+        <td id="LC1011" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1012" class="blob-num js-line-number" data-line-number="1012"></td>
+        <td id="LC1012" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>FNN<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1013" class="blob-num js-line-number" data-line-number="1013"></td>
+        <td id="LC1013" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b2a2e97af14aa50ef4dce15a170e1d7329aebb7643bab4a6cf35609555acccce<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1014" class="blob-num js-line-number" data-line-number="1014"></td>
+        <td id="LC1014" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1015" class="blob-num js-line-number" data-line-number="1015"></td>
+        <td id="LC1015" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ipred<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.9-6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1016" class="blob-num js-line-number" data-line-number="1016"></td>
+        <td id="LC1016" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b8d36438eb9b7209d27b85738dcad03b2e535dcb2f4191432780d9cbf00d3cef<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1017" class="blob-num js-line-number" data-line-number="1017"></td>
+        <td id="LC1017" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1018" class="blob-num js-line-number" data-line-number="1018"></td>
+        <td id="LC1018" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>statmod<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4.30<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1019" class="blob-num js-line-number" data-line-number="1019"></td>
+        <td id="LC1019" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9d2c1722a85f53623a9ee9f73d835119ae22ae2b8ec7b50d675401e314ea641f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1020" class="blob-num js-line-number" data-line-number="1020"></td>
+        <td id="LC1020" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1021" class="blob-num js-line-number" data-line-number="1021"></td>
+        <td id="LC1021" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>miscTools<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6-22<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1022" class="blob-num js-line-number" data-line-number="1022"></td>
+        <td id="LC1022" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d00bb2602d1d31e9e1e13c8868cfe69d432bbe15afa8d4bbb83b3c9e0b9dcfea<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1023" class="blob-num js-line-number" data-line-number="1023"></td>
+        <td id="LC1023" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1024" class="blob-num js-line-number" data-line-number="1024"></td>
+        <td id="LC1024" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>maxLik<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1025" class="blob-num js-line-number" data-line-number="1025"></td>
+        <td id="LC1025" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>181ab87721b1e6e3859c60d12eea2f67a7135bfa679db73c20a9ef76d82c4b4a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1026" class="blob-num js-line-number" data-line-number="1026"></td>
+        <td id="LC1026" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1027" class="blob-num js-line-number" data-line-number="1027"></td>
+        <td id="LC1027" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>mlogit<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1028" class="blob-num js-line-number" data-line-number="1028"></td>
+        <td id="LC1028" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5d9f5d20efd9d654e15875d813d9da3e756c7b8f25d8bb1f5d689a128fa7cd96<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1029" class="blob-num js-line-number" data-line-number="1029"></td>
+        <td id="LC1029" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1030" class="blob-num js-line-number" data-line-number="1030"></td>
+        <td id="LC1030" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>getopt<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.20.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1031" class="blob-num js-line-number" data-line-number="1031"></td>
+        <td id="LC1031" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3d6c12d32d6cd4b2909be626e570e158b3ed960e4739510e3a251e7f172de38e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1032" class="blob-num js-line-number" data-line-number="1032"></td>
+        <td id="LC1032" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1033" class="blob-num js-line-number" data-line-number="1033"></td>
+        <td id="LC1033" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gsalib<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1034" class="blob-num js-line-number" data-line-number="1034"></td>
+        <td id="LC1034" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e1b23b986c18b89a94c58d9db45e552d1bce484300461803740dacdf7c937fcc<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1035" class="blob-num js-line-number" data-line-number="1035"></td>
+        <td id="LC1035" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1036" class="blob-num js-line-number" data-line-number="1036"></td>
+        <td id="LC1036" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>optparse<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1037" class="blob-num js-line-number" data-line-number="1037"></td>
+        <td id="LC1037" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>0b1f1d336f1be386260fb5bbdf74f01787c09176d69febf8d563e5af75e5c4b9<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1038" class="blob-num js-line-number" data-line-number="1038"></td>
+        <td id="LC1038" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1039" class="blob-num js-line-number" data-line-number="1039"></td>
+        <td id="LC1039" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>miniUI<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1040" class="blob-num js-line-number" data-line-number="1040"></td>
+        <td id="LC1040" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9c92032071ee75ee9c26c4cfd3115877fbcb15de2fd2023109c670784b51cce1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1041" class="blob-num js-line-number" data-line-number="1041"></td>
+        <td id="LC1041" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1042" class="blob-num js-line-number" data-line-number="1042"></td>
+        <td id="LC1042" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>hms<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1043" class="blob-num js-line-number" data-line-number="1043"></td>
+        <td id="LC1043" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a57820b3e3221e973cba9500b4ad7953730110ee398693d150af833f26d5d0bc<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1044" class="blob-num js-line-number" data-line-number="1044"></td>
+        <td id="LC1044" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1045" class="blob-num js-line-number" data-line-number="1045"></td>
+        <td id="LC1045" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>readr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1046" class="blob-num js-line-number" data-line-number="1046"></td>
+        <td id="LC1046" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1a29b99009a06f2cee18d08bc6201fd4985b6d45c76cefca65084dcc1a2f7cb3<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1047" class="blob-num js-line-number" data-line-number="1047"></td>
+        <td id="LC1047" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1048" class="blob-num js-line-number" data-line-number="1048"></td>
+        <td id="LC1048" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>forcats<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1049" class="blob-num js-line-number" data-line-number="1049"></td>
+        <td id="LC1049" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>95814610ec18b8a8830eba63751954387f9d21400d6ab40394ed0ff22c0cb657<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1050" class="blob-num js-line-number" data-line-number="1050"></td>
+        <td id="LC1050" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1051" class="blob-num js-line-number" data-line-number="1051"></td>
+        <td id="LC1051" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>haven<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1052" class="blob-num js-line-number" data-line-number="1052"></td>
+        <td id="LC1052" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5f7bf6dbee431b4e64771d9d97ee2c3da5b8f66a5e81fd1ec78a236eb3de6cba<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1053" class="blob-num js-line-number" data-line-number="1053"></td>
+        <td id="LC1053" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1054" class="blob-num js-line-number" data-line-number="1054"></td>
+        <td id="LC1054" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>labelled<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1055" class="blob-num js-line-number" data-line-number="1055"></td>
+        <td id="LC1055" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9b7f1c5644f0e30496c291c84c52204b47d2b7da9aaefa332898aaae3226bfa2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1056" class="blob-num js-line-number" data-line-number="1056"></td>
+        <td id="LC1056" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1057" class="blob-num js-line-number" data-line-number="1057"></td>
+        <td id="LC1057" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>classInt<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-24<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1058" class="blob-num js-line-number" data-line-number="1058"></td>
+        <td id="LC1058" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f3dc9084450ea3da07e1ea5eeb097fd2fedc7e29e5d7794b418bcb438c4fcfa2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1059" class="blob-num js-line-number" data-line-number="1059"></td>
+        <td id="LC1059" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1060" class="blob-num js-line-number" data-line-number="1060"></td>
+        <td id="LC1060" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>questionr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1061" class="blob-num js-line-number" data-line-number="1061"></td>
+        <td id="LC1061" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1dcad3c980548352f3a775ec089359b3f7737762e97c2a97c9a39cda4de54f56<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1062" class="blob-num js-line-number" data-line-number="1062"></td>
+        <td id="LC1062" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1063" class="blob-num js-line-number" data-line-number="1063"></td>
+        <td id="LC1063" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>klaR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6-13<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1064" class="blob-num js-line-number" data-line-number="1064"></td>
+        <td id="LC1064" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>56b9689fc7ed5ece159056bcea181c9e670205a570095e76779a2a03d156171b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1065" class="blob-num js-line-number" data-line-number="1065"></td>
+        <td id="LC1065" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1066" class="blob-num js-line-number" data-line-number="1066"></td>
+        <td id="LC1066" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>neuRosim<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2-12<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1067" class="blob-num js-line-number" data-line-number="1067"></td>
+        <td id="LC1067" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f4f718c7bea2f4b61a914023015f4c71312f8a180124dcbc2327b71b7be256c3<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1068" class="blob-num js-line-number" data-line-number="1068"></td>
+        <td id="LC1068" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1069" class="blob-num js-line-number" data-line-number="1069"></td>
+        <td id="LC1069" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>locfit<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5-9.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1070" class="blob-num js-line-number" data-line-number="1070"></td>
+        <td id="LC1070" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f524148fdb29aac3a178618f88718d3d4ac91283014091aa11a01f1c70cd4e51<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1071" class="blob-num js-line-number" data-line-number="1071"></td>
+        <td id="LC1071" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1072" class="blob-num js-line-number" data-line-number="1072"></td>
+        <td id="LC1072" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>GGally<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1073" class="blob-num js-line-number" data-line-number="1073"></td>
+        <td id="LC1073" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f4143f45254fed794be991180aeffe459f6756bfa08acad963707d8e843cfd0a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1074" class="blob-num js-line-number" data-line-number="1074"></td>
+        <td id="LC1074" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1075" class="blob-num js-line-number" data-line-number="1075"></td>
+        <td id="LC1075" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>beanplot<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1076" class="blob-num js-line-number" data-line-number="1076"></td>
+        <td id="LC1076" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>49da299139a47171c5b4ccdea79ffbbc152894e05d552e676f135147c0c9b372<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1077" class="blob-num js-line-number" data-line-number="1077"></td>
+        <td id="LC1077" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1078" class="blob-num js-line-number" data-line-number="1078"></td>
+        <td id="LC1078" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>clValid<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6-6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1079" class="blob-num js-line-number" data-line-number="1079"></td>
+        <td id="LC1079" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c13ef1b6258e34ba53615b78f39dbe4d8ba47b976b3c24a3eedaecf5ffba19ed<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1080" class="blob-num js-line-number" data-line-number="1080"></td>
+        <td id="LC1080" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1081" class="blob-num js-line-number" data-line-number="1081"></td>
+        <td id="LC1081" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>matrixStats<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.53.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1082" class="blob-num js-line-number" data-line-number="1082"></td>
+        <td id="LC1082" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>df70bc9fb64716a7a633b5d0c2a2422b2c8d93ac5e64574528a325505df9712e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1083" class="blob-num js-line-number" data-line-number="1083"></td>
+        <td id="LC1083" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1084" class="blob-num js-line-number" data-line-number="1084"></td>
+        <td id="LC1084" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>DiscriMiner<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-29<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1085" class="blob-num js-line-number" data-line-number="1085"></td>
+        <td id="LC1085" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5aab7671086ef9940e030324651976456f0e84dab35edb7048693ade885228c6<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1086" class="blob-num js-line-number" data-line-number="1086"></td>
+        <td id="LC1086" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1087" class="blob-num js-line-number" data-line-number="1087"></td>
+        <td id="LC1087" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ellipse<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1088" class="blob-num js-line-number" data-line-number="1088"></td>
+        <td id="LC1088" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1a9a9c52195b26c2b4d51ad159ab98aff7aa8ca25fdc6b2198818d1a0adb023d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1089" class="blob-num js-line-number" data-line-number="1089"></td>
+        <td id="LC1089" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1090" class="blob-num js-line-number" data-line-number="1090"></td>
+        <td id="LC1090" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>leaps<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1091" class="blob-num js-line-number" data-line-number="1091"></td>
+        <td id="LC1091" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>55a879cdad5a4c9bc3b5697dd4d364b3a094a49d8facb6692f5ce6af82adf285<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1092" class="blob-num js-line-number" data-line-number="1092"></td>
+        <td id="LC1092" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1093" class="blob-num js-line-number" data-line-number="1093"></td>
+        <td id="LC1093" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>nloptr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1094" class="blob-num js-line-number" data-line-number="1094"></td>
+        <td id="LC1094" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>84225b993cb1ef7854edda9629858662cc8592b0d1344baadea4177486ece1eb<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1095" class="blob-num js-line-number" data-line-number="1095"></td>
+        <td id="LC1095" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1096" class="blob-num js-line-number" data-line-number="1096"></td>
+        <td id="LC1096" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>lme4<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1-15<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1097" class="blob-num js-line-number" data-line-number="1097"></td>
+        <td id="LC1097" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7d9fd6309aae9cfa691236b3841a60f88ec70110faf2c1dabcbdff18e1ce8669<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1098" class="blob-num js-line-number" data-line-number="1098"></td>
+        <td id="LC1098" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1099" class="blob-num js-line-number" data-line-number="1099"></td>
+        <td id="LC1099" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pbkrtest<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4-7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1100" class="blob-num js-line-number" data-line-number="1100"></td>
+        <td id="LC1100" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5cbb03ad2b2468720a5a610a0ebda48ac08119a34fca77810a85f554225c23ea<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1101" class="blob-num js-line-number" data-line-number="1101"></td>
+        <td id="LC1101" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1102" class="blob-num js-line-number" data-line-number="1102"></td>
+        <td id="LC1102" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>car<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1-6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1103" class="blob-num js-line-number" data-line-number="1103"></td>
+        <td id="LC1103" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d2426a66f63324d9db34dc89becb728d2d4b6d5f183f2efe02cbf683646a8492<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1104" class="blob-num js-line-number" data-line-number="1104"></td>
+        <td id="LC1104" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1105" class="blob-num js-line-number" data-line-number="1105"></td>
+        <td id="LC1105" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>flashClust<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.01-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1106" class="blob-num js-line-number" data-line-number="1106"></td>
+        <td id="LC1106" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>48a7849bb86530465ff3fbfac1c273f0df4b846e67d5eee87187d250c8bf9450<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1107" class="blob-num js-line-number" data-line-number="1107"></td>
+        <td id="LC1107" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1108" class="blob-num js-line-number" data-line-number="1108"></td>
+        <td id="LC1108" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>FactoMineR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.39<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1109" class="blob-num js-line-number" data-line-number="1109"></td>
+        <td id="LC1109" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b0bb1d6d7d1f3cb11a4b63c377321e10078a36f29bc78dfa3b80c7c149f4a08a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1110" class="blob-num js-line-number" data-line-number="1110"></td>
+        <td id="LC1110" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1111" class="blob-num js-line-number" data-line-number="1111"></td>
+        <td id="LC1111" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>flexclust<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3-5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1112" class="blob-num js-line-number" data-line-number="1112"></td>
+        <td id="LC1112" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>dbf49969c93a7b314d9dc3299a0764ed9a804ba7dcbdc08a1235f244f4b85059<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1113" class="blob-num js-line-number" data-line-number="1113"></td>
+        <td id="LC1113" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1114" class="blob-num js-line-number" data-line-number="1114"></td>
+        <td id="LC1114" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>flexmix<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.3-14<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1115" class="blob-num js-line-number" data-line-number="1115"></td>
+        <td id="LC1115" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>837c7f175a211b3c484b2c7b81ec9729889a614c5c6e7d70c95a2c1d60ff846a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1116" class="blob-num js-line-number" data-line-number="1116"></td>
+        <td id="LC1116" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1117" class="blob-num js-line-number" data-line-number="1117"></td>
+        <td id="LC1117" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>prabclus<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.2-6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1118" class="blob-num js-line-number" data-line-number="1118"></td>
+        <td id="LC1118" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>41792980e40ba18204fab92d85120dcd468860e2204e52fb42636c6f7aee5a62<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1119" class="blob-num js-line-number" data-line-number="1119"></td>
+        <td id="LC1119" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1120" class="blob-num js-line-number" data-line-number="1120"></td>
+        <td id="LC1120" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>diptest<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.75-7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1121" class="blob-num js-line-number" data-line-number="1121"></td>
+        <td id="LC1121" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>462900100ca598ef21dbe566bf1ab2ce7c49cdeab6b7a600a50489b05f61b61b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1122" class="blob-num js-line-number" data-line-number="1122"></td>
+        <td id="LC1122" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1123" class="blob-num js-line-number" data-line-number="1123"></td>
+        <td id="LC1123" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>trimcluster<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1124" class="blob-num js-line-number" data-line-number="1124"></td>
+        <td id="LC1124" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>622fb61580cc19b9061c6ee28ffd751250a127f07904b45a0e1c5438d25b4f53<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1125" class="blob-num js-line-number" data-line-number="1125"></td>
+        <td id="LC1125" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1126" class="blob-num js-line-number" data-line-number="1126"></td>
+        <td id="LC1126" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>fpc<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1-11<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1127" class="blob-num js-line-number" data-line-number="1127"></td>
+        <td id="LC1127" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5975b31b63ad1e7b9c081ae42414e3d4de7a45e1a80100c2931aae5716d65411<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1128" class="blob-num js-line-number" data-line-number="1128"></td>
+        <td id="LC1128" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1129" class="blob-num js-line-number" data-line-number="1129"></td>
+        <td id="LC1129" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>BiasedUrn<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.07<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1130" class="blob-num js-line-number" data-line-number="1130"></td>
+        <td id="LC1130" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2377c2e59d68e758a566452d7e07e88663ae61a182b9ee455d8b4269dda3228e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1131" class="blob-num js-line-number" data-line-number="1131"></td>
+        <td id="LC1131" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1132" class="blob-num js-line-number" data-line-number="1132"></td>
+        <td id="LC1132" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>TeachingDemos<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.10<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1133" class="blob-num js-line-number" data-line-number="1133"></td>
+        <td id="LC1133" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2ef4c2e36ba13e32f66000e84281a3616584c86b255bca8643ff3fe4f78ed704<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1134" class="blob-num js-line-number" data-line-number="1134"></td>
+        <td id="LC1134" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1135" class="blob-num js-line-number" data-line-number="1135"></td>
+        <td id="LC1135" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>kohonen<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.0.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1136" class="blob-num js-line-number" data-line-number="1136"></td>
+        <td id="LC1136" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [</td>
+      </tr>
+      <tr>
+        <td id="L1137" class="blob-num js-line-number" data-line-number="1137"></td>
+        <td id="LC1137" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>429864d72858c29d4187bed48ac1c17cf2ecb08f18090b6bf44dff55174609ab<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> kohonen_3.0.4.tar.gz</span></td>
+      </tr>
+      <tr>
+        <td id="L1138" class="blob-num js-line-number" data-line-number="1138"></td>
+        <td id="LC1138" class="blob-code blob-code-inner js-file-line">        ],</td>
+      </tr>
+      <tr>
+        <td id="L1139" class="blob-num js-line-number" data-line-number="1139"></td>
+        <td id="LC1139" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1140" class="blob-num js-line-number" data-line-number="1140"></td>
+        <td id="LC1140" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>base64<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1141" class="blob-num js-line-number" data-line-number="1141"></td>
+        <td id="LC1141" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>8e259c2b12446197d1152b83a81bab84ccb5a5b77021a9b5645dd4c63c804bd1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1142" class="blob-num js-line-number" data-line-number="1142"></td>
+        <td id="LC1142" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1143" class="blob-num js-line-number" data-line-number="1143"></td>
+        <td id="LC1143" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>doRNG<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.6.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1144" class="blob-num js-line-number" data-line-number="1144"></td>
+        <td id="LC1144" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>939c2282c72c0b89fc7510f4bff901a4e99007dc006f46762c8f594c0ecbd876<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1145" class="blob-num js-line-number" data-line-number="1145"></td>
+        <td id="LC1145" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1146" class="blob-num js-line-number" data-line-number="1146"></td>
+        <td id="LC1146" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>nleqslv<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.3.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1147" class="blob-num js-line-number" data-line-number="1147"></td>
+        <td id="LC1147" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>87eee7dad496539ede21bdb02bb0bc3793c9a390c000b0cd2bcd9b41ce5d3ad8<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1148" class="blob-num js-line-number" data-line-number="1148"></td>
+        <td id="LC1148" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1149" class="blob-num js-line-number" data-line-number="1149"></td>
+        <td id="LC1149" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Deriv<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.8.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1150" class="blob-num js-line-number" data-line-number="1150"></td>
+        <td id="LC1150" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>de4b7dfd4653dec9ae49987b8588c5ecfd7ef59081d9a1c55834da94bb5342d1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1151" class="blob-num js-line-number" data-line-number="1151"></td>
+        <td id="LC1151" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1152" class="blob-num js-line-number" data-line-number="1152"></td>
+        <td id="LC1152" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RGCCA<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1153" class="blob-num js-line-number" data-line-number="1153"></td>
+        <td id="LC1153" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>20f341fca8f616c556699790814debdf2ac7aa4dd9ace2071100c66af1549d7d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1154" class="blob-num js-line-number" data-line-number="1154"></td>
+        <td id="LC1154" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1155" class="blob-num js-line-number" data-line-number="1155"></td>
+        <td id="LC1155" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pheatmap<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1156" class="blob-num js-line-number" data-line-number="1156"></td>
+        <td id="LC1156" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>51468765380119c302ee9afd52d0483123c0670297f4b906edc79235939960c6<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1157" class="blob-num js-line-number" data-line-number="1157"></td>
+        <td id="LC1157" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1158" class="blob-num js-line-number" data-line-number="1158"></td>
+        <td id="LC1158" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>openxlsx<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>4.0.17<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1159" class="blob-num js-line-number" data-line-number="1159"></td>
+        <td id="LC1159" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>116b9829c5a85ab1b7368d9f7f34a2248436f54bbf6ad635186c8a70b5a204d7<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1160" class="blob-num js-line-number" data-line-number="1160"></td>
+        <td id="LC1160" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1161" class="blob-num js-line-number" data-line-number="1161"></td>
+        <td id="LC1161" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pvclust<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1162" class="blob-num js-line-number" data-line-number="1162"></td>
+        <td id="LC1162" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1a4615214992307fd7c786cf4607a3ae2af5c0d4067f5053e1c195798a70d741<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1163" class="blob-num js-line-number" data-line-number="1163"></td>
+        <td id="LC1163" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1164" class="blob-num js-line-number" data-line-number="1164"></td>
+        <td id="LC1164" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RCircos<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1165" class="blob-num js-line-number" data-line-number="1165"></td>
+        <td id="LC1165" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7fd06e2efc33b5c30fc4ba3945b04021f255ba4ffcc394348df7488b9394444a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1166" class="blob-num js-line-number" data-line-number="1166"></td>
+        <td id="LC1166" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1167" class="blob-num js-line-number" data-line-number="1167"></td>
+        <td id="LC1167" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>lambda.r<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1168" class="blob-num js-line-number" data-line-number="1168"></td>
+        <td id="LC1168" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7dc4188ce1d4a6b026a1b128719ff60234ae1e3ffa583941bbcd8473ad18146f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1169" class="blob-num js-line-number" data-line-number="1169"></td>
+        <td id="LC1169" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1170" class="blob-num js-line-number" data-line-number="1170"></td>
+        <td id="LC1170" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>futile.options<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1171" class="blob-num js-line-number" data-line-number="1171"></td>
+        <td id="LC1171" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ee84ece359397fbb63f145d11af678f5c8618570971e78cc64ac60dc0d14e8c2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1172" class="blob-num js-line-number" data-line-number="1172"></td>
+        <td id="LC1172" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1173" class="blob-num js-line-number" data-line-number="1173"></td>
+        <td id="LC1173" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>futile.logger<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1174" class="blob-num js-line-number" data-line-number="1174"></td>
+        <td id="LC1174" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5e8b32d65f77a86d17d90fd8690fc085aa0612df8018e4d6d6c1a60fa65776e4<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1175" class="blob-num js-line-number" data-line-number="1175"></td>
+        <td id="LC1175" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1176" class="blob-num js-line-number" data-line-number="1176"></td>
+        <td id="LC1176" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>VennDiagram<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.6.19<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1177" class="blob-num js-line-number" data-line-number="1177"></td>
+        <td id="LC1177" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c2baf466e072878643a28e971f11691dc830610ae8e7077d1adbd0be73e11338<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1178" class="blob-num js-line-number" data-line-number="1178"></td>
+        <td id="LC1178" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1179" class="blob-num js-line-number" data-line-number="1179"></td>
+        <td id="LC1179" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>xlsxjars<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1180" class="blob-num js-line-number" data-line-number="1180"></td>
+        <td id="LC1180" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>37c1517f95f8bca6e3514429394d2457b9e62383305eba288416fb53ab2e6ae6<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1181" class="blob-num js-line-number" data-line-number="1181"></td>
+        <td id="LC1181" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1182" class="blob-num js-line-number" data-line-number="1182"></td>
+        <td id="LC1182" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>xlsx<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.5.7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1183" class="blob-num js-line-number" data-line-number="1183"></td>
+        <td id="LC1183" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>36727bc330c281dab8a028fab2dde92d032345974b15e3dde920ee16dc6db363<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1184" class="blob-num js-line-number" data-line-number="1184"></td>
+        <td id="LC1184" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1185" class="blob-num js-line-number" data-line-number="1185"></td>
+        <td id="LC1185" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>forecast<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>8.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1186" class="blob-num js-line-number" data-line-number="1186"></td>
+        <td id="LC1186" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [</td>
+      </tr>
+      <tr>
+        <td id="L1187" class="blob-num js-line-number" data-line-number="1187"></td>
+        <td id="LC1187" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>eb3fab64ed139d068e7d026cd3880f1b623f4153a832fb71845488fa75e8b812<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> forecast_8.2.tar.gz</span></td>
+      </tr>
+      <tr>
+        <td id="L1188" class="blob-num js-line-number" data-line-number="1188"></td>
+        <td id="LC1188" class="blob-code blob-code-inner js-file-line">        ],</td>
+      </tr>
+      <tr>
+        <td id="L1189" class="blob-num js-line-number" data-line-number="1189"></td>
+        <td id="LC1189" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1190" class="blob-num js-line-number" data-line-number="1190"></td>
+        <td id="LC1190" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>fma<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1191" class="blob-num js-line-number" data-line-number="1191"></td>
+        <td id="LC1191" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f516eff79e14d4ffefcdc2db06d97ae57f998e37e871264457078f671384fafc<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1192" class="blob-num js-line-number" data-line-number="1192"></td>
+        <td id="LC1192" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1193" class="blob-num js-line-number" data-line-number="1193"></td>
+        <td id="LC1193" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>expsmooth<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1194" class="blob-num js-line-number" data-line-number="1194"></td>
+        <td id="LC1194" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ac7da36347f983d6ec71715daefd2797fe2fc505c019f4965cff9f77ce79982a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1195" class="blob-num js-line-number" data-line-number="1195"></td>
+        <td id="LC1195" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1196" class="blob-num js-line-number" data-line-number="1196"></td>
+        <td id="LC1196" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>fpp<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1197" class="blob-num js-line-number" data-line-number="1197"></td>
+        <td id="LC1197" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9c87dd8591b8a87327cae7a03fd362a5492495a96609e5845ccbeefb96e916cb<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1198" class="blob-num js-line-number" data-line-number="1198"></td>
+        <td id="LC1198" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1199" class="blob-num js-line-number" data-line-number="1199"></td>
+        <td id="LC1199" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>maptools<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.9-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1200" class="blob-num js-line-number" data-line-number="1200"></td>
+        <td id="LC1200" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3bf88cd06f69168d169727ca90d378dfedca77d80ebd26380b2708b3c6aab41c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1201" class="blob-num js-line-number" data-line-number="1201"></td>
+        <td id="LC1201" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1202" class="blob-num js-line-number" data-line-number="1202"></td>
+        <td id="LC1202" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tensor<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1203" class="blob-num js-line-number" data-line-number="1203"></td>
+        <td id="LC1203" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e1dec23e3913a82e2c79e76313911db9050fb82711a0da227f94fc6df2d3aea6<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1204" class="blob-num js-line-number" data-line-number="1204"></td>
+        <td id="LC1204" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1205" class="blob-num js-line-number" data-line-number="1205"></td>
+        <td id="LC1205" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>polyclip<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.6-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1206" class="blob-num js-line-number" data-line-number="1206"></td>
+        <td id="LC1206" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c33aac743f1a4c35d37791486a6628838f5fbff51001b4270aba813163e1bd1f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1207" class="blob-num js-line-number" data-line-number="1207"></td>
+        <td id="LC1207" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1208" class="blob-num js-line-number" data-line-number="1208"></td>
+        <td id="LC1208" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>goftest<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1209" class="blob-num js-line-number" data-line-number="1209"></td>
+        <td id="LC1209" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>db6cb1ff6e18520b172e93fca5d7d953bd2d06f4af73bf90aa0a09df8cad71a0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1210" class="blob-num js-line-number" data-line-number="1210"></td>
+        <td id="LC1210" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1211" class="blob-num js-line-number" data-line-number="1211"></td>
+        <td id="LC1211" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>spatstat.utils<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.8-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1212" class="blob-num js-line-number" data-line-number="1212"></td>
+        <td id="LC1212" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>cf412cb4ef44af63e8c9e01ca2aa86d665788cdb128fba5a0d9c499beb317214<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1213" class="blob-num js-line-number" data-line-number="1213"></td>
+        <td id="LC1213" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1214" class="blob-num js-line-number" data-line-number="1214"></td>
+        <td id="LC1214" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>spatstat.data<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1215" class="blob-num js-line-number" data-line-number="1215"></td>
+        <td id="LC1215" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f5f1da10a19b1eb3911d56aadea294e1c428d332076cf2ca8ad50c1b832ffc5b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1216" class="blob-num js-line-number" data-line-number="1216"></td>
+        <td id="LC1216" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1217" class="blob-num js-line-number" data-line-number="1217"></td>
+        <td id="LC1217" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>spatstat<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.55-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1218" class="blob-num js-line-number" data-line-number="1218"></td>
+        <td id="LC1218" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6392b947a2c970dc3d1787d077398c67e0b8ab053061e4d8a4ad12de3ee0b716<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1219" class="blob-num js-line-number" data-line-number="1219"></td>
+        <td id="LC1219" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1220" class="blob-num js-line-number" data-line-number="1220"></td>
+        <td id="LC1220" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rgdal<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-16<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1221" class="blob-num js-line-number" data-line-number="1221"></td>
+        <td id="LC1221" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>017fefea4f9a6d4540d128c707197b7025b55e4aff98fc763065366b025b03c9<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1222" class="blob-num js-line-number" data-line-number="1222"></td>
+        <td id="LC1222" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1223" class="blob-num js-line-number" data-line-number="1223"></td>
+        <td id="LC1223" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gdalUtils<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0.1.7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1224" class="blob-num js-line-number" data-line-number="1224"></td>
+        <td id="LC1224" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>931138a03b37678f47a41a27dca4ba1938bed07a8a3e869f42feaa76aa380c59<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1225" class="blob-num js-line-number" data-line-number="1225"></td>
+        <td id="LC1225" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1226" class="blob-num js-line-number" data-line-number="1226"></td>
+        <td id="LC1226" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pracma<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1227" class="blob-num js-line-number" data-line-number="1227"></td>
+        <td id="LC1227" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>0ccaef86c1446971ca244e6dbcc605222c2f652b23a5db921070e37a6240f5f9<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1228" class="blob-num js-line-number" data-line-number="1228"></td>
+        <td id="LC1228" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1229" class="blob-num js-line-number" data-line-number="1229"></td>
+        <td id="LC1229" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RCurl<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.95-4.10<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1230" class="blob-num js-line-number" data-line-number="1230"></td>
+        <td id="LC1230" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6f8324f1cb2de6ca818851bd9b83be33083f8752e76ce4187b7c39bda781fe0a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1231" class="blob-num js-line-number" data-line-number="1231"></td>
+        <td id="LC1231" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1232" class="blob-num js-line-number" data-line-number="1232"></td>
+        <td id="LC1232" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bio3d<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.3-3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1233" class="blob-num js-line-number" data-line-number="1233"></td>
+        <td id="LC1233" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f4b45847eb8a4175dacea659f30a8075769ec1ae19daec6842b0d72227b48633<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1234" class="blob-num js-line-number" data-line-number="1234"></td>
+        <td id="LC1234" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1235" class="blob-num js-line-number" data-line-number="1235"></td>
+        <td id="LC1235" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>AUC<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1236" class="blob-num js-line-number" data-line-number="1236"></td>
+        <td id="LC1236" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e705f2c63d336249d19187f3401120d738d42d323fce905f3e157c2c56643766<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1237" class="blob-num js-line-number" data-line-number="1237"></td>
+        <td id="LC1237" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1238" class="blob-num js-line-number" data-line-number="1238"></td>
+        <td id="LC1238" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>interpretR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1239" class="blob-num js-line-number" data-line-number="1239"></td>
+        <td id="LC1239" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>4c08a6dffd6fd5764f27812f3a085c53e6a21d59ae82d903c9c0da93fd1dd059<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1240" class="blob-num js-line-number" data-line-number="1240"></td>
+        <td id="LC1240" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1241" class="blob-num js-line-number" data-line-number="1241"></td>
+        <td id="LC1241" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>cvAUC<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1242" class="blob-num js-line-number" data-line-number="1242"></td>
+        <td id="LC1242" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c4d8ed53b93869650aa2f666cf6d1076980cbfea7fa41f0b8227595be849738d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1243" class="blob-num js-line-number" data-line-number="1243"></td>
+        <td id="LC1243" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1244" class="blob-num js-line-number" data-line-number="1244"></td>
+        <td id="LC1244" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>SuperLearner<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0-23<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1245" class="blob-num js-line-number" data-line-number="1245"></td>
+        <td id="LC1245" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>846c01080256d4c1d4570535599662ee8bcd95ceff753f2bcaaff0cf5a7f7a11<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1246" class="blob-num js-line-number" data-line-number="1246"></td>
+        <td id="LC1246" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1247" class="blob-num js-line-number" data-line-number="1247"></td>
+        <td id="LC1247" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>lpSolve<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>5.6.13<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1248" class="blob-num js-line-number" data-line-number="1248"></td>
+        <td id="LC1248" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d5d41c53212dead4fd8e6425a9d3c5767cdc5feb19d768a4704116d791cf498d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1249" class="blob-num js-line-number" data-line-number="1249"></td>
+        <td id="LC1249" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1250" class="blob-num js-line-number" data-line-number="1250"></td>
+        <td id="LC1250" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>mediation<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>4.4.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1251" class="blob-num js-line-number" data-line-number="1251"></td>
+        <td id="LC1251" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b17784c001305d5f3b84573a673cef31475520d9baec972e42431be193bf305f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1252" class="blob-num js-line-number" data-line-number="1252"></td>
+        <td id="LC1252" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1253" class="blob-num js-line-number" data-line-number="1253"></td>
+        <td id="LC1253" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ModelMetrics<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1254" class="blob-num js-line-number" data-line-number="1254"></td>
+        <td id="LC1254" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>487d53fda57da4b29f83a927dda8b1ae6655ab044ee3eec33c38aeb27eed3d85<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1255" class="blob-num js-line-number" data-line-number="1255"></td>
+        <td id="LC1255" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1256" class="blob-num js-line-number" data-line-number="1256"></td>
+        <td id="LC1256" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>CVST<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1257" class="blob-num js-line-number" data-line-number="1257"></td>
+        <td id="LC1257" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a27fd2bfa778fce9b9a68d2b9206c66af27b3c36a973dd45ce673886a267aa9f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1258" class="blob-num js-line-number" data-line-number="1258"></td>
+        <td id="LC1258" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1259" class="blob-num js-line-number" data-line-number="1259"></td>
+        <td id="LC1259" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>DRR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.0.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1260" class="blob-num js-line-number" data-line-number="1260"></td>
+        <td id="LC1260" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7493389c1fb9ddc4d4261e15bf2d4198603227275688b1d3e3994d47e976a1f9<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1261" class="blob-num js-line-number" data-line-number="1261"></td>
+        <td id="LC1261" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1262" class="blob-num js-line-number" data-line-number="1262"></td>
+        <td id="LC1262" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>dimRed<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1263" class="blob-num js-line-number" data-line-number="1263"></td>
+        <td id="LC1263" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fb0cef7a21b8a5219c74e5227a282168599dd63e904130366f3d2fed8a625a39<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1264" class="blob-num js-line-number" data-line-number="1264"></td>
+        <td id="LC1264" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1265" class="blob-num js-line-number" data-line-number="1265"></td>
+        <td id="LC1265" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>lubridate<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.7.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1266" class="blob-num js-line-number" data-line-number="1266"></td>
+        <td id="LC1266" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2cffbf54afce1d068e65241fb876a77b10ee907d5a19d2ffa84d5ba8a2c3f3df<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1267" class="blob-num js-line-number" data-line-number="1267"></td>
+        <td id="LC1267" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1268" class="blob-num js-line-number" data-line-number="1268"></td>
+        <td id="LC1268" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ddalpha<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3.1.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1269" class="blob-num js-line-number" data-line-number="1269"></td>
+        <td id="LC1269" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fe70c65758fc75365ac6ee537010777b24cb49fb830c5c899a19a0964b8e888f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1270" class="blob-num js-line-number" data-line-number="1270"></td>
+        <td id="LC1270" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1271" class="blob-num js-line-number" data-line-number="1271"></td>
+        <td id="LC1271" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gower<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1272" class="blob-num js-line-number" data-line-number="1272"></td>
+        <td id="LC1272" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>eb91b2d2784d237c7055abcf3cfa4fc0b2226b855a0c29fc5a4e8eaa689079d5<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1273" class="blob-num js-line-number" data-line-number="1273"></td>
+        <td id="LC1273" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1274" class="blob-num js-line-number" data-line-number="1274"></td>
+        <td id="LC1274" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RcppRoll<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1275" class="blob-num js-line-number" data-line-number="1275"></td>
+        <td id="LC1275" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>51c76812687e2a8572c6037b0c095c0a30ee6a24783edf2c7c717d547ddfbfa7<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1276" class="blob-num js-line-number" data-line-number="1276"></td>
+        <td id="LC1276" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1277" class="blob-num js-line-number" data-line-number="1277"></td>
+        <td id="LC1277" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>psych<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.7.8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1278" class="blob-num js-line-number" data-line-number="1278"></td>
+        <td id="LC1278" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f328ea602e22b0e7e5f310a8d19f305d8e0a3a86040cdfb64863b68b56d55135<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1279" class="blob-num js-line-number" data-line-number="1279"></td>
+        <td id="LC1279" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1280" class="blob-num js-line-number" data-line-number="1280"></td>
+        <td id="LC1280" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>broom<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1281" class="blob-num js-line-number" data-line-number="1281"></td>
+        <td id="LC1281" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2e261b40006432e787dc208c2a8943c6ae714968879dd3361ba1ee6ea5603785<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1282" class="blob-num js-line-number" data-line-number="1282"></td>
+        <td id="LC1282" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1283" class="blob-num js-line-number" data-line-number="1283"></td>
+        <td id="LC1283" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>recipes<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1284" class="blob-num js-line-number" data-line-number="1284"></td>
+        <td id="LC1284" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>891a30cce1529e29a832f3aab92b38c9a0ef959a6fb144c0bf07595c871a59b1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1285" class="blob-num js-line-number" data-line-number="1285"></td>
+        <td id="LC1285" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1286" class="blob-num js-line-number" data-line-number="1286"></td>
+        <td id="LC1286" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>caret<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>6.0-78<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1287" class="blob-num js-line-number" data-line-number="1287"></td>
+        <td id="LC1287" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>dea8799853b9b0843d994b4dad09d1535547f36752ff70a956004111e3ef3640<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1288" class="blob-num js-line-number" data-line-number="1288"></td>
+        <td id="LC1288" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1289" class="blob-num js-line-number" data-line-number="1289"></td>
+        <td id="LC1289" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>adabag<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>4.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1290" class="blob-num js-line-number" data-line-number="1290"></td>
+        <td id="LC1290" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>47019eb8cefc8372996fbb2642f64d4a91d7cedc192690a8d8be6e7e03cd3c81<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1291" class="blob-num js-line-number" data-line-number="1291"></td>
+        <td id="LC1291" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1292" class="blob-num js-line-number" data-line-number="1292"></td>
+        <td id="LC1292" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>parallelMap<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1293" class="blob-num js-line-number" data-line-number="1293"></td>
+        <td id="LC1293" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a52d93572c1b85281e41d8e3c2db97dda5fce96c222e04171b4489ec5000cd08<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1294" class="blob-num js-line-number" data-line-number="1294"></td>
+        <td id="LC1294" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1295" class="blob-num js-line-number" data-line-number="1295"></td>
+        <td id="LC1295" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ParamHelpers<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.10<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1296" class="blob-num js-line-number" data-line-number="1296"></td>
+        <td id="LC1296" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>80629ba62e93b0b706bf2e451578b94fbb9c5b95ff109ecfb5b011bfe0a0fa5b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1297" class="blob-num js-line-number" data-line-number="1297"></td>
+        <td id="LC1297" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1298" class="blob-num js-line-number" data-line-number="1298"></td>
+        <td id="LC1298" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ggvis<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1299" class="blob-num js-line-number" data-line-number="1299"></td>
+        <td id="LC1299" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>34d517783016aaa1c4bef8972f4c06df5cd9ca0568035b647e60a8369043ecdc<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1300" class="blob-num js-line-number" data-line-number="1300"></td>
+        <td id="LC1300" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1301" class="blob-num js-line-number" data-line-number="1301"></td>
+        <td id="LC1301" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>mlr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.12<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1302" class="blob-num js-line-number" data-line-number="1302"></td>
+        <td id="LC1302" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>cfe00089ae4cd88c6d03826eda43d4fe29e467e3a7c95d103fafca8308f5c161<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1303" class="blob-num js-line-number" data-line-number="1303"></td>
+        <td id="LC1303" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1304" class="blob-num js-line-number" data-line-number="1304"></td>
+        <td id="LC1304" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>unbalanced<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1305" class="blob-num js-line-number" data-line-number="1305"></td>
+        <td id="LC1305" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9be32b1ce9d972f1abfff2fbe18f5bb5ba9c3f4fb1282063dc410b82ad4d1ea2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1306" class="blob-num js-line-number" data-line-number="1306"></td>
+        <td id="LC1306" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1307" class="blob-num js-line-number" data-line-number="1307"></td>
+        <td id="LC1307" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RSNNS<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4-10<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1308" class="blob-num js-line-number" data-line-number="1308"></td>
+        <td id="LC1308" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f00d34a62e67ec14a7c1963f9f7f0f01c94fcf79ec7a5774a2fa49e475d81ace<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1309" class="blob-num js-line-number" data-line-number="1309"></td>
+        <td id="LC1309" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1310" class="blob-num js-line-number" data-line-number="1310"></td>
+        <td id="LC1310" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>abc.data<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1311" class="blob-num js-line-number" data-line-number="1311"></td>
+        <td id="LC1311" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b242f43c3d05de2e8962d25181c6b1bb6ca1852d4838868ae6241ca890b161af<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1312" class="blob-num js-line-number" data-line-number="1312"></td>
+        <td id="LC1312" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1313" class="blob-num js-line-number" data-line-number="1313"></td>
+        <td id="LC1313" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>abc<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1314" class="blob-num js-line-number" data-line-number="1314"></td>
+        <td id="LC1314" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>0bd2dcd4ee1915448d325fb5e66bee68e0497cbd91ef67a11b400b2fbe52ff59<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1315" class="blob-num js-line-number" data-line-number="1315"></td>
+        <td id="LC1315" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1316" class="blob-num js-line-number" data-line-number="1316"></td>
+        <td id="LC1316" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>lhs<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.16<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1317" class="blob-num js-line-number" data-line-number="1317"></td>
+        <td id="LC1317" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9cd199c3b5b2be1736d585ef0fd39a00e31fc015a053333a7a319668d0809425<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1318" class="blob-num js-line-number" data-line-number="1318"></td>
+        <td id="LC1318" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1319" class="blob-num js-line-number" data-line-number="1319"></td>
+        <td id="LC1319" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tensorA<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.36<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1320" class="blob-num js-line-number" data-line-number="1320"></td>
+        <td id="LC1320" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>97b3e72f26ca3a756d045008764d787a32c68f0a276fb7a29b6e1b4592fdecf6<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1321" class="blob-num js-line-number" data-line-number="1321"></td>
+        <td id="LC1321" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1322" class="blob-num js-line-number" data-line-number="1322"></td>
+        <td id="LC1322" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>EasyABC<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1323" class="blob-num js-line-number" data-line-number="1323"></td>
+        <td id="LC1323" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1dd7b1383a7c891cafb34d9cec65d92f1511a336cff1b219e63c0aa791371b9f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1324" class="blob-num js-line-number" data-line-number="1324"></td>
+        <td id="LC1324" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1325" class="blob-num js-line-number" data-line-number="1325"></td>
+        <td id="LC1325" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>shape<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1326" class="blob-num js-line-number" data-line-number="1326"></td>
+        <td id="LC1326" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f4cb1b7d7c84cf08d2fa97f712ea7eb53ed5fa16e5c7293b820bceabea984d41<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1327" class="blob-num js-line-number" data-line-number="1327"></td>
+        <td id="LC1327" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1328" class="blob-num js-line-number" data-line-number="1328"></td>
+        <td id="LC1328" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>whisker<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1329" class="blob-num js-line-number" data-line-number="1329"></td>
+        <td id="LC1329" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>484836510fcf123a66ddd13cdc8f32eb98e814cad82ed30c0294f55742b08c7c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1330" class="blob-num js-line-number" data-line-number="1330"></td>
+        <td id="LC1330" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1331" class="blob-num js-line-number" data-line-number="1331"></td>
+        <td id="LC1331" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>commonmark<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1332" class="blob-num js-line-number" data-line-number="1332"></td>
+        <td id="LC1332" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>865ecf9432763393ca9de52d0106a58c4be9e8d5196da60e068eed0b67ca68ed<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1333" class="blob-num js-line-number" data-line-number="1333"></td>
+        <td id="LC1333" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1334" class="blob-num js-line-number" data-line-number="1334"></td>
+        <td id="LC1334" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>desc<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1335" class="blob-num js-line-number" data-line-number="1335"></td>
+        <td id="LC1335" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>32ff99b658db3bf0172cf30d15b7f34021144ffc08a5896afd3d30055fc4074c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1336" class="blob-num js-line-number" data-line-number="1336"></td>
+        <td id="LC1336" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1337" class="blob-num js-line-number" data-line-number="1337"></td>
+        <td id="LC1337" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>roxygen2<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>6.0.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1338" class="blob-num js-line-number" data-line-number="1338"></td>
+        <td id="LC1338" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d22ddc05cd5308a48b8359b932e1f7f4c23fdf0c857ac8e52c42381b6bfcff76<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1339" class="blob-num js-line-number" data-line-number="1339"></td>
+        <td id="LC1339" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1340" class="blob-num js-line-number" data-line-number="1340"></td>
+        <td id="LC1340" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>git2r<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.21.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1341" class="blob-num js-line-number" data-line-number="1341"></td>
+        <td id="LC1341" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>0480e4c47394ad1724c80982eff3be5ce34168046939340bf22cc1df6b6baf87<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1342" class="blob-num js-line-number" data-line-number="1342"></td>
+        <td id="LC1342" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1343" class="blob-num js-line-number" data-line-number="1343"></td>
+        <td id="LC1343" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rversions<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1344" class="blob-num js-line-number" data-line-number="1344"></td>
+        <td id="LC1344" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>21d0809f46505de89a2be7be9449e39c39cff5bc77e584dec976ee6c0b884f44<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1345" class="blob-num js-line-number" data-line-number="1345"></td>
+        <td id="LC1345" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1346" class="blob-num js-line-number" data-line-number="1346"></td>
+        <td id="LC1346" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>devtools<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.13.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1347" class="blob-num js-line-number" data-line-number="1347"></td>
+        <td id="LC1347" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fa59488415d7b601dc743cf6080834e6fbd49dda6ecd60629cca0fd8ced47cf4<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1348" class="blob-num js-line-number" data-line-number="1348"></td>
+        <td id="LC1348" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1349" class="blob-num js-line-number" data-line-number="1349"></td>
+        <td id="LC1349" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Rook<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1350" class="blob-num js-line-number" data-line-number="1350"></td>
+        <td id="LC1350" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>00f4ecfa4c5c57018acbb749080c07154549a6ecaa8d4130dd9de79427504903<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1351" class="blob-num js-line-number" data-line-number="1351"></td>
+        <td id="LC1351" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1352" class="blob-num js-line-number" data-line-number="1352"></td>
+        <td id="LC1352" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Cairo<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5-9<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1353" class="blob-num js-line-number" data-line-number="1353"></td>
+        <td id="LC1353" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>patches<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>Cairo-1.5-9.patch<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1354" class="blob-num js-line-number" data-line-number="1354"></td>
+        <td id="LC1354" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [</td>
+      </tr>
+      <tr>
+        <td id="L1355" class="blob-num js-line-number" data-line-number="1355"></td>
+        <td id="LC1355" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>2a867b6cae96671d6bc3acf9334d6615dc01f6ecf1953a27cde8a43c724a38f4<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> Cairo_1.5-9.tar.gz</span></td>
+      </tr>
+      <tr>
+        <td id="L1356" class="blob-num js-line-number" data-line-number="1356"></td>
+        <td id="LC1356" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>3efa99888503949eefe586faf3f6f80566674c5a8cfb2c62b648b42f22466dfa<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> Cairo-1.5-9.patch</span></td>
+      </tr>
+      <tr>
+        <td id="L1357" class="blob-num js-line-number" data-line-number="1357"></td>
+        <td id="LC1357" class="blob-code blob-code-inner js-file-line">        ],</td>
+      </tr>
+      <tr>
+        <td id="L1358" class="blob-num js-line-number" data-line-number="1358"></td>
+        <td id="LC1358" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1359" class="blob-num js-line-number" data-line-number="1359"></td>
+        <td id="LC1359" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RMTstat<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1360" class="blob-num js-line-number" data-line-number="1360"></td>
+        <td id="LC1360" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>81eb4c5434d04cb66c749a434c33ceb1c07d92ba79765d4e9233c13a092ec2da<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1361" class="blob-num js-line-number" data-line-number="1361"></td>
+        <td id="LC1361" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1362" class="blob-num js-line-number" data-line-number="1362"></td>
+        <td id="LC1362" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Lmoments<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1363" class="blob-num js-line-number" data-line-number="1363"></td>
+        <td id="LC1363" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e974b65d6116d540bc2c934c40c5552f64d7781b77c259a5b7724b1338c9e08e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1364" class="blob-num js-line-number" data-line-number="1364"></td>
+        <td id="LC1364" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1365" class="blob-num js-line-number" data-line-number="1365"></td>
+        <td id="LC1365" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>distillery<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1366" class="blob-num js-line-number" data-line-number="1366"></td>
+        <td id="LC1366" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3d3a8445471b19a6b652761ca783994b2d2108b64ff539b0597a9db9697d17d4<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1367" class="blob-num js-line-number" data-line-number="1367"></td>
+        <td id="LC1367" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1368" class="blob-num js-line-number" data-line-number="1368"></td>
+        <td id="LC1368" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>extRemes<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0-8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1369" class="blob-num js-line-number" data-line-number="1369"></td>
+        <td id="LC1369" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d53d50d0feb6295f72c4f646242e1506ca51911c026f881d443d65f1c68ad75e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1370" class="blob-num js-line-number" data-line-number="1370"></td>
+        <td id="LC1370" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1371" class="blob-num js-line-number" data-line-number="1371"></td>
+        <td id="LC1371" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pixmap<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4-11<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1372" class="blob-num js-line-number" data-line-number="1372"></td>
+        <td id="LC1372" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6fa010749a59cdf56aad9f81271473b7d55697036203f2cd5d81372bcded7412<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1373" class="blob-num js-line-number" data-line-number="1373"></td>
+        <td id="LC1373" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1374" class="blob-num js-line-number" data-line-number="1374"></td>
+        <td id="LC1374" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tkrplot<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.0-23<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1375" class="blob-num js-line-number" data-line-number="1375"></td>
+        <td id="LC1375" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>87a4323ce3bc6c852c2dae4727639b9a1c30724327a812379f21d73cecd7deb2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1376" class="blob-num js-line-number" data-line-number="1376"></td>
+        <td id="LC1376" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1377" class="blob-num js-line-number" data-line-number="1377"></td>
+        <td id="LC1377" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>misc3d<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.8-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1378" class="blob-num js-line-number" data-line-number="1378"></td>
+        <td id="LC1378" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>75de3d2237f67f9e58a36e80a6bbf7e796d43eb46789f2dd1311270007bf5f62<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1379" class="blob-num js-line-number" data-line-number="1379"></td>
+        <td id="LC1379" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1380" class="blob-num js-line-number" data-line-number="1380"></td>
+        <td id="LC1380" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>multicool<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-10<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1381" class="blob-num js-line-number" data-line-number="1381"></td>
+        <td id="LC1381" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [</td>
+      </tr>
+      <tr>
+        <td id="L1382" class="blob-num js-line-number" data-line-number="1382"></td>
+        <td id="LC1382" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>5bb0cb0d9eb64420c862877247a79bb0afadacfe23262ec8c3fa26e5e34d6ff9<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> multicool_0.1-10.tar.gz</span></td>
+      </tr>
+      <tr>
+        <td id="L1383" class="blob-num js-line-number" data-line-number="1383"></td>
+        <td id="LC1383" class="blob-code blob-code-inner js-file-line">        ],</td>
+      </tr>
+      <tr>
+        <td id="L1384" class="blob-num js-line-number" data-line-number="1384"></td>
+        <td id="LC1384" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1385" class="blob-num js-line-number" data-line-number="1385"></td>
+        <td id="LC1385" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>plot3D<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1386" class="blob-num js-line-number" data-line-number="1386"></td>
+        <td id="LC1386" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f6fe4a001387132626fc553ed1d5720d448b8064eb5a6917458a798e1d381632<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1387" class="blob-num js-line-number" data-line-number="1387"></td>
+        <td id="LC1387" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1388" class="blob-num js-line-number" data-line-number="1388"></td>
+        <td id="LC1388" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>plot3Drgl<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1389" class="blob-num js-line-number" data-line-number="1389"></td>
+        <td id="LC1389" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>466d428d25c066c9c96d892f24da930513d42b1bdf76d3b53628c3ba13c3e48a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1390" class="blob-num js-line-number" data-line-number="1390"></td>
+        <td id="LC1390" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1391" class="blob-num js-line-number" data-line-number="1391"></td>
+        <td id="LC1391" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>OceanView<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1392" class="blob-num js-line-number" data-line-number="1392"></td>
+        <td id="LC1392" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e67f6f376737e1e5cf22fdfe2769a8f674e90c886b0e43942e97d9a3e6924f1c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1393" class="blob-num js-line-number" data-line-number="1393"></td>
+        <td id="LC1393" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1394" class="blob-num js-line-number" data-line-number="1394"></td>
+        <td id="LC1394" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ks<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.11.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1395" class="blob-num js-line-number" data-line-number="1395"></td>
+        <td id="LC1395" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>648e23578445049e4f73238b1c4b3a07e365c55577a9d8172cc69eaaf1377cf1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1396" class="blob-num js-line-number" data-line-number="1396"></td>
+        <td id="LC1396" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1397" class="blob-num js-line-number" data-line-number="1397"></td>
+        <td id="LC1397" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>logcondens<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1398" class="blob-num js-line-number" data-line-number="1398"></td>
+        <td id="LC1398" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>72e61abc1f3eb28830266fbe5b0da0999eb5520586000a3024e7c26be93c02eb<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1399" class="blob-num js-line-number" data-line-number="1399"></td>
+        <td id="LC1399" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1400" class="blob-num js-line-number" data-line-number="1400"></td>
+        <td id="LC1400" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Iso<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.0-17<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1401" class="blob-num js-line-number" data-line-number="1401"></td>
+        <td id="LC1401" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c007d6eaf6335a15c1912b0804276ff39abce27b7a61539a91b8fda653629252<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1402" class="blob-num js-line-number" data-line-number="1402"></td>
+        <td id="LC1402" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1403" class="blob-num js-line-number" data-line-number="1403"></td>
+        <td id="LC1403" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>penalized<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.9-50<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1404" class="blob-num js-line-number" data-line-number="1404"></td>
+        <td id="LC1404" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c12b3259e019f91c7bd02827ea3a27f842d9c15950fa6cc114dff23c89c297d1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1405" class="blob-num js-line-number" data-line-number="1405"></td>
+        <td id="LC1405" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1406" class="blob-num js-line-number" data-line-number="1406"></td>
+        <td id="LC1406" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>clusterRepro<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.5-1.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1407" class="blob-num js-line-number" data-line-number="1407"></td>
+        <td id="LC1407" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b7fcb9db0c762a2e6e22a0a0689affd73504c56f13c13b04272a946630334e6f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1408" class="blob-num js-line-number" data-line-number="1408"></td>
+        <td id="LC1408" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1409" class="blob-num js-line-number" data-line-number="1409"></td>
+        <td id="LC1409" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>randomForestSRC<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.5.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1410" class="blob-num js-line-number" data-line-number="1410"></td>
+        <td id="LC1410" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ad45878dab93cdf5fbdd88cbcf5e6cdcceb7fae6b9dd8d2ccddac2d6ce2faadc<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1411" class="blob-num js-line-number" data-line-number="1411"></td>
+        <td id="LC1411" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1412" class="blob-num js-line-number" data-line-number="1412"></td>
+        <td id="LC1412" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>sm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.2-5.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1413" class="blob-num js-line-number" data-line-number="1413"></td>
+        <td id="LC1413" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>49f26c52728ac9dd2152d80ef1d3d59b98269bdc81616f81548fa4ed842ed842<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1414" class="blob-num js-line-number" data-line-number="1414"></td>
+        <td id="LC1414" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1415" class="blob-num js-line-number" data-line-number="1415"></td>
+        <td id="LC1415" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pbivnorm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1416" class="blob-num js-line-number" data-line-number="1416"></td>
+        <td id="LC1416" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>07c37d507cb8f8d2d9ae51a9a6d44dfbebd8a53e93c242c4378eaddfb1cc5f16<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1417" class="blob-num js-line-number" data-line-number="1417"></td>
+        <td id="LC1417" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1418" class="blob-num js-line-number" data-line-number="1418"></td>
+        <td id="LC1418" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>lavaan<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.5-23.1097<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1419" class="blob-num js-line-number" data-line-number="1419"></td>
+        <td id="LC1419" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9aa7c3278f08f46b91fb0357dbdb9539936ba54e11d270d7febce0049efc9d87<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1420" class="blob-num js-line-number" data-line-number="1420"></td>
+        <td id="LC1420" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1421" class="blob-num js-line-number" data-line-number="1421"></td>
+        <td id="LC1421" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>matrixcalc<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0-3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1422" class="blob-num js-line-number" data-line-number="1422"></td>
+        <td id="LC1422" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>17e6caeeecd596b850a6caaa257984398de9ec5d2b41ce83c428f112614b9cb0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1423" class="blob-num js-line-number" data-line-number="1423"></td>
+        <td id="LC1423" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1424" class="blob-num js-line-number" data-line-number="1424"></td>
+        <td id="LC1424" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>arm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.9-3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1425" class="blob-num js-line-number" data-line-number="1425"></td>
+        <td id="LC1425" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1cefcc1d82431f1b3ed014ff04dd087fd0da3396df5a25144ffa80a8d01fe700<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1426" class="blob-num js-line-number" data-line-number="1426"></td>
+        <td id="LC1426" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1427" class="blob-num js-line-number" data-line-number="1427"></td>
+        <td id="LC1427" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>mi<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1428" class="blob-num js-line-number" data-line-number="1428"></td>
+        <td id="LC1428" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>34f44353101e8c3cb6bf59c5f4ff5b2391d884dcbb9d23066a11ee756b9987c0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1429" class="blob-num js-line-number" data-line-number="1429"></td>
+        <td id="LC1429" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1430" class="blob-num js-line-number" data-line-number="1430"></td>
+        <td id="LC1430" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>visNetwork<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1431" class="blob-num js-line-number" data-line-number="1431"></td>
+        <td id="LC1431" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>bc2e75cf4cc1410d8eb528a38870666117e674f1b9ba5fa1ff769b8ab2e2462f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1432" class="blob-num js-line-number" data-line-number="1432"></td>
+        <td id="LC1432" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1433" class="blob-num js-line-number" data-line-number="1433"></td>
+        <td id="LC1433" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rgexf<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.15.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1434" class="blob-num js-line-number" data-line-number="1434"></td>
+        <td id="LC1434" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2e8a7978d1fb977318e6310ba65b70a9c8890185c819a7951ac23425c6dc8147<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1435" class="blob-num js-line-number" data-line-number="1435"></td>
+        <td id="LC1435" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1436" class="blob-num js-line-number" data-line-number="1436"></td>
+        <td id="LC1436" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>influenceR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1437" class="blob-num js-line-number" data-line-number="1437"></td>
+        <td id="LC1437" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>4fc9324179bd8896875fc0e879a8a96b9ef2a6cf42a296c3b7b4d9098519e98a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1438" class="blob-num js-line-number" data-line-number="1438"></td>
+        <td id="LC1438" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1439" class="blob-num js-line-number" data-line-number="1439"></td>
+        <td id="LC1439" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>downloader<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1440" class="blob-num js-line-number" data-line-number="1440"></td>
+        <td id="LC1440" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1890e75b028775154023f2135cafb3e3eed0fe908138ab4f7eff1fc1b47dafab<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1441" class="blob-num js-line-number" data-line-number="1441"></td>
+        <td id="LC1441" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1442" class="blob-num js-line-number" data-line-number="1442"></td>
+        <td id="LC1442" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>DiagrammeR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1443" class="blob-num js-line-number" data-line-number="1443"></td>
+        <td id="LC1443" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2b186dae1b19018681b979e9444bf16559c42740d8382676fbaf3b0f8a44337e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1444" class="blob-num js-line-number" data-line-number="1444"></td>
+        <td id="LC1444" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1445" class="blob-num js-line-number" data-line-number="1445"></td>
+        <td id="LC1445" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>sem<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>3.1-9<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1446" class="blob-num js-line-number" data-line-number="1446"></td>
+        <td id="LC1446" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>4a33780202506543da85877cd2813250114420d6ec5e75457bc67477cd332cb9<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1447" class="blob-num js-line-number" data-line-number="1447"></td>
+        <td id="LC1447" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1448" class="blob-num js-line-number" data-line-number="1448"></td>
+        <td id="LC1448" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>jpeg<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1449" class="blob-num js-line-number" data-line-number="1449"></td>
+        <td id="LC1449" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d032befeb3a414cefdbf70ba29a6c01541c54387cc0a1a98a4022d86cbe60a16<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1450" class="blob-num js-line-number" data-line-number="1450"></td>
+        <td id="LC1450" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1451" class="blob-num js-line-number" data-line-number="1451"></td>
+        <td id="LC1451" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>network<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.13.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1452" class="blob-num js-line-number" data-line-number="1452"></td>
+        <td id="LC1452" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7a04ea89261cdf32ccb52222810699d5fca59a849053e306b5ec9dd5c1184f87<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1453" class="blob-num js-line-number" data-line-number="1453"></td>
+        <td id="LC1453" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1454" class="blob-num js-line-number" data-line-number="1454"></td>
+        <td id="LC1454" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>statnet.common<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>4.0.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1455" class="blob-num js-line-number" data-line-number="1455"></td>
+        <td id="LC1455" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>206e1967df661b277c6fde68f8b0bf4589508f569ff94f1ec5126c4c56a1867b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1456" class="blob-num js-line-number" data-line-number="1456"></td>
+        <td id="LC1456" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1457" class="blob-num js-line-number" data-line-number="1457"></td>
+        <td id="LC1457" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>sna<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1458" class="blob-num js-line-number" data-line-number="1458"></td>
+        <td id="LC1458" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2292b3190e8d879e494527ae9d9d1174c31cb4183749ecb455aedd8d534048cf<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1459" class="blob-num js-line-number" data-line-number="1459"></td>
+        <td id="LC1459" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1460" class="blob-num js-line-number" data-line-number="1460"></td>
+        <td id="LC1460" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>glasso<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.8<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1461" class="blob-num js-line-number" data-line-number="1461"></td>
+        <td id="LC1461" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>patches<span class="pl-pds">&#39;</span></span>: [(<span class="pl-s"><span class="pl-pds">&#39;</span>glasso-1.8-ifort-no-fixed.patch<span class="pl-pds">&#39;</span></span>, <span class="pl-c1">1</span>)],</td>
+      </tr>
+      <tr>
+        <td id="L1462" class="blob-num js-line-number" data-line-number="1462"></td>
+        <td id="LC1462" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [</td>
+      </tr>
+      <tr>
+        <td id="L1463" class="blob-num js-line-number" data-line-number="1463"></td>
+        <td id="LC1463" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>fc9ba74519388c194e14bae39d41f3fec8c2aade0177df364f61753f0fbf8a3d<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> glasso_1.8.tar.gz</span></td>
+      </tr>
+      <tr>
+        <td id="L1464" class="blob-num js-line-number" data-line-number="1464"></td>
+        <td id="LC1464" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>87e966b6651c2d9ccd8a2c2ba842eef8dcbeaa3fdd25085bb1d5aff6e79f409c<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> glasso-1.8-ifort-no-fixed.patch</span></td>
+      </tr>
+      <tr>
+        <td id="L1465" class="blob-num js-line-number" data-line-number="1465"></td>
+        <td id="LC1465" class="blob-code blob-code-inner js-file-line">        ],</td>
+      </tr>
+      <tr>
+        <td id="L1466" class="blob-num js-line-number" data-line-number="1466"></td>
+        <td id="LC1466" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1467" class="blob-num js-line-number" data-line-number="1467"></td>
+        <td id="LC1467" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>huge<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1468" class="blob-num js-line-number" data-line-number="1468"></td>
+        <td id="LC1468" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>042b771c334cf4d1a92c5c546ca025238919f772a50457594b7e0bd243498d8c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1469" class="blob-num js-line-number" data-line-number="1469"></td>
+        <td id="LC1469" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1470" class="blob-num js-line-number" data-line-number="1470"></td>
+        <td id="LC1470" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>d3Network<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.5.2.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1471" class="blob-num js-line-number" data-line-number="1471"></td>
+        <td id="LC1471" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5c798dc0c87c6d574abb7c1f1903346e6b0fec8adfd1df7aef5e4f9e7e3a09be<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1472" class="blob-num js-line-number" data-line-number="1472"></td>
+        <td id="LC1472" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1473" class="blob-num js-line-number" data-line-number="1473"></td>
+        <td id="LC1473" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ggm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1474" class="blob-num js-line-number" data-line-number="1474"></td>
+        <td id="LC1474" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>832ffe81ff87c6f1a6644e689ebbfb172924b4c4584ac8108d1244d153219ed8<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1475" class="blob-num js-line-number" data-line-number="1475"></td>
+        <td id="LC1475" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1476" class="blob-num js-line-number" data-line-number="1476"></td>
+        <td id="LC1476" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>BDgraph<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.44<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1477" class="blob-num js-line-number" data-line-number="1477"></td>
+        <td id="LC1477" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>06c3cbe72024d6f38329bed1393ef1e8c877fe2343cabe0c8cd8bd8b9cacb714<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1478" class="blob-num js-line-number" data-line-number="1478"></td>
+        <td id="LC1478" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1479" class="blob-num js-line-number" data-line-number="1479"></td>
+        <td id="LC1479" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>qgraph<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1480" class="blob-num js-line-number" data-line-number="1480"></td>
+        <td id="LC1480" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f62a908a4185f30c2f6924a69f1a569a636fa3053de1e92288367b498b93f841<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1481" class="blob-num js-line-number" data-line-number="1481"></td>
+        <td id="LC1481" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1482" class="blob-num js-line-number" data-line-number="1482"></td>
+        <td id="LC1482" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>HWxtest<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1483" class="blob-num js-line-number" data-line-number="1483"></td>
+        <td id="LC1483" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7cfcf7860d655945f9d3bbda4590374d3100bb5da6b49956f2e701b910a20e0c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1484" class="blob-num js-line-number" data-line-number="1484"></td>
+        <td id="LC1484" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1485" class="blob-num js-line-number" data-line-number="1485"></td>
+        <td id="LC1485" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>diveRsity<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.9.90<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1486" class="blob-num js-line-number" data-line-number="1486"></td>
+        <td id="LC1486" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b8f49cdbfbd82805206ad293fcb2dad65b962fb5523059a3e3aecaedf5c0ee86<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1487" class="blob-num js-line-number" data-line-number="1487"></td>
+        <td id="LC1487" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1488" class="blob-num js-line-number" data-line-number="1488"></td>
+        <td id="LC1488" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>doSNOW<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.16<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1489" class="blob-num js-line-number" data-line-number="1489"></td>
+        <td id="LC1489" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>161434ecd55f04d6b070da784b222a7686c914b73de558eef6048a229022398e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1490" class="blob-num js-line-number" data-line-number="1490"></td>
+        <td id="LC1490" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1491" class="blob-num js-line-number" data-line-number="1491"></td>
+        <td id="LC1491" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>phangorn<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.4.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1492" class="blob-num js-line-number" data-line-number="1492"></td>
+        <td id="LC1492" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>31d0ea035b48d3940013f369e514351db19f9f92b2832c53f09f752b4a998875<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1493" class="blob-num js-line-number" data-line-number="1493"></td>
+        <td id="LC1493" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1494" class="blob-num js-line-number" data-line-number="1494"></td>
+        <td id="LC1494" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>geepack<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1495" class="blob-num js-line-number" data-line-number="1495"></td>
+        <td id="LC1495" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7effe67381129a48154c445704490ea3b5f2e1adedb66cb65f61369dd1f8d38d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1496" class="blob-num js-line-number" data-line-number="1496"></td>
+        <td id="LC1496" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1497" class="blob-num js-line-number" data-line-number="1497"></td>
+        <td id="LC1497" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>biom<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3.12<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1498" class="blob-num js-line-number" data-line-number="1498"></td>
+        <td id="LC1498" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>4ad17f7811c7346dc4923bd6596a007c177eebb1944a9f46e5674afcc5fdd5a1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1499" class="blob-num js-line-number" data-line-number="1499"></td>
+        <td id="LC1499" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1500" class="blob-num js-line-number" data-line-number="1500"></td>
+        <td id="LC1500" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pim<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1501" class="blob-num js-line-number" data-line-number="1501"></td>
+        <td id="LC1501" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>174568a01f68b9601a4ea89ca5857bf4888242f00e4212bfb7a422d6292300d5<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1502" class="blob-num js-line-number" data-line-number="1502"></td>
+        <td id="LC1502" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1503" class="blob-num js-line-number" data-line-number="1503"></td>
+        <td id="LC1503" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>minpack.lm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1504" class="blob-num js-line-number" data-line-number="1504"></td>
+        <td id="LC1504" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>14cb7dba3ef2b46da0479b46d46c76198e129a31f6157cd8b37f178adb15d5a3<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1505" class="blob-num js-line-number" data-line-number="1505"></td>
+        <td id="LC1505" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1506" class="blob-num js-line-number" data-line-number="1506"></td>
+        <td id="LC1506" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rootSolve<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1507" class="blob-num js-line-number" data-line-number="1507"></td>
+        <td id="LC1507" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>08b3bb63f04fc0b065cb615b6ca1ef95eb6df7a813eb9eb625bc15c6de332c22<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1508" class="blob-num js-line-number" data-line-number="1508"></td>
+        <td id="LC1508" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1509" class="blob-num js-line-number" data-line-number="1509"></td>
+        <td id="LC1509" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>diagram<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.6.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1510" class="blob-num js-line-number" data-line-number="1510"></td>
+        <td id="LC1510" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7c2bc5d5d634c3b8ca7fea79fb463e412962d88f47a77a74c811cc62f375ce38<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1511" class="blob-num js-line-number" data-line-number="1511"></td>
+        <td id="LC1511" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1512" class="blob-num js-line-number" data-line-number="1512"></td>
+        <td id="LC1512" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>FME<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1513" class="blob-num js-line-number" data-line-number="1513"></td>
+        <td id="LC1513" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3619d88df2a41ca8819b93bb7dff3b8233f76ff8ab0ca67c664f530f835935e4<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1514" class="blob-num js-line-number" data-line-number="1514"></td>
+        <td id="LC1514" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1515" class="blob-num js-line-number" data-line-number="1515"></td>
+        <td id="LC1515" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bmp<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1516" class="blob-num js-line-number" data-line-number="1516"></td>
+        <td id="LC1516" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>bdf790249b932e80bc3a188a288fef079d218856cf64ffb88428d915423ea649<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1517" class="blob-num js-line-number" data-line-number="1517"></td>
+        <td id="LC1517" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1518" class="blob-num js-line-number" data-line-number="1518"></td>
+        <td id="LC1518" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>readbitmap<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1519" class="blob-num js-line-number" data-line-number="1519"></td>
+        <td id="LC1519" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2d45ddd1ee0eb7482d5d4a9cfe41b3aa645de8af89295b4b205d73b19ac6d821<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1520" class="blob-num js-line-number" data-line-number="1520"></td>
+        <td id="LC1520" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1521" class="blob-num js-line-number" data-line-number="1521"></td>
+        <td id="LC1521" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>imager<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.40.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1522" class="blob-num js-line-number" data-line-number="1522"></td>
+        <td id="LC1522" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [</td>
+      </tr>
+      <tr>
+        <td id="L1523" class="blob-num js-line-number" data-line-number="1523"></td>
+        <td id="LC1523" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>12be25495c32883961e2503c8064aa90473fc36046630f582ae28c1c06995c9d<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> imager_0.40.2.tar.gz</span></td>
+      </tr>
+      <tr>
+        <td id="L1524" class="blob-num js-line-number" data-line-number="1524"></td>
+        <td id="LC1524" class="blob-code blob-code-inner js-file-line">        ],</td>
+      </tr>
+      <tr>
+        <td id="L1525" class="blob-num js-line-number" data-line-number="1525"></td>
+        <td id="LC1525" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1526" class="blob-num js-line-number" data-line-number="1526"></td>
+        <td id="LC1526" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>signal<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.7-6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1527" class="blob-num js-line-number" data-line-number="1527"></td>
+        <td id="LC1527" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6b60277b07cf0167f8272059b128cc82f27a9bab1fd33d74c2a9e1f2abca5def<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1528" class="blob-num js-line-number" data-line-number="1528"></td>
+        <td id="LC1528" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1529" class="blob-num js-line-number" data-line-number="1529"></td>
+        <td id="LC1529" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tuneR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1530" class="blob-num js-line-number" data-line-number="1530"></td>
+        <td id="LC1530" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>4aafd7d6330572711c117fa2d6e21e14485f695db38a7ebf5c7b3ba8723666f6<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1531" class="blob-num js-line-number" data-line-number="1531"></td>
+        <td id="LC1531" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1532" class="blob-num js-line-number" data-line-number="1532"></td>
+        <td id="LC1532" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pastecs<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3-18<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1533" class="blob-num js-line-number" data-line-number="1533"></td>
+        <td id="LC1533" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5188662294bf91545d0c2e4d7de113296f5a8c2cbf38bdc2a90f3f7d03b3b447<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1534" class="blob-num js-line-number" data-line-number="1534"></td>
+        <td id="LC1534" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1535" class="blob-num js-line-number" data-line-number="1535"></td>
+        <td id="LC1535" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>audio<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1536" class="blob-num js-line-number" data-line-number="1536"></td>
+        <td id="LC1536" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b4e229457a0a399b14136ac145e65bb007d9c8d46e421ae79fd26461450164c3<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1537" class="blob-num js-line-number" data-line-number="1537"></td>
+        <td id="LC1537" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1538" class="blob-num js-line-number" data-line-number="1538"></td>
+        <td id="LC1538" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>fftw<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1539" class="blob-num js-line-number" data-line-number="1539"></td>
+        <td id="LC1539" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>80413901ce751c0700ac53283366cfcfe3cbeec2982d29721a0275f9fb9de204<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1540" class="blob-num js-line-number" data-line-number="1540"></td>
+        <td id="LC1540" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1541" class="blob-num js-line-number" data-line-number="1541"></td>
+        <td id="LC1541" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>seewave<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1542" class="blob-num js-line-number" data-line-number="1542"></td>
+        <td id="LC1542" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5ea4fd79fe99f094c6bb9092e6048490175e9bedcd6d6e97badc1143df861f44<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1543" class="blob-num js-line-number" data-line-number="1543"></td>
+        <td id="LC1543" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1544" class="blob-num js-line-number" data-line-number="1544"></td>
+        <td id="LC1544" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gsw<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0-5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1545" class="blob-num js-line-number" data-line-number="1545"></td>
+        <td id="LC1545" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>eb468918ee91e429b47fbcac43269eca627b7f64b61520de5bbe8fa223e96453<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1546" class="blob-num js-line-number" data-line-number="1546"></td>
+        <td id="LC1546" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1547" class="blob-num js-line-number" data-line-number="1547"></td>
+        <td id="LC1547" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>oce<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.9-23<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1548" class="blob-num js-line-number" data-line-number="1548"></td>
+        <td id="LC1548" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>390fd082710ee1586074ff20df61208df4c76b9f2dc0c9b1125aade4c934b04c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1549" class="blob-num js-line-number" data-line-number="1549"></td>
+        <td id="LC1549" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1550" class="blob-num js-line-number" data-line-number="1550"></td>
+        <td id="LC1550" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ineq<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2-13<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1551" class="blob-num js-line-number" data-line-number="1551"></td>
+        <td id="LC1551" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e0876403f59a3dfc2ea7ffc0d965416e1ecfdecf154e5856e5f54800b3efda25<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1552" class="blob-num js-line-number" data-line-number="1552"></td>
+        <td id="LC1552" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1553" class="blob-num js-line-number" data-line-number="1553"></td>
+        <td id="LC1553" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>soundecology<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1554" class="blob-num js-line-number" data-line-number="1554"></td>
+        <td id="LC1554" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>276164d5eb92c78726c647be16232d2443acbf7061371ddde2672b4fdb7a069a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1555" class="blob-num js-line-number" data-line-number="1555"></td>
+        <td id="LC1555" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1556" class="blob-num js-line-number" data-line-number="1556"></td>
+        <td id="LC1556" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>memuse<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>4.0-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1557" class="blob-num js-line-number" data-line-number="1557"></td>
+        <td id="LC1557" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fbf8716a1388692ee439f69ac99643fa427eb100027d8911ff0fbfdcb5b6c3bc<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1558" class="blob-num js-line-number" data-line-number="1558"></td>
+        <td id="LC1558" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1559" class="blob-num js-line-number" data-line-number="1559"></td>
+        <td id="LC1559" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pinfsc50<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1560" class="blob-num js-line-number" data-line-number="1560"></td>
+        <td id="LC1560" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b6b9b6365a3f408533264d7ec820494f57eccaf362553e8478a46a8e5b474aba<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1561" class="blob-num js-line-number" data-line-number="1561"></td>
+        <td id="LC1561" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1562" class="blob-num js-line-number" data-line-number="1562"></td>
+        <td id="LC1562" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>vcfR<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.7.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1563" class="blob-num js-line-number" data-line-number="1563"></td>
+        <td id="LC1563" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ba6bce3861d1c87d2746984e736a0cbb977fd5ac450995f143b322887ed1a4ef<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1564" class="blob-num js-line-number" data-line-number="1564"></td>
+        <td id="LC1564" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1565" class="blob-num js-line-number" data-line-number="1565"></td>
+        <td id="LC1565" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>glmmML<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1566" class="blob-num js-line-number" data-line-number="1566"></td>
+        <td id="LC1566" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>abc9ded054787f5459e0e419697927eb031f221be8e0cfdbf306f776d4b9bb59<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1567" class="blob-num js-line-number" data-line-number="1567"></td>
+        <td id="LC1567" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1568" class="blob-num js-line-number" data-line-number="1568"></td>
+        <td id="LC1568" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ucminf<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1569" class="blob-num js-line-number" data-line-number="1569"></td>
+        <td id="LC1569" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a2eb382f9b24e949d982e311578518710f8242070b3aa3314a331c1e1e7f6f07<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1570" class="blob-num js-line-number" data-line-number="1570"></td>
+        <td id="LC1570" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1571" class="blob-num js-line-number" data-line-number="1571"></td>
+        <td id="LC1571" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ordinal<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2015.6-28<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1572" class="blob-num js-line-number" data-line-number="1572"></td>
+        <td id="LC1572" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fa33e29cc82bf241ad94fbbf5bb4dd6c9fe01803ba389957a4194d81e5979351<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1573" class="blob-num js-line-number" data-line-number="1573"></td>
+        <td id="LC1573" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1574" class="blob-num js-line-number" data-line-number="1574"></td>
+        <td id="LC1574" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Rtsne<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.13<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1575" class="blob-num js-line-number" data-line-number="1575"></td>
+        <td id="LC1575" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [</td>
+      </tr>
+      <tr>
+        <td id="L1576" class="blob-num js-line-number" data-line-number="1576"></td>
+        <td id="LC1576" class="blob-code blob-code-inner js-file-line">            <span class="pl-s"><span class="pl-pds">&#39;</span>1c3bffe3bd11733ee4fe01749c293669daafda1af2ec74f9158f6080625b999d<span class="pl-pds">&#39;</span></span>,  <span class="pl-c"><span class="pl-c">#</span> Rtsne_0.13.tar.gz</span></td>
+      </tr>
+      <tr>
+        <td id="L1577" class="blob-num js-line-number" data-line-number="1577"></td>
+        <td id="LC1577" class="blob-code blob-code-inner js-file-line">        ],</td>
+      </tr>
+      <tr>
+        <td id="L1578" class="blob-num js-line-number" data-line-number="1578"></td>
+        <td id="LC1578" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1579" class="blob-num js-line-number" data-line-number="1579"></td>
+        <td id="LC1579" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>cowplot<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.9.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1580" class="blob-num js-line-number" data-line-number="1580"></td>
+        <td id="LC1580" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>8b92ce7f92937fde06b0cfb86c7634a39b3b2101e362cc55c4bec6b3fde1d28f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1581" class="blob-num js-line-number" data-line-number="1581"></td>
+        <td id="LC1581" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1582" class="blob-num js-line-number" data-line-number="1582"></td>
+        <td id="LC1582" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tsne<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1583" class="blob-num js-line-number" data-line-number="1583"></td>
+        <td id="LC1583" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>66fdf5d73e69594af529a9c4f261d972872b9b7bffd19f85c1adcd66afd80c69<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1584" class="blob-num js-line-number" data-line-number="1584"></td>
+        <td id="LC1584" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1585" class="blob-num js-line-number" data-line-number="1585"></td>
+        <td id="LC1585" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pbapply<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1586" class="blob-num js-line-number" data-line-number="1586"></td>
+        <td id="LC1586" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>cdfdaf9b8aecbe48daac858aecaf65a766b74a363d1eb7cd6ebf27c0549f6552<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1587" class="blob-num js-line-number" data-line-number="1587"></td>
+        <td id="LC1587" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1588" class="blob-num js-line-number" data-line-number="1588"></td>
+        <td id="LC1588" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RcppProgress<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1589" class="blob-num js-line-number" data-line-number="1589"></td>
+        <td id="LC1589" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3b1ecc82ced98eb481819a28737dac3658586e11ad16a92abd14c4649ae15e25<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1590" class="blob-num js-line-number" data-line-number="1590"></td>
+        <td id="LC1590" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1591" class="blob-num js-line-number" data-line-number="1591"></td>
+        <td id="LC1591" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>sn<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1592" class="blob-num js-line-number" data-line-number="1592"></td>
+        <td id="LC1592" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fcfc077a2c1eb35b1ed875fea296b225540aefb05564cbb54477f266a0a2f850<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1593" class="blob-num js-line-number" data-line-number="1593"></td>
+        <td id="LC1593" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1594" class="blob-num js-line-number" data-line-number="1594"></td>
+        <td id="LC1594" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tclust<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1595" class="blob-num js-line-number" data-line-number="1595"></td>
+        <td id="LC1595" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fe4479a73b947d8f6c1cc63587283a8b6223d430d39eee4e5833a06d3d1726d2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1596" class="blob-num js-line-number" data-line-number="1596"></td>
+        <td id="LC1596" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1597" class="blob-num js-line-number" data-line-number="1597"></td>
+        <td id="LC1597" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ranger<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.9.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1598" class="blob-num js-line-number" data-line-number="1598"></td>
+        <td id="LC1598" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>17ecc45dae291f07c9a579bf05effe9d39dc70c75eefe4f5035422da6f9134de<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1599" class="blob-num js-line-number" data-line-number="1599"></td>
+        <td id="LC1599" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1600" class="blob-num js-line-number" data-line-number="1600"></td>
+        <td id="LC1600" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>hexbin<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.27.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1601" class="blob-num js-line-number" data-line-number="1601"></td>
+        <td id="LC1601" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>46d47b1efef75d6f126af686a4dd614228b60418b9a5bde9e9e5d11200a0ee52<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1602" class="blob-num js-line-number" data-line-number="1602"></td>
+        <td id="LC1602" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1603" class="blob-num js-line-number" data-line-number="1603"></td>
+        <td id="LC1603" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>pryr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1604" class="blob-num js-line-number" data-line-number="1604"></td>
+        <td id="LC1604" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d39834316504c49ecd4936cbbcaf3ee3dae6ded287af42475bf38c9e682f721b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1605" class="blob-num js-line-number" data-line-number="1605"></td>
+        <td id="LC1605" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1606" class="blob-num js-line-number" data-line-number="1606"></td>
+        <td id="LC1606" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>moments<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.14<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1607" class="blob-num js-line-number" data-line-number="1607"></td>
+        <td id="LC1607" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2a3b81e60dafdd092d2bdd3513d7038855ca7d113dc71df1229f7518382a3e39<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1608" class="blob-num js-line-number" data-line-number="1608"></td>
+        <td id="LC1608" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1609" class="blob-num js-line-number" data-line-number="1609"></td>
+        <td id="LC1609" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>laeken<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1610" class="blob-num js-line-number" data-line-number="1610"></td>
+        <td id="LC1610" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>465174263f2d495162bf1ee8ab35b362dae8088e458c162ce517813267d813e6<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1611" class="blob-num js-line-number" data-line-number="1611"></td>
+        <td id="LC1611" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1612" class="blob-num js-line-number" data-line-number="1612"></td>
+        <td id="LC1612" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>VIM<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>4.7.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1613" class="blob-num js-line-number" data-line-number="1613"></td>
+        <td id="LC1613" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>cdd64cbdca23c097efa8d5084bfc1c0d1449744e90a41680a5246db979d14cee<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1614" class="blob-num js-line-number" data-line-number="1614"></td>
+        <td id="LC1614" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1615" class="blob-num js-line-number" data-line-number="1615"></td>
+        <td id="LC1615" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>proxy<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4-21<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1616" class="blob-num js-line-number" data-line-number="1616"></td>
+        <td id="LC1616" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>607770418758c7cb856c2e5da1e877270a60adc4a1f588588127edeff44330ee<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1617" class="blob-num js-line-number" data-line-number="1617"></td>
+        <td id="LC1617" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1618" class="blob-num js-line-number" data-line-number="1618"></td>
+        <td id="LC1618" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>smoother<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1619" class="blob-num js-line-number" data-line-number="1619"></td>
+        <td id="LC1619" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>91b55b82f805cfa1deedacc0a4e844a2132aa59df593f3b05676954cf70a195b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1620" class="blob-num js-line-number" data-line-number="1620"></td>
+        <td id="LC1620" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1621" class="blob-num js-line-number" data-line-number="1621"></td>
+        <td id="LC1621" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>dynamicTreeCut<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.63-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1622" class="blob-num js-line-number" data-line-number="1622"></td>
+        <td id="LC1622" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>831307f64eddd68dcf01bbe2963be99e5cde65a636a13ce9de229777285e4db9<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1623" class="blob-num js-line-number" data-line-number="1623"></td>
+        <td id="LC1623" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1624" class="blob-num js-line-number" data-line-number="1624"></td>
+        <td id="LC1624" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>DT<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1625" class="blob-num js-line-number" data-line-number="1625"></td>
+        <td id="LC1625" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>3daa96b819ca54e5fbc2c7d78cb3637982a2d44be58cea0683663b71cfc7fa19<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1626" class="blob-num js-line-number" data-line-number="1626"></td>
+        <td id="LC1626" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1627" class="blob-num js-line-number" data-line-number="1627"></td>
+        <td id="LC1627" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>beeswarm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1628" class="blob-num js-line-number" data-line-number="1628"></td>
+        <td id="LC1628" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>0115425e210dced05da8e162c8455526a47314f72e441ad2a33dcab3f94ac843<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1629" class="blob-num js-line-number" data-line-number="1629"></td>
+        <td id="LC1629" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1630" class="blob-num js-line-number" data-line-number="1630"></td>
+        <td id="LC1630" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>vipor<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1631" class="blob-num js-line-number" data-line-number="1631"></td>
+        <td id="LC1631" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7d19251ac37639d6a0fed2d30f1af4e578785677df5e53dcdb2a22771a604f84<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1632" class="blob-num js-line-number" data-line-number="1632"></td>
+        <td id="LC1632" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1633" class="blob-num js-line-number" data-line-number="1633"></td>
+        <td id="LC1633" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>ggbeeswarm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1634" class="blob-num js-line-number" data-line-number="1634"></td>
+        <td id="LC1634" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>bbac8552f67ff1945180fbcda83f7f1c47908f27ba4e84921a39c45d6e123333<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1635" class="blob-num js-line-number" data-line-number="1635"></td>
+        <td id="LC1635" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1636" class="blob-num js-line-number" data-line-number="1636"></td>
+        <td id="LC1636" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>shinydashboard<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.6.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1637" class="blob-num js-line-number" data-line-number="1637"></td>
+        <td id="LC1637" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1ee38f257433d24455426bc9d85c36f588735a54fbf6143935fed9cccb3bf193<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1638" class="blob-num js-line-number" data-line-number="1638"></td>
+        <td id="LC1638" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1639" class="blob-num js-line-number" data-line-number="1639"></td>
+        <td id="LC1639" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rrcov<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4-3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1640" class="blob-num js-line-number" data-line-number="1640"></td>
+        <td id="LC1640" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d89631e0dfb39777af9fe303cc0537bbc82c6f3d2a1ed360de950c13dfc34f4d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1641" class="blob-num js-line-number" data-line-number="1641"></td>
+        <td id="LC1641" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1642" class="blob-num js-line-number" data-line-number="1642"></td>
+        <td id="LC1642" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>WriteXLS<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>4.0.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1643" class="blob-num js-line-number" data-line-number="1643"></td>
+        <td id="LC1643" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a0541da45e16bc4bf994cdf3f07a0e202c38d52386460c64e27fe6c1cd889d5b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1644" class="blob-num js-line-number" data-line-number="1644"></td>
+        <td id="LC1644" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1645" class="blob-num js-line-number" data-line-number="1645"></td>
+        <td id="LC1645" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bst<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3-14<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1646" class="blob-num js-line-number" data-line-number="1646"></td>
+        <td id="LC1646" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>08013994d3ac79ffc78585cb2831d4d2e52f39423ba880f84c6224e4c6b6360b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1647" class="blob-num js-line-number" data-line-number="1647"></td>
+        <td id="LC1647" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1648" class="blob-num js-line-number" data-line-number="1648"></td>
+        <td id="LC1648" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>mpath<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3-4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1649" class="blob-num js-line-number" data-line-number="1649"></td>
+        <td id="LC1649" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2a77539924c1aaf9eece2277b415f1df7146c44f04886b4e96d2d9ad32b6c262<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1650" class="blob-num js-line-number" data-line-number="1650"></td>
+        <td id="LC1650" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1651" class="blob-num js-line-number" data-line-number="1651"></td>
+        <td id="LC1651" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>timereg<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.9.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1652" class="blob-num js-line-number" data-line-number="1652"></td>
+        <td id="LC1652" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b0b969807e72003cc537c979f01b62e6199fa335baca4cf92473babcd19cac35<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1653" class="blob-num js-line-number" data-line-number="1653"></td>
+        <td id="LC1653" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1654" class="blob-num js-line-number" data-line-number="1654"></td>
+        <td id="LC1654" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>peperr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1-7<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1655" class="blob-num js-line-number" data-line-number="1655"></td>
+        <td id="LC1655" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>73e0422c71f2df59cd4a0f820c87dd828f2952b60df2d6c58f62a35559d74605<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1656" class="blob-num js-line-number" data-line-number="1656"></td>
+        <td id="LC1656" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1657" class="blob-num js-line-number" data-line-number="1657"></td>
+        <td id="LC1657" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>heatmap3<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1658" class="blob-num js-line-number" data-line-number="1658"></td>
+        <td id="LC1658" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>055e30a2fee0e8b6e499cdc5ccb7e37e5615ed3d52cc7058fc5ca5fc808cf393<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1659" class="blob-num js-line-number" data-line-number="1659"></td>
+        <td id="LC1659" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1660" class="blob-num js-line-number" data-line-number="1660"></td>
+        <td id="LC1660" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>GlobalOptions<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.0.12<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1661" class="blob-num js-line-number" data-line-number="1661"></td>
+        <td id="LC1661" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c09da3f9b1646d0f815056cdbeb5fff7dda29f7dd8742d245f5f6dc7066077a9<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1662" class="blob-num js-line-number" data-line-number="1662"></td>
+        <td id="LC1662" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1663" class="blob-num js-line-number" data-line-number="1663"></td>
+        <td id="LC1663" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>circlize<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1664" class="blob-num js-line-number" data-line-number="1664"></td>
+        <td id="LC1664" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ca768f40123262db745046a6209e59023cfd50af4d99bddc8ccffb3cdf21e95d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1665" class="blob-num js-line-number" data-line-number="1665"></td>
+        <td id="LC1665" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1666" class="blob-num js-line-number" data-line-number="1666"></td>
+        <td id="LC1666" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>GetoptLong<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1667" class="blob-num js-line-number" data-line-number="1667"></td>
+        <td id="LC1667" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f526f006e3ed8507f1f236430ac9e97341c1ee9c207fbb68f936dd4d377b28b5<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1668" class="blob-num js-line-number" data-line-number="1668"></td>
+        <td id="LC1668" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1669" class="blob-num js-line-number" data-line-number="1669"></td>
+        <td id="LC1669" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>dendextend<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.7.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1670" class="blob-num js-line-number" data-line-number="1670"></td>
+        <td id="LC1670" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ad50970790561a661f0035e8f5e50943191755ff7c1d8a4befa3406b9bc23bcf<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1671" class="blob-num js-line-number" data-line-number="1671"></td>
+        <td id="LC1671" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1672" class="blob-num js-line-number" data-line-number="1672"></td>
+        <td id="LC1672" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RInside<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2.14<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1673" class="blob-num js-line-number" data-line-number="1673"></td>
+        <td id="LC1673" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>8de5340993fe879ca00fa559c5b1b27b408ba78bfc5f67d36d6f0b8d8e8649cf<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1674" class="blob-num js-line-number" data-line-number="1674"></td>
+        <td id="LC1674" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1675" class="blob-num js-line-number" data-line-number="1675"></td>
+        <td id="LC1675" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>limSolve<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5.5.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1676" class="blob-num js-line-number" data-line-number="1676"></td>
+        <td id="LC1676" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>2f27c03411e0d771ad50d5412125bf4fa0ba461051610edc77e20d28488e86d2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1677" class="blob-num js-line-number" data-line-number="1677"></td>
+        <td id="LC1677" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1678" class="blob-num js-line-number" data-line-number="1678"></td>
+        <td id="LC1678" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>dbplyr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1679" class="blob-num js-line-number" data-line-number="1679"></td>
+        <td id="LC1679" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b348e7a02623f037632c85fb11be16c40c01755ae6ca02c8c189cdc192a699db<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1680" class="blob-num js-line-number" data-line-number="1680"></td>
+        <td id="LC1680" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1681" class="blob-num js-line-number" data-line-number="1681"></td>
+        <td id="LC1681" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>modelr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1682" class="blob-num js-line-number" data-line-number="1682"></td>
+        <td id="LC1682" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>25b95198d6aa23e28a0bd97dcdc78264ef168ae403928bff01e1ee81ca021ce7<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1683" class="blob-num js-line-number" data-line-number="1683"></td>
+        <td id="LC1683" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1684" class="blob-num js-line-number" data-line-number="1684"></td>
+        <td id="LC1684" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rematch<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1685" class="blob-num js-line-number" data-line-number="1685"></td>
+        <td id="LC1685" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a409dec978cd02914cdddfedc974d9b45bd2975a124d8870d52cfd7d37d47578<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1686" class="blob-num js-line-number" data-line-number="1686"></td>
+        <td id="LC1686" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1687" class="blob-num js-line-number" data-line-number="1687"></td>
+        <td id="LC1687" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>cellranger<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1688" class="blob-num js-line-number" data-line-number="1688"></td>
+        <td id="LC1688" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5d38f288c752bbb9cea6ff830b8388bdd65a8571fd82d8d96064586bd588cf99<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1689" class="blob-num js-line-number" data-line-number="1689"></td>
+        <td id="LC1689" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1690" class="blob-num js-line-number" data-line-number="1690"></td>
+        <td id="LC1690" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>readxl<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1691" class="blob-num js-line-number" data-line-number="1691"></td>
+        <td id="LC1691" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fbd62f07fed7946363698a57be88f4ef3fa254ecf456ef292535849c787fc7ad<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1692" class="blob-num js-line-number" data-line-number="1692"></td>
+        <td id="LC1692" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1693" class="blob-num js-line-number" data-line-number="1693"></td>
+        <td id="LC1693" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>debugme<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1694" class="blob-num js-line-number" data-line-number="1694"></td>
+        <td id="LC1694" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>4dae0e2450d6689a6eab560e36f8a7c63853abbab64994028220b8fd4b793ab1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1695" class="blob-num js-line-number" data-line-number="1695"></td>
+        <td id="LC1695" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1696" class="blob-num js-line-number" data-line-number="1696"></td>
+        <td id="LC1696" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>callr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1697" class="blob-num js-line-number" data-line-number="1697"></td>
+        <td id="LC1697" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>778595e3f0b08f4e33a3103bd8e84a183945074f9e7404cdee8d72b7d3b8a154<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1698" class="blob-num js-line-number" data-line-number="1698"></td>
+        <td id="LC1698" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1699" class="blob-num js-line-number" data-line-number="1699"></td>
+        <td id="LC1699" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>clipr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1700" class="blob-num js-line-number" data-line-number="1700"></td>
+        <td id="LC1700" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>44a2f1ab4fde53e4fe81cf5800aa6ad45b72b5da93d6fe4d3661d7397220e8af<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1701" class="blob-num js-line-number" data-line-number="1701"></td>
+        <td id="LC1701" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1702" class="blob-num js-line-number" data-line-number="1702"></td>
+        <td id="LC1702" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>reprex<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1703" class="blob-num js-line-number" data-line-number="1703"></td>
+        <td id="LC1703" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7a6fc5f2a8f48ca5c6829811b899671b861f3d17cbe98bf87d343a5cf54ead80<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1704" class="blob-num js-line-number" data-line-number="1704"></td>
+        <td id="LC1704" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1705" class="blob-num js-line-number" data-line-number="1705"></td>
+        <td id="LC1705" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>selectr<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1706" class="blob-num js-line-number" data-line-number="1706"></td>
+        <td id="LC1706" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5e222b462b6d0ced877897da5cf2385128010c143979911e349f3c9c8991b94d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1707" class="blob-num js-line-number" data-line-number="1707"></td>
+        <td id="LC1707" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1708" class="blob-num js-line-number" data-line-number="1708"></td>
+        <td id="LC1708" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>rvest<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1709" class="blob-num js-line-number" data-line-number="1709"></td>
+        <td id="LC1709" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>0d6e8837fb1df79b1c83e7b48d8f1e6245f34a10c4bb6952e7bec7867e4abb12<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1710" class="blob-num js-line-number" data-line-number="1710"></td>
+        <td id="LC1710" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1711" class="blob-num js-line-number" data-line-number="1711"></td>
+        <td id="LC1711" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tidyverse<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1712" class="blob-num js-line-number" data-line-number="1712"></td>
+        <td id="LC1712" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ad67a27bb4e89417a15338fe1a40251a7b5dedba60e9b72637963d3de574c37b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1713" class="blob-num js-line-number" data-line-number="1713"></td>
+        <td id="LC1713" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1714" class="blob-num js-line-number" data-line-number="1714"></td>
+        <td id="LC1714" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>R.cache<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.13.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1715" class="blob-num js-line-number" data-line-number="1715"></td>
+        <td id="LC1715" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>d3d4a99a676734ea53e96747d87857fa69615e59858804e92f8ad9ddcf62c5c1<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1716" class="blob-num js-line-number" data-line-number="1716"></td>
+        <td id="LC1716" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1717" class="blob-num js-line-number" data-line-number="1717"></td>
+        <td id="LC1717" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>R.rsp<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.42.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1718" class="blob-num js-line-number" data-line-number="1718"></td>
+        <td id="LC1718" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a02ebd3857849896f30993ed8306c88b03116250261d9d85dcee48103f0498fd<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1719" class="blob-num js-line-number" data-line-number="1719"></td>
+        <td id="LC1719" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1720" class="blob-num js-line-number" data-line-number="1720"></td>
+        <td id="LC1720" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>listenv<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.7.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1721" class="blob-num js-line-number" data-line-number="1721"></td>
+        <td id="LC1721" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6126020b111870baea08b36afa82777cd578e88c17db5435cd137f11b3964555<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1722" class="blob-num js-line-number" data-line-number="1722"></td>
+        <td id="LC1722" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1723" class="blob-num js-line-number" data-line-number="1723"></td>
+        <td id="LC1723" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>globals<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.11.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1724" class="blob-num js-line-number" data-line-number="1724"></td>
+        <td id="LC1724" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ac285bd040d02ddc230486a193f76fad78bb6f013577c702b0b58e9af6f3579f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1725" class="blob-num js-line-number" data-line-number="1725"></td>
+        <td id="LC1725" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1726" class="blob-num js-line-number" data-line-number="1726"></td>
+        <td id="LC1726" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>future<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.7.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1727" class="blob-num js-line-number" data-line-number="1727"></td>
+        <td id="LC1727" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>382a2a7c5840ea86ba0c995fbbef37b9bde9e0e5754aa8a39e8bb4f047e1df51<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1728" class="blob-num js-line-number" data-line-number="1728"></td>
+        <td id="LC1728" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1729" class="blob-num js-line-number" data-line-number="1729"></td>
+        <td id="LC1729" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gdistance<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1730" class="blob-num js-line-number" data-line-number="1730"></td>
+        <td id="LC1730" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c1a74a86e31c26b6b1cd49c151c2e0ba362565667ec9971c08efc4194167cff3<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1731" class="blob-num js-line-number" data-line-number="1731"></td>
+        <td id="LC1731" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1732" class="blob-num js-line-number" data-line-number="1732"></td>
+        <td id="LC1732" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>vioplot<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1733" class="blob-num js-line-number" data-line-number="1733"></td>
+        <td id="LC1733" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>601f043630999e0498f0fba213d3d3fefd6ff0abf8fdb22119199b3d8d58939b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1734" class="blob-num js-line-number" data-line-number="1734"></td>
+        <td id="LC1734" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1735" class="blob-num js-line-number" data-line-number="1735"></td>
+        <td id="LC1735" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>emulator<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2-15<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1736" class="blob-num js-line-number" data-line-number="1736"></td>
+        <td id="LC1736" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e221f185f610ca34d169c42dc560209094825ed0a4fe35db97892ca4ffc1e7e6<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1737" class="blob-num js-line-number" data-line-number="1737"></td>
+        <td id="LC1737" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1738" class="blob-num js-line-number" data-line-number="1738"></td>
+        <td id="LC1738" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gmm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.6-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1739" class="blob-num js-line-number" data-line-number="1739"></td>
+        <td id="LC1739" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>c1d6ac78cfa302895934fbefbf6d073bfdd5c0c92708bfe4a46fb7775804383e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1740" class="blob-num js-line-number" data-line-number="1740"></td>
+        <td id="LC1740" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1741" class="blob-num js-line-number" data-line-number="1741"></td>
+        <td id="LC1741" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tmvtnorm<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4-10<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1742" class="blob-num js-line-number" data-line-number="1742"></td>
+        <td id="LC1742" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>1a9f35e9b4899672e9c0b263affdc322ecb52ec198b2bb015af9d022faad73f0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1743" class="blob-num js-line-number" data-line-number="1743"></td>
+        <td id="LC1743" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1744" class="blob-num js-line-number" data-line-number="1744"></td>
+        <td id="LC1744" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>IDPmisc<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.17<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1745" class="blob-num js-line-number" data-line-number="1745"></td>
+        <td id="LC1745" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>18ec9db0aab1de526b8e57ac1f0223811806a814777149b793722b999e6f7c59<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1746" class="blob-num js-line-number" data-line-number="1746"></td>
+        <td id="LC1746" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1747" class="blob-num js-line-number" data-line-number="1747"></td>
+        <td id="LC1747" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gap<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1-21<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1748" class="blob-num js-line-number" data-line-number="1748"></td>
+        <td id="LC1748" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>fa94b64e3a9c77ff3b4bd5ef0faeb42e647bbaedf3127933bef30568cc5c546f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1749" class="blob-num js-line-number" data-line-number="1749"></td>
+        <td id="LC1749" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1750" class="blob-num js-line-number" data-line-number="1750"></td>
+        <td id="LC1750" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>qrnn<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>2.0.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1751" class="blob-num js-line-number" data-line-number="1751"></td>
+        <td id="LC1751" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>a4f786f767c02d65e6200ed0688c4e99e415815f44a6e980103dbb695ffc8f70<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1752" class="blob-num js-line-number" data-line-number="1752"></td>
+        <td id="LC1752" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1753" class="blob-num js-line-number" data-line-number="1753"></td>
+        <td id="LC1753" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>DHARMa<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.5<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1754" class="blob-num js-line-number" data-line-number="1754"></td>
+        <td id="LC1754" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>97e3ad80583eb6612f59e225100a10364e39d23076e9a295c5f75c4aa1bffbd5<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1755" class="blob-num js-line-number" data-line-number="1755"></td>
+        <td id="LC1755" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1756" class="blob-num js-line-number" data-line-number="1756"></td>
+        <td id="LC1756" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>bridgesampling<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4-0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1757" class="blob-num js-line-number" data-line-number="1757"></td>
+        <td id="LC1757" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9577b535535b46022d06a7372ee309e2eb2ef0d045d65e2f3ed507f9b88062bf<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1758" class="blob-num js-line-number" data-line-number="1758"></td>
+        <td id="LC1758" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1759" class="blob-num js-line-number" data-line-number="1759"></td>
+        <td id="LC1759" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>BayesianTools<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1.4<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1760" class="blob-num js-line-number" data-line-number="1760"></td>
+        <td id="LC1760" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ed0b68020a9f1b10eda4135a0734e2c88a09e7d3d1fd7b83772cdec1b680358e<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1761" class="blob-num js-line-number" data-line-number="1761"></td>
+        <td id="LC1761" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1762" class="blob-num js-line-number" data-line-number="1762"></td>
+        <td id="LC1762" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gomms<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1763" class="blob-num js-line-number" data-line-number="1763"></td>
+        <td id="LC1763" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>52828c6fe9b78d66bde5474e45ff153efdb153f2bd9f0e52a20a668e842f2dc5<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1764" class="blob-num js-line-number" data-line-number="1764"></td>
+        <td id="LC1764" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1765" class="blob-num js-line-number" data-line-number="1765"></td>
+        <td id="LC1765" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>feather<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.3.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1766" class="blob-num js-line-number" data-line-number="1766"></td>
+        <td id="LC1766" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f1069bf920e9bc3da6bf43542a3a7ccc3142544d759945115ecade69dd5ccde0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1767" class="blob-num js-line-number" data-line-number="1767"></td>
+        <td id="LC1767" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1768" class="blob-num js-line-number" data-line-number="1768"></td>
+        <td id="LC1768" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>tidyverse<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1769" class="blob-num js-line-number" data-line-number="1769"></td>
+        <td id="LC1769" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>ad67a27bb4e89417a15338fe1a40251a7b5dedba60e9b72637963d3de574c37b<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1770" class="blob-num js-line-number" data-line-number="1770"></td>
+        <td id="LC1770" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1771" class="blob-num js-line-number" data-line-number="1771"></td>
+        <td id="LC1771" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>dummies<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.5.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1772" class="blob-num js-line-number" data-line-number="1772"></td>
+        <td id="LC1772" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>7551bc2df0830b98c53582cac32145d5ce21f5a61d97e2bb69fd848e3323c805<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1773" class="blob-num js-line-number" data-line-number="1773"></td>
+        <td id="LC1773" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1774" class="blob-num js-line-number" data-line-number="1774"></td>
+        <td id="LC1774" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>SimSeq<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.4.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1775" class="blob-num js-line-number" data-line-number="1775"></td>
+        <td id="LC1775" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>5ab9d4fe2cb1b7634432ff125a9e04d2f574fed06246a93859f8004e10790f19<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1776" class="blob-num js-line-number" data-line-number="1776"></td>
+        <td id="LC1776" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1777" class="blob-num js-line-number" data-line-number="1777"></td>
+        <td id="LC1777" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>fdrtool<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.2.15<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1778" class="blob-num js-line-number" data-line-number="1778"></td>
+        <td id="LC1778" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>65f964aa768d0703ceb7a199adc5e79ca79a6d29d7bc053a262eb533697686c0<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1779" class="blob-num js-line-number" data-line-number="1779"></td>
+        <td id="LC1779" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1780" class="blob-num js-line-number" data-line-number="1780"></td>
+        <td id="LC1780" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>uniqueAtomMat<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.1-3-2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1781" class="blob-num js-line-number" data-line-number="1781"></td>
+        <td id="LC1781" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>f7024e73274e1e76a870ce5e26bd58f76e8f6df0aa9775c631b861d83f4f53d7<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1782" class="blob-num js-line-number" data-line-number="1782"></td>
+        <td id="LC1782" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1783" class="blob-num js-line-number" data-line-number="1783"></td>
+        <td id="LC1783" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>PoissonSeq<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.1.2<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1784" class="blob-num js-line-number" data-line-number="1784"></td>
+        <td id="LC1784" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6f3dc30ad22e33e4fcfa37b3427c093d591c02f1b89a014d85e63203f6031dc2<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1785" class="blob-num js-line-number" data-line-number="1785"></td>
+        <td id="LC1785" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1786" class="blob-num js-line-number" data-line-number="1786"></td>
+        <td id="LC1786" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>aod<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.3<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1787" class="blob-num js-line-number" data-line-number="1787"></td>
+        <td id="LC1787" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e377effe345987850ece985eabf79750ca1979d75469d17a323c21515ad1dda8<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1788" class="blob-num js-line-number" data-line-number="1788"></td>
+        <td id="LC1788" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1789" class="blob-num js-line-number" data-line-number="1789"></td>
+        <td id="LC1789" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>cghFLasso<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.2-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1790" class="blob-num js-line-number" data-line-number="1790"></td>
+        <td id="LC1790" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6e697959b35a3ceb2baa1542ef81f0335006a5a9c937f0173c6483979cb4302c<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1791" class="blob-num js-line-number" data-line-number="1791"></td>
+        <td id="LC1791" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1792" class="blob-num js-line-number" data-line-number="1792"></td>
+        <td id="LC1792" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>svd<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4.1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1793" class="blob-num js-line-number" data-line-number="1793"></td>
+        <td id="LC1793" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>6f585cb622cc52e2b7f3efddb7a363e91771bff80b8facb554755c2b33b7f402<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1794" class="blob-num js-line-number" data-line-number="1794"></td>
+        <td id="LC1794" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1795" class="blob-num js-line-number" data-line-number="1795"></td>
+        <td id="LC1795" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>Rssa<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>1.0<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1796" class="blob-num js-line-number" data-line-number="1796"></td>
+        <td id="LC1796" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9cc20a7101d8dff4c6cfb789f9bdc14e2b3bb128d7613a67b0f9633cf006902a<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1797" class="blob-num js-line-number" data-line-number="1797"></td>
+        <td id="LC1797" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1798" class="blob-num js-line-number" data-line-number="1798"></td>
+        <td id="LC1798" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>JBTools<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.7.2.9<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1799" class="blob-num js-line-number" data-line-number="1799"></td>
+        <td id="LC1799" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>b33cfa17339df7113176ad1832cbb0533acf5d25c36b95e888f561d586c5d62f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1800" class="blob-num js-line-number" data-line-number="1800"></td>
+        <td id="LC1800" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1801" class="blob-num js-line-number" data-line-number="1801"></td>
+        <td id="LC1801" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>RUnit<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.4.31<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1802" class="blob-num js-line-number" data-line-number="1802"></td>
+        <td id="LC1802" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>9d764092216391c9d7e13bbe1585f5d00c357ed8b04c7e66ed82d229c34119cb<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1803" class="blob-num js-line-number" data-line-number="1803"></td>
+        <td id="LC1803" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1804" class="blob-num js-line-number" data-line-number="1804"></td>
+        <td id="LC1804" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>DistributionUtils<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.5-1<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1805" class="blob-num js-line-number" data-line-number="1805"></td>
+        <td id="LC1805" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>e92a29003d5e5974f53e40bdb8417e2bdabe784304e21360d7a1cbec7818853f<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1806" class="blob-num js-line-number" data-line-number="1806"></td>
+        <td id="LC1806" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1807" class="blob-num js-line-number" data-line-number="1807"></td>
+        <td id="LC1807" class="blob-code blob-code-inner js-file-line">    (<span class="pl-s"><span class="pl-pds">&#39;</span>gapfill<span class="pl-pds">&#39;</span></span>, <span class="pl-s"><span class="pl-pds">&#39;</span>0.9.6<span class="pl-pds">&#39;</span></span>, {</td>
+      </tr>
+      <tr>
+        <td id="L1808" class="blob-num js-line-number" data-line-number="1808"></td>
+        <td id="LC1808" class="blob-code blob-code-inner js-file-line">        <span class="pl-s"><span class="pl-pds">&#39;</span>checksums<span class="pl-pds">&#39;</span></span>: [<span class="pl-s"><span class="pl-pds">&#39;</span>850d0be9d05e3f3620f0f5143496321f1004ed966299bffd6a67a9abd8d9040d<span class="pl-pds">&#39;</span></span>],</td>
+      </tr>
+      <tr>
+        <td id="L1809" class="blob-num js-line-number" data-line-number="1809"></td>
+        <td id="LC1809" class="blob-code blob-code-inner js-file-line">    }),</td>
+      </tr>
+      <tr>
+        <td id="L1810" class="blob-num js-line-number" data-line-number="1810"></td>
+        <td id="LC1810" class="blob-code blob-code-inner js-file-line">]</td>
+      </tr>
+      <tr>
+        <td id="L1811" class="blob-num js-line-number" data-line-number="1811"></td>
+        <td id="LC1811" class="blob-code blob-code-inner js-file-line">
+</td>
+      </tr>
+      <tr>
+        <td id="L1812" class="blob-num js-line-number" data-line-number="1812"></td>
+        <td id="LC1812" class="blob-code blob-code-inner js-file-line">moduleclass <span class="pl-k">=</span> <span class="pl-s"><span class="pl-pds">&#39;</span>lang<span class="pl-pds">&#39;</span></span></td>
+      </tr>
+</table>
+
+  <div class="BlobToolbar position-absolute js-file-line-actions dropdown js-menu-container js-select-menu d-none" aria-hidden="true">
+    <button class="btn-octicon ml-0 px-2 p-0 bg-white border border-gray-dark rounded-1 js-menu-target" type="button" aria-expanded="false" aria-haspopup="true" aria-label="Inline file action toolbar" aria-controls="inline-file-actions">
+      <svg class="octicon octicon-kebab-horizontal" viewBox="0 0 13 16" version="1.1" width="13" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M1.5 9a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zm5 0a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3zM13 7.5a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0z"/></svg>
+    </button>
+    <div class="dropdown-menu-content js-menu-content" id="inline-file-actions">
+      <ul class="BlobToolbar-dropdown dropdown-menu dropdown-menu-se mt-2">
+        <li><clipboard-copy class="dropdown-item" id="js-copy-lines" style="cursor:pointer;" data-original-text="Copy lines">Copy lines</clipboard-copy></li>
+        <li><clipboard-copy class="dropdown-item" id="js-copy-permalink" style="cursor:pointer;" data-original-text="Copy permalink">Copy permalink</clipboard-copy></li>
+        <li><a class="dropdown-item js-update-url-with-hash" id="js-view-git-blame" href="/easybuilders/easybuild-easyconfigs/blame/96d4f7857072ade7e058ed0f83b53791ef6b6b12/easybuild/easyconfigs/r/R/R-3.4.4-foss-2018a-X11-20180131.eb">View git blame</a></li>
+          <li><a class="dropdown-item" id="js-new-issue" href="/easybuilders/easybuild-easyconfigs/issues/new">Open new issue</a></li>
+      </ul>
+    </div>
+  </div>
+
+  </div>
+
+  </div>
+
+  <button type="button" data-facebox="#jump-to-line" data-facebox-class="linejump" data-hotkey="l" class="d-none">Jump to Line</button>
+  <div id="jump-to-line" style="display:none">
+    <!-- '"` --><!-- </textarea></xmp> --></option></form><form class="js-jump-to-line-form" action="" accept-charset="UTF-8" method="get"><input name="utf8" type="hidden" value="&#x2713;" />
+      <input class="form-control linejump-input js-jump-to-line-field" type="text" placeholder="Jump to line&hellip;" aria-label="Jump to line" autofocus>
+      <button type="submit" class="btn">Go</button>
+</form>  </div>
+
+
+  </div>
+  <div class="modal-backdrop js-touch-events"></div>
+</div>
+
+    </div>
+  </div>
+
+  </div>
+
+      
+<div class="footer container-lg px-3" role="contentinfo">
+  <div class="position-relative d-flex flex-justify-between pt-6 pb-2 mt-6 f6 text-gray border-top border-gray-light ">
+    <ul class="list-style-none d-flex flex-wrap ">
+      <li class="mr-3">&copy; 2018 <span title="0.33267s from unicorn-845cbf78fb-mxj2l">GitHub</span>, Inc.</li>
+        <li class="mr-3"><a data-ga-click="Footer, go to terms, text:terms" href="https://github.com/site/terms">Terms</a></li>
+        <li class="mr-3"><a data-ga-click="Footer, go to privacy, text:privacy" href="https://github.com/site/privacy">Privacy</a></li>
+        <li class="mr-3"><a href="https://help.github.com/articles/github-security/" data-ga-click="Footer, go to security, text:security">Security</a></li>
+        <li class="mr-3"><a href="https://status.github.com/" data-ga-click="Footer, go to status, text:status">Status</a></li>
+        <li><a data-ga-click="Footer, go to help, text:help" href="https://help.github.com">Help</a></li>
+    </ul>
+
+    <a aria-label="Homepage" title="GitHub" class="footer-octicon" href="https://github.com">
+      <svg height="24" class="octicon octicon-mark-github" viewBox="0 0 16 16" version="1.1" width="24" aria-hidden="true"><path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+</a>
+   <ul class="list-style-none d-flex flex-wrap ">
+        <li class="mr-3"><a data-ga-click="Footer, go to contact, text:contact" href="https://github.com/contact">Contact GitHub</a></li>
+      <li class="mr-3"><a href="https://developer.github.com" data-ga-click="Footer, go to api, text:api">API</a></li>
+      <li class="mr-3"><a href="https://training.github.com" data-ga-click="Footer, go to training, text:training">Training</a></li>
+      <li class="mr-3"><a href="https://shop.github.com" data-ga-click="Footer, go to shop, text:shop">Shop</a></li>
+        <li class="mr-3"><a href="https://blog.github.com" data-ga-click="Footer, go to blog, text:blog">Blog</a></li>
+        <li><a data-ga-click="Footer, go to about, text:about" href="https://github.com/about">About</a></li>
+
+    </ul>
+  </div>
+  <div class="d-flex flex-justify-center pb-6">
+    <span class="f6 text-gray-light"></span>
+  </div>
+</div>
+
+
+
+  <div id="ajax-error-message" class="ajax-error-message flash flash-error">
+    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>
+    <button type="button" class="flash-close js-ajax-error-dismiss" aria-label="Dismiss error">
+      <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+    </button>
+    You can’t perform that action at this time.
+  </div>
+
+
+    <script crossorigin="anonymous" integrity="sha512-wIuAKDhvxe9wCaNR1tzCk3rtl+wXEWC28rmRpzmx0h98VEeWC6Y3xCWV1xAW6NP6eQQX+x8ZGhW6Sdut+mLRuw==" type="application/javascript" src="https://assets-cdn.github.com/assets/compat-a48960bafc17c30572990bbab3664e9c.js"></script>
+    <script crossorigin="anonymous" integrity="sha512-p2dj0M9bdLkvNuMgpb7zWmX32xE8xcY6YhDCo20ZriI2fk9tj8/8o98UF/beOTEI6ii8MIJMtKIb7RQnLmQkbA==" type="application/javascript" src="https://assets-cdn.github.com/assets/frameworks-92b196ce6913906278278c620acece50.js"></script>
+    
+    <script crossorigin="anonymous" async="async" integrity="sha512-lXaVVoQJPxJPV/ng2qFbuSrXGhcS30nK7ICj7N2AcDrVyn2B97XdXUEJBOwWjlKdijpmTVbBBbpUMMhvYpcnBw==" type="application/javascript" src="https://assets-cdn.github.com/assets/github-80cedacd4cb60ab13be1385a8c947598.js"></script>
+    
+    
+    
+  <div class="js-stale-session-flash stale-session-flash flash flash-warn flash-banner d-none">
+    <svg class="octicon octicon-alert" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M8.893 1.5c-.183-.31-.52-.5-.887-.5s-.703.19-.886.5L.138 13.499a.98.98 0 0 0 0 1.001c.193.31.53.501.886.501h13.964c.367 0 .704-.19.877-.5a1.03 1.03 0 0 0 .01-1.002L8.893 1.5zm.133 11.497H6.987v-2.003h2.039v2.003zm0-3.004H6.987V5.987h2.039v4.006z"/></svg>
+    <span class="signed-in-tab-flash">You signed in with another tab or window. <a href="">Reload</a> to refresh your session.</span>
+    <span class="signed-out-tab-flash">You signed out in another tab or window. <a href="">Reload</a> to refresh your session.</span>
+  </div>
+  <div class="facebox" id="facebox" style="display:none;">
+  <div class="facebox-popup">
+    <div class="facebox-content" role="dialog" aria-labelledby="facebox-header" aria-describedby="facebox-description">
+    </div>
+    <button type="button" class="facebox-close js-facebox-close" aria-label="Close modal">
+      <svg class="octicon octicon-x" viewBox="0 0 12 16" version="1.1" width="12" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/></svg>
+    </button>
+  </div>
+</div>
+
+  <div class="Popover js-hovercard-content position-absolute" style="display: none; outline: none;" tabindex="0">
+  <div class="Popover-message Popover-message--bottom-left Popover-message--large Box box-shadow-large" style="width:360px;">
+  </div>
+</div>
+
+<div id="hovercard-aria-description" class="sr-only">
+  Press h to open a hovercard with more details.
+</div>
+
+
+  </body>
+</html>
+


### PR DESCRIPTION
As raised in #2383, we currently do a poor job of verifying whether the specified files actually really are easyconfig files before we start processing them...

The fix for this is pretty straightforward: initialize the `EasyConfigParser` object a bit earlier, since that also includes a "raw" parse of the easyconfig file (basically just interpreting the Python code in it).

This leads to a clear error when something other than an easyconfig file is passed by accident, for example an HTML page obtained by incorrectly downloading an easyconfig file using `wget`:

```
$ eb test/framework/sandbox/not_an_easyconfig.eb
== temporary log file in case of crash /tmp/eb-P6752K/easybuild-h_JEyc.log
ERROR: Failed to process easyconfig /Volumes/work/easybuild-framework/test/framework/sandbox/not_an_easyconfig.eb: Parsing easyconfig file failed: invalid syntax (<string>, line 1)
```