### PR TITLE
flesh out setting up of configuration into dedicated 'set_up_configuration' function

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -190,7 +190,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     # purposely session state very early, to avoid modules loaded by EasyBuild meddling in
     init_session_state = session_state()
 
-    eb_go, cfg_settings = set_up_configuration(args)
+    eb_go, cfg_settings = set_up_configuration(args=args, logfile=logfile, testing=testing)
     options, orig_paths = eb_go.options, eb_go.args
 
     global _log

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -39,20 +39,17 @@ import copy
 import os
 import stat
 import sys
-import tempfile
 import traceback
 
 # IMPORTANT this has to be the first easybuild import as it customises the logging
 #  expect missing log output when this not the case!
-from easybuild.tools.build_log import EasyBuildError, init_logging, print_error, print_msg, print_warning, stop_logging
+from easybuild.tools.build_log import EasyBuildError, print_error, print_msg, stop_logging
 
-import easybuild.tools.config as config
-import easybuild.tools.options as eboptions
-from easybuild.framework.easyblock import EasyBlock, build_and_install_one, inject_checksums
+from easybuild.framework.easyblock import build_and_install_one, inject_checksums
 from easybuild.framework.easyconfig import EASYCONFIGS_PKG_SUBDIR
 from easybuild.framework.easyconfig.easyconfig import verify_easyconfig_filename
 from easybuild.framework.easyconfig.style import cmdline_easyconfigs_style_check
-from easybuild.framework.easyconfig.tools import alt_easyconfig_paths, categorize_files_by_type, dep_graph
+from easybuild.framework.easyconfig.tools import categorize_files_by_type, dep_graph
 from easybuild.framework.easyconfig.tools import det_easyconfig_paths, dump_env_script, get_paths_for
 from easybuild.framework.easyconfig.tools import parse_easyconfigs, review_pr, run_contrib_checks, skip_available
 from easybuild.framework.easyconfig.tweak import obtain_ec_for, tweak
@@ -64,25 +61,14 @@ from easybuild.tools.github import check_github, find_easybuild_easyconfig, inst
 from easybuild.tools.github import new_pr, merge_pr, update_pr
 from easybuild.tools.hooks import START, END, load_hooks, run_hook
 from easybuild.tools.modules import modules_tool
-from easybuild.tools.options import parse_external_modules_metadata, process_software_build_specs, use_color
-from easybuild.tools.robot import check_conflicts, det_robot_path, dry_run, resolve_dependencies, search_easyconfigs
+from easybuild.tools.options import set_up_configuration, use_color
+from easybuild.tools.robot import check_conflicts, dry_run, resolve_dependencies, search_easyconfigs
 from easybuild.tools.package.utilities import check_pkg_support
 from easybuild.tools.parallelbuild import submit_jobs
 from easybuild.tools.repository.repository import init_repository
 from easybuild.tools.testing import create_test_report, overall_test_report, regtest, session_state
-from easybuild.tools.version import this_is_easybuild
 
 _log = None
-
-
-def log_start(log, eb_command_line, eb_tmpdir):
-    """Log startup info."""
-    log.info(this_is_easybuild())
-
-    # log used command line
-    log.info("Command line: %s", ' '.join(eb_command_line))
-
-    log.info("Using %s as temporary directory", eb_tmpdir)
 
 
 def find_easyconfigs_by_specs(build_specs, robot_path, try_to_generate, testing=False):
@@ -187,96 +173,10 @@ def run_contrib_style_checks(ecs, check_contrib, check_style):
     return check_contrib or check_style
 
 
-def check_root_usage(allow_use_as_root=False):
-    """
-    Check whether we are running as root, and act accordingly
-
-    :param allow_use_as_root: allow use of EasyBuild as root (but do print a warning when doing so)
-    """
-    if os.getuid() == 0:
-        if allow_use_as_root:
-            msg = "Using EasyBuild as root is NOT recommended, please proceed with care!\n"
-            msg += "(this is only allowed because EasyBuild was configured with "
-            msg += "--allow-use-as-root-and-accept-consequences)"
-            print_warning(msg)
-        else:
-            raise EasyBuildError("You seem to be running EasyBuild with root privileges which is not wise, "
-                                 "so let's end this here.")
-
-
 def clean_exit(logfile, tmpdir, testing, silent=False):
     """Small utility function to perform a clean exit."""
     cleanup(logfile, tmpdir, testing, silent=silent)
     sys.exit(0)
