### PR TITLE
don't always require easyconfig files to resolve dependencies

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1121,11 +1121,8 @@ class EasyConfig(object):
                         # try finding subtoolchain for dep for which an easyconfig file is available
                         # this may fail, since it requires that the easyconfigs for parent toolchain
                         # and subtoolchains are available
-                        try:
-                            tc = robot_find_subtoolchain_for_dep(dep, self.modules_tool, parent_first=True)
-                            self.log.debug("Using subtoolchain %s for dep %s", tc, dep_str)
-                        except EasyBuildError as err:
-                            self.log.debug("Ignoring error while looking for subtoolchain for dep %s: %s", dep_str, err)
+                        tc = robot_find_subtoolchain_for_dep(dep, self.modules_tool, parent_first=True)
+                        self.log.debug("Using subtoolchain %s for dep %s", tc, dep_str)
 
                     if tc is None:
                         tc = dep['toolchain']

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1114,7 +1114,7 @@ class EasyConfig(object):
                         # determine 'smallest' subtoolchain for which a matching easyconfig file is available
                         self.log.debug("Looking for minimal toolchain for dependency %s (parent toolchain: %s)...",
                                        dep_str, dep['toolchain'])
-                        tc = robot_find_minimal_toolchain_of_dependency(dep, self.modules_tool)
+                        tc = robot_find_subtoolchain_for_dep(dep, self.modules_tool)
                         if tc is None:
                             raise EasyBuildError("Failed to determine minimal toolchain for dep %s", dep_str)
                     else:
@@ -1122,7 +1122,7 @@ class EasyConfig(object):
                         # this may fail, since it requires that the easyconfigs for parent toolchain
                         # and subtoolchains are available
                         try:
-                            tc = robot_find_minimal_toolchain_of_dependency(dep, self.modules_tool, parent_first=True)
+                            tc = robot_find_subtoolchain_for_dep(dep, self.modules_tool, parent_first=True)
                             self.log.debug("Using subtoolchain %s for dep %s", tc, dep_str)
                         except EasyBuildError as err:
                             self.log.debug("Ignoring error while looking for subtoolchain for dep %s: %s", dep_str, err)
@@ -1644,9 +1644,9 @@ def verify_easyconfig_filename(path, specs, parsed_ec=None):
     _log.info("Contents of %s verified against easyconfig filename, matches %s", path, specs)
 
 
-def robot_find_minimal_toolchain_of_dependency(dep, modtool, parent_tc=None, parent_first=False):
+def robot_find_subtoolchain_for_dep(dep, modtool, parent_tc=None, parent_first=False):
     """
-    Find the minimal toolchain of a dependency
+    Find the subtoolchain to use for a dependency
 
     :param dep: dependency target dict (long and short module names may not exist yet)
     :param parent_tc: toolchain from which to derive the toolchain hierarchy to search (default: use dep's toolchain)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1125,12 +1125,12 @@ class EasyConfig(object):
                         self.log.debug("Using subtoolchain %s for dep %s", tc, dep_str)
 
                     if tc is None:
-                        tc = dep['toolchain']
-                        self.log.debug("Inheriting toolchain %s from parent for dep %s", tc, dep_str)
-
-                    # put derived toolchain in place, or complain if none could be found
-                    self.log.debug("Figured out toolchain to use for dep %s: %s", dep_str, tc)
-                    dep['toolchain'] = orig_dep['toolchain'] = tc
+                        self.log.debug("Inheriting toolchain %s from parent for dep %s", dep['toolchain'], dep_str)
+                    else:
+                        # put derived toolchain in place
+                        self.log.debug("Figured out toolchain to use for dep %s: %s", dep_str, tc)
+                        dep['toolchain'] = orig_dep['toolchain'] = tc
+                        dep['toolchain_inherited'] = orig_dep['toolchain_inherited'] = False
 
                 if not dep['external_module']:
                     # make sure 'dummy' is set correctly

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1656,9 +1656,12 @@ def robot_find_minimal_toolchain_of_dependency(dep, modtool, parent_tc=None, par
     if parent_tc is None:
         parent_tc = dep['toolchain']
 
-    avail_modules = []
-    if build_option('use_existing_modules') and not build_option('retain_all_deps'):
+    use_existing_modules = build_option('use_existing_modules') and not build_option('retain_all_deps')
+
+    if use_existing_modules:
         avail_modules = modtool.available()
+    else:
+        avail_modules = []
 
     newdep = copy.deepcopy(dep)
 
@@ -1674,7 +1677,7 @@ def robot_find_minimal_toolchain_of_dependency(dep, modtool, parent_tc=None, par
         if eb_file is not None:
             module_exists = False
             # if necessary check if module exists
-            if build_option('use_existing_modules') and not build_option('retain_all_deps'):
+            if use_existing_modules:
                 full_mod_name = ActiveMNS().det_full_module_name(newdep)
                 # fallback to checking with modtool.exist is required,
                 # for hidden modules and external modules where module name may be partial
@@ -1687,7 +1690,8 @@ def robot_find_minimal_toolchain_of_dependency(dep, modtool, parent_tc=None, par
 
         # select the toolchain to return, defaulting to the first element (lowest possible toolchain)
         minimal_toolchain = possible_toolchains[0]['toolchain']
-        if build_option('use_existing_modules') and not build_option('retain_all_deps'):
+
+        if use_existing_modules:
             # take the last element in the case of using existing modules (allows for potentially better optimisation)
             filtered_possibilities = [tc for tc in possible_toolchains if tc['module_exists']]
             if filtered_possibilities:
@@ -1872,13 +1876,6 @@ class ActiveMNS(object):
     def _det_module_name_with(self, mns_method, ec, force_visible=False):
         """
         Determine module name using specified module naming scheme method, based on supplied easyconfig.
