### PR TITLE
fix composing of lib64 fallback paths in sanity check

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2292,9 +2292,9 @@ class EasyBlock(object):
                 if not found and build_option('lib64_fallback_sanity_check'):
                     xs_alt = None
                     if all(x.startswith('lib/') for x in xs):
-                        xs_alt = [os.path.join('lib64', *os.path.split(x)[1:]) for x in xs]
+                        xs_alt = [os.path.join('lib64', *x.split(os.path.sep)[1:]) for x in xs]
                     elif all(x.startswith('lib64/') for x in xs):
-                        xs_alt = [os.path.join('lib', *os.path.split(x)[1:]) for x in xs]
+                        xs_alt = [os.path.join('lib', *x.split(os.path.sep)[1:]) for x in xs]
 
                     if xs_alt:
                         self.log.info("%s not found at %s in %s, consider fallback locations: %s",

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1637,6 +1637,15 @@ class ToyBuildTest(EnhancedTestCase):
         # sanity check passes when lib64 fallback is enabled (by default), since lib/libtoy.a is also considered
         self.test_toy_build(ec_file=test_ec, raise_error=True)
 
+        # check whether fallback works for files that's more than 1 subdir deep
+        ectxt = read_file(ec_file)
+        ectxt = re.sub("\s*'files'.*", "'files': ['bin/toy', 'lib/test/libtoy.a'],", ectxt)
+        postinstallcmd = "mkdir -p %(installdir)s/lib64/test && "
+        postinstallcmd += "mv %(installdir)s/lib/libtoy.a %(installdir)s/lib64/test/libtoy.a"
+        ectxt = re.sub("postinstallcmds.*", "postinstallcmds = ['%s']" % postinstallcmd, ectxt)
+        write_file(test_ec, ectxt)
+        self.test_toy_build(ec_file=test_ec, raise_error=True)
+
     def test_toy_dumped_easyconfig(self):
         """ Test dumping of file in eb_filerepo in both .eb and .yeb format """
         filename = 'toy-0.0'


### PR DESCRIPTION
Fix for a bug that @vanzod hit in https://github.com/easybuilders/easybuild-easyconfigs/pull/6918

`os.path.split` doesn't do what I thought it would do:

```
>>> os.path.split('lib/python2.7/site-packages')
('lib/python2.7', 'site-packages')
>>> 'lib/python2.7/site-packages'.split(os.path.sep)
['lib', 'python2.7', 'site-packages']
```