-
-
-def set_up_configuration(args=None, logfile=None, testing=False):
-    """
-    Set up EasyBuild configuration, by parsing configuration settings & initialising build options.
-
-    :param args: command line arguments to take into account when parsing the EasyBuild configuration settings
-    :param logfile: log file to use
-    :param testing: enable testing mode
-    """
-
-    # parse EasyBuild configuration settings
-    eb_go = eboptions.parse_options(args=args)
-    options = eb_go.options
-
-    # tmpdir is set by option parser via set_tmpdir function
-    tmpdir = tempfile.gettempdir()
-
-    # set umask (as early as possible)
-    if options.umask is not None:
-        new_umask = int(options.umask, 8)
-        old_umask = os.umask(new_umask)
-
-    search_query = options.search or options.search_filename or options.search_short
-
-    # initialise logging for main
-    log, logfile = init_logging(logfile, logtostdout=options.logtostdout,
-                                silent=(testing or options.terse or search_query), colorize=options.color)
-
-    # log startup info (must be done after setting up logger)
-    eb_cmd_line = eb_go.generate_cmd_line() + eb_go.args
-    log_start(log, eb_cmd_line, tmpdir)
-
-    # can't log umask setting before logger is set up...
-    if options.umask is not None:
-        log.info("umask set to '%s' (used to be '%s')", oct(new_umask), oct(old_umask))
-
-    # disallow running EasyBuild as root (by default)
-    check_root_usage(allow_use_as_root=options.allow_use_as_root_and_accept_consequences)
-
-    # process software build specifications (if any), i.e.
-    # software name/version, toolchain name/version, extra patches, ...
-    (try_to_generate, build_specs) = process_software_build_specs(options)
-
-    # determine robot path
-    # --try-X, --dep-graph, --search use robot path for searching, so enable it with path of installed easyconfigs
-    tweaked_ecs = try_to_generate and build_specs
-    tweaked_ecs_paths, pr_path = alt_easyconfig_paths(tmpdir, tweaked_ecs=tweaked_ecs, from_pr=options.from_pr)
-    auto_robot = try_to_generate or options.check_conflicts or options.dep_graph or search_query
-    robot_path = det_robot_path(options.robot_paths, tweaked_ecs_paths, pr_path, auto_robot=auto_robot)
-    log.debug("Full robot path: %s" % robot_path)
-
-    # configure & initialize build options
-    config_options_dict = eb_go.get_options_by_section('config')
-    build_options = {
-        'build_specs': build_specs,
-        'command_line': eb_cmd_line,
-        'external_modules_metadata': parse_external_modules_metadata(options.external_modules_metadata),
-        'pr_path': pr_path,
-        'robot_path': robot_path,
-        'silent': testing,
-        'try_to_generate': try_to_generate,
-        'valid_stops': [x[0] for x in EasyBlock.get_steps()],
-    }
-    # initialise the EasyBuild configuration & build options
-    config.init(options, config_options_dict)
-    config.init_build_options(build_options=build_options, cmdline_options=options)
-
-    return eb_go, (build_specs, log, logfile, robot_path, search_query, tmpdir, try_to_generate, tweaked_ecs_paths)
 
 
 def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -41,7 +41,7 @@ from datetime import datetime
 from vsc.utils import fancylogger
 from vsc.utils.exceptions import LoggedException
 
-from easybuild.tools.version import VERSION
+from easybuild.tools.version import VERSION, this_is_easybuild
 
 
 # EasyBuild message prefix
