### PR TITLE
avoid use of sys.maxint in dependencies_for

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -36,7 +36,6 @@ Generating module files.
 import copy
 import os
 import re
-import sys
 import tempfile
 from distutils.version import LooseVersion
 from textwrap import wrap
@@ -86,19 +85,21 @@ def module_load_regex(modfilepath):
     return re.compile(regex, re.M)
 
 
-def dependencies_for(mod_name, modtool, depth=sys.maxint):
+def dependencies_for(mod_name, modtool, depth=None):
     """
     Obtain a list of dependencies for the given module, determined recursively, up to a specified depth (optionally)
-    :param depth: recursion depth (default is sys.maxint, which should be equivalent to infinite recursion depth)
+    :param depth: recursion depth (default is None, which corresponds to infinite recursion depth)
     """
     mod_filepath = modtool.modulefile_path(mod_name)
     modtxt = read_file(mod_filepath)
     loadregex = module_load_regex(mod_filepath)
     mods = loadregex.findall(modtxt)
 
-    if depth > 0:
+    if depth is None or depth > 0:
+        if depth > 0:
+            depth = depth - 1
         # recursively determine dependencies for these dependency modules, until depth is non-positive
-        moddeps = [dependencies_for(mod, modtool, depth=depth - 1) for mod in mods]
+        moddeps = [dependencies_for(mod, modtool, depth=depth) for mod in mods]
     else:
         # ignore any deeper dependencies
         moddeps = []

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -41,7 +41,7 @@ from easybuild.framework.easyconfig.tools import process_easyconfig
 from easybuild.tools import config
 from easybuild.tools.filetools import mkdir, read_file, write_file
 from easybuild.tools.modules import curr_module_paths
-from easybuild.tools.module_generator import ModuleGeneratorLua, ModuleGeneratorTcl
+from easybuild.tools.module_generator import ModuleGeneratorLua, ModuleGeneratorTcl, dependencies_for
 from easybuild.tools.module_naming_scheme.utilities import is_valid_module_name
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, ActiveMNS
@@ -1066,6 +1066,22 @@ class ModuleGeneratorTest(EnhancedTestCase):
         }
         for ecfile, mns_vals in test_ecs.items():
             test_ec(ecfile, *mns_vals)
+
+    def test_dependencies_for(self):
+        """Test for dependencies_for function."""
+        expected = [
+            'GCC/6.4.0-2.28',
+            'OpenMPI/2.1.2-GCC-6.4.0-2.28',
+            'OpenBLAS/0.2.20-GCC-6.4.0-2.28',
+            'FFTW/3.3.7-gompi-2018a',
+            'ScaLAPACK/2.0.2-gompi-2018a-OpenBLAS-0.2.20',
+            'hwloc/1.11.8-GCC-6.4.0-2.28',
+            'gompi/2018a',
+        ]
+        self.assertEqual(dependencies_for('foss/2018a', self.modtool), expected)
+
+        # only with depth=0, only direct dependencies are returned
+        self.assertEqual(dependencies_for('foss/2018a', self.modtool, depth=0), expected[:-2])
 
 
 class TclModuleGeneratorTest(ModuleGeneratorTest):


### PR DESCRIPTION
Relying on `sys.maxint` is a bit silly, and strictly speaking is not actually infinite recursion depth.

Moreover, `sys.maxint` is no longer available in Python 3, so not relying on it anymore helps with making EasyBuild compatible with both Python 2 and 3.