### PR TITLE
make print functions more robust w.r.t. arguments being passed to format the message to be printed

### DIFF
--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -226,7 +226,7 @@ def stop_logging(logfile, logtostdout=False):
         fancylogger.logToFile(logfile, enable=False)
 
 
-def print_msg(msg, log=None, silent=False, prefix=True, newline=True, stderr=False):
+def print_msg(msg, *args, **kwargs):
     """
     Print a message.
 
@@ -236,6 +236,17 @@ def print_msg(msg, log=None, silent=False, prefix=True, newline=True, stderr=Fal
     :param newline: end message with newline
     :param stderr: print to stderr rather than stdout
     """
+    if args:
+        msg = msg % args
+
+    log = kwargs.pop('log', None)
+    silent = kwargs.pop('silent', False)
+    prefix = kwargs.pop('prefix', True)
+    newline = kwargs.pop('newline', True)
+    stderr = kwargs.pop('stderr', False)
+    if kwargs:
+        raise EasyBuildError("Unknown named arguments passed to print_msg: %s", kwargs)
+
     if log:
         log.info(msg)
     if not silent:
@@ -272,9 +283,16 @@ def dry_run_set_dirs(prefix, builddir, software_installdir, module_installdir):
     DRY_RUN_SOFTWARE_INSTALL_DIR = (re.compile(re.escape(software_installdir)), software_installdir[len(prefix):])
 
 
-def dry_run_msg(msg, silent=False):
+def dry_run_msg(msg, *args, **kwargs):
     """Print dry run message."""
     # replace fake build/install dir in dry run message with original value
+    if args:
+        msg = msg % args
+
+    silent = kwargs.pop('silent', False)
+    if kwargs:
+        raise EasyBuildError("Unknown named arguments passed to dry_run_msg: %s", kwargs)
+
     for dry_run_var in [DRY_RUN_BUILD_DIR, DRY_RUN_MODULES_INSTALL_DIR, DRY_RUN_SOFTWARE_INSTALL_DIR]:
         if dry_run_var is not None:
             msg = dry_run_var[0].sub(dry_run_var[1], msg)
@@ -282,31 +300,56 @@ def dry_run_msg(msg, silent=False):
     print_msg(msg, silent=silent, prefix=False)
 
 
-def dry_run_warning(msg, silent=False):
+def dry_run_warning(msg, *args, **kwargs):
     """Print dry run message."""
+    if args:
+        msg = msg % args
+
+    silent = kwargs.pop('silent', False)
+    if kwargs:
+        raise EasyBuildError("Unknown named arguments passed to dry_run_warning: %s", kwargs)
+
     dry_run_msg("\n!!!\n!!! WARNING: %s\n!!!\n" % msg, silent=silent)
 
 
-def print_error(message, log=None, exitCode=1, opt_parser=None, exit_on_error=True, silent=False):
+def print_error(msg, *args, **kwargs):
     """
     Print error message and exit EasyBuild
     """
+    if args:
+        msg = msg % args
+
+    log = kwargs.pop('log', None)
+    exitCode = kwargs.pop('exitCode', 1)
+    opt_parser = kwargs.pop('opt_parser', None)
+    exit_on_error = kwargs.pop('exit_on_error', True)
+    silent = kwargs.pop('silent', False)
+    if kwargs:
+        raise EasyBuildError("Unknown named arguments passed to print_error: %s", kwargs)
+
     if exit_on_error:
         if not silent:
             if opt_parser:
                 opt_parser.print_shorthelp()
-            sys.stderr.write("ERROR: %s\n" % message)
+            sys.stderr.write("ERROR: %s\n" % msg)
         sys.exit(exitCode)
     elif log is not None:
-        raise EasyBuildError(message)
+        raise EasyBuildError(msg)
 
 
-def print_warning(message, silent=False):
+def print_warning(msg, *args, **kwargs):
     """
     Print warning message.
     """
+    if args:
+        msg = msg % args
+
+    silent = kwargs.pop('silent', False)
+    if kwargs:
+        raise EasyBuildError("Unknown named arguments passed to print_warning: %s", kwargs)
+
     if not silent:
