### PR TITLE
Add option to skip pre-creation of install directory 

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -36,6 +36,7 @@ The EasyBlock class should serve as a base class for all easyblocks.
 :author: Fotis Georgatos (Uni.Lu, NTUA)
 :author: Damian Alvarez (Forschungszentrum Juelich GmbH)
 :author: Maxime Boissonneault (Compute Canada)
+:author: Davide Vanzo (Vanderbilt University)
 """
 
 import copy
@@ -1673,9 +1674,13 @@ class EasyBlock(object):
         for mod_symlink_path in mod_symlink_paths:
             pardirs.append(os.path.join(install_path('mod'), mod_symlink_path, mod_subdir))
 
-        self.log.info("Checking dirs that need to be created: %s" % pardirs)
-        for pardir in pardirs:
-            mkdir(pardir, parents=True)
+        # skip directory creation if pre-create-installdir is set to False
+        if build_option('pre_create_installdir'):
+            self.log.info("Checking dirs that need to be created: %s" % pardirs)
+            for pardir in pardirs:
+                mkdir(pardir, parents=True)
+        else:
+            self.log.info("Skipped installation dirs check per user request")
 
     def checksum_step(self):
         """Verify checksum of sources and patches, if a checksum is available."""

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -218,6 +218,7 @@ BUILD_OPTIONS_CMDLINE = {
         'extended_dry_run_ignore_errors',
         'mpi_tests',
         'modules_tool_version_check',
+        'pre_create_installdir',
     ],
     WARN: [
         'check_ebroot_env_vars',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -400,7 +400,7 @@ class EasyBuildOptions(GeneralOption):
             'output-format': ("Set output format", 'choice', 'store', FORMAT_TXT, [FORMAT_TXT, FORMAT_RST]),
             'parallel': ("Specify (maximum) level of parallellism used during build procedure",
                          'int', 'store', None),
-            'pre-create-installdir': ("Creates installation directory before submitting build jobs", 
+            'pre-create-installdir': ("Create installation directory before submitting build jobs", 
                                       None, 'store_true', True),
             'pretend': (("Does the build/installation in a test directory located in $HOME/easybuildinstall"),
                         None, 'store_true', False, 'p'),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -401,7 +401,7 @@ class EasyBuildOptions(GeneralOption):
             'parallel': ("Specify (maximum) level of parallellism used during build procedure",
                          'int', 'store', None),
             'pre-create-installdir': ("Creates installation directory before submitting build jobs", 
-                                      None, 'store_true', True), 
+                                      None, 'store_true', True),
             'pretend': (("Does the build/installation in a test directory located in $HOME/easybuildinstall"),
                         None, 'store_true', False, 'p'),
             'read-only-installdir': ("Set read-only permissions on installation directory after installation",

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -400,6 +400,8 @@ class EasyBuildOptions(GeneralOption):
             'output-format': ("Set output format", 'choice', 'store', FORMAT_TXT, [FORMAT_TXT, FORMAT_RST]),
             'parallel': ("Specify (maximum) level of parallellism used during build procedure",
                          'int', 'store', None),
+            'pre-create-installdir': ("Creates installation directory before submitting build jobs", 
+                                      None, 'store_true', True), 
             'pretend': (("Does the build/installation in a test directory located in $HOME/easybuildinstall"),
                         None, 'store_true', False, 'p'),
             'read-only-installdir': ("Set read-only permissions on installation directory after installation",


### PR DESCRIPTION
Allows to skip pre-creation of installation directory when running parallel build jobs.

See #2628 