### PR TITLE
fix default value for extension checksums to avoid TypeError when indexing a None

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -490,7 +490,7 @@ class EasyBlock(object):
                         'options': ext_options,
                     }
 
-                    checksums = ext_options.get('checksums', None)
+                    checksums = ext_options.get('checksums', [])
 
                     if ext_options.get('source_tmpl', None):
                         fn = resolve_template(ext_options['source_tmpl'], ext_src)


### PR DESCRIPTION
fix for bug introduced in #2561, which is triggered only for an extension that i) has one or more `patches`, and ii) does *not* have any `checksums`

```
ERROR: Traceback (most recent call last):
  File "/lib/python2.6/site-packages/easybuild_framework-3.6.3.dev0-py2.7.egg/easybuild/main.py", line 126, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/lib/python2.7/site-packages/easybuild_framework-3.6.3.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2831, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/lib/python2.7/site-packages/easybuild_framework-3.6.3.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2747, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/lib/python2.7/site-packages/easybuild_framework-3.6.3.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2613, in run_step
    step_method(self)()
  File "/lib/python2.7/site-packages/easybuild_framework-3.6.3.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 1651, in fetch_step
    self.exts = self.fetch_extension_sources(skip_checksums=skip_checksums)
  File "/lib/python2.7/site-packages/easybuild_framework-3.6.3.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 542, in fetch_extension_sources
    checksum = self.get_checksum_for(checksums[1:], filename=patch, index=idx)
TypeError: 'NoneType' object has no attribute '__getitem__'
```

Not sure it's worth puzzling together a test for this...