### PR TITLE
skip checksum check for extensions that are specified only by name 

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1726,11 +1726,15 @@ class EasyBlock(object):
 
         # also check checksums for extensions
         for ext in self.cfg['exts_list']:
-            ext_name = ext[0]
-            # take into account that extension may be a 2-tuple with just name/version
-            ext_opts = ext[2] if len(ext) == 3 else {}
-            # only a single source per extension is supported (see source_tmpl)
-            checksum_issues.extend(self.check_checksums_for(ext_opts, sub="of extension %s" % ext_name, source_cnt=1))
+            # just skip extensions for which only a name is specified
+            # those are just there to check for things that are in the "standard library"
+            if not isinstance(ext, basestring):
+                ext_name = ext[0]
+                # take into account that extension may be a 2-tuple with just name/version
+                ext_opts = ext[2] if len(ext) == 3 else {}
+                # only a single source per extension is supported (see source_tmpl)
+                res = self.check_checksums_for(ext_opts, sub="of extension %s" % ext_name, source_cnt=1)
+                checksum_issues.extend(res)
 
         return checksum_issues
 

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-1.3.12-test.eb
@@ -25,6 +25,7 @@ exts_default_options = {
 }
 
 exts_list = [
+    'ls',  # extension that is part of "standard library"
     ('bar', '0.0', {
         'buildopts': " && gcc bar.c -o anotherbar",
         'checksums': ['f3676716b610545a4e8035087f5be0a0248adee0abb3930d3edb76d498ae91e7'],  # checksum for 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3535,7 +3535,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertEqual(ec['patches'], ['toy-0.0_fix-silly-typo-in-printf-statement.patch'])
         self.assertEqual(ec['checksums'], [toy_source_sha256, toy_patch_sha256])
         self.assertEqual(ec['exts_default_options'], {'source_urls': ['http://example.com/%(name)s']})
-        self.assertEqual(ec['exts_list'][0], ('bar', '0.0', {
+        self.assertEqual(ec['exts_list'][0], 'ls')
+        self.assertEqual(ec['exts_list'][1], ('bar', '0.0', {
             'buildopts': " && gcc bar.c -o anotherbar",
             'checksums': [
                 bar_tar_gz_sha256,
@@ -3546,7 +3547,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             'toy_ext_param': "mv anotherbar bar_bis",
             'unknowneasyconfigparameterthatshouldbeignored': 'foo',
         }))
-        self.assertEqual(ec['exts_list'][1], ('barbar', '0.0', {
+        self.assertEqual(ec['exts_list'][2], ('barbar', '0.0', {
             'checksums': ['a33100d1837d6d54edff7d19f195056c4bd9a4c8d399e72feaf90f0216c4c91c'],
         }))
 
@@ -3562,7 +3563,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         # if any checksums are present already, it doesn't matter if they're wrong (since they will be replaced)
         ectxt = read_file(test_ec)
-        for chksum in ec['checksums'] + [c for e in ec['exts_list'] for c in e[2]['checksums']]:
+        for chksum in ec['checksums'] + [c for e in ec['exts_list'][1:] for c in e[2]['checksums']]:
             ectxt = ectxt.replace(chksum, chksum[::-1])
         write_file(test_ec, ectxt)
 

--- a/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
@@ -47,22 +47,25 @@ class Toy_Extension(ExtensionEasyBlock):
 
     def run(self):
         """Build toy extension."""
-        super(Toy_Extension, self).run(unpack_src=True)
-        EB_toy.configure_step(self.master, name=self.name)
-        EB_toy.build_step(self.master, name=self.name, buildopts=self.cfg['buildopts'])
+        if self.src:
+            super(Toy_Extension, self).run(unpack_src=True)
+            EB_toy.configure_step(self.master, name=self.name)
+            EB_toy.build_step(self.master, name=self.name, buildopts=self.cfg['buildopts'])
 
-        if self.cfg['toy_ext_param']:
-            run_cmd(self.cfg['toy_ext_param'])
+            if self.cfg['toy_ext_param']:
+                run_cmd(self.cfg['toy_ext_param'])
 
-        EB_toy.install_step(self.master, name=self.name)
+            EB_toy.install_step(self.master, name=self.name)
 
-        return self.module_generator.set_environment('TOY_EXT_%s' % self.name.upper(), self.name)
+            return self.module_generator.set_environment('TOY_EXT_%s' % self.name.upper(), self.name)
 
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for toy extensions."""
         self.log.info("Loaded modules: %s", self.modules_tool.list())
         custom_paths = {
-            'files': ['bin/%s' % self.name, 'lib/lib%s.a' % self.name],
-            'dirs': [],
+            'files': [],
+            'dirs': ['.'],  # minor hack to make sure there's always a non-empty list
         }
+        if self.src:
+            custom_paths['files'].extend(['bin/%s' % self.name, 'lib/lib%s.a' % self.name])
         return super(Toy_Extension, self).sanity_check_step(custom_paths=custom_paths)


### PR DESCRIPTION
automated checking for checksums in files touched by PRs fails on `R` easyconfigs, since those include a bunch of name-only extensions in `exts_list` to "sanity check" the base installation...