### PR TITLE
fix error message that is raised for incorrect type of value in sanity_check_paths

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2219,8 +2219,8 @@ class EasyBlock(object):
                 if isinstance(xs, basestring):
                     xs = (xs,)
                 elif not isinstance(xs, tuple):
-                    raise EasyBuildError("Unsupported type '%s' encountered in %s, not a string or tuple",
-                                         key, type(xs))
+                    raise EasyBuildError("Unsupported type %s encountered in '%s', not a string or tuple",
+                                         type(xs), key)
 
                 found = check_path(xs, typ, check_fn)
 


### PR DESCRIPTION
Error produced now when a `None` entry gets included in the `'dirs'` list in `sanity_check_paths` is:

```
 Unsupported type 'dirs' encountered in <type 'NoneType'>, not a string or tuple
```

while it should be:

```
 Unsupported type <type 'NoneType'> encountered in 'dirs', not a string or tuple
```