### PR TITLE
fix order of keys in 'toolchain' value for dumped easyconfig file (name, version) + run style check on dumped easyconfigs in dump tests

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -821,7 +821,7 @@ class EasyConfig(object):
             ectxt = autopep8.fix_code(ectxt, options=autopep8_opts)
             self.log.debug("Dumped easyconfig after autopep8 reformatting: %s", ectxt)
 
-        write_file(fp, ectxt.strip())
+        write_file(fp, ectxt)
 
         self.enable_templating = orig_enable_templating
 

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -289,9 +289,9 @@ class FormatOneZero(EasyConfigFormatConfigObj):
         Inline comments on items of iterable values are also extracted.
         """
         self.comments = {
-            'above' : {},  # comments for a particular parameter definition
-            'header' : [],  # header comment lines
-            'inline' : {},  # inline comments
+            'above': {},  # comments for a particular parameter definition
+            'header': [],  # header comment lines
+            'inline': {},  # inline comments
             'iter': {},  # (inline) comments on elements of iterable values
             'tail': [],
          }
@@ -412,7 +412,7 @@ def retrieve_blocks_in_spec(spec, only_blocks, silent=False):
 
             if 'dependencies' in block:
                 for dep in block['dependencies']:
-                    if not dep in [b['name'] for b in blocks]:
+                    if dep not in [b['name'] for b in blocks]:
                         raise EasyBuildError("Block %s depends on %s, but block was not found.", name, dep)
 
                     dep = [b for b in blocks if b['name'] == dep][0]

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -236,6 +236,8 @@ class FormatOneZero(EasyConfigFormatConfigObj):
                     # dependency easyconfig parameters were parsed, so these need special care to 'unparse' them
                     if key in DEPENDENCY_PARAMETERS:
                         valstr = [dump_dependency(d, ecfg['toolchain']) for d in val]
+                    elif key == 'toolchain':
+                        valstr = "{'name': '%(name)s', 'version': '%(version)s'}" % ecfg[key]
                     else:
                         valstr = quote_py_str(ecfg[key])
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -53,6 +53,7 @@ from easybuild.framework.easyconfig.easyconfig import det_subtoolchain_version, 
 from easybuild.framework.easyconfig.licenses import License, LicenseGPLv3
 from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconfig
 from easybuild.framework.easyconfig.templates import template_constant_dict, to_template_str
+from easybuild.framework.easyconfig.style import check_easyconfigs_style
 from easybuild.framework.easyconfig.tools import categorize_files_by_type, check_sha256_checksums, dep_graph
 from easybuild.framework.easyconfig.tools import find_related_easyconfigs, get_paths_for, parse_easyconfigs
 from easybuild.framework.easyconfig.tweak import obtain_ec_for, tweak_one
@@ -1511,6 +1512,7 @@ class EasyConfigTest(EnhancedTestCase):
             "]",
             '',
             "foo_extra1 = 'foobar'",
+            '',
         ])
 
         handle, testec = tempfile.mkstemp(prefix=self.test_prefix, suffix='.eb')
@@ -1523,6 +1525,8 @@ class EasyConfigTest(EnhancedTestCase):
 
         # check parsing of dumped easyconfig
         EasyConfig(testec)
+
+        check_easyconfigs_style([testec])
 
     def test_dump_template(self):
         """ Test EasyConfig's dump() method for files containing templates"""
@@ -1589,7 +1593,9 @@ class EasyConfigTest(EnhancedTestCase):
             self.assertTrue(regex.search(ectxt), "Pattern '%s' found in: %s" % (regex.pattern, ectxt))
 
         # reparsing the dumped easyconfig file should work
-        ecbis = EasyConfig(testec)
+        EasyConfig(testec)
+
+        check_easyconfigs_style([testec])
 
     def test_dump_comments(self):
         """ Test dump() method for files containing comments """
@@ -1647,7 +1653,9 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertTrue(ectxt.endswith("# trailing comment"))
 
         # reparsing the dumped easyconfig file should work
-        ecbis = EasyConfig(testec)
+        EasyConfig(testec)
+
+        check_easyconfigs_style([testec])
 
     def test_to_template_str(self):
         """ Test for to_template_str method """

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1453,7 +1453,12 @@ class EasyConfigTest(EnhancedTestCase):
             self.assertEqual(ecdict, ec.asdict())
             ectxt = read_file(test_ec)
 
-            patterns = [r"^name = ['\"]", r"^version = ['0-9\.]", r'^description = ["\']']
+            patterns = [
+                r"^name = ['\"]",
+                r"^version = ['0-9\.]",
+                r'^description = ["\']',
+                r"^toolchain = {'name': .*, 'version': .*}",
+            ]
             for pattern in patterns:
                 regex = re.compile(pattern, re.M)
                 self.assertTrue(regex.search(ectxt), "Pattern '%s' found in: %s" % (regex.pattern, ectxt))
@@ -1496,7 +1501,7 @@ class EasyConfigTest(EnhancedTestCase):
             "homepage = 'http://foo.com/'",
             'description = "foo description"',
             '',
-            "toolchain = {'version': 'dummy', 'name': 'dummy'}",
+            "toolchain = {'name': 'dummy', 'version': 'dummy'}",
             '',
             "dependencies = [",
             "    ('GCC', '4.6.4', '-test'),",
@@ -1516,7 +1521,8 @@ class EasyConfigTest(EnhancedTestCase):
         ectxt = read_file(testec)
         self.assertEqual(rawtxt, ectxt)
 
-        dumped_ec = EasyConfig(testec)
+        # check parsing of dumped easyconfig
+        EasyConfig(testec)
 
     def test_dump_template(self):
         """ Test EasyConfig's dump() method for files containing templates"""


### PR DESCRIPTION
Minor bug fix for something silly that has been annoying me...