### PR TITLE
move mk_rst_table function from easybuild.tools.docs to easybuild.tools.utilities

### DIFF
--- a/easybuild/base/generaloption.py
+++ b/easybuild/base/generaloption.py
@@ -45,8 +45,7 @@ from optparse import gettext as _gettext  # this is gettext.gettext normally
 
 from easybuild.base.fancylogger import getLogger, setroot, setLogLevel, getDetailsLogLevels
 from easybuild.base.optcomplete import autocomplete, CompleterOption
-from easybuild.tools.docs import mk_rst_table
-from easybuild.tools.utilities import nub, shell_quote
+from easybuild.tools.utilities import mk_rst_table, nub, shell_quote
 
 
 HELP_OUTPUT_FORMATS = ['', 'rst', 'short', 'config']

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -56,7 +56,6 @@ from easybuild.base import fancylogger
 from easybuild.framework.easyconfig import EASYCONFIGS_PKG_SUBDIR
 from easybuild.framework.easyconfig.easyconfig import ITERATE_OPTIONS, EasyConfig, ActiveMNS, get_easyblock_class
 from easybuild.framework.easyconfig.easyconfig import get_module_path, letter_dir_for, resolve_template
-from easybuild.framework.easyconfig.format.format import INDENT_4SPACES
 from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconfig
 from easybuild.framework.easyconfig.style import MAX_LINE_LENGTH
 from easybuild.framework.easyconfig.tools import get_paths_for
@@ -91,7 +90,7 @@ from easybuild.tools.package.utilities import package
 from easybuild.tools.repository.repository import init_repository
 from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
 from easybuild.tools.systemtools import det_parallelism, use_group
-from easybuild.tools.utilities import get_class_for, quote_str, remove_unwanted_chars, trace_msg
+from easybuild.tools.utilities import INDENT_4SPACES, get_class_for, quote_str, remove_unwanted_chars, trace_msg
 from easybuild.tools.version import this_is_easybuild, VERBOSE_VERSION, VERSION
 
 

--- a/easybuild/framework/easyconfig/format/format.py
+++ b/easybuild/framework/easyconfig/format/format.py
@@ -38,7 +38,7 @@ from easybuild.framework.easyconfig.format.version import ToolchainVersionOperat
 from easybuild.framework.easyconfig.format.convert import Dependency
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.configobj import Section
-from easybuild.tools.utilities import INDENT_4SPACES, get_subclasses
+from easybuild.tools.utilities import get_subclasses
 
 
 # format is mandatory major.minor

--- a/easybuild/framework/easyconfig/format/format.py
+++ b/easybuild/framework/easyconfig/format/format.py
@@ -38,10 +38,8 @@ from easybuild.framework.easyconfig.format.version import ToolchainVersionOperat
 from easybuild.framework.easyconfig.format.convert import Dependency
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.configobj import Section
-from easybuild.tools.utilities import get_subclasses
+from easybuild.tools.utilities import INDENT_4SPACES, get_subclasses
 
-
-INDENT_4SPACES = ' ' * 4
 
 # format is mandatory major.minor
 FORMAT_VERSION_KEYWORD = "EASYCONFIGFORMAT"

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -37,14 +37,14 @@ import tempfile
 
 from easybuild.base import fancylogger
 from easybuild.framework.easyconfig.format.format import DEPENDENCY_PARAMETERS, EXCLUDED_KEYS_REPLACE_TEMPLATES
-from easybuild.framework.easyconfig.format.format import FORMAT_DEFAULT_VERSION, GROUPED_PARAMS, INDENT_4SPACES
+from easybuild.framework.easyconfig.format.format import FORMAT_DEFAULT_VERSION, GROUPED_PARAMS
 from easybuild.framework.easyconfig.format.format import LAST_PARAMS, get_format_version
 from easybuild.framework.easyconfig.format.pyheaderconfigobj import EasyConfigFormatConfigObj
 from easybuild.framework.easyconfig.format.version import EasyVersion
 from easybuild.framework.easyconfig.templates import to_template_str
 from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.filetools import read_file, write_file
-from easybuild.tools.utilities import quote_py_str
+from easybuild.tools.utilities import INDENT_4SPACES, quote_py_str
 
 
 EB_FORMAT_EXTENSION = '.eb'

--- a/easybuild/framework/easyconfig/format/yeb.py
+++ b/easybuild/framework/easyconfig/format/yeb.py
@@ -32,9 +32,9 @@ Useful: http://www.yaml.org/spec/1.2/spec.html
 import os
 
 from easybuild.base import fancylogger
-from easybuild.framework.easyconfig.format.format import INDENT_4SPACES, EasyConfigFormat
+from easybuild.framework.easyconfig.format.format import EasyConfigFormat
 from easybuild.framework.easyconfig.format.pyheaderconfigobj import build_easyconfig_constants_dict
