### PR TITLE
specify filename pattern for output file of jobs submitted to Slurm

### DIFF
--- a/easybuild/tools/job/slurm.py
+++ b/easybuild/tools/job/slurm.py
@@ -158,7 +158,13 @@ class SlurmJob(object):
         self.script = script
         self.name = name
 
-        self.job_specs = {'wrap': self.script, 'job-name': self.name}
+        self.job_specs = {
+            'job-name': self.name,
+            # pattern for output file for submitted job;
+            # SLURM replaces %x with job name, %j with job ID (see https://slurm.schedmd.com/sbatch.html#lbAF)
+            'output': '%x-%j.out',
+            'wrap': self.script,
+        }
 
         if env_vars:
             self.job_specs['export'] = ','.join(sorted(env_vars.keys()))

--- a/test/framework/parallelbuild.py
+++ b/test/framework/parallelbuild.py
@@ -335,18 +335,20 @@ class ParallelBuildTest(EnhancedTestCase):
 
         self.assertEqual(len(jobs), 8)
 
+        # last job (gzip) has a dependency on second-to-last job (goolf)
+        self.assertEqual(jobs[-2].job_specs['job-name'], 'goolf-1.4.10')
         expected = {
-            'job-name': 'gzip-1.5-goolf-1.4.10',
-            'wrap': "echo '%s'" % test_ec,
-            'nodes': 1,
-            'ntasks': 3,
-            'time': 300,  # 60*5 (unit is minutes)
             'dependency': 'afterok:%s' % jobs[-2].jobid,
             'hold': True,
+            'job-name': 'gzip-1.5-goolf-1.4.10',
+            'nodes': 1,
+            'ntasks': 3,
+            'ntasks-per-node': 3,
+            'output': '%x-%j.out',
+            'time': 300,  # 60*5 (unit is minutes)
+            'wrap': "echo '%s'" % test_ec,
         }
-        for key, val in expected.items():
-            self.assertTrue(key in jobs[-1].job_specs)
-            self.assertEqual(jobs[-1].job_specs[key], expected[key])
+        self.assertEqual(jobs[-1].job_specs, expected)
 
 
 def suite():


### PR DESCRIPTION
Small enhancement on top of #2642 

Without this, the output files are named according to the Slurm default, e.g. `slurm-12345.out`