-        sys.stderr.write("\nWARNING: %s\n\n" % message)
+        sys.stderr.write("\nWARNING: %s\n\n" % msg)
 
 
 def time_str_since(start_time):

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -36,7 +36,8 @@ from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
 from vsc.utils.fancylogger import getLogger, getRootLoggerName, logToFile, setLogFormat
 
-from easybuild.tools.build_log import LOGGING_FORMAT, EasyBuildError, print_msg, print_warning, time_str_since
+from easybuild.tools.build_log import LOGGING_FORMAT, EasyBuildError, dry_run_msg, dry_run_warning
+from easybuild.tools.build_log import print_error, print_msg, print_warning, time_str_since
 from easybuild.tools.filetools import read_file, write_file
 
 
@@ -198,6 +199,7 @@ class BuildLogTest(EnhancedTestCase):
         logToFile(tmplog, enable=True)
         log = getLogger('test_easybuildlog')
 
+        self.mock_stderr(True)  # avoid that some log statement spit out stuff to stderr while tests are running
         for level in ['ERROR', 'WARNING', 'INFO', 'DEBUG', 'DEVEL']:
             log.setLevelName(level)
             log.raiseError = False
@@ -208,18 +210,20 @@ class BuildLogTest(EnhancedTestCase):
             log.info('fyi')
             log.debug('gdb')
             log.devel('tmi')
+        self.mock_stderr(False)
 
         logToFile(tmplog, enable=False)
         logtxt = read_file(tmplog)
 
         root = getRootLoggerName()
 
