### PR TITLE
replace 'except IOError, err:' pattern with 'except IOError as err:' for compatibility with Python 3.x

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -612,7 +612,7 @@ class EasyBlock(object):
                 if download_file(filename, url, fullpath):
                     return fullpath
 
-            except IOError, err:
+            except IOError as err:
                 raise EasyBuildError("Downloading file %s from url %s to %s failed: %s", filename, url, fullpath, err)
 
         else:
@@ -735,7 +735,7 @@ class EasyBlock(object):
                             if download_file(filename, fullurl, targetpath):
                                 downloaded = True
 
-                        except IOError, err:
+                        except IOError as err:
                             self.log.debug("Failed to download %s from %s: %s" % (filename, url, err))
                             failedpaths.append(fullurl)
                             continue
@@ -904,7 +904,7 @@ class EasyBlock(object):
                 try:
                     rmtree2(dir_name)
                     self.log.info("Removed old directory %s" % dir_name)
-                except OSError, err:
+                except OSError as err:
                     raise EasyBuildError("Removal of old directory %s failed: %s", dir_name, err)
             elif build_option('module_only'):
                 self.log.info("Not touching existing directory %s in module-only mode...", dir_name)
@@ -915,7 +915,7 @@ class EasyBlock(object):
                     backupdir = "%s.%s" % (dir_name, timestamp)
                     shutil.move(dir_name, backupdir)
                     self.log.info("Moved old directory %s to %s" % (dir_name, backupdir))
-                except OSError, err:
+                except OSError as err:
                     raise EasyBuildError("Moving old directory to backup %s %s failed: %s", dir_name, backupdir, err)
 
         if dontcreateinstalldir:
@@ -1339,7 +1339,7 @@ class EasyBlock(object):
                 self.modules_tool.unload([self.short_mod_name])
                 self.modules_tool.remove_module_path(os.path.join(fake_mod_path, self.mod_subdir))
                 rmtree2(os.path.dirname(fake_mod_path))
-            except OSError, err:
+            except OSError as err:
                 raise EasyBuildError("Failed to clean up fake module dir %s: %s", fake_mod_path, err)
         elif self.short_mod_name is None:
             self.log.warning("Not unloading module, since self.short_mod_name is not set.")
@@ -1791,7 +1791,7 @@ class EasyBlock(object):
                 try:
                     beginpath = self.src[srcind]['finalpath']
                     self.log.debug("Determine begin path for patch %s: %s" % (patch['name'], beginpath))
-                except IndexError, err:
+                except IndexError as err:
                     raise EasyBuildError("Can't apply patch %s to source at index %s of list %s: %s",
                                          patch['name'], srcind, self.src, err)
             else:
@@ -1961,7 +1961,7 @@ class EasyBlock(object):
                 self.log.debug("Obtained class %s for extension %s" % (cls, ext['name']))
                 if cls is not None:
                     inst = cls(self, ext)
-            except (ImportError, NameError), err:
+            except (ImportError, NameError) as err:
                 self.log.debug("Failed to use extension-specific class for extension %s: %s" % (ext['name'], err))
 
             # alternative attempt: use class specified in class map (if any)
@@ -1972,7 +1972,7 @@ class EasyBlock(object):
                 try:
                     cls = get_class_for(mod_path, class_name)
                     inst = cls(self, ext)
-                except (ImportError, NameError), err:
+                except (ImportError, NameError) as err:
                     raise EasyBuildError("Failed to load specified class %s for extension %s: %s",
                                          class_name, ext['name'], err)
 
@@ -1984,7 +1984,7 @@ class EasyBlock(object):
                     inst = cls(self, ext)
                     self.log.debug("Installing extension %s with default class %s (from %s)",
                                    ext['name'], default_class, default_class_modpath)
-                except (ImportError, NameError), err:
+                except (ImportError, NameError) as err:
                     raise EasyBuildError("Also failed to use default class %s from %s for extension %s: %s, giving up",
                                          default_class, default_class_modpath, ext['name'], err)
             else:
@@ -2324,7 +2324,7 @@ class EasyBlock(object):
                 # unload all loaded modules before loading fake module
                 # this ensures that loading of dependencies is tested, and avoids conflicts with build dependencies
                 fake_mod_data = self.load_fake_module(purge=True)
-            except EasyBuildError, err:
+            except EasyBuildError as err:
                 self.sanity_check_fail_msgs.append("loading fake module failed: %s" % err)
                 self.log.warning("Sanity check: %s" % self.sanity_check_fail_msgs[-1])
 
@@ -2402,7 +2402,7 @@ class EasyBlock(object):
                     os.rmdir(base)
                     base = os.path.dirname(base)
 
-            except OSError, err:
+            except OSError as err:
                 raise EasyBuildError("Cleaning up builddir %s failed: %s", self.builddir, err)
 
         if not build_option('cleanup_builddir'):
@@ -2506,7 +2506,7 @@ class EasyBlock(object):
                 perms = stat.S_IROTH | stat.S_IWOTH | stat.S_IXOTH
                 adjust_permissions(self.installdir, perms, add=False, recursive=True, group_id=self.group[1],
                                    relative=True, ignore_errors=True)
-            except EasyBuildError, err:
+            except EasyBuildError as err:
                 raise EasyBuildError("Unable to change group permissions of file(s): %s", err)
             self.log.info("Successfully made software only available for group %s (gid %s)" % self.group)
 
@@ -2563,7 +2563,7 @@ class EasyBlock(object):
             try:
                 self.log.debug("Running test %s" % path)
                 run_cmd(path, log_all=True, simple=True)
-            except EasyBuildError, err:
+            except EasyBuildError as err:
                 raise EasyBuildError("Running test %s failed: %s", path, err)
 
     def update_config_template_run_step(self):
@@ -2834,7 +2834,7 @@ def build_and_install_one(ecdict, init_env):
         app_class = get_easyblock_class(easyblock, name=name)
         app = app_class(ecdict['ec'])
         _log.info("Obtained application instance of for %s (easyblock: %s)" % (name, easyblock))
