### PR TITLE
fix lib64 fallback for 'lib'/'lib64' dirs entry in sanity_check_paths

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2300,9 +2300,9 @@ class EasyBlock(object):
                 # for library files in lib/, also consider fallback to lib64/ equivalent (and vice versa)
                 if not found and build_option('lib64_fallback_sanity_check'):
                     xs_alt = None
-                    if all(x.startswith('lib/') for x in xs):
+                    if all(x.startswith('lib/') or x == 'lib' for x in xs):
                         xs_alt = [os.path.join('lib64', *x.split(os.path.sep)[1:]) for x in xs]
-                    elif all(x.startswith('lib64/') for x in xs):
+                    elif all(x.startswith('lib64/') or x == 'lib64' for x in xs):
                         xs_alt = [os.path.join('lib', *x.split(os.path.sep)[1:]) for x in xs]
 
                     if xs_alt:

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1667,7 +1667,7 @@ class ToyBuildTest(EnhancedTestCase):
         # sanity check passes when lib64 fallback is enabled (by default), since lib/libtoy.a is also considered
         self.test_toy_build(ec_file=test_ec, raise_error=True)
 
-        # also check with 'lib' in sanity check dirs (special case)
+        # also check with 'lib64' in sanity check dirs (special case)
         ectxt = re.sub("\s*'files'.*", "'files': ['bin/toy'],", ectxt)
         ectxt = re.sub("\s*'dirs'.*", "'dirs': ['lib64'],", ectxt)
         write_file(test_ec, ectxt)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1643,6 +1643,17 @@ class ToyBuildTest(EnhancedTestCase):
         # all is fine is lib64 fallback check is enabled (which it is by default)
         self.test_toy_build(ec_file=test_ec, raise_error=True)
 
+        # also check with 'lib' in sanity check dirs (special case)
+        ectxt = re.sub("\s*'files'.*", "'files': ['bin/toy'],", ectxt)
+        ectxt = re.sub("\s*'dirs'.*", "'dirs': ['lib'],", ectxt)
+        write_file(test_ec, ectxt)
+
+        error_pattern = r"Sanity check failed: no \(non-empty\) directory found at 'lib' in "
+        self.assertErrorRegex(EasyBuildError, error_pattern, self.test_toy_build, ec_file=test_ec,
+                              extra_args=['--disable-lib64-fallback-sanity-check'], raise_error=True, verbose=False)
+
+        self.test_toy_build(ec_file=test_ec, raise_error=True)
+
         # also check other way around (lib64 -> lib)
         ectxt = read_file(ec_file)
         ectxt = re.sub("\s*'files'.*", "'files': ['bin/toy', 'lib64/libtoy.a'],", ectxt)
@@ -1654,6 +1665,17 @@ class ToyBuildTest(EnhancedTestCase):
                               extra_args=['--disable-lib64-fallback-sanity-check'], raise_error=True, verbose=False)
 
         # sanity check passes when lib64 fallback is enabled (by default), since lib/libtoy.a is also considered
+        self.test_toy_build(ec_file=test_ec, raise_error=True)
+
+        # also check with 'lib' in sanity check dirs (special case)
+        ectxt = re.sub("\s*'files'.*", "'files': ['bin/toy'],", ectxt)
+        ectxt = re.sub("\s*'dirs'.*", "'dirs': ['lib64'],", ectxt)
+        write_file(test_ec, ectxt)
+
+        error_pattern = r"Sanity check failed: no \(non-empty\) directory found at 'lib64' in "
+        self.assertErrorRegex(EasyBuildError, error_pattern, self.test_toy_build, ec_file=test_ec,
+                              extra_args=['--disable-lib64-fallback-sanity-check'], raise_error=True, verbose=False)
+
         self.test_toy_build(ec_file=test_ec, raise_error=True)
 
         # check whether fallback works for files that's more than 1 subdir deep


### PR DESCRIPTION
fix for bug that popped up in https://github.com/easybuilders/easybuild-easyconfigs/pull/7069

For `'lib'` or `'lib64'` entries in `dirs` in `sanity_check_paths`, the fallback mechanism failed because it checks for entries starting with `lib/` or `lib64/` (to avoid that partial matches on something like `'library'` would trigger the fallback too).