-from easybuild.tools.utilities import only_if_module_is_available, quote_str
+from easybuild.tools.utilities import INDENT_4SPACES, only_if_module_is_available, quote_str
 
 
 _log = fancylogger.getLogger('easyconfig.format.yeb', fname=False)

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -61,14 +61,12 @@ from easybuild.tools.modules import modules_tool
 from easybuild.tools.ordereddict import OrderedDict
 from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
 from easybuild.tools.toolchain.utilities import search_toolchain
+from easybuild.tools.utilities import INDENT_2SPACES, INDENT_4SPACES
 from easybuild.tools.utilities import import_available_modules, mk_rst_table, nub, quote_str
 
 
 _log = fancylogger.getLogger('tools.docs')
 
-
-INDENT_4SPACES = ' ' * 4
-INDENT_2SPACES = ' ' * 2
 
 DETAILED = 'detailed'
 SIMPLE = 'simple'

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -61,7 +61,7 @@ from easybuild.tools.modules import modules_tool
 from easybuild.tools.ordereddict import OrderedDict
 from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
 from easybuild.tools.toolchain.utilities import search_toolchain
-from easybuild.tools.utilities import import_available_modules, nub, quote_str
+from easybuild.tools.utilities import import_available_modules, mk_rst_table, nub, quote_str
 
 
 _log = fancylogger.getLogger('tools.docs')
@@ -75,41 +75,6 @@ SIMPLE = 'simple'
 
 FORMAT_TXT = 'txt'
 FORMAT_RST = 'rst'
-
-
-def mk_rst_table(titles, columns):
-    """
-    Returns an rst table with given titles and columns (a nested list of string columns for each column)
-    """
-    title_cnt, col_cnt = len(titles), len(columns)
-    if title_cnt != col_cnt:
-        msg = "Number of titles/columns should be equal, found %d titles and %d columns" % (title_cnt, col_cnt)
-        raise ValueError(msg)
-    table = []
-    tmpl = []
-    line = []
-
-    # figure out column widths
-    for i, title in enumerate(titles):
-        width = max(map(len, columns[i] + [title]))
-
-        # make line template
-        tmpl.append('{%s:{c}<%s}' % (i, width))
-
-    line = [''] * col_cnt
-    line_tmpl = INDENT_4SPACES.join(tmpl)
-    table_line = line_tmpl.format(*line, c='=')
-
-    table.append(table_line)
-    table.append(line_tmpl.format(*titles, c=' '))
-    table.append(table_line)
-
-    for row in map(list, zip(*columns)):
-        table.append(line_tmpl.format(*row, c=' '))
-
-    table.extend([table_line, ''])
-
-    return table
 
 
 def generate_doc(name, params):

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -40,6 +40,7 @@ from easybuild.tools.config import build_option
 
 _log = fancylogger.getLogger('tools.utilities')
 
+INDENT_4SPACES = ' ' * 4
 
 # a list of all ascii characters
 ASCII_CHARS = string.maketrans('', '')
@@ -231,3 +232,38 @@ def get_subclasses_dict(klass, include_base_class=False):
 def get_subclasses(klass, include_base_class=False):
     """Get list of all subclasses, recursively from the specified base class."""
     return get_subclasses_dict(klass, include_base_class=include_base_class).keys()
+
+
+def mk_rst_table(titles, columns):
+    """
+    Returns an rst table with given titles and columns (a nested list of string columns for each column)
+    """
+    title_cnt, col_cnt = len(titles), len(columns)
+    if title_cnt != col_cnt:
+        msg = "Number of titles/columns should be equal, found %d titles and %d columns" % (title_cnt, col_cnt)
+        raise ValueError(msg)
+    table = []
+    tmpl = []
+    line = []
+
+    # figure out column widths
+    for i, title in enumerate(titles):
+        width = max(map(len, columns[i] + [title]))
+
+        # make line template
+        tmpl.append('{%s:{c}<%s}' % (i, width))
+
+    line = [''] * col_cnt
+    line_tmpl = INDENT_4SPACES.join(tmpl)
+    table_line = line_tmpl.format(*line, c='=')
+
+    table.append(table_line)
+    table.append(line_tmpl.format(*titles, c=' '))
+    table.append(table_line)
+
+    for row in map(list, zip(*columns)):
+        table.append(line_tmpl.format(*row, c=' '))
+
+    table.extend([table_line, ''])
+
+    return table

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -40,6 +40,7 @@ from easybuild.tools.config import build_option
 
 _log = fancylogger.getLogger('tools.utilities')
 
+INDENT_2SPACES = ' ' * 2
 INDENT_4SPACES = ' ' * 4
 
 # a list of all ascii characters


### PR DESCRIPTION
`mk_rst_table` was thrown into `easybuild.tools.docs` when ingesting `vsc-base` (see #2708), but that causes some problems because it's needed in `easybuild.base.generaloption` when porting the modules in the `easybuild.base` namespace to Python 3 as a first step

It'll be easier to have `mk_rst_table` parked in `easybuild.tools.utilities` for now, and keep `easybuild.base` more isolated from `easybuild.tools` (only `easybuild.tools.utilities` is required by `easybuild.base.*` after this change)