### PR TITLE
fall back to downloading using the requests Python package (if installed) when urllib2 fails due to SSL error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ before_install:
     # autopep8 1.3.4 is last one to support Python 2.6
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'autopep8<1.3.5'; else pip install autopep8; fi
     # optional Python packages for EasyBuild
-    - pip install GC3Pie pycodestyle python-graph-dot python-hglib PyYAML
+    - pip install GC3Pie pycodestyle python-graph-dot python-hglib PyYAML requests
     # git config is required to make actual git commits (cfr. tests for GitRepository)
     - git config --global user.name "Travis CI"
     - git config --global user.email "travis@travis-ci.org"

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -498,14 +498,13 @@ def download_file(filename, url, path, forced=False):
                 _log.warning("HTTPError occurred while trying to download %s to %s: %s" % (url, path, err))
                 attempt_cnt += 1
         except IOError as err:
+            _log.warning("IOError occurred while trying to download %s to %s: %s" % (url, path, err))
             error_re = re.compile(r"<urlopen error \[Errno 1\] _ssl.c:.*: error:.*:"
                                   "SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure>")
             if error_re.match(str(err)):
-                raise EasyBuildError("SSL issues with urllib2. If you are using RHEL/CentOS 6.x please\n"
+                raise EasyBuildError("SSL issues with urllib2. If you are using RHEL/CentOS 6.x please "
                                      "install the python-requests and pyOpenSSL RPM packages and try again.")
-            else:
-                _log.warning("IOError occurred while trying to download %s to %s: %s" % (url, path, err))
-                attempt_cnt += 1
+            attempt_cnt += 1
         except Exception, err:
             raise EasyBuildError("Unexpected error occurred when trying to download %s to %s: %s", url, path, err)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -466,6 +466,7 @@ def download_file(filename, url, path, forced=False):
 
     # use custom HTTP header
     headers = {'User-Agent': 'EasyBuild', 'Accept': '*/*'}
+    # for backward compatibility, and to avoid relying on 3rd party Python library 'requests'
     url_req = urllib2.Request(url, headers=headers)
     used_urllib = urllib2
 
@@ -476,10 +477,10 @@ def download_file(filename, url, path, forced=False):
                 url_fd = urllib2.urlopen(url_req, timeout=timeout)
                 status_code = url_fd.getcode()
             else:
-                url_req = requests.get(url, headers=headers, stream=True, timeout=timeout)
-                status_code = url_req.status_code
-                url_req.raise_for_status()
-                url_fd = url_req.raw
+                r = requests.get(url, headers=headers, stream=True, timeout=timeout)
+                status_code = r.status_code
+                r.raise_for_status()
+                url_fd = r.raw
                 url_fd.decode_content = True
             _log.debug('response code for given url %s: %s' % (url, status_code))
             write_file(path, url_fd.read(), forced=forced, backup=True)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -467,7 +467,7 @@ def download_file(filename, url, path, forced=False):
     attempt_cnt = 0
 
     # use custom HTTP header
-    headers = {'User-Agent': 'EasyBuild',  "Accept" : "*/*"}
+    headers = {'User-Agent' : 'EasyBuild',  "Accept" : "*/*"}
     if not HAVE_REQUESTS:
         url_req = urllib2.Request(url, headers=headers)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -477,10 +477,10 @@ def download_file(filename, url, path, forced=False):
                 url_fd = urllib2.urlopen(url_req, timeout=timeout)
                 status_code = url_fd.getcode()
             else:
-                r = requests.get(url, headers=headers, stream=True, timeout=timeout)
-                status_code = r.status_code
-                r.raise_for_status()
-                url_fd = r.raw
+                response = requests.get(url, headers=headers, stream=True, timeout=timeout)
+                status_code = response.status_code
+                response.raise_for_status()
+                url_fd = response.raw
                 url_fd.decode_content = True
             _log.debug('response code for given url %s: %s' % (url, status_code))
             write_file(path, url_fd.read(), forced=forced, backup=True)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -467,7 +467,7 @@ def download_file(filename, url, path, forced=False):
     attempt_cnt = 0
 
     # use custom HTTP header
-    headers = {'User-Agent' : 'EasyBuild',  "Accept" : "*/*"}
+    headers = {'User-Agent': 'EasyBuild', 'Accept': '*/*'}
     if not HAVE_REQUESTS:
         url_req = urllib2.Request(url, headers=headers)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -478,6 +478,7 @@ def download_file(filename, url, path, forced=False):
                 status_code = url_req.status_code
                 url_req.raise_for_status()
                 url_fd = url_req.raw
+                url_fd.decode_content = True
             else:
                 # urllib2 does the right thing for http proxy setups, urllib does not!
                 url_fd = urllib2.urlopen(url_req, timeout=timeout)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -498,8 +498,14 @@ def download_file(filename, url, path, forced=False):
                 _log.warning("HTTPError occurred while trying to download %s to %s: %s" % (url, path, err))
                 attempt_cnt += 1
         except IOError as err:
-            _log.warning("IOError occurred while trying to download %s to %s: %s" % (url, path, err))
-            attempt_cnt += 1
+            error_re = re.compile(r"<urlopen error \[Errno 1\] _ssl.c:.*: error:.*:"
+                                  "SSL routines:SSL23_GET_SERVER_HELLO:sslv3 alert handshake failure>")
+            if error_re.match(str(err)):
+                raise EasyBuildError("SSL issues with urllib2. If you are using RHEL/CentOS 6.x please\n"
+                                     "install the python-requests and pyOpenSSL RPM packages and try again.")
+            else:
+                _log.warning("IOError occurred while trying to download %s to %s: %s" % (url, path, err))
+                attempt_cnt += 1
         except Exception, err:
             raise EasyBuildError("Unexpected error occurred when trying to download %s to %s: %s", url, path, err)
 


### PR DESCRIPTION
This fixes #2522 for me, on a new enough CentOS 6 with these packages
installed:
python-requests-2.6.0-4.el6.noarch
pyOpenSSL-0.13.1-2.el6.x86_64