### PR TITLE
determine file_info for all easyconfigs before any actual copying

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1615,11 +1615,13 @@ def clean_up_easyconfigs(paths):
 
 def det_file_info(paths, target_dir):
     """
-    Determine useful information on easyconfig files relative to a target directory, before any actual operation (e.g. copying) is performed
+    Determine useful information on easyconfig files relative to a target directory,
+    before any actual operation (e.g. copying) is performed
 
     :param paths: list of paths to easyconfig files
     :param target_dir: target directory
-    :return: dict with useful information on easyconfig files (corresponding EasyConfig instances, paths, status) relative to a target directory
+    :return: dict with useful information on easyconfig files (corresponding EasyConfig instances, paths, status)
+             relative to a target directory
     """
     file_info = {
         'ecs': [],

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1851,7 +1851,7 @@ class EasyConfigTest(EnhancedTestCase):
         # passing an empty list of paths is fine
         res = copy_easyconfigs([], target_dir)
         self.assertEqual(res, {'ecs': [], 'new': [], 'new_file_in_existing_folder': [],
-                               'new_folder': [], 'paths_in_repo': []})
+                               'new_folder': [], 'paths': [], 'paths_in_repo': []})
         self.assertEqual(os.listdir(ecs_target_dir), [])
 
         # copy test easyconfigs, purposely under a different name
@@ -1868,7 +1868,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         res = copy_easyconfigs(ecs_to_copy, target_dir)
         self.assertEqual(sorted(res.keys()), ['ecs', 'new', 'new_file_in_existing_folder',
-                                              'new_folder', 'paths_in_repo'])
+                                              'new_folder', 'paths', 'paths_in_repo'])
         self.assertEqual(len(res['ecs']), len(test_ecs))
         self.assertTrue(all(isinstance(ec, EasyConfig) for ec in res['ecs']))
         self.assertTrue(all(res['new']))
@@ -1900,7 +1900,7 @@ class EasyConfigTest(EnhancedTestCase):
         # copy single easyconfig with buildstats included for running further tests
         res = copy_easyconfigs([toy_ec], target_dir)
 
-        self.assertEqual([len(x) for x in res.values()], [1, 1, 1, 1, 1])
+        self.assertEqual([len(x) for x in res.values()], [1, 1, 1, 1, 1, 1])
         self.assertEqual(res['ecs'][0].full_mod_name, 'toy/0.0')
 
         # toy-0.0.eb was already copied into target_dir, so should not be marked as new anymore


### PR DESCRIPTION
fixes an issue with `--new-pr` where both `new` and `update` labels were added (if submitted by a maintainer) when the PR includes multiple versions of the same new software