-    except EasyBuildError, err:
+    except EasyBuildError as err:
         print_error("Failed to get application instance for %s (easyblock: %s): %s" % (name, easyblock, err.msg),
                     silent=silent)
 
@@ -2860,7 +2860,7 @@ def build_and_install_one(ecdict, init_env):
             reprod_dir_root = os.path.dirname(app.logfile)
             reprod_dir = reproduce_build(app, reprod_dir_root)
         result = app.run_all_steps(run_test_cases=run_test_cases)
-    except EasyBuildError, err:
+    except EasyBuildError as err:
         first_n = 300
         errormsg = "build failed (first %d chars): %s" % (first_n, err.msg[:first_n])
         _log.warning(errormsg)
@@ -2915,7 +2915,7 @@ def build_and_install_one(ecdict, init_env):
                     repo.add_patch(patch['path'], app.name)
                 repo.commit("Built %s" % app.full_mod_name)
                 del repo
-            except EasyBuildError, err:
+            except EasyBuildError as err:
                 _log.warn("Unable to commit easyconfig to repository: %s", err)
 
         # cleanup logs

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1314,7 +1314,7 @@ def get_easyblock_class(easyblock, name=None, error_on_failed_import=True, error
             try:
                 __import__(modulepath, globals(), locals(), [''])
                 modulepath_imported = True
-            except ImportError, err:
+            except ImportError as err:
                 _log.debug("Failed to import module '%s': %s" % (modulepath, err))
 
             # check if determining module path based on software name would have resulted in a different module path
@@ -1332,7 +1332,7 @@ def get_easyblock_class(easyblock, name=None, error_on_failed_import=True, error
                 _log.debug("getting class for %s.%s" % (modulepath, class_name))
                 cls = get_class_for(modulepath, class_name)
                 _log.info("Successfully obtained %s class instance from %s" % (class_name, modulepath))
-            except ImportError, err:
+            except ImportError as err:
                 # when an ImportError occurs, make sure that it's caused by not finding the easyblock module,
                 # and not because of a broken import statement in the easyblock module
                 error_re = re.compile(r"No module named %s" % modulepath.replace("easybuild.easyblocks.", ''))
@@ -1353,10 +1353,10 @@ def get_easyblock_class(easyblock, name=None, error_on_failed_import=True, error
 
         return cls
 
-    except EasyBuildError, err:
+    except EasyBuildError as err:
         # simply reraise rather than wrapping it into another error
         raise err
-    except Exception, err:
+    except Exception as err:
         raise EasyBuildError("Failed to obtain class for %s easyblock (not available?): %s", easyblock, err)
 
 
@@ -1473,7 +1473,7 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
         # create easyconfig
         try:
             ec = EasyConfig(spec, build_specs=build_specs, validate=validate, hidden=hidden)
-        except EasyBuildError, err:
+        except EasyBuildError as err:
             raise EasyBuildError("Failed to process easyconfig %s: %s", spec, err.msg)
 
         name = ec['name']

--- a/easybuild/framework/easyconfig/format/format.py
+++ b/easybuild/framework/easyconfig/format/format.py
@@ -84,7 +84,7 @@ def get_format_version(txt):
         try:
             maj_min = res.groupdict()
             format_version = EasyVersion(FORMAT_VERSION_TEMPLATE % maj_min)
-        except (KeyError, TypeError), err:
+        except (KeyError, TypeError) as err:
             raise EasyBuildError("Failed to get version from match %s: %s", res.groups(), err)
     return format_version
 

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -258,7 +258,7 @@ class EasyConfigFormatConfigObj(EasyConfigFormat):
         """Parse the section block by trying to convert it into a ConfigObj instance"""
         try:
             self.configobj = ConfigObj(section.split('\n'))
-        except SyntaxError, err:
+        except SyntaxError as err:
             raise EasyBuildError('Failed to convert section text %s: %s', section, err)
 
         self.log.debug("Found ConfigObj instance %s" % self.configobj)

--- a/easybuild/framework/easyconfig/format/version.py
+++ b/easybuild/framework/easyconfig/format/version.py
@@ -231,7 +231,7 @@ class VersionOperator(object):
         else:
             try:
                 version = EasyVersion(version_str)
-            except (AttributeError, ValueError), err:
+            except (AttributeError, ValueError) as err:
                 self.parse_error('Failed to convert %s to an EasyVersion instance: %s' % (version_str, err))
 
         self.log.debug('converted string %s to version %s' % (version_str, version))

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -157,7 +157,7 @@ class EasyConfigParser(object):
 
         try:
             self.rawcontent = self.get_fn[0](*self.get_fn[1])
-        except IOError, err:
+        except IOError as err:
             raise EasyBuildError('Failed to obtain content with %s: %s', self.get_fn, err)
 
         if not isinstance(self.rawcontent, basestring):
@@ -207,7 +207,7 @@ class EasyConfigParser(object):
 
         try:
             self.set_fn[0](*self.set_fn[1])
-        except IOError, err:
+        except IOError as err:
             raise EasyBuildError("Failed to process content with %s: %s", self.set_fn, err)
 
     def set_specifications(self, specs):

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -272,7 +272,7 @@ def get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None):
             if os.path.exists(path):
                 paths.append(os.path.abspath(path))
                 _log.debug("Added %s to list of paths for easybuild/%s" % (path, subdir))
-        except OSError, err:
+        except OSError as err:
             raise EasyBuildError(str(err))
 
     return paths
@@ -387,7 +387,7 @@ def parse_easyconfigs(paths, validate=True):
 
                 easyconfigs.extend(process_easyconfig(ec_file, **kwargs))
 
-        except IOError, err:
+        except IOError as err:
             raise EasyBuildError("Processing easyconfigs in path %s failed: %s", path, err)
 
     return easyconfigs, generated_ecs

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -349,7 +349,7 @@ def tweak_one(orig_ec, tweaked_ec, tweaks, targetdir=None):
 
             # get rid of temporary file
             os.remove(tmpfn)
-        except OSError, err:
+        except OSError as err:
             raise EasyBuildError("Failed to determine suiting filename for tweaked easyconfig file: %s", err)
 
         if targetdir is None:

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -81,7 +81,7 @@ def find_easyconfigs_by_specs(build_specs, robot_path, try_to_generate, testing=
             # (try to) cleanup
             try:
                 os.remove(ec_file)
-            except OSError, err:
+            except OSError as err:
                 _log.warning("Failed to remove generated easyconfig file %s: %s" % (ec_file, err))
 
             # don't use a generated easyconfig unless generation was requested (using a --try-X option)
@@ -113,7 +113,7 @@ def build_and_install_software(ecs, init_session_state, exit_on_failure=True):
             ec_res['log_file'] = app_log
             if not ec_res['success']:
                 ec_res['err'] = EasyBuildError(err)
-        except Exception, err:
+        except Exception as err:
             # purposely catch all exceptions
             ec_res['success'] = False
             ec_res['err'] = err

--- a/easybuild/scripts/add_header.py
+++ b/easybuild/scripts/add_header.py
@@ -73,7 +73,7 @@ def write_header(filename, header, skip=None):
         f.writelines(output)
         f.close()
         print "added header to %s" % filename
-    except IOError, err:
+    except IOError as err:
         print "something went wrong trying to add header to %s: %s" % (filename, err)
 
 def add_header(directory, header, skipreg, filenamereg, dirregex):

--- a/easybuild/scripts/fix_broken_easyconfigs.py
+++ b/easybuild/scripts/fix_broken_easyconfigs.py
@@ -96,7 +96,7 @@ def process_easyconfig_file(ec_file):
                     i += 1
                 os.rename(ec_file, backup_ec_file)
                 log.info("Backed up %s to %s" % (ec_file, backup_ec_file))
-            except OSError, err:
+            except OSError as err:
                 raise EasyBuildError("Failed to backup %s before rewriting it: %s", ec_file, err)
 
         write_file(ec_file, fixed_ectxt)
@@ -122,7 +122,7 @@ try:
 
     try:
         import easybuild.easyblocks.generic.configuremake
-    except ImportError, err:
+    except ImportError as err:
         raise EasyBuildError("easyblocks are not available in Python search path: %s", err)
 
     for path in go.args:
@@ -137,9 +137,9 @@ try:
     for ec_file in ec_files:
         try:
             process_easyconfig_file(ec_file)
-        except EasyBuildError, err:
+        except EasyBuildError as err:
             log.warning("Ignoring issue when processing %s: %s", ec_file, err)
 
-except EasyBuildError, err:
+except EasyBuildError as err:
     sys.stderr.write("ERROR: %s\n" % err)
     sys.exit(1)

--- a/easybuild/scripts/generate_software_list.py
+++ b/easybuild/scripts/generate_software_list.py
@@ -133,7 +133,7 @@ for root, subfolders, files in walk(options.path):
                         ec.easyblock = module
                 configs.append(ec)
                 names.append(ec.name)
-        except Exception, err:
+        except Exception as err:
             raise EasyBuildError("faulty easyconfig %s: %s", ec_file, err)
 
 log.info("Found easyconfigs: %s" % [x.name for x in configs])

--- a/easybuild/scripts/mk_tmpl_easyblock_for.py
+++ b/easybuild/scripts/mk_tmpl_easyblock_for.py
@@ -229,6 +229,6 @@ try:
     f = open(easyblock_path, "w")
     f.write(txt)
     f.close()
-except (IOError, OSError), err:
+except (IOError, OSError) as err:
     sys.stderr.write("ERROR! Writing template easyblock for %s to %s failed: %s" % (name, easyblock_path, err))
     sys.exit(1)

--- a/easybuild/scripts/port_easyblock.py
+++ b/easybuild/scripts/port_easyblock.py
@@ -88,7 +88,7 @@ def rename_module(path):
                 return path
         else:
             error("Specified easyblock %s not found!")
-    except OSError, err:
+    except OSError as err:
         error("Failed to check module name: %s" % err)
 
 # refactor function and argument names that have changed during cleanup
@@ -334,7 +334,7 @@ try:
     f = open(easyblock, "r")
     easyblock_txt = f.read()
     f.close()
-except IOError, err:
+except IOError as err:
     error("Failed to read easyblock %s: %s" % (easyblock, err))
 
 # refactor
@@ -350,13 +350,13 @@ try:
     f = open(easyblock, "w")
     f.write(easyblock_txt)
     f.close()
-except IOError, err:
+except IOError as err:
     error("Failed to write refactored easyblock %s: %s" % (easyblock, err))
 
 # check for PyLint warnings/errors
 try:
     all_checks.append(run_pylint(easyblock))
-except NameError, err:
+except NameError as err:
     error("It seems like PyLint is not available: %s" % err)
 
 

--- a/easybuild/scripts/prep_for_release.py
+++ b/easybuild/scripts/prep_for_release.py
@@ -48,7 +48,7 @@ import sys
 from distutils.version import LooseVersion
 try:
     import git
-except ImportError, err:
+except ImportError as err:
     sys.stderr.write("Failed to import git Python module, which is required to run this script: %s\n" % err)
     sys.exit(1)
 
@@ -76,7 +76,7 @@ def get_easybuild_version(home, version_file=None):
         f = open(version_file, "r")
         versiontxt = f.read()
         f.close()
-    except IOError, err:
+    except IOError as err:
         error("Failed to read %s's version file at %s: %s" % (easybuild_package, version_file, err))
 
     # determine current version set
@@ -105,7 +105,7 @@ def get_last_git_version_tag(home):
         else:
             error("No git version tags set?")
 
-    except git.GitCommandError, err:
+    except git.GitCommandError as err:
         error("Failed to determine last %s git tag: %s" % (easybuild_package, err))
 
 # check whether version has been bumped and
@@ -135,7 +135,7 @@ def check_release_notes(home, easybuild_version):
         f = open(os.path.join(home, fn), "r")
         releasenotes = f.read()
         f.close()
-    except IOError, err:
+    except IOError as err:
         error("Failed to read %s: %s" % (fn, err))
 
     ver_re = re.compile(r"^v%s\s\([A-Z][a-z]+\s[0-9]+[a-z]+\s[0-9]+\)$" % easybuild_version, re.M)
@@ -173,7 +173,7 @@ def check_license_headers(home, license_header_re, filename_re, dirname_re):
                         warning("Could not find license header in %s" % fullfn)
                         ok - False
 
-    except (OSError, IOError), err:
+    except (OSError, IOError) as err:
         error("Failed to check for license header in all code files: %s" % err)
 
     return ok
@@ -188,7 +188,7 @@ def check_clean_master_branch(home):
         gitrepo = git.Git(home)
         git_status = gitrepo.execute(["git", "status"])
 
-    except git.GitCommandError, err:
+    except git.GitCommandError as err:
         error("Failed to determine status of git repository.")
 
     master_re = re.compile(r"^# On branch master$", re.M)

--- a/easybuild/scripts/repo_setup.py
+++ b/easybuild/scripts/repo_setup.py
@@ -91,6 +91,6 @@ __path__ = extend_path(__path__, __name__)
     os.mkdir(dirname)
     create_subdirs(dirname)
 
-except (IOError, OSError), err:
+except (IOError, OSError) as err:
     sys.stderr.write("Repo setup failed: %s" % err)
     sys.exit(1)

--- a/easybuild/tools/asyncprocess.py
+++ b/easybuild/tools/asyncprocess.py
@@ -107,7 +107,7 @@ class Popen(subprocess.Popen):
 
         try:
             written = os.write(self.stdin.fileno(), inp)
-        except OSError, why:
+        except OSError as why:
             if why[0] == errno.EPIPE: #broken pipe
                 return self._close('stdin')
             raise

--- a/easybuild/tools/configobj.py
+++ b/easybuild/tools/configobj.py
@@ -1644,7 +1644,7 @@ class ConfigObj(Section):
                             comment = ''
                             try:
                                 value = unrepr(value)
-                            except Exception, e:
+                            except Exception as e:
                                 if type(e) == UnknownType:
                                     msg = 'Unknown name or type in value at line %s.'
                                 else:
@@ -1657,7 +1657,7 @@ class ConfigObj(Section):
                         comment = ''
                         try:
                             value = unrepr(value)
-                        except Exception, e:
+                        except Exception as e:
                             if isinstance(e, UnknownType):
                                 msg = 'Unknown name or type in value at line %s.'
                             else:
@@ -1932,11 +1932,11 @@ class ConfigObj(Section):
                                        raise_errors=True,
                                        file_error=True,
                                        _inspec=True)
-            except ConfigObjError, e:
+            except ConfigObjError as e:
                 # FIXME: Should these errors have a reference
                 #        to the already parsed ConfigObj ?
                 raise ConfigspecError('Parsing configspec failed: %s' % e)
-            except IOError, e:
+            except IOError as e:
                 raise IOError('Reading configspec failed: %s' % e)
 
         self.configspec = configspec
@@ -2192,7 +2192,7 @@ class ConfigObj(Section):
                                         val,
                                         missing=missing
                                         )
-            except validator.baseErrorClass, e:
+            except validator.baseErrorClass as e:
                 if not preserve_errors or isinstance(e, self._vdtMissingValue):
                     out[entry] = False
                 else:

--- a/easybuild/tools/convert.py
+++ b/easybuild/tools/convert.py
@@ -202,10 +202,10 @@ class ListOfStringsAndDictOfStrings(Convert):
                     'raise_allowed': True,
                 }
                 res.append(DictOfStrings(element, **kwargs))
