### PR TITLE
fix check_pr_eligible_to_merge to only consider the status of the last test report

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -952,6 +952,7 @@ def check_pr_eligible_to_merge(pr_data):
                 elif 'FAILED' in comment:
                     res = not_eligible(msg_tmpl % 'FAILED')
                     test_report_found = True
+                    break
                 else:
                     print_warning("Failed to determine outcome of test report for comment:\n%s" % comment)
 

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -474,6 +474,7 @@ class GithubTest(EnhancedTestCase):
 
         pr_data['issue_comments'] = [
             {'body': "@easybuild-easyconfigs/maintainers: please review/merge?"},
+            {'body': "Test report by @boegel\n**SUCCESS**\nit's all good!"},
             {'body': "Test report by @boegel\n**FAILED**\nnothing ever works..."},
             {'body': "this is just a regular comment"},
         ]


### PR DESCRIPTION
without this, if the last report failed it does output

```last test report is successful: FAILED => not eligible for merging!```

but keeps looking for test reports until it finds a successful one (or runs out of comments).