### PR TITLE
add support for disabling mapping of (sub)toolchains when --try-toolchain is used

### DIFF
--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -120,26 +120,26 @@ def tweak(easyconfigs, build_specs, modtool, targetdirs=None):
             else:
                 target_toolchain['version'] = source_toolchain['version']
 
-            try:
-                src_to_dst_tc_mapping = map_toolchain_hierarchies(source_toolchain, target_toolchain, modtool)
-            except EasyBuildError as err:
-                # make sure exception was raised by match_minimum_tc_specs because toolchain mapping could not be done
-                if "No possible mapping from source toolchain" in err.msg:
-
-                    if build_option('force'):
-                        warning_msg = "Combining --try-toolchain with --force for toolchains with unequal capabilities:"
-                        warning_msg += " disabling recursion and not changing (sub)toolchains for dependencies."
-                        print_warning(warning_msg)
-                        revert_to_regex = True
-                        modifying_toolchains = False
-                    else:
+            if build_option('map_toolchains'):
+                try:
+                    src_to_dst_tc_mapping = map_toolchain_hierarchies(source_toolchain, target_toolchain, modtool)
+                except EasyBuildError as err:
+                    # make sure exception was raised by match_minimum_tc_specs because toolchain mapping didn't work
+                    if "No possible mapping from source toolchain" in err.msg:
                         error_msg = err.msg + '\n'
                         error_msg += "Toolchain %s is not equivalent to toolchain %s in terms of capabilities. "
-                        error_msg += "(If you know what you are doing, you can use --force to proceed anyway.)"
+                        error_msg += "(If you know what you are doing, "
+                        error_msg += "you can use --disable-map-toolchains to proceed anyway.)"
                         raise EasyBuildError(error_msg, target_toolchain['name'], source_toolchain['name'])
-                else:
-                    # simply re-raise the exception if something else went wrong
-                    raise err
+                    else:
+                        # simply re-raise the exception if something else went wrong
+                        raise err
+            else:
+                msg = "Mapping of (sub)toolchains disabled, so falling back to regex mode, "
+                msg += "disabling recursion and not changing (sub)toolchains for dependencies"
+                _log.info(msg)
+                revert_to_regex = True
+                modifying_toolchains = False
 
         if not revert_to_regex:
             _log.debug("Applying build specifications recursively (no software name/version found): %s", build_specs)

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -221,6 +221,7 @@ BUILD_OPTIONS_CMDLINE = {
         'cleanup_tmpdir',
         'extended_dry_run_ignore_errors',
         'mpi_tests',
+        'map_toolchains',
         'modules_tool_version_check',
         'pre_create_installdir',
     ],

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -325,6 +325,9 @@ class EasyBuildOptions(GeneralOption):
             hlp = "Try to %s (USE WITH CARE!)" % (hlp[0].lower() + hlp[1:])
             opts["try-%s" % longopt] = (hlp,) + opts[longopt][1:]
 
+        opts['map-toolchains'] = ("Enable mapping of (sub)toolchains when --try-toolchain(-version) is used",
+                                  None, 'store_true', True)
+
         self.log.debug("software_options: descr %s opts %s" % (descr, opts))
         self.add_group_parser(opts, descr)
 


### PR DESCRIPTION
Fix for #2662 reported by @mboisson , or at least it provides a replacement for `--try-toolchain --force`: you can use `--disable-map-toolchains --try-toolchain`, or configure EasyBuild with `export EASYBUILD_DISABLE_MAP_TOOLCHAINS=1`.

cc @bartoldeman (since this changes what got merged via #2605), @ocaisa