-            except AllowedValueError, msg:
+            except AllowedValueError as msg:
                 # reraise it as regular ValueError
                 raise ValueError(str(msg))
-            except ValueError, msg:
+            except ValueError as msg:
                 # ValueError because the string can't be converted to DictOfStrings
                 # assuming regular string value
                 self.log.debug('ValueError catched with message %s, treat as regular string.' % msg)

--- a/easybuild/tools/environment.py
+++ b/easybuild/tools/environment.py
@@ -58,7 +58,7 @@ def write_changes(filename):
             script.write('export %s=%s\n' % (key, shell_quote(_changes[key])))
 
         script.close()
-    except IOError, err:
+    except IOError as err:
         if script is not None:
             script.close()
         raise EasyBuildError("Failed to write to %s: %s", filename, err)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -186,7 +186,7 @@ def read_file(path, log_error=True):
     try:
         with open(path, 'r') as handle:
             txt = handle.read()
-    except IOError, err:
+    except IOError as err:
         if log_error:
             raise EasyBuildError("Failed to read %s: %s", path, err)
 
@@ -229,7 +229,7 @@ def write_file(path, txt, append=False, forced=False, backup=False, always_overw
         mkdir(os.path.dirname(path), parents=True)
         with open(path, 'a' if append else 'w') as handle:
             handle.write(txt)
-    except IOError, err:
+    except IOError as err:
         raise EasyBuildError("Failed to write to %s: %s", path, err)
 
 
@@ -277,7 +277,7 @@ def remove_file(path):
         # note: file may also be a broken symlink...
         if os.path.exists(path) or os.path.islink(path):
             os.remove(path)
-    except OSError, err:
+    except OSError as err:
         raise EasyBuildError("Failed to remove file %s: %s", path, err)
 
 
@@ -291,7 +291,7 @@ def remove_dir(path):
     try:
         if os.path.exists(path):
             rmtree2(path)
-    except OSError, err:
+    except OSError as err:
         raise EasyBuildError("Failed to remove directory %s: %s", path, err)
 
 
@@ -553,7 +553,7 @@ def download_file(filename, url, path, forced=False):
                 _log.info("Downloading using requests package instead of urllib2")
                 used_urllib = requests
             attempt_cnt += 1
-        except Exception, err:
+        except Exception as err:
             raise EasyBuildError("Unexpected error occurred when trying to download %s to %s: %s", url, path, err)
 
         if not downloaded and attempt_cnt < max_attempts:
@@ -704,9 +704,9 @@ def compute_checksum(path, checksum_type=DEFAULT_CHECKSUM):
 
     try:
         checksum = CHECKSUM_FUNCTIONS[checksum_type](path)
-    except IOError, err:
+    except IOError as err:
         raise EasyBuildError("Failed to read %s: %s", path, err)
-    except MemoryError, err:
+    except MemoryError as err:
         _log.warning("A memory error occurred when computing the checksum for %s: %s" % (path, err))
         checksum = 'dummy_checksum_due_to_memory_error'
 
@@ -720,7 +720,7 @@ def calc_block_checksum(path, algorithm):
     try:
         # in hashlib, blocksize is a class parameter
         blocksize = algorithm.blocksize * 262144  # 2^18
-    except AttributeError, err:
+    except AttributeError as err:
         blocksize = 16777216  # 2^24
     _log.debug("Using blocksize %s for calculating the checksum" % blocksize)
 
@@ -729,7 +729,7 @@ def calc_block_checksum(path, algorithm):
         for block in iter(lambda: f.read(blocksize), b''):
             algorithm.update(block)
         f.close()
-    except IOError, err:
+    except IOError as err:
         raise EasyBuildError("Failed to read %s: %s", path, err)
 
     return algorithm.hexdigest()
@@ -1040,7 +1040,7 @@ def apply_regex_substitutions(path, regex_subs):
                     line = regex.sub(subtxt, line)
                 sys.stdout.write(line)
 
-        except OSError, err:
+        except OSError as err:
             raise EasyBuildError("Failed to patch %s: %s", path, err)
 
 
@@ -1132,7 +1132,7 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
                 else:
                     _log.debug("Group id of %s is already OK (%s)" % (path, group_id))
 
-        except OSError, err:
+        except OSError as err:
             if ignore_errors:
                 # ignore errors while adjusting permissions (for example caused by bad links)
                 _log.info("Failed to chmod/chown %s (but ignoring it): %s" % (path, err))
@@ -1209,7 +1209,7 @@ def mkdir(path, parents=False, set_gid=None, sticky=None):
                 os.makedirs(path)
             else:
                 os.mkdir(path)
-        except OSError, err:
+        except OSError as err:
             raise EasyBuildError("Failed to create directory %s: %s", path, err)
 
         # set group ID and sticky bits, if desired
@@ -1223,7 +1223,7 @@ def mkdir(path, parents=False, set_gid=None, sticky=None):
                 new_subdir = path[len(existing_parent_path):].lstrip(os.path.sep)
                 new_path = os.path.join(existing_parent_path, new_subdir.split(os.path.sep)[0])
                 adjust_permissions(new_path, bits, add=True, relative=True, recursive=True, onlydirs=True)
-            except OSError, err:
+            except OSError as err:
                 raise EasyBuildError("Failed to set groud ID/sticky bit: %s", err)
     else:
         _log.debug("Not creating existing path %s" % path)
@@ -1285,7 +1285,7 @@ def rmtree2(path, n=3):
             shutil.rmtree(path)
             ok = True
             break
-        except OSError, err:
+        except OSError as err:
             _log.debug("Failed to remove path %s with shutil.rmtree at attempt %d: %s" % (path, n, err))
             time.sleep(2)
 
@@ -1367,7 +1367,7 @@ def move_logs(src_logfile, target_logfile):
                 run.run_cmd("%s %s" % (zip_log_cmd, new_log_path))
                 _log.info("Zipped log %s using '%s'", new_log_path, zip_log_cmd)
 
-    except (IOError, OSError), err:
+    except (IOError, OSError) as err:
         raise EasyBuildError("Failed to move log file(s) %s* to new log file %s*: %s",
                              src_logfile, target_logfile, err)
 
@@ -1387,14 +1387,14 @@ def cleanup(logfile, tempdir, testing, silent=False):
             try:
                 for log in [logfile] + glob.glob('%s.[0-9]*' % logfile):
                     os.remove(log)
-            except OSError, err:
+            except OSError as err:
                 raise EasyBuildError("Failed to remove log file(s) %s*: %s", logfile, err)
             print_msg("Temporary log file(s) %s* have been removed." % (logfile), log=None, silent=testing or silent)
 
         if tempdir is not None:
             try:
                 shutil.rmtree(tempdir, ignore_errors=True)
-            except OSError, err:
+            except OSError as err:
                 raise EasyBuildError("Failed to remove temporary directory %s: %s", tempdir, err)
             print_msg("Temporary directory %s has been removed." % tempdir, log=None, silent=testing or silent)
 
@@ -1466,13 +1466,13 @@ def copytree(src, dst, symlinks=False, ignore=None):
                 shutil.copy2(srcname, dstname)
         # catch the Error from the recursive copytree so that we can
         # continue with other files
-        except Error, err:
+        except Error as err:
             errors.extend(err.args[0])
-        except EnvironmentError, why:
+        except EnvironmentError as why:
             errors.append((srcname, dstname, str(why)))
     try:
         shutil.copystat(src, dst)
-    except OSError, why:
+    except OSError as why:
         if WindowsError is not None and isinstance(why, WindowsError):
             # Copying file access times may fail on Windows
             pass
@@ -1557,7 +1557,7 @@ def det_size(path):
                 fullpath = os.path.join(dirpath, filename)
                 if os.path.exists(fullpath):
                     installsize += os.path.getsize(fullpath)
-    except OSError, err:
+    except OSError as err:
         _log.warn("Could not determine install size: %s" % err)
 
     return installsize

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -63,14 +63,14 @@ _log = fancylogger.getLogger('github', fname=False)
 try:
     import keyring
     HAVE_KEYRING = True
-except ImportError, err:
+except ImportError as err:
     _log.warning("Failed to import 'keyring' Python module: %s" % err)
     HAVE_KEYRING = False
 
 try:
     from vsc.utils.rest import RestClient
     HAVE_GITHUB_API = True
-except ImportError, err:
+except ImportError as err:
     _log.warning("Failed to import from 'vsc.utils.rest' Python module: %s" % err)
     HAVE_GITHUB_API = False
 
@@ -244,7 +244,7 @@ def github_api_get_request(request_f, github_user=None, token=None, **kwargs):
 
     try:
         status, data = url.get(**kwargs)
-    except socket.gaierror, err:
+    except socket.gaierror as err:
         _log.warning("Error occurred while performing get request: %s", err)
         status, data = 0, None
 
@@ -270,7 +270,7 @@ def github_api_put_request(request_f, github_user=None, token=None, **kwargs):
 
     try:
         status, data = url.put(**kwargs)
-    except socket.gaierror, err:
+    except socket.gaierror as err:
         _log.warning("Error occurred while performing put request: %s", err)
         status, data = 0, {'message': err}
 
@@ -487,7 +487,7 @@ def post_comment_in_issue(issue, txt, account=GITHUB_EB_MAIN, repo=GITHUB_EASYCO
     if not isinstance(issue, int):
         try:
             issue = int(issue)
-        except ValueError, err:
+        except ValueError as err:
             raise EasyBuildError("Failed to parse specified pull request number '%s' as an int: %s; ", issue, err)
 
     dry_run = build_option('dry_run') or build_option('extended_dry_run')

--- a/easybuild/tools/jenkins.py
+++ b/easybuild/tools/jenkins.py
@@ -108,7 +108,7 @@ def write_to_xml(succes, failed, filename):
         output_file = open(filename, "w")
         root.writexml(output_file)
         output_file.close()
-    except IOError, err:
+    except IOError as err:
         raise EasyBuildError("Failed to write out XML file %s: %s", filename, err)
 
 
@@ -149,7 +149,7 @@ def aggregate_xml_in_dirs(base_dir, output_filename):
             xml_file = xml_file[0]
             try:
                 dom = xml.parse(xml_file)
-            except IOError, err:
+            except IOError as err:
                 raise EasyBuildError("Failed to read/parse XML file %s: %s", xml_file, err)
             # only one should be present, we are just discarding the rest
             testcase = dom.getElementsByTagName("testcase")[0]
@@ -165,7 +165,7 @@ def aggregate_xml_in_dirs(base_dir, output_filename):
         output_file = open(output_filename, "w")
         root.writexml(output_file, addindent="\t", newl="\n")
         output_file.close()
-    except IOError, err:
+    except IOError as err:
         raise EasyBuildError("Failed to write out XML file %s: %s", output_filename, err)
 
     print "Aggregate regtest results written to %s" % output_filename

--- a/easybuild/tools/job/pbs_python.py
+++ b/easybuild/tools/job/pbs_python.py
@@ -207,7 +207,7 @@ class PbsJob(object):
 
         try:
             self.pbsconn = self._server.connect_to_server()
-        except Exception, err:
+        except Exception as err:
             raise EasyBuildError("Failed to connect to the default pbs server: %s", err)
 
         # setup the resources requested

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -161,7 +161,7 @@ class ModuleGenerator(object):
                 mkdir(os.path.dirname(class_mod_file), parents=True)
                 os.symlink(mod_filepath, class_mod_file)
 
-        except OSError, err:
+        except OSError as err:
             raise EasyBuildError("Failed to create symlinks from %s to %s: %s", class_mod_files, mod_filepath, err)
 
     def define_env_var(self, env_var):

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -233,7 +233,7 @@ class ModulesTool(object):
             else:
                 raise EasyBuildError("Failed to determine version from option '%s' output: %s",
                                      self.VERSION_OPTION, txt)
-        except (OSError), err:
+        except (OSError) as err:
             raise EasyBuildError("Failed to check version: %s", err)
 
         if self.REQ_VERSION is None and self.MAX_VERSION is None:
@@ -756,7 +756,7 @@ class ModulesTool(object):
                 if tweak_fn is not None:
                     stdout = tweak_fn(stdout)
                 exec stdout
-            except Exception, err:
+            except Exception as err:
                 out = "stdout: %s, stderr: %s" % (stdout, stderr)
                 raise EasyBuildError("Changing environment as dictated by module failed: %s (%s)", err, out)
 
@@ -1274,7 +1274,7 @@ class Lmod(ModulesTool):
                     cache_file = open(cache_fp, 'w')
                     cache_file.write(stdout)
                     cache_file.close()
-                except (IOError, OSError), err:
+                except (IOError, OSError) as err:
                     raise EasyBuildError("Failed to update Lmod spider cache %s: %s", cache_fp, err)
 
     def use(self, path, priority=None):

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1454,7 +1454,7 @@ def set_tmpdir(tmpdir=None, raise_error=False):
         else:
             # use tempfile default parent dir
             current_tmpdir = tempfile.mkdtemp(prefix='eb-')
-    except OSError, err:
+    except OSError as err:
         raise EasyBuildError("Failed to create temporary directory (tmpdir: %s): %s", tmpdir, err)
 
     # avoid having special characters like '[' and ']' in the tmpdir pathname,
@@ -1494,7 +1494,7 @@ def set_tmpdir(tmpdir=None, raise_error=False):
             _log.debug("Temporary directory %s allows to execute files, good!" % tempfile.gettempdir())
         os.remove(tmptest_file)
 
-    except OSError, err:
+    except OSError as err:
         raise EasyBuildError("Failed to test whether temporary directory allows to execute files: %s", err)
 
     return current_tmpdir

--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -200,5 +200,5 @@ def prepare_easyconfig(ec):
         _log.debug("Cleaning up log file %s..." % easyblock_instance.logfile)
         easyblock_instance.close_log()
         os.remove(easyblock_instance.logfile)
-    except (OSError, EasyBuildError), err:
+    except (OSError, EasyBuildError) as err:
         raise EasyBuildError("An error occurred while preparing %s: %s", ec, err)

--- a/easybuild/tools/repository/gitrepo.py
+++ b/easybuild/tools/repository/gitrepo.py
@@ -102,7 +102,7 @@ class GitRepository(FileRepository):
             client.clone(self.repo)
             reponame = os.listdir(self.wc)[0]
             self.log.debug("rep name is %s" % reponame)
-        except (git.GitCommandError, OSError), err:
+        except (git.GitCommandError, OSError) as err:
             # it might already have existed
             self.log.warning("Git local repo initialization failed, it might already exist: %s", err)
 
@@ -111,14 +111,14 @@ class GitRepository(FileRepository):
             self.wc = os.path.join(self.wc, reponame)
             self.log.debug("connectiong to git repo in %s" % self.wc)
             self.client = git.Git(self.wc)
-        except (git.GitCommandError, OSError), err:
+        except (git.GitCommandError, OSError) as err:
             raise EasyBuildError("Could not create a local git repo in wc %s: %s", self.wc, err)
 
         # try to get the remote data in the local repo
         try:
             res = self.client.pull()
             self.log.debug("pulled succesfully to %s in %s" % (res, self.wc))
-        except (git.GitCommandError, OSError), err:
+        except (git.GitCommandError, OSError) as err:
             raise EasyBuildError("pull in working copy %s went wrong: %s", self.wc, err)
 
     def stage_file(self, path):
@@ -173,12 +173,12 @@ class GitRepository(FileRepository):
         try:
             self.client.commit('-am %s' % completemsg)
             self.log.debug("succesfull commit: %s", self.client.log('HEAD^!'))
-        except GitCommandError, err:
+        except GitCommandError as err:
             self.log.warning("Commit from working copy %s failed, empty commit? (msg: %s): %s", self.wc, msg, err)
         try:
             info = self.client.push()
             self.log.debug("push info: %s ", info)
-        except GitCommandError, err:
+        except GitCommandError as err:
             self.log.warning("Push from working copy %s to remote %s failed (msg: %s): %s",
                              self.wc, self.repo, msg, err)
 
@@ -189,5 +189,5 @@ class GitRepository(FileRepository):
         try:
             self.wc = os.path.dirname(self.wc)
             rmtree2(self.wc)
-        except IOError, err:
+        except IOError as err:
             raise EasyBuildError("Can't remove working copy %s: %s", self.wc, err)

--- a/easybuild/tools/repository/hgrepo.py
+++ b/easybuild/tools/repository/hgrepo.py
@@ -102,7 +102,7 @@ class HgRepository(FileRepository):
         try:
             client = hglib.clone(self.repo, self.wc)
             self.log.debug("repo %s cloned in %s" % (self.repo, self.wc))
-        except (HgCommandError, OSError), err:
+        except (HgCommandError, OSError) as err:
             # it might already have existed
             self.log.warning("Mercurial local repo initialization failed, it might already exist: %s" % err)
 
@@ -110,18 +110,18 @@ class HgRepository(FileRepository):
         try:
             self.log.debug("connection to mercurial repo in %s" % self.wc)
             self.client = hglib.open(self.wc)
-        except HgServerError, err:
+        except HgServerError as err:
             raise EasyBuildError("Could not connect to local mercurial repo: %s", err)
-        except (HgCapabilityError, HgResponseError), err:
+        except (HgCapabilityError, HgResponseError) as err:
             raise EasyBuildError("Server response: %s", err)
-        except (OSError, ValueError), err:
+        except (OSError, ValueError) as err:
             raise EasyBuildError("Could not create a local mercurial repo in wc %s: %s", self.wc, err)
 
         # try to get the remote data in the local repo
         try:
             self.client.pull()
             self.log.debug("pulled succesfully in %s" % self.wc)
-        except (HgCommandError, HgServerError, HgResponseError, OSError, ValueError), err:
+        except (HgCommandError, HgServerError, HgResponseError, OSError, ValueError) as err:
             raise EasyBuildError("pull in working copy %s went wrong: %s", self.wc, err)
 
     def stage_file(self, path):
@@ -175,7 +175,7 @@ class HgRepository(FileRepository):
         try:
             self.client.commit('"%s"' % completemsg, user=user)
             self.log.debug("succesfull commit")
-        except (HgCommandError, HgServerError, HgResponseError, ValueError), err:
+        except (HgCommandError, HgServerError, HgResponseError, ValueError) as err:
             self.log.warning("Commit from working copy %s (msg: %s) failed, empty commit?\n%s" % (self.wc, msg, err))
         try:
             if self.client.push():
@@ -183,7 +183,7 @@ class HgRepository(FileRepository):
             else:
                 info = "nothing to push"
             self.log.debug("push info: %s " % info)
-        except (HgCommandError, HgServerError, HgResponseError, ValueError), err:
+        except (HgCommandError, HgServerError, HgResponseError, ValueError) as err:
             tup = (self.wc, self.repo, msg, err)
             self.log.warning("Push from working copy %s to remote %s (msg: %s) failed: %s" % tup)
 
@@ -193,5 +193,5 @@ class HgRepository(FileRepository):
         """
         try:
             rmtree2(self.wc)
-        except IOError, err:
+        except IOError as err:
             raise EasyBuildError("Can't remove working copy %s: %s", self.wc, err)

--- a/easybuild/tools/repository/repository.py
+++ b/easybuild/tools/repository/repository.py
@@ -169,7 +169,7 @@ def init_repository(repository, repository_path):
             else:
                 raise EasyBuildError("repository_path should be a string or list/tuple of maximum 2 elements "
                                      "(current: %s, type %s)", repository_path, type(repository_path))
-        except Exception, err:
+        except Exception as err:
             raise EasyBuildError("Failed to create a repository instance for %s (class %s) with args %s (msg: %s)",
                                  repository, repo.__name__, repository_path, err)
     else:

--- a/easybuild/tools/repository/svnrepo.py
+++ b/easybuild/tools/repository/svnrepo.py
@@ -132,7 +132,7 @@ class SvnRepository(FileRepository):
             try:
                 res = self.client.checkout(self.repo, self.wc)
                 self.log.debug("Checked out revision %s in %s" % (res.number, self.wc))
-            except ClientError, err:
+            except ClientError as err:
                 raise EasyBuildError("Checkout of path / in working copy %s went wrong: %s", self.wc, err)
 
     def stage_file(self, path):
@@ -182,7 +182,7 @@ class SvnRepository(FileRepository):
 
         try:
             self.client.checkin(self.wc, completemsg, recurse=True)
-        except ClientError, err:
+        except ClientError as err:
             raise EasyBuildError("Commit from working copy %s (msg: %s) failed: %s", self.wc, msg, err)
 
     def cleanup(self):
@@ -191,5 +191,5 @@ class SvnRepository(FileRepository):
         """
         try:
             rmtree2(self.wc)
-        except OSError, err:
+        except OSError as err:
             raise EasyBuildError("Can't remove working copy %s: %s", self.wc, err)

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -171,7 +171,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
             os.chdir(path)
 
         _log.debug("run_cmd: running cmd %s (in %s)" % (cmd, os.getcwd()))
-    except OSError, err:
+    except OSError as err:
         _log.warning("Failed to change to %s: %s" % (path, err))
         _log.info("running cmd %s in non-existing directory, might fail!", cmd)
 
@@ -193,7 +193,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
     try:
         proc = subprocess.Popen(cmd, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                 stdin=subprocess.PIPE, close_fds=True, executable=exec_cmd)
-    except OSError, err:
+    except OSError as err:
         raise EasyBuildError("run_cmd init cmd %s failed:%s", cmd, err)
     if inp:
         proc.stdin.write(inp)
@@ -233,7 +233,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
 
     try:
         os.chdir(cwd)
-    except OSError, err:
+    except OSError as err:
         raise EasyBuildError("Failed to return to %s after executing command: %s", cwd, err)
 
     return parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp)
@@ -293,7 +293,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
             os.chdir(path)
 
         _log.debug("run_cmd_qa: running cmd %s (in %s)" % (cmd, os.getcwd()))
-    except OSError, err:
+    except OSError as err:
         _log.warning("Failed to change to %s: %s" % (path, err))
         _log.info("running cmd %s in non-existing directory, might fail!" % cmd)
 
@@ -366,7 +366,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
 
     try:
         p = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT, stdin=PIPE, close_fds=True, executable="/bin/bash")
