### PR TITLE
lower required Lmod version to 6.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ python: 2.6
 env:
   matrix:
     # purposely specifying slowest builds first, to gain time overall
+    - LMOD_VERSION=6.5.1
+    - LMOD_VERSION=6.5.1 TEST_EASYBUILD_MODULE_SYNTAX=Tcl
     - LMOD_VERSION=6.6.3
     - LMOD_VERSION=6.6.3 TEST_EASYBUILD_MODULE_SYNTAX=Tcl
     - LMOD_VERSION=7.7.16
@@ -105,8 +107,10 @@ script:
     - EB_BOOTSTRAP_EXPECTED="20180925.01 d29478d5131fbf560a3806ef2613dc24e653c2857967788aace05107f614913b"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
-    - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap
+    # don't test bootstrap script when using Lmod 6.5.1 for now, since EasyBuild 3.7.0 requires Lmod 6.6.3...
+    - if [ -z "$LMOD_VERSION" ] || [ "x$LMOD_VERSION" != 'x6.5.1' ]; then python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap; fi
     # unset $PYTHONPATH to avoid mixing two EasyBuild 'installations' when testing bootstrapped EasyBuild module
     - unset PYTHONPATH
     # simply sanity check on bootstrapped EasyBuild module
-    - module use /tmp/$TRAVIS_JOB_ID/eb_bootstrap/modules/all; module load EasyBuild; eb --version
+    - module use /tmp/$TRAVIS_JOB_ID/eb_bootstrap/modules/all
+    - if [ -z "$LMOD_VERSION" ] || [ "x$LMOD_VERSION" != 'x6.5.1' ]; then module load EasyBuild; eb --version; fi

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1107,7 +1107,7 @@ class Lmod(ModulesTool):
     """Interface to Lmod."""
     COMMAND = 'lmod'
     COMMAND_ENVIRONMENT = 'LMOD_CMD'
-    REQ_VERSION = '6.6.3'
+    REQ_VERSION = '6.5.1'
     REQ_VERSION_DEPENDS_ON = '7.6.1'
     VERSION_REGEXP = r"^Modules\s+based\s+on\s+Lua:\s+Version\s+(?P<version>\d\S*)\s"
     USER_CACHE_DIR = os.path.join(os.path.expanduser('~'), '.lmod.d', '.cache')


### PR DESCRIPTION
Lmod 6.5.1 is the latest packaged version available for CentOS 7 currently.

Tests pass with Lmod 6.5.1, so it should be good enough.
The requirement for Lmod 6.6.3 was introduced in #2575, where I already highlighted that requiring Lmod 6.6.3 may be a bit too strict (cfr. https://github.com/easybuilders/easybuild-framework/pull/2575#discussion_r216639721).

See also discussion in https://lists.ugent.be/wws/arc/easybuild/2018-09/msg00021.html (cc @oleholmnielsen)