@@ -204,19 +204,22 @@ def init_logging(logfile, logtostdout=False, silent=False, colorize=fancylogger.
     return log, logfile
 
 
+def log_start(log, eb_command_line, eb_tmpdir):
+    """Log startup info."""
+    log.info(this_is_easybuild())
+
+    # log used command line
+    log.info("Command line: %s", ' '.join(eb_command_line))
+
+    log.info("Using %s as temporary directory", eb_tmpdir)
+
+
 def stop_logging(logfile, logtostdout=False):
     """Stop logging."""
     if logtostdout:
         fancylogger.logToScreen(enable=False, stdout=True)
     if logfile is not None:
         fancylogger.logToFile(logfile, enable=False)
-
-
-def get_log(name=None):
-    """
-    (NO LONGER SUPPORTED!) Generate logger object
-    """
-    log.nosupport("Use of get_log function", '2.0')
 
 
 def print_msg(msg, log=None, silent=False, prefix=True, newline=True, stderr=False):

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -438,13 +438,17 @@ def init_build_options(build_options=None, cmdline_options=None):
 
 def build_option(key, **kwargs):
     """Obtain value specified build option."""
+
     build_options = BuildOptions()
     if key in build_options:
         return build_options[key]
     elif 'default' in kwargs:
         return kwargs['default']
     else:
-        raise EasyBuildError("Undefined build option: %s", key)
+        error_msg = "Undefined build option: '%s'. " % key
+        error_msg += "Make sure you have set up the EasyBuild configuration using set_up_configuration() "
+        error_msg += "(from easybuild.tools.options) in case you're not using EasyBuild via the 'eb' CLI."
+        raise EasyBuildError(error_msg)
 
 
 def build_path():

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -90,6 +90,7 @@ from easybuild.tools.toolchain.compiler import DEFAULT_OPT_LEVEL, OPTARCH_MAP_CH
 from easybuild.tools.repository.repository import avail_repositories
 from easybuild.tools.version import this_is_easybuild
 
+
 try:
     from humanfriendly.terminal import terminal_supports_colors
 except ImportError:
@@ -1168,13 +1169,14 @@ def check_root_usage(allow_use_as_root=False):
                                  "so let's end this here.")
 
 
-def set_up_configuration(args=None, logfile=None, testing=False):
+def set_up_configuration(args=None, logfile=None, testing=False, silent=False):
     """
     Set up EasyBuild configuration, by parsing configuration settings & initialising build options.
 
     :param args: command line arguments to take into account when parsing the EasyBuild configuration settings
     :param logfile: log file to use
     :param testing: enable testing mode
+    :param silent: stay silent (no printing)
     """
 
     # parse EasyBuild configuration settings
@@ -1193,7 +1195,8 @@ def set_up_configuration(args=None, logfile=None, testing=False):
 
     # initialise logging for main
     log, logfile = init_logging(logfile, logtostdout=options.logtostdout,
-                                silent=(testing or options.terse or search_query), colorize=options.color)
+                                silent=(testing or options.terse or search_query or silent),
+                                colorize=options.color)
 
     # log startup info (must be done after setting up logger)
     eb_cmd_line = eb_go.generate_cmd_line() + eb_go.args

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -53,9 +53,10 @@ from easybuild.framework.easyblock import MODULE_ONLY_STEPS, SOURCE_STEP, FETCH_
 from easybuild.framework.easyconfig import EASYCONFIGS_PKG_SUBDIR
 from easybuild.framework.easyconfig.easyconfig import HAVE_AUTOPEP8
 from easybuild.framework.easyconfig.format.pyheaderconfigobj import build_easyconfig_constants_dict
-from easybuild.framework.easyconfig.tools import get_paths_for
+from easybuild.framework.easyconfig.tools import alt_easyconfig_paths, get_paths_for
 from easybuild.tools import build_log, run  # build_log should always stay there, to ensure EasyBuildLog
-from easybuild.tools.build_log import DEVEL_LOG_LEVEL, EasyBuildError, raise_easybuilderror
+from easybuild.tools.build_log import DEVEL_LOG_LEVEL, EasyBuildError
+from easybuild.tools.build_log import init_logging, log_start, print_warning, raise_easybuilderror
 from easybuild.tools.config import CONT_IMAGE_FORMATS, CONT_TYPES, DEFAULT_CONT_TYPE
 from easybuild.tools.config import DEFAULT_ALLOW_LOADED_MODULES, DEFAULT_FORCE_DOWNLOAD, DEFAULT_JOB_BACKEND
 from easybuild.tools.config import DEFAULT_LOGFILE_FORMAT, DEFAULT_MAX_FAIL_RATIO_PERMS, DEFAULT_MNS