-    except OSError, err:
+    except OSError as err:
         raise EasyBuildError("run_cmd_qa init cmd %s failed:%s", cmd, err)
 
     ec = p.poll()
@@ -383,7 +383,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
                 cmd_log.write(out)
             stdout_err += out
         # recv_some may throw Exception
-        except (IOError, Exception), err:
+        except (IOError, Exception) as err:
             _log.debug("run_cmd_qa cmd %s: read failed: %s", cmd, err)
             out = None
 
@@ -462,7 +462,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
 
     try:
         os.chdir(cwd)
-    except OSError, err:
+    except OSError as err:
         raise EasyBuildError("Failed to return to %s after executing command: %s", cwd, err)
 
     return parse_cmd_output(cmd, stdout_err, ec, simple, log_all, log_ok, regexp)

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -681,13 +681,13 @@ def use_group(group_name):
     """Use group with specified name."""
     try:
         group_id = grp.getgrnam(group_name).gr_gid
-    except KeyError, err:
+    except KeyError as err:
         raise EasyBuildError("Failed to get group ID for '%s', group does not exist (err: %s)", group_name, err)
 
     group = (group_name, group_id)
     try:
         os.setgid(group_id)
-    except OSError, err:
+    except OSError as err:
         err_msg = "Failed to use group %s: %s; " % (group, err)
         user = pwd.getpwuid(os.getuid()).pw_name
         grp_members = grp.getgrgid(group_id).gr_mem
