### PR TITLE
use 'tar xzf' (gzip) rather than 'tar xZf' (ancient compress) to unpack *.tar.Z source files

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -148,8 +148,8 @@ EXTRACT_CMDS = {
     '.zip':     "unzip -qq %(filepath)s",
     # iso file
     '.iso':     "7z x %(filepath)s",
-    # tar.Z: using compress (LZW)
-    '.tar.z':   "tar xZf %(filepath)s",
+    # tar.Z: using compress (LZW), but can be handled with gzip so use 'z'
+    '.tar.z':   "tar xzf %(filepath)s",
 }
 
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -93,7 +93,7 @@ class FileToolsTest(EnhancedTestCase):
             ('test.tar.xz', "unxz test.tar.xz --stdout | tar x"),
             ('test.txz', "unxz test.txz --stdout | tar x"),
             ('test.iso', "7z x test.iso"),
-            ('test.tar.Z', "tar xZf test.tar.Z"),
+            ('test.tar.Z', "tar xzf test.tar.Z"),
         ]
         for (fn, expected_cmd) in tests:
             cmd = ft.extract_cmd(fn)


### PR DESCRIPTION
fix for failure to unpack a `.tar.Z` file because `compress` utility is not available:

```
tar (child): compress: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

(see also https://bugs.launchpad.net/ubuntu/+source/tar/+bug/70610)