### PR TITLE
significantly speed up robot_find_subtoolchain_for_dep by specifying whether dep is resolved via an external module

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1696,9 +1696,12 @@ def robot_find_subtoolchain_for_dep(dep, modtool, parent_tc=None, parent_first=F
             # check whether module already exists or not (but only if that info will actually be used)
             mod_exists = None
             if parent_first or use_existing_modules:
+                mod_exists = mod_name in avail_modules
                 # fallback to checking with modtool.exist is required,
                 # for hidden modules and external modules where module name may be partial
-                mod_exists = mod_name in avail_modules or modtool.exist([mod_name], skip_avail=True)[0]
+                if not mod_exists:
+                    maybe_partial = dep.get('external_module', True)
+                    mod_exists = modtool.exist([mod_name], skip_avail=True, maybe_partial=maybe_partial)[0]
 
             # add the subtoolchain to list of candidates
             cand_subtcs.append({'toolchain': tc, 'mod_exists': mod_exists})

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -119,7 +119,7 @@ class ModulesTest(EnhancedTestCase):
         else:
             self.assertEqual(len(ms), TEST_MODULES_COUNT)
 
-    def test_exists(self):
+    def test_exist(self):
         """Test if testing for module existence works."""
         self.init_testmods()
         self.assertEqual(self.modtool.exist(['OpenMPI/2.1.2-GCC-6.4.0-2.28']), [True])
@@ -127,7 +127,7 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(self.modtool.exist(['foo/1.2.3']), [False])
         self.assertEqual(self.modtool.exist(['foo/1.2.3'], skip_avail=True), [False])
 
-        # exists works on hidden modules
+        # exist works on hidden modules
         self.assertEqual(self.modtool.exist(['toy/.0.0-deps']), [True])
         self.assertEqual(self.modtool.exist(['toy/.0.0-deps'], skip_avail=True), [True])
 
@@ -138,7 +138,11 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(self.modtool.exist(['OpenMPI/2.1.2']), [False])
         self.assertEqual(self.modtool.exist(['OpenMPI/2.1.2'], skip_avail=True), [False])
 
-        # exists works on hidden modules in Lua syntax (only with Lmod)
+        # if we instruct modtool.exist not to consider partial module names, it doesn't
+        self.assertEqual(self.modtool.exist(['OpenMPI'], maybe_partial=False), [False])
+        self.assertEqual(self.modtool.exist(['OpenMPI'], maybe_partial=False, skip_avail=True), [False])
+
+        # exist works on hidden modules in Lua syntax (only with Lmod)
         test_modules_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'modules'))
         if isinstance(self.modtool, Lmod):
             # make sure only the .lua module file is there, otherwise this test doesn't work as intended
@@ -146,7 +150,7 @@ class ModulesTest(EnhancedTestCase):
             self.assertFalse(os.path.exists(os.path.join(test_modules_path, 'bzip2', '.1.0.6')))
             self.assertEqual(self.modtool.exist(['bzip2/.1.0.6']), [True])
 
-        # exists also works on lists of module names
+        # exist also works on lists of module names
         # list should be sufficiently long, since for short lists 'show' is always used
         mod_names = ['OpenMPI/2.1.2-GCC-6.4.0-2.28', 'foo/1.2.3', 'GCC',
                      'ScaLAPACK/2.0.2-gompi-2017b-OpenBLAS-0.2.20'


### PR DESCRIPTION
I noticed that the easyconfigs test suite became significantly slower after #2690 got merged, so I did a profile run to figure out where most time was being spent...

It turns out that a whopping 75% of time was spent in the `mod_exist_via_show` inner function of `ModulesTool.exist`, which is only used as a fallback check in case a (visible) module is not found via the list produced by `module avail`.
This is required because a module name can be partial, in the case of external modules (cfr. https://easybuild.readthedocs.io/en/latest/Using_external_modules.html).

`mod_exist_via_show` is expensive since it involves actually calling out to the modules tool (e.g. Lmod) every time. We already have a "show cache", which helps quite a bit (it cuts down actual `module show` calls to with about 75% in the case of the easyconfigs test suite), but we still call `module show` once for every module name that is not found in the output of `module avail`.

Since `robot_find_subtoolchain_for_dep` knows when a dependency is resolved via an external module or not, it can pass down this information to `ModulesTool.exist` to avoid all these needless `module show` calls when we are certain that the module name is not partial (since that can only occur with dependencies marked as external modules).

It's worth mentioning that `ModulesTool.exist` already handles hidden module names separately, and so a fallback to `show` is already in place for module names for which the actual module file starts with a `.`.
For modules that are hidden via Lmod's feature to hide modules via `.modulerc` were also save, since we run `module --show-hidden avail` with Lmod, and so hidden modules *will* be listed.

This change has a dramatic effect on the time needed for easyconfig test suite: it was cut down from ~2550s to ~550s (on my laptop).