### PR TITLE
grab maximum amount of comments to fix issue with --merge-pr if there any many comments in a PR

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -942,6 +942,7 @@ def check_pr_eligible_to_merge(pr_data):
                 elif 'FAILED' in comment:
                     res = not_eligible(msg_tmpl % 'FAILED')
                     test_report_found = True
+                    break
                 else:
                     print_warning("Failed to determine outcome of test report for comment:\n%s" % comment)
 
@@ -1004,7 +1005,7 @@ def merge_pr(pr):
 
     # also fetch comments
     comments_url = lambda g: g.repos[pr_target_account][pr_target_repo].issues[pr].comments
-    status, comments_data = github_api_get_request(comments_url, github_user)
+    status, comments_data = github_api_get_request(comments_url, github_user, per_page=GITHUB_MAX_PER_PAGE)
     if status != HTTP_STATUS_OK:
         raise EasyBuildError("Failed to get comments for PR #%d from %s/%s (status: %d %s)",
                              pr, pr_target_account, pr_target_repo, status, comments_data)


### PR DESCRIPTION
This fixes a problem I ran into when merging https://github.com/easybuilders/easybuild-easyconfigs/pull/6677 using `eb --merge-pr`:

```
$ eb --merge-pr 6677

== temporary log file in case of crash /Users/kehoste/work/TMP/eb-OIjkhI/easybuild-VQoHGP.log

easybuilders/easybuild-easyconfigs PR #6677 was submitted by akesandgren, you are using GitHub account 'boegel'

Checking eligibility of easybuilders/easybuild-easyconfigs PR #6677 for merging...
* targets develop branch: OK
* test suite passes: OK
* last test report is successful: FAILED => not eligible for merging!
* last test report is successful: FAILED => not eligible for merging!
* last test report is successful: OK
* approved review: OK (by boegel)
* milestone is set: OK (3.7.0)

WARNING: Review indicates this PR should not be merged (use -f/--force to do so anyway)
```

The problem is that this PR has many comments, exceeded the default number of comments that are returned by the GitHub API.

There's still a problem when a PR has more than 100 comments, but to fix that we'll need to make the fetching of comments page-aware, cfr. https://developer.github.com/v3/#pagination + https://developer.github.com/v3/guides/traversing-with-pagination/