### PR TITLE
skip running of configuration checks while only a single configuration level is taken into account during --show-config

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2935,6 +2935,11 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     def test_show_config_cfg_levels(self):
         """Test --show-config in relation to how configuring across multiple configuration levels interacts with it."""
+
+        # make sure default module syntax is used
+        if 'EASYBUILD_MODULE_SYNTAX' in os.environ:
+            del os.environ['EASYBUILD_MODULE_SYNTAX']
+
         # configuring --modules-tool and --module-syntax on different levels should NOT cause problems
         # cfr. bug report https://github.com/easybuilders/easybuild-framework/issues/2564
         os.environ['EASYBUILD_MODULES_TOOL'] = 'EnvironmentModulesC'
@@ -2957,6 +2962,10 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     def test_modules_tool_vs_syntax_check(self):
         """Verify that check for modules tool vs syntax works."""
+
+        # make sure default module syntax is used
+        if 'EASYBUILD_MODULE_SYNTAX' in os.environ:
+            del os.environ['EASYBUILD_MODULE_SYNTAX']
 
         # using EnvironmentModulesC modules tool with default module syntax (Lua) is a problem
         os.environ['EASYBUILD_MODULES_TOOL'] = 'EnvironmentModulesC'

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2464,11 +2464,11 @@ class CommandLineOptionsTest(EnhancedTestCase):
             else:
                 self.assertFalse(regex.search(txt), "Pattern '%s' NOT found in: %s" % (regex.pattern, txt))
 
-    def _run_mock_eb(self, args, do_build=False, raise_error=False, verbose=False, testing=True, strip=False):
+    def _run_mock_eb(self, args, strip=False, **kwargs):
         """Helper function to mock easybuild runs"""
         self.mock_stdout(True)
         self.mock_stderr(True)
-        self.eb_main(args, do_build=do_build, raise_error=raise_error, verbose=verbose, testing=testing)
+        self.eb_main(args, **kwargs)
         stdout_txt = self.get_stdout()
         stderr_txt = self.get_stderr()
         self.mock_stdout(False)
@@ -2932,6 +2932,28 @@ class CommandLineOptionsTest(EnhancedTestCase):
         txt, _ = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False, strip=True)
         regex = re.compile(r'^include-easyblocks \(E\) = .*/testeasyblocktoinclude.py$', re.M)
         self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
+
+    def test_show_config_cfg_levels(self):
+        """Test --show-config in relation to how configuring across multiple configuration levels interacts with it."""
+        # configuring --modules-tool and --module-syntax on different levels should NOT cause problems
+        # cfr. bug report https://github.com/easybuilders/easybuild-framework/issues/2564
+        os.environ['EASYBUILD_MODULES_TOOL'] = 'EnvironmentModulesC'
+        args = [
+            '--module-syntax=Tcl',
+            '--show-config',
+        ]
+        # set init_config to False to avoid that eb_main (called by _run_mock_eb) re-initialises configuration
+        # this fails because $EASYBUILD_MODULES_TOOL=EnvironmentModulesC conflicts with default module syntax (Lua)
+        stdout, _ = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False, strip=True, init_config=False)
+
+        patterns = [
+            "^# Current EasyBuild configuration",
+            "^module-syntax\s*\(C\) = Tcl",
+            "^modules-tool\s*\(E\) = EnvironmentModulesC",
+        ]
+        for pattern in patterns:
+            regex = re.compile(pattern, re.M)
+            self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
 
     def test_prefix(self):
         """Test which configuration settings are affected by --prefix."""

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -250,7 +250,7 @@ class EnhancedTestCase(_EnhancedTestCase):
         self.modtool.set_mod_paths()
 
     def eb_main(self, args, do_build=False, return_error=False, logfile=None, verbose=False, raise_error=False,
-                reset_env=True, raise_systemexit=False, testing=True):
+                reset_env=True, raise_systemexit=False, testing=True, init_config=True):
         """Helper method to call EasyBuild main function."""
         cleanup()
 
@@ -282,8 +282,9 @@ class EnhancedTestCase(_EnhancedTestCase):
 
         os.chdir(self.cwd)
 
-        # make sure config is reinitialized
-        init_config(with_include=False)
+        if init_config:
+            # make sure config is reinitialized
+            init_config(with_include=False)
 
         # restore environment to what it was before running main,
         # changes may have been made by eb_main (e.g. $TMPDIR & co)

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -250,7 +250,7 @@ class EnhancedTestCase(_EnhancedTestCase):
         self.modtool.set_mod_paths()
 
     def eb_main(self, args, do_build=False, return_error=False, logfile=None, verbose=False, raise_error=False,
-                reset_env=True, raise_systemexit=False, testing=True, init_config=True):
+                reset_env=True, raise_systemexit=False, testing=True, redo_init_config=True):
         """Helper method to call EasyBuild main function."""
         cleanup()
 
@@ -282,7 +282,7 @@ class EnhancedTestCase(_EnhancedTestCase):
 
         os.chdir(self.cwd)
 
-        if init_config:
+        if redo_init_config:
             # make sure config is reinitialized
             init_config(with_include=False)
 


### PR DESCRIPTION
fixes #2564 (cc @omula)

Without this change, the `postprocess` method was triggered several times when `--show-config` is used: once for the initial processing of the configuration options, and then a couple times more while while the `show_method` figures out on which configuration level each setting was defined.

This change skips the configuration checks part that was done in `postprocess` when `show_config` is triggered (but the checks are still run during the initial processing of the configuration options).