### PR TITLE
always skip symlinks in adjust_permissions

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -956,7 +956,7 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None):
     apatch_root, apatch_file = os.path.split(apatch)
     apatch_name, apatch_extension = os.path.splitext(apatch_file)
     # Supports only bz2, gz and xz. zip can be archives which are not supported.
-    if apatch_extension in ['.gz','.bz2','.xz']:
+    if apatch_extension in ['.gz', '.bz2', '.xz']:
         # split again to get the second extension
         apatch_subname, apatch_subextension = os.path.splitext(apatch_name)
         if apatch_subextension == ".patch":
@@ -1095,7 +1095,7 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
             if relative:
 
                 # relative permissions (add or remove)
-                perms = os.stat(path)[stat.ST_MODE]
+                perms = os.lstat(path)[stat.ST_MODE]
 
                 if add:
                     os.lchmod(path, perms | permissionBits)
@@ -1108,7 +1108,7 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
 
             if group_id:
                 # only change the group id if it the current gid is different from what we want
-                cur_gid = os.stat(path).st_gid
+                cur_gid = os.lstat(path).st_gid
                 if not cur_gid == group_id:
                     _log.debug("Changing group id of %s to %s" % (path, group_id))
                     os.lchown(path, -1, group_id)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1062,7 +1062,7 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
 
     if skip_symlinks is not None:
         depr_msg = "Use of 'skip_symlinks' argument for 'adjust_permissions' is deprecated "
-        depr_msg += "(symlinks are always skipped now)"
+        depr_msg += "(symlinks are never followed anymore)"
         _log.deprecated(depr_msg, '4.0')
 
     name = os.path.abspath(name)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1092,19 +1092,22 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
     for path in allpaths:
 
         try:
-            if relative:
+            # don't change permissions if path is a symlink, since we're not checking where the symlink points to
+            # this is done because of security concerns (symlink may point out of installation directory)
+            if not os.path.islink(path):
+                if relative:
 
-                # relative permissions (add or remove)
-                perms = os.lstat(path)[stat.ST_MODE]
+                    # relative permissions (add or remove)
+                    perms = os.lstat(path)[stat.ST_MODE]
 
-                if add:
-                    os.chmod(path, perms | permissionBits)
+                    if add:
+                        os.chmod(path, perms | permissionBits)
+                    else:
+                        os.chmod(path, perms & ~permissionBits)
+
                 else:
-                    os.chmod(path, perms & ~permissionBits)
-
-            else:
-                # hard permissions bits (not relative)
-                os.chmod(path, permissionBits)
+                    # hard permissions bits (not relative)
+                    os.chmod(path, permissionBits)
 
             if group_id:
                 # only change the group id if it the current gid is different from what we want

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1098,13 +1098,13 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
                 perms = os.lstat(path)[stat.ST_MODE]
 
                 if add:
-                    os.lchmod(path, perms | permissionBits)
+                    os.chmod(path, perms | permissionBits)
                 else:
-                    os.lchmod(path, perms & ~permissionBits)
+                    os.chmod(path, perms & ~permissionBits)
 
             else:
                 # hard permissions bits (not relative)
-                os.lchmod(path, permissionBits)
+                os.chmod(path, permissionBits)
 
             if group_id:
                 # only change the group id if it the current gid is different from what we want

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1098,20 +1098,20 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
                 perms = os.stat(path)[stat.ST_MODE]
 
                 if add:
-                    os.chmod(path, perms | permissionBits)
+                    os.lchmod(path, perms | permissionBits)
                 else:
-                    os.chmod(path, perms & ~permissionBits)
+                    os.lchmod(path, perms & ~permissionBits)
 
             else:
                 # hard permissions bits (not relative)
-                os.chmod(path, permissionBits)
+                os.lchmod(path, permissionBits)
 
             if group_id:
                 # only change the group id if it the current gid is different from what we want
                 cur_gid = os.stat(path).st_gid
                 if not cur_gid == group_id:
                     _log.debug("Changing group id of %s to %s" % (path, group_id))