-        devel_msg = r"%s.test_easybuildlog \[DEVEL\] :: tmi" % root
-        debug_msg = r"%s.test_easybuildlog \[DEBUG\] :: gdb" % root
-        info_msg = r"%s.test_easybuildlog \[INFO\] :: fyi" % root
-        warning_msg = r"%s.test_easybuildlog \[WARNING\] :: this is a warning" % root
-        deprecated_msg = r"%s.test_easybuildlog \[WARNING\] :: Deprecated functionality, .*: almost kaput; see .*" % root
-        error_msg = r"%s.test_easybuildlog \[ERROR\] :: EasyBuild crashed with an error \(at .* in .*\): kaput" % root
+        prefix = '%s.test_easybuildlog' % root
+        devel_msg = r"%s \[DEVEL\] :: tmi" % prefix
+        debug_msg = r"%s \[DEBUG\] :: gdb" % prefix
+        info_msg = r"%s \[INFO\] :: fyi" % prefix
+        warning_msg = r"%s \[WARNING\] :: this is a warning" % prefix
+        deprecated_msg = r"%s \[WARNING\] :: Deprecated functionality, .*: almost kaput; see .*" % prefix
+        error_msg = r"%s \[ERROR\] :: EasyBuild crashed with an error \(at .* in .*\): kaput" % prefix
 
         expected_logtxt = '\n'.join([
             error_msg,
@@ -233,24 +237,57 @@ class BuildLogTest(EnhancedTestCase):
 
     def test_print_warning(self):
         """Test print_warning"""
-        self.mock_stderr(True)
-        self.mock_stdout(True)
-        print_warning('You have been warned.')
-        stderr = self.get_stderr()
-        stdout = self.get_stdout()
-        self.mock_stdout(False)
-        self.mock_stderr(False)
+        def run_check(args, silent=False, expected_stderr=''):
+            """Helper function to check stdout/stderr produced via print_warning."""
+            self.mock_stderr(True)
+            self.mock_stdout(True)
+            print_warning(*args, silent=silent)
+            stderr = self.get_stderr()
+            stdout = self.get_stdout()
+            self.mock_stdout(False)
+            self.mock_stderr(False)
+            self.assertEqual(stdout, '')
+            self.assertEqual(stderr, expected_stderr)
 
-        self.assertEqual(stderr, "\nWARNING: You have been warned.\n\n")
-        self.assertEqual(stdout, '')
+        run_check(['You have been warned.'], expected_stderr="\nWARNING: You have been warned.\n\n")
+        run_check(['You have been %s.', 'warned'], expected_stderr="\nWARNING: You have been warned.\n\n")
+        run_check(['You %s %s %s.', 'have', 'been', 'warned'], expected_stderr="\nWARNING: You have been warned.\n\n")
+        run_check(['You have been warned.'], silent=True)
+        run_check(['You have been %s.', 'warned'], silent=True)
+        run_check(['You %s %s %s.', 'have', 'been', 'warned'], silent=True)
+
+        self.assertErrorRegex(EasyBuildError, "Unknown named arguments", print_warning, 'foo', unknown_arg='bar')
+
+    def test_print_error(self):
+        """Test print_error"""
+        def run_check(args, silent=False, expected_stderr=''):
+            """Helper function to check stdout/stderr produced via print_error."""
+            self.mock_stderr(True)
+            self.mock_stdout(True)
+            self.assertErrorRegex(SystemExit, '1', print_error, *args, silent=silent)
+            stderr = self.get_stderr()
+            stdout = self.get_stdout()
+            self.mock_stdout(False)
+            self.mock_stderr(False)
+            self.assertEqual(stdout, '')
+            self.assertTrue(stderr.startswith(expected_stderr))
+
+        run_check(['You have failed.'], expected_stderr="ERROR: You have failed.\n")
+        run_check(['You have %s.', 'failed'], expected_stderr="ERROR: You have failed.\n")
+        run_check(['%s %s %s.', 'You', 'have', 'failed'], expected_stderr="ERROR: You have failed.\n")
+        run_check(['You have failed.'], silent=True)
+        run_check(['You have %s.', 'failed'], silent=True)
+        run_check(['%s %s %s.', 'You', 'have', 'failed'], silent=True)
+
+        self.assertErrorRegex(EasyBuildError, "Unknown named arguments", print_error, 'foo', unknown_arg='bar')
 
     def test_print_msg(self):
         """Test print_msg"""
-        def run_check(msg, expected_stdout='', expected_stderr='', **kwargs):
-            """Helper function to check stdout/stderr produced via print_msg"""
+        def run_check(msg, args, expected_stdout='', expected_stderr='', **kwargs):
+            """Helper function to check stdout/stderr produced via print_msg."""
             self.mock_stdout(True)
             self.mock_stderr(True)
-            print_msg(msg, **kwargs)
+            print_msg(msg, *args, **kwargs)
             stdout = self.get_stdout()
             stderr = self.get_stderr()
             self.mock_stdout(False)
@@ -258,16 +295,24 @@ class BuildLogTest(EnhancedTestCase):
             self.assertEqual(stdout, expected_stdout)
             self.assertEqual(stderr, expected_stderr)
 
-        run_check("testing, 1, 2, 3", expected_stdout="== testing, 1, 2, 3\n")
-        run_check("testing, 1, 2, 3", expected_stdout="== testing, 1, 2, 3", newline=False)
-        run_check("testing, 1, 2, 3", expected_stdout="testing, 1, 2, 3\n", prefix=False)
-        run_check("testing, 1, 2, 3", expected_stdout="testing, 1, 2, 3", prefix=False, newline=False)
-        run_check("testing, 1, 2, 3", expected_stderr="== testing, 1, 2, 3\n", stderr=True)
-        run_check("testing, 1, 2, 3", expected_stderr="== testing, 1, 2, 3", stderr=True, newline=False)
-        run_check("testing, 1, 2, 3", expected_stderr="testing, 1, 2, 3\n", stderr=True, prefix=False)
-        run_check("testing, 1, 2, 3", expected_stderr="testing, 1, 2, 3", stderr=True, prefix=False, newline=False)
-        run_check("testing, 1, 2, 3", silent=True)
-        run_check("testing, 1, 2, 3", silent=True, stderr=True)
+        run_check("testing, 1, 2, 3", [], expected_stdout="== testing, 1, 2, 3\n")
+        run_check("testing, %s", ['1, 2, 3'], expected_stdout="== testing, 1, 2, 3\n")
+        run_check("testing, %s, %s, %s", ['1', '2', '3'], expected_stdout="== testing, 1, 2, 3\n")
+        run_check("testing, 1, 2, 3", [], expected_stdout="== testing, 1, 2, 3", newline=False)
+        run_check("testing, %s, 2, %s", ['1', '3'], expected_stdout="== testing, 1, 2, 3", newline=False)
+        run_check("testing, 1, 2, 3", [], expected_stdout="testing, 1, 2, 3\n", prefix=False)
+        run_check("testing, 1, 2, 3", [], expected_stdout="testing, 1, 2, 3", prefix=False, newline=False)
+        run_check("testing, 1, 2, 3", [], expected_stderr="== testing, 1, 2, 3\n", stderr=True)
+        run_check("testing, 1, 2, 3", [], expected_stderr="== testing, 1, 2, 3", stderr=True, newline=False)
+        run_check("testing, 1, %s, 3", ['2'], expected_stderr="== testing, 1, 2, 3", stderr=True, newline=False)
+        run_check("testing, 1, 2, 3", [], expected_stderr="testing, 1, 2, 3\n", stderr=True, prefix=False)
+        run_check("testing, 1, 2, 3", [], expected_stderr="testing, 1, 2, 3", stderr=True, prefix=False, newline=False)
+        run_check("testing, 1, 2, 3", [], silent=True)
+        run_check("testing, 1, %s, %s", ['2', '3'], silent=True)
+        run_check("testing, 1, 2, 3", [], silent=True, stderr=True)
+        run_check("testing, %s, %s, 3", ['1', '2'], silent=True, stderr=True)
+
+        self.assertErrorRegex(EasyBuildError, "Unknown named arguments", print_msg, 'foo', unknown_arg='bar')
 
     def test_time_str_since(self):
         """Test time_str_since"""
@@ -282,6 +327,48 @@ class BuildLogTest(EnhancedTestCase):
         self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=4500.1)), '01h15m00s')
         self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=12305.1)), '03h25m05s')
         self.assertEqual(time_str_since(datetime.now() - timedelta(seconds=54321.1)), '15h05m21s')
