### PR TITLE
fix SUBTOOLCHAINS spec for intel-para toolchain

### DIFF
--- a/easybuild/toolchains/intel-para.py
+++ b/easybuild/toolchains/intel-para.py
@@ -40,4 +40,4 @@ class IntelPara(Ipsmpi, IntelMKL, IntelFFTW):
     Intel Math Kernel Library (MKL) and Intel FFTW wrappers.
     """
     NAME = 'intel-para'
-    SUBTOOLCHAIN = [Ipsmpi.NAME, Iimkl]
+    SUBTOOLCHAIN = [Ipsmpi.NAME, Iimkl.NAME]


### PR DESCRIPTION
slipped through the cracks in #2466 