@@ -63,7 +64,7 @@ from easybuild.tools.config import DEFAULT_MODULE_SYNTAX, DEFAULT_MODULES_TOOL, 
 from easybuild.tools.config import DEFAULT_PATH_SUBDIRS, DEFAULT_PKG_RELEASE, DEFAULT_PKG_TOOL, DEFAULT_PKG_TYPE
 from easybuild.tools.config import DEFAULT_PNS, DEFAULT_PREFIX, DEFAULT_REPOSITORY, EBROOT_ENV_VAR_ACTIONS
 from easybuild.tools.config import ERROR, IGNORE, FORCE_DOWNLOAD_CHOICES, LOADED_MODULES_ACTIONS, WARN
-from easybuild.tools.config import get_pretend_installpath, mk_full_default_path
+from easybuild.tools.config import get_pretend_installpath, init, init_build_options, mk_full_default_path
 from easybuild.tools.configobj import ConfigObj, ConfigObjError
 from easybuild.tools.docs import FORMAT_TXT, FORMAT_RST
 from easybuild.tools.docs import avail_cfgfile_constants, avail_easyconfig_constants, avail_easyconfig_licenses
@@ -82,6 +83,7 @@ from easybuild.tools.module_naming_scheme import GENERAL_CLASS
 from easybuild.tools.module_naming_scheme.utilities import avail_module_naming_schemes
 from easybuild.tools.modules import Lmod
 from easybuild.tools.ordereddict import OrderedDict
+from easybuild.tools.robot import det_robot_path
 from easybuild.tools.run import run_cmd
 from easybuild.tools.package.utilities import avail_package_naming_schemes
 from easybuild.tools.toolchain.compiler import DEFAULT_OPT_LEVEL, OPTARCH_MAP_CHAR, OPTARCH_SEP, Compiler
@@ -1147,6 +1149,92 @@ def parse_options(args=None, with_include=True):
         raise EasyBuildError("Failed to parse configuration options: %s" % err)
 
     return eb_go
+
+
+def check_root_usage(allow_use_as_root=False):
+    """
+    Check whether we are running as root, and act accordingly
+
+    :param allow_use_as_root: allow use of EasyBuild as root (but do print a warning when doing so)
+    """
+    if os.getuid() == 0:
+        if allow_use_as_root:
+            msg = "Using EasyBuild as root is NOT recommended, please proceed with care!\n"
+            msg += "(this is only allowed because EasyBuild was configured with "
+            msg += "--allow-use-as-root-and-accept-consequences)"
+            print_warning(msg)
+        else:
+            raise EasyBuildError("You seem to be running EasyBuild with root privileges which is not wise, "
+                                 "so let's end this here.")
+
+
+def set_up_configuration(args=None, logfile=None, testing=False):
+    """
+    Set up EasyBuild configuration, by parsing configuration settings & initialising build options.
+
+    :param args: command line arguments to take into account when parsing the EasyBuild configuration settings
+    :param logfile: log file to use
+    :param testing: enable testing mode
+    """
+
+    # parse EasyBuild configuration settings
+    eb_go = parse_options(args=args)
+    options = eb_go.options
+
+    # tmpdir is set by option parser via set_tmpdir function
+    tmpdir = tempfile.gettempdir()
+
+    # set umask (as early as possible)
+    if options.umask is not None:
+        new_umask = int(options.umask, 8)
+        old_umask = os.umask(new_umask)
+
+    search_query = options.search or options.search_filename or options.search_short
+
+    # initialise logging for main
+    log, logfile = init_logging(logfile, logtostdout=options.logtostdout,
+                                silent=(testing or options.terse or search_query), colorize=options.color)
+
+    # log startup info (must be done after setting up logger)
+    eb_cmd_line = eb_go.generate_cmd_line() + eb_go.args
+    log_start(log, eb_cmd_line, tmpdir)
+
+    # can't log umask setting before logger is set up...
+    if options.umask is not None:
+        log.info("umask set to '%s' (used to be '%s')", oct(new_umask), oct(old_umask))
+
+    # disallow running EasyBuild as root (by default)
+    check_root_usage(allow_use_as_root=options.allow_use_as_root_and_accept_consequences)
+
+    # process software build specifications (if any), i.e.
+    # software name/version, toolchain name/version, extra patches, ...
+    (try_to_generate, build_specs) = process_software_build_specs(options)
+
+    # determine robot path
+    # --try-X, --dep-graph, --search use robot path for searching, so enable it with path of installed easyconfigs
+    tweaked_ecs = try_to_generate and build_specs
+    tweaked_ecs_paths, pr_path = alt_easyconfig_paths(tmpdir, tweaked_ecs=tweaked_ecs, from_pr=options.from_pr)
+    auto_robot = try_to_generate or options.check_conflicts or options.dep_graph or search_query
+    robot_path = det_robot_path(options.robot_paths, tweaked_ecs_paths, pr_path, auto_robot=auto_robot)
+    log.debug("Full robot path: %s" % robot_path)
+
+    # configure & initialize build options
+    config_options_dict = eb_go.get_options_by_section('config')
+    build_options = {
+        'build_specs': build_specs,
+        'command_line': eb_cmd_line,
+        'external_modules_metadata': parse_external_modules_metadata(options.external_modules_metadata),
+        'pr_path': pr_path,
+        'robot_path': robot_path,
+        'silent': testing,
+        'try_to_generate': try_to_generate,
+        'valid_stops': [x[0] for x in EasyBlock.get_steps()],
+    }
+    # initialise the EasyBuild configuration & build options
+    init(options, config_options_dict)
+    init_build_options(build_options=build_options, cmdline_options=options)
+
+    return eb_go, (build_specs, log, logfile, robot_path, search_query, tmpdir, try_to_generate, tweaked_ecs_paths)
 
 
 def process_software_build_specs(options):