+
+    def test_dry_run_msg(self):
+        """Test dry_run_msg"""
+        def run_check(msg, args, expected_stdout='', **kwargs):
+            """Helper function to check stdout/stderr produced via dry_run_msg."""
+            self.mock_stdout(True)
+            self.mock_stderr(True)
+            dry_run_msg(msg, *args, **kwargs)
+            stdout = self.get_stdout()
+            stderr = self.get_stderr()
+            self.mock_stdout(False)
+            self.mock_stderr(False)
+            self.assertEqual(stdout, expected_stdout)
+            self.assertEqual(stderr, '')
+
+        run_check("test 123", [], expected_stdout="test 123\n")
+        run_check("test %s", ['123'], expected_stdout="test 123\n")
+        run_check("test 123", [], silent=True)
+        run_check("test %s", ['123'], silent=True)
+
+        self.assertErrorRegex(EasyBuildError, "Unknown named arguments", dry_run_msg, 'foo', unknown_arg='bar')
+
+    def test_dry_run_warning(self):
+        """Test dry_run_warningmsg"""
+        def run_check(msg, args, expected_stdout='', **kwargs):
+            """Helper function to check stdout/stderr produced via dry_run_warningmsg."""
+            self.mock_stdout(True)
+            self.mock_stderr(True)
+            dry_run_warning(msg, *args, **kwargs)
+            stdout = self.get_stdout()
+            stderr = self.get_stderr()
+            self.mock_stdout(False)
+            self.mock_stderr(False)
+            self.assertEqual(stdout, expected_stdout)
+            self.assertEqual(stderr, '')
+
+        run_check("test 123", [], expected_stdout="\n!!!\n!!! WARNING: test 123\n!!!\n\n")
+        run_check("test %s", ['123'], expected_stdout="\n!!!\n!!! WARNING: test 123\n!!!\n\n")
+        run_check("test 123", [], silent=True)
+        run_check("test %s", ['123'], silent=True)
+
+        self.assertErrorRegex(EasyBuildError, "Unknown named arguments", dry_run_warning, 'foo', unknown_arg='bar')
 
 
 def suite():


### PR DESCRIPTION
This avoids that `print_warning("Example: %s", foo)` gets interpreted as `print_warning("Example: %s", silent=True)`, but as `print_warning("Example: %s" % foo)`.

Strictly speaking, this is backwards incompatible, but if any code out there now uses `print_warning(msg, arg`) it's most likely not working as intended. And using `print_warning` with `silent=True` is quite silly anyway, that only makes sense in the tests.