### PR TITLE
add support for using custom module file template (WIP)

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2438,20 +2438,25 @@ class EasyBlock(object):
         else:
             trace_msg("generating module file @ %s" % self.mod_filepath)
 
-        txt = self.module_generator.MODULE_SHEBANG
-        if txt:
-            txt += '\n'
-
+        mod_header = ''
         if self.modules_header:
-            txt += self.modules_header + '\n'
+            mod_header = self.modules_header + '\n'
 
-        txt += self.make_module_description()
-        txt += self.make_module_group_check()
-        txt += self.make_module_dep()
-        txt += self.make_module_extend_modpath()
-        txt += self.make_module_req()
-        txt += self.make_module_extra()
-        txt += self.make_module_footer()
+        modfile_tmpl_vals = {
+            # see MODULES_TEMPLATE_KEYS in module_generator.py for list of required keys
+            'header': mod_header,
+            'descr': self.make_module_description(),
+            'group_check': self.make_module_group_check(),
+            'deps': self.make_module_dep(),
+            'modpath': self.make_module_extend_modpath(),
+            'env_vars': self.make_module_req() + self.make_module_extra(),
+            'footer': self.make_module_footer(),
+            'installdir': self.installdir,
+        }
+        # include template values from EasyConfig object as well, which can be useful in custom module file templates
+        modfile_tmpl_vals.update(self.cfg.template_values)
+
+        txt = self.module_generator.from_template(modfile_tmpl_vals)
 
         if self.dry_run:
             # only report generating actual module file during dry run, don't mention temporary module files

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -153,6 +153,7 @@ BUILD_OPTIONS_CMDLINE = {
         'job_target_resource',
         'modules_footer',
         'modules_header',
+        'modules_template',
         'mpi_cmd_template',
         'only_blocks',
         'optarch',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -77,7 +77,7 @@ from easybuild.tools.hooks import KNOWN_HOOKS
 from easybuild.tools.include import include_easyblocks, include_module_naming_schemes, include_toolchains
 from easybuild.tools.job.backend import avail_job_backends
 from easybuild.tools.modules import avail_modules_tools
-from easybuild.tools.module_generator import ModuleGeneratorLua, avail_module_generators
+from easybuild.tools.module_generator import DEFAULT_MODULES_TEMPLATE, ModuleGeneratorLua, avail_module_generators
 from easybuild.tools.module_naming_scheme import GENERAL_CLASS
 from easybuild.tools.module_naming_scheme.utilities import avail_module_naming_schemes
 from easybuild.tools.modules import Lmod
@@ -400,7 +400,7 @@ class EasyBuildOptions(GeneralOption):
             'output-format': ("Set output format", 'choice', 'store', FORMAT_TXT, [FORMAT_TXT, FORMAT_RST]),
             'parallel': ("Specify (maximum) level of parallellism used during build procedure",
                          'int', 'store', None),
-            'pre-create-installdir': ("Create installation directory before submitting build jobs", 
+            'pre-create-installdir': ("Create installation directory before submitting build jobs",
                                       None, 'store_true', True),
             'pretend': (("Does the build/installation in a test directory located in $HOME/easybuildinstall"),
                         None, 'store_true', False, 'p'),
@@ -481,6 +481,7 @@ class EasyBuildOptions(GeneralOption):
                                None, 'store_or_None', None, {'metavar': "PATH"}),
             'modules-header': ("Path to file containing header to be added to all generated module files",
                                None, 'store_or_None', None, {'metavar': "PATH"}),
+            'modules-template': ("Location of module file template", None, 'store_or_None', None, {'metavar': "PATH"}),
             'modules-tool': ("Modules tool to use",
                              'choice', 'store', DEFAULT_MODULES_TOOL, sorted(avail_modules_tools().keys())),
             'packagepath': ("The destination path for the packages built by package-tool",
@@ -560,6 +561,7 @@ class EasyBuildOptions(GeneralOption):
             'show-default-configfiles': ("Show list of default config files", None, 'store_true', False),
             'show-default-moduleclasses': ("Show default module classes with description",
                                            None, 'store_true', False),
+            'show-default-modules-template': ("Show default module file template", None, 'store_true', False),
             'terse': ("Terse output (machine-readable)", None, 'store_true', False),
         })
 
@@ -770,7 +772,7 @@ class EasyBuildOptions(GeneralOption):
                 self.options.avail_repositories, self.options.show_default_moduleclasses,
                 self.options.avail_modules_tools, self.options.avail_module_naming_schemes,
                 self.options.show_default_configfiles, self.options.avail_toolchain_opts,
-                self.options.avail_hooks,
+                self.options.avail_hooks, self.options.show_default_modules_template,
                 ]):
             build_easyconfig_constants_dict()  # runs the easyconfig constants sanity check
             self._postprocess_list_avail()
@@ -970,6 +972,10 @@ class EasyBuildOptions(GeneralOption):
         # dump default moduleclasses with description
         if self.options.show_default_moduleclasses:
             msg += self.show_default_moduleclasses()
+
+        # dump default modules template
+        if self.options.show_default_modules_template:
+            msg = DEFAULT_MODULES_TEMPLATE
 
         if self.options.avail_hooks:
             msg += self.avail_list('hooks (in order of execution)', KNOWN_HOOKS)


### PR DESCRIPTION
Adds support for specifying a custom module file template via `--modules-template`, as well as for dumping the default modules template:

```
$ eb --show-default-modules-template
$shebang$header$descr$group_check$deps$modpath$env_vars$footer
```

This should meet the use case of @ax3l discussed in #2624, since it allows using a custom template like:

```
$shebang$header$descr$group_check$deps$modpath$env_vars$footer
prepend_path("CMAKE_PREFIX_PATH", "%(installdir)s")
```

In some sense this is already supported via `--modules-footer` though, so the added benefit is limited for that particular use case, but it does provide more control over the generated module files...

(WIP since tests are missing)