-        Returns a string representing the module name, e.g. 'GCC/4.6.3', 'Python/2.7.5-ictce-4.1.13',
-        with the following requirements:
-            - module name is specified as a relative path
-            - string representing module name has length > 0
-            - module name only contains printable characters (string.printable, except carriage-control chars)
-        """
-        """
         Returns a string representing the module name, e.g. 'GCC/4.6.3', 'Python/2.7.5-ictce-4.1.13',
         with the following requirements:
             - module name is specified as a relative path

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1658,7 +1658,8 @@ def robot_find_subtoolchain_for_dep(dep, modtool, parent_tc=None, parent_first=F
     if parent_tc is None:
         parent_tc = dep['toolchain']
 
-    use_existing_modules = build_option('use_existing_modules') and not build_option('retain_all_deps')
+    retain_all_deps = build_option('retain_all_deps')
+    use_existing_modules = build_option('use_existing_modules') and not retain_all_deps
 
     if use_existing_modules:
         avail_modules = modtool.available()
@@ -1703,7 +1704,7 @@ def robot_find_subtoolchain_for_dep(dep, modtool, parent_tc=None, parent_first=F
     # - parent toolchain first (minimal toolchains mode *not* enabled)
     # - module for dependency is already available for one of the subtoolchains
     # If so, we retain the subtoolchain closest to the parent (so top of the list of candidates)
-    if parent_first and cand_subtcs_with_mod:
+    if parent_first and cand_subtcs_with_mod and not retain_all_deps:
         minimal_toolchain = cand_subtcs_with_mod[0]['toolchain']
 
     # scenario II:

--- a/easybuild/scripts/generate_software_list.py
+++ b/easybuild/scripts/generate_software_list.py
@@ -34,10 +34,10 @@ from datetime import date
 from optparse import OptionParser
 
 import easybuild.tools.config as config
-import easybuild.tools.options as eboptions
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, get_easyblock_class
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.github import Githubfs
+from easybuild.tools.options import set_up_configuration
 from vsc.utils import fancylogger
 
 # parse options
@@ -86,22 +86,20 @@ if options.local:
     import os
     walk = os.walk
     join = os.path.join
-    read = lambda ec_file : ec_file
+    read = lambda ec_file: ec_file
 
     log.info('parsing easyconfigs from location %s' % options.path)
 else:
     fs = Githubfs(options.username, options.repo, options.branch)
     walk = Githubfs(options.username, options.repo, options.branch).walk
     join = fs.join
-    read = lambda ec_file : fs.read(ec_file, api=False)
+    read = lambda ec_file: fs.read(ec_file, api=False)
 
     log.info('parsing easyconfigs from user %s reponame %s' % (options.username, options.repo))
 
 
 # configure EasyBuild, by parsing options
-eb_go = eboptions.parse_options(args=args)
-config.init(eb_go.options, eb_go.get_options_by_section('config'))
-config.init_build_options({'validate': False, 'external_modules_metadata': {}})
+set_up_configuration(args=args + ['--force'])
 
 
 configs = []
@@ -124,7 +122,7 @@ for root, subfolders, files in walk(options.path):
         try:
             ec = EasyConfig(ec_file)
             log.info("found valid easyconfig %s" % ec)
-            if not ec.name in names:
+            if ec.name not in names:
                 log.info("found new software package %s" % ec.name)
                 ec.easyblock = None
                 # check if an easyblock exists
@@ -140,7 +138,7 @@ for root, subfolders, files in walk(options.path):
 
 log.info("Found easyconfigs: %s" % [x.name for x in configs])
 # sort by name
-configs = sorted(configs, key=lambda config : config.name.lower())
+configs = sorted(configs, key=lambda config: config.name.lower())
 firstl = ""
 
 # print out the configs in markdown format for the wiki

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -397,7 +397,7 @@ def init_build_options(build_options=None, cmdline_options=None):
         # building a dependency graph implies force, so that all dependencies are retained
         # and also skips validation of easyconfigs (e.g. checking os dependencies)
         retain_all_deps = False
-        if cmdline_options.dep_graph:
+        if cmdline_options.dep_graph or cmdline_options.check_conflicts:
             _log.info("Enabling force to generate dependency graph.")
             cmdline_options.force = True
             retain_all_deps = True

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -279,7 +279,7 @@ def resolve_dependencies(easyconfigs, modtool, retain_all_deps=False):
     ordered_ecs = []
     # all available modules can be used for resolving dependencies except those that will be installed
     being_installed = [p['full_mod_name'] for p in easyconfigs]
-    avail_modules = [m for m in avail_modules if not m in being_installed]
+    avail_modules = [m for m in avail_modules if m not in being_installed]
 
     _log.debug('easyconfigs before resolving deps: %s' % easyconfigs)
 
@@ -352,7 +352,7 @@ def resolve_dependencies(easyconfigs, modtool, retain_all_deps=False):
                         verify_easyconfig_filename(path, cand_dep, parsed_ec=processed_ecs)
 
                         for ec in processed_ecs:
-                            if not ec in easyconfigs + additional:
+                            if ec not in easyconfigs + additional:
                                 additional.append(ec)
                                 _log.debug("Added %s as dependency of %s" % (ec, entry))
                 else:
@@ -394,7 +394,7 @@ def search_easyconfigs(query, short=False, filename_only=False, terse=False):
     var_defs, _hits = search_file(search_path, query, short=short, ignore_dirs=ignore_dirs, terse=terse,
                                   silent=True, filename_only=False)
 
-     # filter out archived easyconfigs, these are handled separately
+    # filter out archived easyconfigs, these are handled separately
     hits, archived_hits = [], []
     for hit in _hits:
         if EASYCONFIGS_ARCHIVE_DIR in hit.split(os.path.sep):

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -330,8 +330,8 @@ def resolve_dependencies(easyconfigs, modtool, retain_all_deps=False, raise_erro
         missing_external_modules = [d['full_mod_name'] for ec in easyconfigs for d in ec['dependencies']
                                     if d.get('external_module', False)]
         if missing_external_modules:
-            raise EasyBuildError("Missing modules for one or more dependencies marked as external modules: %s",
-                                 missing_external_modules)
+            raise EasyBuildError("Missing modules for dependencies marked as external modules: %s",
+                                 ', '.join(missing_external_modules))
 
         # robot: look for existing dependencies, add them
         if robot and easyconfigs:

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -394,8 +394,8 @@ def resolve_dependencies(easyconfigs, modtool, retain_all_deps=False, raise_erro
         elif not robot:
             # no use in continuing if robot is not enabled, dependencies won't be resolved anyway
             missing_deps = [dep for x in easyconfigs for dep in x['dependencies']]
-            raise_error_missing_deps(missing_deps, extra_msg="enabled dependency resolution via --robot?")
-            break
+            if missing_deps:
+                raise_error_missing_deps(missing_deps, extra_msg="enable dependency resolution via --robot?")
 
     if missing_easyconfigs:
         if raise_error_missing_ecs:

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -413,7 +413,7 @@ class Toolchain(object):
                 missing_dep_mods.append(dep_mod_name)
 
         if missing_dep_mods:
-            raise EasyBuildError("Missing modules for one or more dependencies: %s", ', '.join(missing_dep_mods))
+            raise EasyBuildError("Missing modules for dependencies (use --robot?): %s", ', '.join(missing_dep_mods))
 
         return deps
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1095,7 +1095,7 @@ class EasyBlockTest(EnhancedTestCase):
         try:
             eb.check_readiness_step()
         except EasyBuildError, err:
-            err_regex = re.compile("Missing modules for one or more dependencies: nosuchsoftware/1.2.3-GCC-6.4.0-2.28")
+            err_regex = re.compile("Missing modules dependencies .*: nosuchsoftware/1.2.3-GCC-6.4.0-2.28")
             self.assertTrue(err_regex.search(str(err)), "Pattern '%s' found in '%s'" % (err_regex.pattern, err))
 
         shutil.rmtree(tmpdir)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -465,7 +465,7 @@ class EasyBlockTest(EnhancedTestCase):
             "toolchain = {'name': 'gompi', 'version': '2018a'}",
             'dependencies = [',
             "   ('FFTW', '3.3.7'),",
-            "   ('OpenBLAS', '0.2.20'),",
+            "   ('OpenBLAS', '0.2.20', '', ('GCC', '6.4.0-2.28')),",
             ']',
         ])
         self.writeEC()
@@ -488,8 +488,8 @@ class EasyBlockTest(EnhancedTestCase):
                 "}",
             ])
             lapack_load = '\n'.join([
-                "if { ![ is-loaded OpenBLAS/0.2.20-gompi-2018a ] } {",
-                "    module load OpenBLAS/0.2.20-gompi-2018a",
+                "if { ![ is-loaded OpenBLAS/0.2.20-GCC-6.4.0-2.28 ] } {",
+                "    module load OpenBLAS/0.2.20-GCC-6.4.0-2.28",
                 "}",
             ])
         elif get_module_syntax() == 'Lua':
