### PR TITLE
clean error when 'eb' is cancelled by user

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -527,5 +527,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
 if __name__ == "__main__":
     try:
         main()
-    except EasyBuildError, e:
-        print_error(e.msg)
+    except EasyBuildError as err:
+        print_error(err.msg)
+    except KeyboardInterrupt:
+        print_error("Cancelled by user (keyboard interrupt)")


### PR DESCRIPTION
This results in a cleaner error when `eb` is cancelled with Ctrl-C:

```
$ eb example.eb
== temporary log file in case of crash /tmp/eb-tQTW_H/easybuild-1veSdb.log
^CERROR: Cancelled by user (keyboard interrupt)
```