-                    os.chown(path, -1, group_id)
+                    os.lchown(path, -1, group_id)
                 else:
                     _log.debug("Group id of %s is already OK (%s)" % (path, group_id))
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1054,11 +1054,16 @@ def convert_name(name, upper=False):
 
 
 def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs=False, recursive=True,
-                       group_id=None, relative=True, ignore_errors=False, skip_symlinks=True):
+                       group_id=None, relative=True, ignore_errors=False, skip_symlinks=None):
     """
     Add or remove (if add is False) permissionBits from all files (if onlydirs is False)
     and directories (if onlyfiles is False) in path
     """
+
+    if skip_symlinks is not None:
+        depr_msg = "Use of 'skip_symlinks' argument for 'adjust_permissions' is deprecated "
+        depr_msg += "(symlinks are always skipped now)"
+        _log.deprecated(depr_msg, '4.0')
 
     name = os.path.abspath(name)
 
@@ -1068,14 +1073,7 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
         for root, dirs, files in os.walk(name):
             paths = []
             if not onlydirs:
-                if skip_symlinks:
-                    for path in files:
-                        if os.path.islink(os.path.join(root, path)):
-                            _log.debug("Not adjusting permissions for symlink %s", path)
-                        else:
-                            paths.append(path)
-                else:
-                    paths.extend(files)
+                paths.extend(files)
             if not onlyfiles:
                 # os.walk skips symlinked dirs by default, i.e., no special handling needed here
                 paths.extend(dirs)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1092,6 +1092,7 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
         try:
             # don't change permissions if path is a symlink, since we're not checking where the symlink points to
             # this is done because of security concerns (symlink may point out of installation directory)
+            # (note: os.lchmod is not supported on Linux)
             if not os.path.islink(path):
                 if relative:
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -961,18 +961,15 @@ class FileToolsTest(EnhancedTestCase):
         perms = stat.S_IRUSR|stat.S_IWUSR|stat.S_IXUSR
 
         ft.adjust_permissions(testdir, perms, recursive=True, ignore_errors=True)
-        ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
 
         # introducing a broken symlinks doesn't cause problems
         ft.remove_file(test_files[0])
         ft.adjust_permissions(testdir, perms, recursive=True, ignore_errors=True)
-        ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
 
         # multiple/all broken symlinks is no problem either, since symlinks are always skipped
         ft.remove_file(test_files[1])
         ft.remove_file(test_files[2])
         ft.adjust_permissions(testdir, perms, recursive=True, ignore_errors=True)
