### PR TITLE
Correct error statements in module checks

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -242,16 +242,16 @@ class ModulesTool(object):
         if self.REQ_VERSION is not None:
             self.log.debug("Required minimum version defined.")
             if StrictVersion(self.version) < StrictVersion(self.REQ_VERSION):
-                raise EasyBuildError("EasyBuild requires v%s >= v%s, found v%s",
-                                     self.__class__.__name__, self.version, self.REQ_VERSION)
+                raise EasyBuildError("EasyBuild requires %s >= v%s, found v%s",
+                                     self.__class__.__name__, self.REQ_VERSION, self.version)
             else:
                 self.log.debug('Version %s matches requirement >= %s', self.version, self.REQ_VERSION)
 
         if self.MAX_VERSION is not None:
             self.log.debug("Maximum allowed version defined.")
             if StrictVersion(self.version) > StrictVersion(self.MAX_VERSION):
-                raise EasyBuildError("EasyBuild requires v%s <= v%s, found v%s",
-                                     self.__class__.__name__, self.version, self.MAX_VERSION)
+                raise EasyBuildError("EasyBuild requires %s <= v%s, found v%s",
+                                     self.__class__.__name__, self.MAX_VERSION, self.version)
             else:
                 self.log.debug('Version %s matches requirement <= %s', self.version, self.MAX_VERSION)
 


### PR DESCRIPTION
Without this you get an error like:
```
ERROR: EasyBuild requires vLmod >= v6.6, found v6.6.3
```