@@ -710,7 +710,7 @@ def det_parallelism(par=None, maxpar=None):
         if not isinstance(par, int):
             try:
                 par = int(par)
-            except ValueError, err:
+            except ValueError as err:
                 raise EasyBuildError("Specified level of parallelism '%s' is not an integer value: %s", par, err)
     else:
         par = get_avail_core_count()
@@ -725,7 +725,7 @@ def det_parallelism(par=None, maxpar=None):
             if par_guess < par:
                 par = par_guess
                 _log.info("Limit parallel builds to %s because max user processes is %s" % (par, out))
-        except ValueError, err:
+        except ValueError as err:
             raise EasyBuildError("Failed to determine max user processes (%s, %s): %s", ec, out, err)
 
     if maxpar is not None and maxpar < par:

--- a/easybuild/tools/testing.py
+++ b/easybuild/tools/testing.py
@@ -103,7 +103,7 @@ def regtest(easyconfig_paths, modtool, build_specs=None):
     for ecfile in ecfiles:
         try:
             easyconfigs.extend(process_easyconfig(ecfile, build_specs=build_specs))
-        except EasyBuildError, err:
+        except EasyBuildError as err:
             test_results.append((ecfile, 'parsing_easyconfigs', 'easyconfig file error: %s' % err, _log))
 
     # skip easyconfigs for which a module is already available, unless forced


### PR DESCRIPTION
This will make PRs to the `4.x` branch that aim to make the EasyBuild framework compatible with Python 3.x a bit less verbose.

The changes included here were made using a single `sed` command, and do make change anything functionally, it's literally only replacing `,` with `as` in `except` statements...