### PR TITLE
don't pass down specific environment variables into submitted jobs

### DIFF
--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -155,18 +155,6 @@ def create_job(job_backend, build_command, easyconfig, output_dir='easybuild-bui
 
     returns the job
     """
-    # capture PYTHONPATH, MODULEPATH and all variables starting with EASYBUILD
-    easybuild_vars = {}
-    for name in os.environ:
-        if name.startswith("EASYBUILD"):
-            easybuild_vars[name] = os.environ[name]
-
-    for env_var in ["PYTHONPATH", "MODULEPATH"]:
-        if env_var in os.environ:
-            easybuild_vars[env_var] = os.environ[env_var]
-
-    _log.info("Dictionary of environment variables passed to job: %s" % easybuild_vars)
-
     # obtain unique name based on name/easyconfig version tuple
     ec_tuple = (easyconfig['ec']['name'], det_full_ec_version(easyconfig['ec']))
     name = '-'.join(ec_tuple)
@@ -194,7 +182,7 @@ def create_job(job_backend, build_command, easyconfig, output_dir='easybuild-bui
     if build_option('job_cores'):
         extra['cores'] = build_option('job_cores')
 
-    job = job_backend.make_job(command, name, easybuild_vars, **extra)
+    job = job_backend.make_job(command, name, **extra)
     job.module = easyconfig['ec'].full_mod_name
 
     return job


### PR DESCRIPTION
Strictly speaking, this change is not backward compatible, but based on the feedback in #2632 this is actually more of a bugfix rather than just a change in behavior...

The behavior with this change included basically corresponds EasyBuild versions prior to 3.7.0 (which were not compatible yet with GC3Pie 2.5.0), since with GC3Pie versions prior to 2.5.0 the environment variables that were specified were basically totally ignored (at least when submitting to SLURM). Am I getting that right @riccardomurri?

Currently, EasyBuild passes down all `$EASYBUILD_*` environment variables to ensure that the EasyBuild configuration in the submitted job is correct, but that's actually useless since the entire configuration is also passed down via command line options in the submitted job (which override the `$EASYBUILD_*` environment variables)...

Passing down of `$PYTHONPATH` & `$MODULEPATH` is an attempt to make sure that EasyBuild & loaded modules are passed down into the submitted job as well. That's a pretty broken attempt though... For EasyBuild itself, at least `$PATH` must be passed down too (cfr. #2632), and for loaded modules several other environment variables may be relevant as well.

So, it's better to simply not pass down anything at all, since this provides (in some sense) more control to the user of `eb --job` w.r.t. setting up the job environment (which can also be done via a `.bashrc` login script, for example).

cc @akesandgren