--- a/test/framework/lib.py
+++ b/test/framework/lib.py
@@ -1,0 +1,130 @@
+# #
+# Copyright 2018-2018 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+# #
+"""
+Unit tests for using EasyBuild as a library.
+
+@author: Kenneth Hoste (Ghent University)
+"""
+import os
+import shutil
+import sys
+import tempfile
+from unittest import TextTestRunner
+
+from test.framework.utilities import TestLoaderFiltered
+
+# deliberately *not* using EnhancedTestCase from test.framework.utilities to avoid automatic configuration via setUp
+from vsc.utils.testing import EnhancedTestCase
+
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import BuildOptions
+from easybuild.tools.options import set_up_configuration
+from easybuild.tools.filetools import mkdir
+from easybuild.tools.modules import modules_tool
+from easybuild.tools.run import run_cmd
+
+
+class EasyBuildLibTest(EnhancedTestCase):
+    """Test cases for using EasyBuild as a library."""
+
+    def setUp(self):
+        """Prepare for running test."""
+        super(EasyBuildLibTest, self).setUp()
+
+        # make sure BuildOptions instance is re-created
+        del BuildOptions._instances[BuildOptions]
+
+        self.tmpdir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        """Cleanup after running test."""
+        super(EasyBuildLibTest, self).tearDown()
+
+        shutil.rmtree(self.tmpdir)
+
+    def configure(self):
+        """Utility function to set up EasyBuild configuration."""
+
+        # wipe BuildOption singleton instance, so it gets re-created when set_up_configuration is called
+        del BuildOptions._instances[BuildOptions]
+
+        self.assertFalse(BuildOptions in BuildOptions._instances)
+        set_up_configuration(silent=True)
+        self.assertTrue(BuildOptions in BuildOptions._instances)
+
+    def test_run_cmd(self):
+        """Test use of run_cmd function in the context of using EasyBuild framework as a library."""
+
+        error_pattern = "Undefined build option: .*"
+        error_pattern += " Make sure you have set up the EasyBuild configuration using set_up_configuration\(\)"
+        self.assertErrorRegex(EasyBuildError, error_pattern, run_cmd, "echo hello")
+
+        self.configure()
+
+        # run_cmd works fine if set_up_configuration was called first
+        (out, ec) = run_cmd("echo hello")
+        self.assertEqual(ec, 0)
+        self.assertEqual(out, 'hello\n')
+
+    def test_mkdir(self):
+        """Test use of run_cmd function in the context of using EasyBuild framework as a library."""
+
+        test_dir = os.path.join(self.tmpdir, 'test123')
+
+        error_pattern = "Undefined build option: .*"
+        error_pattern += " Make sure you have set up the EasyBuild configuration using set_up_configuration\(\)"
+        self.assertErrorRegex(EasyBuildError, error_pattern, mkdir, test_dir)
+
+        self.configure()
+
+        # mkdir works fine if set_up_configuration was called first
+        self.assertFalse(os.path.exists(test_dir))
+        mkdir(test_dir)
+        self.assertTrue(os.path.exists(test_dir))
+
+    def test_modules_tool(self):
+        """Test use of modules_tool function in the context of using EasyBuild framework as a library."""
+
+        error_pattern = "Undefined build option: .*"
+        error_pattern += " Make sure you have set up the EasyBuild configuration using set_up_configuration\(\)"
+        self.assertErrorRegex(EasyBuildError, error_pattern, modules_tool)
+
+        self.configure()
+
+        test_mods_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'modules')
+
+        modtool = modules_tool()
+        modtool.use(test_mods_path)
+        self.assertTrue('GCC/4.7.2' in modtool.available())
+        modtool.load(['GCC/4.7.2'])
+        self.assertEqual(modtool.list(), [{'default': None, 'mod_name': 'GCC/4.7.2'}])
+
+
+def suite():
+    return TestLoaderFiltered().loadTestsFromTestCase(EasyBuildLibTest, sys.argv[1:])
+
+
+if __name__ == '__main__':
+    TextTestRunner(verbosity=1).run(suite())

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -59,6 +59,7 @@ import test.framework.general as gen
 import test.framework.github as g
 import test.framework.hooks as h
 import test.framework.include as i
