### PR TITLE
Check gc3pie version using the `pkg_resources` API.

### DIFF
--- a/easybuild/tools/job/gc3pie.py
+++ b/easybuild/tools/job/gc3pie.py
@@ -79,7 +79,7 @@ class GC3Pie(JobBackend):
     terminated.
     """
 
-    REQ_VERSION = '2.4.0'
+    REQ_VERSION = '2.5.0'
 
     @only_if_module_is_available('gc3libs', pkgname='gc3pie')
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Do not rely on `__version__` attributes, which were removed during the development of the 2.5.0 release.

Also, increase minimal required GC3Pie version to 2.5.0