### PR TITLE
avoid '+' in directory name for g++ rpath wrapper

### DIFF
--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -852,7 +852,10 @@ class Toolchain(object):
 
                 # determine location for this wrapper
                 # each wrapper is placed in its own subdirectory to enable $PATH filtering per wrapper separately
-                wrapper_dir = os.path.join(wrappers_dir, '%s_wrapper' % cmd)
+                # avoid '+' character in directory name (for example with 'g++' command), which can cause trouble
+                # (see https://github.com/easybuilders/easybuild-easyconfigs/issues/7339)
+                wrapper_dir_name = '%s_wrapper' % cmd.replace('+', 'x')
+                wrapper_dir = os.path.join(wrappers_dir, wrapper_dir_name)
 
                 cmd_wrapper = os.path.join(wrapper_dir, cmd)
 


### PR DESCRIPTION
Having the RPATH wrapper for `g++` in a temporary (sub)directory named `/tmp/.../g++_wrapper/` can cause trouble, as reported by @casparvl in https://github.com/easybuilders/easybuild-easyconfigs/issues/7339 .

Simply replacing the `+` with `x` fixes that issue.

The existing test for the setting up the RPATH wrappers in `Toolchain.prepare` has been tweaked to test with `g++` rather than `gcc` to cover this change.