@@ -504,8 +504,8 @@ class EasyBlockTest(EnhancedTestCase):
                 'end',
             ])
             lapack_load = '\n'.join([
-                'if not isloaded("OpenBLAS/0.2.20-gompi-2018a") then',
-                '    load("OpenBLAS/0.2.20-gompi-2018a")',
+                'if not isloaded("OpenBLAS/0.2.20-GCC-6.4.0-2.28") then',
+                '    load("OpenBLAS/0.2.20-GCC-6.4.0-2.28")',
                 'end',
             ])
         else:

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1445,8 +1445,9 @@ class EasyConfigTest(EnhancedTestCase):
         """Test EasyConfig's dump() method."""
         test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         build_options = {
-            'valid_module_classes': module_classes(),
             'check_osdeps': False,
+            'robot_path': [test_ecs_dir],
+            'valid_module_classes': module_classes(),
         }
         init_config(build_options=build_options)
         ecfiles = [

--- a/test/framework/easyconfigs/v2.0/toy.eb
+++ b/test/framework/easyconfigs/v2.0/toy.eb
@@ -37,4 +37,4 @@ toolchains = foss == 2018a, dummy == dummy
 # various types of (meaningless) dependencies: simply, with toolchain/suffix
 GCC = 6.4.0-2.28
 OpenMPI = 2.1.2; GCC == 6.4.0-2.28
-OpenBLAS = 0.2.20; gompi == 2018a
+OpenBLAS = 0.2.20; GCC == 6.4.0-2.28

--- a/test/framework/modules/OpenBLAS/0.2.20-GCC-6.4.0-2.28
+++ b/test/framework/modules/OpenBLAS/0.2.20-GCC-6.4.0-2.28
@@ -7,12 +7,12 @@ proc ModulesHelp { } {
 
 module-whatis {OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version. - Homepage: http://xianyi.github.com/OpenBLAS/}
 
-set root    /prefix/software/OpenBLAS/0.2.20-gompi-2018a
+set root    /prefix/software/OpenBLAS/0.2.20-GCC-6.4.0-2.28
 
 conflict    OpenBLAS
 
-if { ![is-loaded gompi/2018a] } {
-    module load gompi/2018a
+if { ![is-loaded GCC/6.4.0-2.28] } {
+    module load GCC/6.4.0-2.28
 }
 
 prepend-path	CPATH		$root/include
@@ -20,7 +20,7 @@ prepend-path	LD_LIBRARY_PATH		$root/lib
 
 setenv	EBROOTOPENBLAS		"$root"
 setenv	EBVERSIONOPENBLAS		"0.2.20"
-setenv	EBDEVELOPENBLAS		"$root/easybuild/OpenBLAS-0.2.20-gompi-2018a-easybuild-devel"
+setenv	EBDEVELOPENBLAS		"$root/easybuild/OpenBLAS-0.2.20-GCC-6.4.0-2.28-easybuild-devel"
 
 
 # built with EasyBuild version 1.4.0dev

--- a/test/framework/modules/OpenBLAS/0.2.20-GCC-7.3.0-2.30
+++ b/test/framework/modules/OpenBLAS/0.2.20-GCC-7.3.0-2.30
@@ -7,12 +7,12 @@ proc ModulesHelp { } {
 
 module-whatis {OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version. - Homepage: http://xianyi.github.com/OpenBLAS/}
 
-set root    /prefix/software/OpenBLAS/0.2.20-gompi-2018b
+set root    /prefix/software/OpenBLAS/0.2.20-GCC-7.3.0-2.30
 
 conflict    OpenBLAS
 
-if { ![is-loaded gompi/2018b] } {
-    module load gompi/2018b
+if { ![is-loaded GCC/7.3.0-2.30] } {
+    module load GCC/7.3.0-2.30
 }
 
 prepend-path	CPATH		$root/include
@@ -20,7 +20,7 @@ prepend-path	LD_LIBRARY_PATH		$root/lib
 
 setenv	EBROOTOPENBLAS		"$root"
 setenv	EBVERSIONOPENBLAS		"0.2.20"
-setenv	EBDEVELOPENBLAS		"$root/easybuild/OpenBLAS-0.2.20-gompi-2018b-easybuild-devel"
+setenv	EBDEVELOPENBLAS		"$root/easybuild/OpenBLAS-0.2.20-GCC-7.3.0-2.30-easybuild-devel"
 
 
 # built with EasyBuild version 1.4.0dev

--- a/test/framework/modules/ScaLAPACK/2.0.2-gompi-2018a-OpenBLAS-0.2.20
+++ b/test/framework/modules/ScaLAPACK/2.0.2-gompi-2018a-OpenBLAS-0.2.20
@@ -17,8 +17,8 @@ if { ![is-loaded gompi/2018a] } {
     module load gompi/2018a
 }
 
-if { ![is-loaded OpenBLAS/0.2.20-gompi-2018a] } {
-    module load OpenBLAS/0.2.20-gompi-2018a
+if { ![is-loaded OpenBLAS/0.2.20-GCC-6.4.0-2.28] } {
+    module load OpenBLAS/0.2.20-GCC-6.4.0-2.28
 }
 
 prepend-path	CPATH		$root/include

--- a/test/framework/modules/ScaLAPACK/2.0.2-gompi-2018b-OpenBLAS-0.2.20
+++ b/test/framework/modules/ScaLAPACK/2.0.2-gompi-2018b-OpenBLAS-0.2.20
@@ -17,8 +17,8 @@ if { ![is-loaded gompi/2018b] } {
     module load gompi/2018b
 }
 
-if { ![is-loaded OpenBLAS/0.2.20-gompi-2018b] } {
-    module load OpenBLAS/0.2.20-gompi-2018b
+if { ![is-loaded OpenBLAS/0.2.20-GCC-6.4.0-2.28] } {
+    module load OpenBLAS/0.2.20-GCC-6.4.0-2.28
 }
 
 prepend-path	CPATH		$root/include
@@ -26,7 +26,7 @@ prepend-path	LD_LIBRARY_PATH		$root/lib
 
 setenv	EBROOTSCALAPACK		"$root"
 setenv	EBVERSIONSCALAPACK		"2.0.2"
-setenv	EBDEVELSCALAPACK		"$root/easybuild/ScaLAPACK-2.0.2-gompi-2018b-OpenBLAS-0.2.20-easybuild-devel"
+setenv	EBDEVELSCALAPACK		"$root/easybuild/ScaLAPACK-2.0.2-GCC-6.4.0-2.28-OpenBLAS-0.2.20-easybuild-devel"
 
 
 # built with EasyBuild version 1.4.0dev

--- a/test/framework/modules/foss/2018a
+++ b/test/framework/modules/foss/2018a
@@ -21,8 +21,8 @@ if { ![is-loaded OpenMPI/2.1.2-GCC-6.4.0-2.28] } {
     module load OpenMPI/2.1.2-GCC-6.4.0-2.28
 }
 
-if { ![is-loaded OpenBLAS/0.2.20-gompi-2018a] } {
-    module load OpenBLAS/0.2.20-gompi-2018a
+if { ![is-loaded OpenBLAS/0.2.20-GCC-6.4.0-2.28] } {
+    module load OpenBLAS/0.2.20-GCC-6.4.0-2.28
 }
 
 if { ![is-loaded FFTW/3.3.7-gompi-2018a] } {

--- a/test/framework/modules/foss/2018a-brokenFFTW
+++ b/test/framework/modules/foss/2018a-brokenFFTW
@@ -21,8 +21,8 @@ if { ![is-loaded OpenMPI/2.1.2-GCC-6.4.0-2.28] } {
     module load OpenMPI/2.1.2-GCC-6.4.0-2.28
 }
 
-if { ![is-loaded OpenBLAS/0.2.20-gompi-2018a] } {
-    module load OpenBLAS/0.2.20-gompi-2018a
+if { ![is-loaded OpenBLAS/0.2.20-GCC-6.4.0-2.28] } {
+    module load OpenBLAS/0.2.20-GCC-6.4.0-2.28
 }
 
 # load statement for FFTW purposely omitted, which doesn't match the toolchain definition

--- a/test/framework/modules/fosscuda/2018a
+++ b/test/framework/modules/fosscuda/2018a
@@ -21,8 +21,8 @@ if { ![is-loaded OpenMPI/2.1.2-GCC-6.4.0-2.28] } {
     module load OpenMPI/2.1.2-GCC-6.4.0-2.28
 }
 
-if { ![is-loaded OpenBLAS/0.2.20-gompi-2018a] } {
-    module load OpenBLAS/0.2.20-gompi-2018a
+if { ![is-loaded OpenBLAS/0.2.20-GCC-6.4.0-2.28] } {
+    module load OpenBLAS/0.2.20-GCC-6.4.0-2.28
 }
 
 if { ![is-loaded FFTW/3.3.7-gompi-2018a] } {

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1838,18 +1838,19 @@ class CommandLineOptionsTest(EnhancedTestCase):
             eb_file,
             '--robot-paths=%s' % test_ecs_path,
         ]
-        error_regex = "Missing modules for one or more dependencies: .*"
+        error_regex = "Missing modules for dependencies .*: toy/\.0.0-deps"
         self.assertErrorRegex(EasyBuildError, error_regex, self.eb_main, args, raise_error=True, do_build=True)
 
         # enable robot, but without passing path required to resolve toy dependency => FAIL
+        # note that --dry-run is now robust against missing easyconfig, so shouldn't use it here
         args = [
             eb_file,
             '--robot',
-            '--dry-run',
         ]
         self.assertErrorRegex(EasyBuildError, 'Missing dependencies', self.eb_main, args, raise_error=True)
 
         # add path to test easyconfigs to robot paths, so dependencies can be resolved
+        args.append('--dry-run')
         self.eb_main(args + ['--robot-paths=%s' % test_ecs_path], raise_error=True)
 
         # copy test easyconfigs to easybuild/easyconfigs subdirectory of temp directory

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -854,10 +854,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
             # GCC/OpenMPI dependencies are there, but part of toolchain => 'x'
             ("GCC-7.3.0-2.30.eb", "GCC/7.3.0-2.30", 'x'),
             ("OpenMPI-3.1.1-GCC-7.3.0-2.30.eb", "OpenMPI/3.1.1-GCC-7.3.0-2.30", 'x'),
-            # OpenBLAS dependency is listed, but not there => ' '
             # toolchain used for OpenBLAS is mapped to GCC/7.3.0-2.30 subtoolchain in gompi/2018b
             # (rather than the original GCC/6.4.0-2.28 as subtoolchain of gompi/2018a)
-            ("OpenBLAS-0.2.20-GCC-7.3.0-2.30.eb", "OpenBLAS/0.2.20-GCC-7.3.0-2.30", ' '),
+            ("OpenBLAS-0.2.20-GCC-7.3.0-2.30.eb", "OpenBLAS/0.2.20-GCC-7.3.0-2.30", 'x'),
             # both FFTW and ScaLAPACK are listed => 'F'
             ("ScaLAPACK-%s.eb" % scalapack_ver, "ScaLAPACK/%s" % scalapack_ver, 'F'),
             ("FFTW-3.3.7-gompi-2018b.eb", "FFTW/3.3.7-gompi-2018b", 'F'),

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1847,7 +1847,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--robot',
             '--dry-run',
         ]
-        self.assertErrorRegex(EasyBuildError, 'Irresolvable dependencies', self.eb_main, args, raise_error=True)
+        self.assertErrorRegex(EasyBuildError, 'Missing dependencies', self.eb_main, args, raise_error=True)
 
         # add path to test easyconfigs to robot paths, so dependencies can be resolved
         self.eb_main(args + ['--robot-paths=%s' % test_ecs_path], raise_error=True)

--- a/test/framework/parallelbuild.py
+++ b/test/framework/parallelbuild.py
@@ -336,15 +336,14 @@ class ParallelBuildTest(EnhancedTestCase):
         jobs = build_easyconfigs_in_parallel("echo '%(spec)s'", ordered_ecs, prepare_first=False)
         self.mock_stdout(False)
 
-        # jobs are submitted for OpenBLAS (missing module), foss & gzip (listed easyconfigs)
-        self.assertEqual(len(jobs), 3)
-
-        self.assertEqual(jobs[0].job_specs['job-name'], 'OpenBLAS-0.2.20-GCC-6.4.0-2.28')
+        # jobs are submitted for foss & gzip (listed easyconfigs)
+        self.assertEqual(len(jobs), 2)
 
         # last job (gzip) has a dependency on second-to-last job (foss)
-        self.assertEqual(jobs[1].job_specs['job-name'], 'foss-2018a')
+        self.assertEqual(jobs[0].job_specs['job-name'], 'foss-2018a')
+
         expected = {
-            'dependency': 'afterok:%s' % jobs[1].jobid,
+            'dependency': 'afterok:%s' % jobs[0].jobid,
             'hold': True,
             'job-name': 'gzip-1.5-foss-2018a',
             'nodes': 1,
@@ -354,7 +353,7 @@ class ParallelBuildTest(EnhancedTestCase):
             'time': 300,  # 60*5 (unit is minutes)
             'wrap': "echo '%s'" % test_ec,
         }
-        self.assertEqual(jobs[-1].job_specs, expected)
+        self.assertEqual(jobs[1].job_specs, expected)
 
 
 def suite():

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -1187,6 +1187,8 @@ class RobotTest(EnhancedTestCase):
         """Test check_conflicts function."""
         test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         init_config(build_options={
+            'force': True,
+            'retain_all_deps': True,
             'robot_path': test_easyconfigs,
             'valid_module_classes': module_classes(),
             'validate': False,

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -224,7 +224,7 @@ class RobotTest(EnhancedTestCase):
 
         # this should not resolve (cannot find gzip-1.4.eb), both with and without robot enabled
         ecs = [deepcopy(easyconfig_dep)]
-        msg = "Irresolvable dependencies encountered"
+        msg = "Missing dependencies"
         self.assertErrorRegex(EasyBuildError, msg, resolve_dependencies, ecs, self.modtool)
 
         # test if dependencies of an automatically found file are also loaded
@@ -1296,7 +1296,7 @@ class RobotTest(EnhancedTestCase):
         test_ectxt = regex.sub(tc_spec, gzip_ectxt)
         write_file(test_ec, test_ectxt)
         ecs, _ = parse_easyconfigs([(test_ec, False)])
-        self.assertErrorRegex(EasyBuildError, "Irresolvable dependencies encountered", resolve_dependencies,
+        self.assertErrorRegex(EasyBuildError, "Missing dependencies", resolve_dependencies,
                               ecs, self.modtool, retain_all_deps=True)
 
         # --consider-archived-easyconfigs must be used to let robot pick up archived easyconfigs

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -1081,6 +1081,7 @@ class RobotTest(EnhancedTestCase):
             'name': 'SQLite',
             'version': '3.8.10.2',
             'toolchain': {'name': 'foss', 'version': '2018a'},
+            'hidden': False,
         }
         res = robot_find_minimal_toolchain_of_dependency(dep, self.modtool)
         self.assertEqual(res, {'name': 'GCC', 'version': '6.4.0-2.28'})
@@ -1117,13 +1118,14 @@ class RobotTest(EnhancedTestCase):
         })
         bar = EasyConfig(barec)
 
-        expected_dep_versions = [
-            '2.1.2-GCC-6.4.0-2.28',
-            '0.2.20-GCC-6.4.0-2.28',
-            '2.0.2-gompi-2018a-OpenBLAS-0.2.20',
-            '3.8.10.2-foss-2018a',
-        ]
-        for dep, expected_dep_version in zip(bar.dependencies(), expected_dep_versions):
+        expected_dep_versions = {
+            'OpenMPI': '2.1.2-GCC-6.4.0-2.28',
+            'OpenBLAS': '0.2.20-gompi-2018a',  # due to existing OpenBLAS/0.2.20-gompi-2018a test module
+            'ScaLAPACK': '2.0.2-gompi-2018a-OpenBLAS-0.2.20',
+            'SQLite': '3.8.10.2-foss-2018a',
+        }
+        for dep in bar.dependencies():
+            expected_dep_version = expected_dep_versions[dep['name']]
             self.assertEqual(det_full_ec_version(dep), expected_dep_version)
 
         # check with --minimal-toolchains enabled
@@ -1134,9 +1136,16 @@ class RobotTest(EnhancedTestCase):
         })
         bar = EasyConfig(barec)
 
+        expected_dep_versions = {
+            'OpenMPI': '2.1.2-GCC-6.4.0-2.28',
+            'OpenBLAS': '0.2.20-GCC-6.4.0-2.28',
+            'ScaLAPACK': '2.0.2-gompi-2018a-OpenBLAS-0.2.20',
+            'SQLite': '3.8.10.2-GCC-6.4.0-2.28',
+        }
+
         # check that all bar dependencies have been processed as expected
-        expected_dep_versions[-1] = '3.8.10.2-GCC-6.4.0-2.28'
-        for dep, expected_dep_version in zip(bar.dependencies(), expected_dep_versions):
+        for dep in bar.dependencies():
+            expected_dep_version = expected_dep_versions[dep['name']]
             self.assertEqual(det_full_ec_version(dep), expected_dep_version)
 
         # Add the gompi/2018a version of SQLite as an available module

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -45,7 +45,7 @@ from easybuild.framework.easyconfig.easyconfig import process_easyconfig, EasyCo
 from easybuild.framework.easyconfig.tools import alt_easyconfig_paths, find_resolved_modules, parse_easyconfigs
 from easybuild.framework.easyconfig.tweak import tweak
 from easybuild.framework.easyconfig.easyconfig import get_toolchain_hierarchy
-from easybuild.framework.easyconfig.easyconfig import robot_find_minimal_toolchain_of_dependency
+from easybuild.framework.easyconfig.easyconfig import robot_find_subtoolchain_for_dep
 from easybuild.framework.easyconfig.tools import skip_available
 from easybuild.tools import config, modules
 from easybuild.tools.build_log import EasyBuildError
@@ -1017,8 +1017,8 @@ class RobotTest(EnhancedTestCase):
         untweaked_hwloc = os.path.join(test_easyconfigs, 'h', 'hwloc', 'hwloc-1.11.8-GCC-6.4.0-2.28.eb')
         self.assertTrue(untweaked_hwloc in specs)
 
-    def test_robot_find_minimal_toolchain_of_dependency(self):
-        """Test robot_find_minimal_toolchain_of_dependency."""
+    def test_robot_find_subtoolchain_for_dep(self):
+        """Test robot_find_subtoolchain_for_dep."""
 
         # replace log.experimental with log.warning to allow experimental code
         easybuild.framework.easyconfig.tools._log.experimental = easybuild.framework.easyconfig.tools._log.warning
@@ -1039,7 +1039,7 @@ class RobotTest(EnhancedTestCase):
             'toolchain': {'name': 'foss', 'version': '2018a'},
         }
         get_toolchain_hierarchy.clear()
-        new_gzip15_toolchain = robot_find_minimal_toolchain_of_dependency(gzip15, self.modtool)
+        new_gzip15_toolchain = robot_find_subtoolchain_for_dep(gzip15, self.modtool)
         self.assertEqual(new_gzip15_toolchain, gzip15['toolchain'])
 
         # no easyconfig for gzip 1.4 with matching non-dummy (sub)toolchain
@@ -1050,7 +1050,7 @@ class RobotTest(EnhancedTestCase):
             'toolchain': {'name': 'foss', 'version': '2018a'},
         }
         get_toolchain_hierarchy.clear()
-        self.assertEqual(robot_find_minimal_toolchain_of_dependency(gzip14, self.modtool), None)
+        self.assertEqual(robot_find_subtoolchain_for_dep(gzip14, self.modtool), None)
 
         gzip14['toolchain'] = {'name': 'gompi', 'version': '2018a'}
 
@@ -1065,14 +1065,14 @@ class RobotTest(EnhancedTestCase):
         # specify alternative parent toolchain
         gompi_1410 = {'name': 'gompi', 'version': '2018a'}
         get_toolchain_hierarchy.clear()
-        new_gzip14_toolchain = robot_find_minimal_toolchain_of_dependency(gzip14, self.modtool, parent_tc=gompi_1410)
+        new_gzip14_toolchain = robot_find_subtoolchain_for_dep(gzip14, self.modtool, parent_tc=gompi_1410)
         self.assertTrue(new_gzip14_toolchain != gzip14['toolchain'])
         self.assertEqual(new_gzip14_toolchain, {'name': 'dummy', 'version': ''})
 
         # default: use toolchain from dependency
         gzip14['toolchain'] = gompi_1410
         get_toolchain_hierarchy.clear()
-        new_gzip14_toolchain = robot_find_minimal_toolchain_of_dependency(gzip14, self.modtool)
+        new_gzip14_toolchain = robot_find_subtoolchain_for_dep(gzip14, self.modtool)
         self.assertTrue(new_gzip14_toolchain != gzip14['toolchain'])
         self.assertEqual(new_gzip14_toolchain, {'name': 'dummy', 'version': ''})
 
@@ -1083,9 +1083,9 @@ class RobotTest(EnhancedTestCase):
             'toolchain': {'name': 'foss', 'version': '2018a'},
             'hidden': False,
         }
-        res = robot_find_minimal_toolchain_of_dependency(dep, self.modtool)
+        res = robot_find_subtoolchain_for_dep(dep, self.modtool)
         self.assertEqual(res, {'name': 'GCC', 'version': '6.4.0-2.28'})
-        res = robot_find_minimal_toolchain_of_dependency(dep, self.modtool, parent_first=True)
+        res = robot_find_subtoolchain_for_dep(dep, self.modtool, parent_first=True)
         self.assertEqual(res, {'name': 'foss', 'version': '2018a'})
 
         #

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -429,7 +429,7 @@ class RobotTest(EnhancedTestCase):
             # for each of these, we know test easyconfigs are available (which are required here)
             "dependencies = [",
             "   ('OpenMPI', '2.1.2'),",  # available with GCC/6.4.0-2.28
-            "   ('OpenBLAS', '0.2.20'),",  # available with gompi/2018a
+            "   ('OpenBLAS', '0.2.20'),",  # available with GCC/6.4.0-2.28
             "   ('ScaLAPACK', '2.0.2', '-OpenBLAS-0.2.20'),",  # available with gompi/2018a
             "   ('SQLite', '3.8.10.2'),",
             "]",
@@ -1120,7 +1120,7 @@ class RobotTest(EnhancedTestCase):
 
         expected_dep_versions = {
             'OpenMPI': '2.1.2-GCC-6.4.0-2.28',
-            'OpenBLAS': '0.2.20-gompi-2018a',  # due to existing OpenBLAS/0.2.20-gompi-2018a test module
+            'OpenBLAS': '0.2.20-GCC-6.4.0-2.28',
             'ScaLAPACK': '2.0.2-gompi-2018a-OpenBLAS-0.2.20',
             'SQLite': '3.8.10.2-foss-2018a',
         }

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1229,7 +1229,7 @@ class ToyBuildTest(EnhancedTestCase):
         self.assertEqual([x['mod_name'] for x in self.modtool.list()], mods)
 
         # check behaviour when a non-existing external (build) dependency is included
-        err_msg = "Missing modules for one or more dependencies marked as external modules:"
+        err_msg = "Missing modules for dependencies marked as external modules:"
 
         extraectxt = "\nbuilddependencies = [('nosuchbuilddep/0.0.0', EXTERNAL_MODULE)]"
         extraectxt += "\nversionsuffix = '-external-deps-broken1'"

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -436,9 +436,11 @@ def init_config(args=None, build_options=None, with_include=True):
 
     # initialize build options
     if build_options is None:
+        test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         build_options = {
             'extended_dry_run': False,
             'external_modules_metadata': ConfigObj(),
+            'robot_path': [test_ecs_dir],
             'valid_module_classes': module_classes(),
             'valid_stops': [x[0] for x in EasyBlock.get_steps()],
         }

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -436,16 +436,17 @@ def init_config(args=None, build_options=None, with_include=True):
 
     # initialize build options
     if build_options is None:
-        test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         build_options = {
             'extended_dry_run': False,
             'external_modules_metadata': ConfigObj(),
-            'robot_path': [test_ecs_dir],
             'valid_module_classes': module_classes(),
             'valid_stops': [x[0] for x in EasyBlock.get_steps()],
         }
     if 'suffix_modules_path' not in build_options:
-        build_options.update({'suffix_modules_path': GENERAL_CLASS})
+        build_options['suffix_modules_path'] = GENERAL_CLASS
+    if 'robot_path' not in build_options:
+        test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+        build_options['robot_path'] = [test_ecs_dir]
     config.init_build_options(build_options=build_options)
 
     return eb_go.options

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -418,10 +418,12 @@ def cleanup():
     tc_utils._initial_toolchain_instances.clear()
     easyconfig._easyconfigs_cache.clear()
     easyconfig._easyconfig_files_cache.clear()
+    easyconfig.get_toolchain_hierarchy.clear()
     mns_toolchain._toolchain_details_cache.clear()
 
     # reset to make sure tempfile picks up new temporary directory to use
     tempfile.tempdir = None
+
 
 def init_config(args=None, build_options=None, with_include=True):
     """(re)initialize configuration"""

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -436,17 +436,21 @@ def init_config(args=None, build_options=None, with_include=True):
 
     # initialize build options
     if build_options is None:
-        build_options = {
-            'extended_dry_run': False,
-            'external_modules_metadata': ConfigObj(),
-            'valid_module_classes': module_classes(),
-            'valid_stops': [x[0] for x in EasyBlock.get_steps()],
-        }
-    if 'suffix_modules_path' not in build_options:
-        build_options['suffix_modules_path'] = GENERAL_CLASS
-    if 'robot_path' not in build_options:
-        test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
-        build_options['robot_path'] = [test_ecs_dir]
+        build_options = {}
+
+    test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+    default_build_options = {
+        'extended_dry_run': False,
+        'external_modules_metadata': ConfigObj(),
+        'robot_path': [test_ecs_dir],
+        'suffix_modules_path': GENERAL_CLASS,
+        'valid_module_classes': module_classes(),
+        'valid_stops': [x[0] for x in EasyBlock.get_steps()],
+    }
+    for key in default_build_options:
+        if key not in build_options:
+            build_options[key] = default_build_options[key]
+
     config.init_build_options(build_options=build_options)
 
     return eb_go.options


### PR DESCRIPTION
potential fix for #2375 

Currently, we always call `robot_find_easyconfig` in `robot_find_minimal_toolchain_of_dependency` which implies that an easyconfig file must be available for each dependency that was installed with a subtoolchain. This is done because determine the module name for this dependency *may* require a full easyconfig file, as enforced by `ActiveMNS.det_full_module_name` (via `ActiveMNS.check_ec_type`).

There's no need for this however, since in some situations a full easyconfig file is not required at all to determine the module name, for example when using the default (flat) module naming scheme `EasyBuildMNS`.