### PR TITLE
Generate pyver etc. when depending on Python-core

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -75,6 +75,7 @@ TEMPLATE_SOFTWARE_VERSIONS = [
     ('Java', 'java'),
     ('Perl', 'perl'),
     ('Python', 'py'),
+    ('Python-core', 'py'),
     ('R', 'r'),
 ]
 # constant templates that can be used in easyconfigs


### PR DESCRIPTION
As I've started to use Python-core at GCCcore level, I found that when moving some depedencies, like wheel-0.31.1 to GCCcore 7.3.0, it failed as %(pyver) initialized by the template code.

This simply introduces name Python-core as an alternative as a fix.