### PR TITLE
templating must be disabled when parsing dependencies in EasyConfig.parse

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -498,13 +498,16 @@ class EasyConfig(object):
             parse_hook_msg = "Running %s hook for %s..." % (PARSE, os.path.basename(self.path))
 
         run_hook(PARSE, hooks, args=[self], msg=parse_hook_msg)
-        self.enable_templating = prev_enable_templating
 
         # parse dependency specifications
+        # it's important that templating is still disabled at this stage!
         self.log.info("Parsing dependency specifications...")
         self['builddependencies'] = [self._parse_dependency(dep, build_only=True) for dep in self['builddependencies']]
         self['dependencies'] = [self._parse_dependency(dep) for dep in self['dependencies']]
         self['hiddendependencies'] = [self._parse_dependency(dep, hidden=True) for dep in self['hiddendependencies']]
+
+        # restore templating
+        self.enable_templating = prev_enable_templating
 
         # update templating dictionary
         self.generate_template_values()

--- a/test/framework/easyconfigs/test_ecs/i/iccifort/iccifort-2013.5.192-GCC-4.8.3.eb
+++ b/test/framework/easyconfigs/test_ecs/i/iccifort/iccifort-2013.5.192-GCC-4.8.3.eb
@@ -10,8 +10,9 @@ description = """Intel C, C++ and Fortran compilers"""
 toolchain = {'name': 'dummy', 'version': 'dummy'}
 
 dependencies = [
-    ('icc', version, versionsuffix),
-    ('ifort', version, versionsuffix),
+    # use of %(version)s & %(versionsuffix)s is a bit silly here, but it should work too...
+    ('icc', version, '%(versionsuffix)s'),
+    ('ifort', '%(version)s', versionsuffix),
 ]
 
 moduleclass = 'toolchain'


### PR DESCRIPTION
fix for problem introduced in #2562 (cc @akesandgren)

Before the changes in #2562, it was OK that templating was enabled when `_parse_dependency` was called, because the templating only occurs when easyconfig parameters are fetched via `self` (using `self[key`), i.e. the `EasyConfig` instance. When the easyconfig parameters are fetching via `local_vars[key]` there is no templating since `local_vars` is a regular `dict` value...

also fixes https://github.com/easybuilders/easybuild-easyconfigs/issues/6818