### PR TITLE
Python 2.6 requires python-daemon 1.x as dep for GC3Pie

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ before_install:
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'paramiko<2.4.0'; fi
     # SQLAlchemy 1.2.0 (dep for GC3Pie) & more recent doesn't work with Python 2.6
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'SQLAlchemy<1.2.0'; fi
+    # python 2.0 (dep for GC3Pie) & more recent doesn't work with Python 2.6
+    - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'python-daemon<2.0'; fi
     # autopep8 1.3.4 is last one to support Python 2.6
     - if [ "x$TRAVIS_PYTHON_VERSION" == 'x2.6' ]; then pip install 'autopep8<1.3.5'; else pip install autopep8; fi
     # optional Python packages for EasyBuild


### PR DESCRIPTION
Somehow the release of GC3Pie 2.5.1 is pulling in `python-daemon` 2.2.0, which is not compatible with Python 2.6, causing tests to fail.

This is an attempt to fix that issue...

cc @riccardomurri 