-        ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
 
         # reconfigure EasyBuild to allow even higher fail ratio (80%)
         build_options = {
@@ -981,7 +978,7 @@ class FileToolsTest(EnhancedTestCase):
         init_config(build_options=build_options)
 
         # 75% < 80%, so OK
-        ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
+        ft.adjust_permissions(testdir, perms, recursive=True, ignore_errors=True)
 
         # reconfigure to allow less failures (10%)
         build_options = {
@@ -990,13 +987,11 @@ class FileToolsTest(EnhancedTestCase):
         init_config(build_options=build_options)
 
         ft.adjust_permissions(testdir, perms, recursive=True, ignore_errors=True)
-        ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
 
         ft.write_file(test_files[0], '')
         ft.write_file(test_files[1], '')
         ft.write_file(test_files[2], '')
         ft.adjust_permissions(testdir, perms, recursive=True, ignore_errors=True)
-        ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
 
     def test_apply_regex_substitutions(self):
         """Test apply_regex_substitutions function."""

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -966,7 +966,7 @@ class FileToolsTest(EnhancedTestCase):
         ft.remove_file(test_files[0])
         ft.adjust_permissions(testdir, perms, recursive=True, ignore_errors=True)
 
-        # multiple/all broken symlinks is no problem either, since symlinks are always skipped
+        # multiple/all broken symlinks is no problem either, since symlinks are never followed
         ft.remove_file(test_files[1])
         ft.remove_file(test_files[2])
         ft.adjust_permissions(testdir, perms, recursive=True, ignore_errors=True)

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -944,11 +944,15 @@ class FileToolsTest(EnhancedTestCase):
             for bit in [stat.S_IXGRP, stat.S_IWOTH, stat.S_IXOTH]:
                 self.assertFalse(perms & bit)
 
+        # broken symlinks are trouble if symlinks are not skipped
+        self.assertErrorRegex(EasyBuildError, "No such file or directory", ft.adjust_permissions, self.test_prefix,
+                              stat.S_IXUSR, skip_symlinks=False)
+
         # restore original umask
         os.umask(orig_umask)
 
-    def test_adjust_permissions_broken_symlinks(self):
-        """Test use of adjust_permissions with broken symlinks in place."""
+    def test_adjust_permissions_max_fail_ratio(self):
+        """Test ratio of allowed failures when adjusting permissions"""
         # set up symlinks in test directory that can be broken to test allowed failure ratio of adjust_permissions
         testdir = os.path.join(self.test_prefix, 'test123')
         test_files = []
@@ -957,14 +961,50 @@ class FileToolsTest(EnhancedTestCase):
             ft.write_file(test_files[-1], '')
             ft.symlink(test_files[-1], os.path.join(testdir, 'symlink%s' % idx))
 
-        perms = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
+        # by default, 50% of failures are allowed (to be robust against broken symlinks)
+        perms = stat.S_IRUSR|stat.S_IWUSR|stat.S_IXUSR
+
+        # one file remove, 1 dir + 2 files + 3 symlinks (of which 1 broken) left => 1/6 (16%) fail ratio is OK
+        ft.remove_file(test_files[0])
+        ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
+        # 2 files removed, 1 dir + 1 file + 3 symlinks (of which 2 broken) left => 2/5 (40%) fail ratio is OK
+        ft.remove_file(test_files[1])
+        ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
+        # 3 files removed, 1 dir + 3 broken symlinks => 75% fail ratio is too high, so error is raised
+        ft.remove_file(test_files[2])
+        error_pattern = r"75.00% of permissions/owner operations failed \(more than 50.00%\), something must be wrong"
+        self.assertErrorRegex(EasyBuildError, error_pattern, ft.adjust_permissions, testdir, perms,
+                              recursive=True, skip_symlinks=False, ignore_errors=True)
+
+        # reconfigure EasyBuild to allow even higher fail ratio (80%)
+        build_options = {
+            'max_fail_ratio_adjust_permissions': 0.8,
+        }
+        init_config(build_options=build_options)
+
+        # 75% < 80%, so OK
         ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
 
-        # removing files result in broken symlinks, but adjust_permissions is robust against that now
-        ft.remove_file(test_files[0])
-        ft.remove_file(test_files[1])
-        ft.remove_file(test_files[2])
+        # reconfigure to allow less failures (10%)
+        build_options = {
+            'max_fail_ratio_adjust_permissions': 0.1,
+        }
+        init_config(build_options=build_options)
 
+        # way too many failures with 3 broken symlinks
+        error_pattern = r"75.00% of permissions/owner operations failed \(more than 10.00%\), something must be wrong"
+        self.assertErrorRegex(EasyBuildError, error_pattern, ft.adjust_permissions, testdir, perms,
+                              recursive=True, skip_symlinks=False, ignore_errors=True)
+
+        # one broken symlink is still too much with max fail ratio of 10%
+        ft.write_file(test_files[0], '')
+        ft.write_file(test_files[1], '')
+        error_pattern = r"16.67% of permissions/owner operations failed \(more than 10.00%\), something must be wrong"
+        self.assertErrorRegex(EasyBuildError, error_pattern, ft.adjust_permissions, testdir, perms,
+                              recursive=True, skip_symlinks=False, ignore_errors=True)
+
+        # all files restored, no more broken symlinks, so OK
+        ft.write_file(test_files[2], '')
         ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
 
     def test_apply_regex_substitutions(self):

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -944,10 +944,6 @@ class FileToolsTest(EnhancedTestCase):
             for bit in [stat.S_IXGRP, stat.S_IWOTH, stat.S_IXOTH]:
                 self.assertFalse(perms & bit)
 
-        # broken symlinks are trouble if symlinks are not skipped
-        self.assertErrorRegex(EasyBuildError, "No such file or directory", ft.adjust_permissions, self.test_prefix,
-                              stat.S_IXUSR, skip_symlinks=False)
-
         # restore original umask
         os.umask(orig_umask)
 
@@ -961,20 +957,22 @@ class FileToolsTest(EnhancedTestCase):
             ft.write_file(test_files[-1], '')
             ft.symlink(test_files[-1], os.path.join(testdir, 'symlink%s' % idx))
 
-        # by default, 50% of failures are allowed (to be robust against broken symlinks)
+        # by default, 50% of failures are allowed (to be robust against failures to change permissions)
         perms = stat.S_IRUSR|stat.S_IWUSR|stat.S_IXUSR
 
-        # one file remove, 1 dir + 2 files + 3 symlinks (of which 1 broken) left => 1/6 (16%) fail ratio is OK
+        ft.adjust_permissions(testdir, perms, recursive=True, ignore_errors=True)
+        ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
+
+        # introducing a broken symlinks doesn't cause problems
         ft.remove_file(test_files[0])
+        ft.adjust_permissions(testdir, perms, recursive=True, ignore_errors=True)
         ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
-        # 2 files removed, 1 dir + 1 file + 3 symlinks (of which 2 broken) left => 2/5 (40%) fail ratio is OK
+
+        # multiple/all broken symlinks is no problem either, since symlinks are always skipped
         ft.remove_file(test_files[1])
-        ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
-        # 3 files removed, 1 dir + 3 broken symlinks => 75% fail ratio is too high, so error is raised
         ft.remove_file(test_files[2])
-        error_pattern = r"75.00% of permissions/owner operations failed \(more than 50.00%\), something must be wrong"
-        self.assertErrorRegex(EasyBuildError, error_pattern, ft.adjust_permissions, testdir, perms,
-                              recursive=True, skip_symlinks=False, ignore_errors=True)
+        ft.adjust_permissions(testdir, perms, recursive=True, ignore_errors=True)
+        ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
 
         # reconfigure EasyBuild to allow even higher fail ratio (80%)
         build_options = {
@@ -991,20 +989,13 @@ class FileToolsTest(EnhancedTestCase):
         }
         init_config(build_options=build_options)
 
-        # way too many failures with 3 broken symlinks
-        error_pattern = r"75.00% of permissions/owner operations failed \(more than 10.00%\), something must be wrong"
-        self.assertErrorRegex(EasyBuildError, error_pattern, ft.adjust_permissions, testdir, perms,
-                              recursive=True, skip_symlinks=False, ignore_errors=True)
+        ft.adjust_permissions(testdir, perms, recursive=True, ignore_errors=True)
+        ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
 
-        # one broken symlink is still too much with max fail ratio of 10%
         ft.write_file(test_files[0], '')
         ft.write_file(test_files[1], '')
-        error_pattern = r"16.67% of permissions/owner operations failed \(more than 10.00%\), something must be wrong"
-        self.assertErrorRegex(EasyBuildError, error_pattern, ft.adjust_permissions, testdir, perms,
-                              recursive=True, skip_symlinks=False, ignore_errors=True)
-
-        # all files restored, no more broken symlinks, so OK
         ft.write_file(test_files[2], '')
+        ft.adjust_permissions(testdir, perms, recursive=True, ignore_errors=True)
         ft.adjust_permissions(testdir, perms, recursive=True, skip_symlinks=False, ignore_errors=True)
 
     def test_apply_regex_substitutions(self):


### PR DESCRIPTION
This was pointed out by @akesandgren.

Using `os.lchmod` & `os.lchown` prevents EasyBuild from trying to change permissions on files it has no business in changing, in case a symlink points to a file outside of the build/install directory...

It probably also helps in avoiding problems like https://github.com/easybuilders/easybuild-easyblocks/issues/1564