+import test.framework.lib as lib
 import test.framework.license as lic
 import test.framework.module_generator as mg
 import test.framework.modules as m
@@ -118,7 +119,7 @@ log = fancylogger.getLogger()
 # call suite() for each module and then run them all
 # note: make sure the options unit tests run first, to avoid running some of them with a readily initialized config
 tests = [gen, bl, o, r, ef, ev, ebco, ep, e, mg, m, mt, f, run, a, robot, b, v, g, tcv, tc, t, c, s, lic, f_c, sc,
-         tw, p, i, pkg, d, env, et, y, st, h, ct]
+         tw, p, i, pkg, d, env, et, y, st, h, ct, lib]
 
 SUITE = unittest.TestSuite([x.suite() for x in tests])
 


### PR DESCRIPTION
This is basically just shuffling code around, no functional changes are included.

Having a dedicated function for setting up the EasyBuild configuration is useful to support using the EasyBuild framework as a library (see also the tests that have been added).

Before these changes, you'd run into problems like:

```
$ python -c "from easybuild.tools.run import run_cmd; run_cmd('echo hello')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/Volumes/work/easybuild-framework/easybuild/tools/run.py", line 87, in cache_aware_func
    res = func(cmd, *args, **kwargs)
  File "/Volumes/work/easybuild-framework/easybuild/tools/run.py", line 127, in run_cmd
    if log_output or (trace and build_option('trace')):
  File "/Volumes/work/easybuild-framework/easybuild/tools/config.py", line 448, in build_option
    raise EasyBuildError("Undefined build option: %s", key)
easybuild.tools.build_log.EasyBuildError: 'Undefined build option: trace'
```

When `set_up_configuration` is used, things work as expected:

```
$ python -c "from easybuild.tools.options import set_up_configuration; 
set_up_configuration(silent=True); from easybuild.tools.run import run_cmd;
print run_cmd('echo hello')"
('hello\n', 0)
```

Also, a clearer error is now produced in case `set_up_configuration` was not called first:

```
easybuild.tools.build_log.EasyBuildError: "Undefined build option: 'trace'.
Make sure you have set up the EasyBuild configuration using set_up_configuration()
(from easybuild.tools.options) in case you're not using EasyBuild via the 'eb' CLI."
```