### PR TITLE
add support for disabling modules tool version check

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -217,6 +217,7 @@ BUILD_OPTIONS_CMDLINE = {
         'cleanup_tmpdir',
         'extended_dry_run_ignore_errors',
         'mpi_tests',
+        'modules_tool_version_check',
     ],
     WARN: [
         'check_ebroot_env_vars',

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -239,21 +239,26 @@ class ModulesTool(object):
         if self.REQ_VERSION is None and self.MAX_VERSION is None:
             self.log.debug("No version requirement defined.")
 
-        if self.REQ_VERSION is not None:
-            self.log.debug("Required minimum version defined.")
-            if StrictVersion(self.version) < StrictVersion(self.REQ_VERSION):
-                raise EasyBuildError("EasyBuild requires %s >= v%s, found v%s",
-                                     self.__class__.__name__, self.REQ_VERSION, self.version)
-            else:
-                self.log.debug('Version %s matches requirement >= %s', self.version, self.REQ_VERSION)
+        elif build_option('modules_tool_version_check'):
+            self.log.debug("Checking whether modules tool version '%s' meets requirements", self.version)
 
-        if self.MAX_VERSION is not None:
-            self.log.debug("Maximum allowed version defined.")
-            if StrictVersion(self.version) > StrictVersion(self.MAX_VERSION):
-                raise EasyBuildError("EasyBuild requires %s <= v%s, found v%s",
-                                     self.__class__.__name__, self.MAX_VERSION, self.version)
-            else:
-                self.log.debug('Version %s matches requirement <= %s', self.version, self.MAX_VERSION)
+            if self.REQ_VERSION is not None:
+                self.log.debug("Required minimum version defined.")
+                if StrictVersion(self.version) < StrictVersion(self.REQ_VERSION):
+                    raise EasyBuildError("EasyBuild requires %s >= v%s, found v%s",
+                                         self.__class__.__name__, self.REQ_VERSION, self.version)
+                else:
+                    self.log.debug('Version %s matches requirement >= %s', self.version, self.REQ_VERSION)
+
+            if self.MAX_VERSION is not None:
+                self.log.debug("Maximum allowed version defined.")
+                if StrictVersion(self.version) > StrictVersion(self.MAX_VERSION):
+                    raise EasyBuildError("EasyBuild requires %s <= v%s, found v%s",
+                                         self.__class__.__name__, self.MAX_VERSION, self.version)
+                else:
+                    self.log.debug('Version %s matches requirement <= %s', self.version, self.MAX_VERSION)
+        else:
+            self.log.debug("Skipping check to see whether modules tool version '%s' meets requirements", self.version)
 
         MODULE_VERSION_CACHE[self.COMMAND] = self.version
 

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -258,7 +258,7 @@ class ModulesTool(object):
                 else:
                     self.log.debug('Version %s matches requirement <= %s', self.version, self.MAX_VERSION)
         else:
-            self.log.debug("Skipping check to see whether modules tool version '%s' meets requirements", self.version)
+            self.log.debug("Skipping modules tool version '%s' requirements check", self.version)
 
         MODULE_VERSION_CACHE[self.COMMAND] = self.version
 

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -391,6 +391,7 @@ class EasyBuildOptions(GeneralOption):
             'minimal-toolchains': ("Use minimal toolchain when resolving dependencies", None, 'store_true', False),
             'module-only': ("Only generate module file(s); skip all steps except for %s" % ', '.join(MODULE_ONLY_STEPS),
                             None, 'store_true', False),
+            'modules-tool-version-check': ("Check version of modules tool being used", None, 'store_true', True),
             'mpi-cmd-template': ("Template for MPI commands (template keys: %(nr_ranks)s, %(cmd)s)",
                                  None, 'store', None),
             'mpi-tests': ("Run MPI tests (when relevant)", None, 'store_true', True),


### PR DESCRIPTION
fix for #2609 

This add support for disabling the version check on the modules tool (e.g. `Lmod`) via `--disable-modules-tool-version-check` or `export EASYBUILD_DISABLE_MODULES_TOOL_VERSION_CHECK=1` (or similar via an EasyBuild configuration file)

cc @fgeorgatos 