### PR TITLE
fix running of set_up_configuration() in Python 3

### DIFF
--- a/easybuild/base/generaloption.py
+++ b/easybuild/base/generaloption.py
@@ -1503,8 +1503,7 @@ class GeneralOption(object):
             self.log.debug("generate_cmd_line no ignore")
 
         args = []
-        opt_dests = list(self.options.__dict__.keys())
-        opt_dests.sort()
+        opt_dests = sorted(self.options.__dict__)
 
         for opt_dest in opt_dests:
             # help is store_or_None, but is not a processed option, so skip it

--- a/easybuild/base/generaloption.py
+++ b/easybuild/base/generaloption.py
@@ -1503,7 +1503,7 @@ class GeneralOption(object):
             self.log.debug("generate_cmd_line no ignore")
 
         args = []
-        opt_dests = self.options.__dict__.keys()
+        opt_dests = list(self.options.__dict__.keys())
         opt_dests.sort()
 
         for opt_dest in opt_dests:

--- a/easybuild/base/generaloption.py
+++ b/easybuild/base/generaloption.py
@@ -1061,7 +1061,7 @@ class GeneralOption(object):
             long_description = description[1]
 
         opt_grp = ExtOptionGroup(self.parser, short_description, long_description, section_name=section_name)
-        keys = opt_dict.keys()
+        keys = list(opt_dict.keys())
         if self.OPTIONGROUP_SORTED_OPTIONS:
             keys.sort()  # alphabetical
         for key in keys:

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -99,7 +99,8 @@ class EasyBuildLog(fancylogger.FancyLogger):
 
     def caller_info(self):
         """Return string with caller info."""
-        (filepath, line, function_name) = self.findCaller()
+        # findCaller returns a 3-tupe in Python 2, a 4-tuple in Python 3 (stack info as extra element)
+        (filepath, line, function_name) = self.findCaller()[:3]
         filepath_dirs = filepath.split(os.path.sep)
 
         for dirName in copy(filepath_dirs):

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -47,7 +47,7 @@ from abc import ABCMeta
 from easybuild.base import fancylogger
 from easybuild.base.frozendict import FrozenDictKnownKeys
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.py2vs3 import string_type
+from easybuild.tools.py2vs3 import create_base_metaclass, string_type
 
 
 _log = fancylogger.getLogger('config', fname=False)
@@ -329,11 +329,12 @@ DEFAULT_MODULECLASSES = [
 ]
 
 
-class ConfigurationVariables(FrozenDictKnownKeys):
-    """This is a dict that supports legacy config names transparently."""
+# singleton metaclass: only one instance is created
+BaseConfigurationVariables = create_base_metaclass('BaseConfigurationVariables', Singleton, FrozenDictKnownKeys)
 
-    # singleton metaclass: only one instance is created
-    __metaclass__ = Singleton
+
+class ConfigurationVariables(BaseConfigurationVariables):
+    """This is a dict that supports legacy config names transparently."""
 
     # list of known/required keys
     REQUIRED = [
@@ -373,11 +374,12 @@ class ConfigurationVariables(FrozenDictKnownKeys):
         return self.items()
 
 
-class BuildOptions(FrozenDictKnownKeys):
-    """Representation of a set of build options, acts like a dictionary."""
+# singleton metaclass: only one instance is created
+BaseBuildOptions = create_base_metaclass('BaseBuildOptions', Singleton, FrozenDictKnownKeys)
 
-    # singleton metaclass: only one instance is created
-    __metaclass__ = Singleton
+
+class BuildOptions(BaseBuildOptions):
+    """Representation of a set of build options, acts like a dictionary."""
 
     KNOWN_KEYS = [k for kss in [BUILD_OPTIONS_CMDLINE, BUILD_OPTIONS_OTHER] for ks in kss.values() for k in ks]
 

--- a/easybuild/tools/configobj.py
+++ b/easybuild/tools/configobj.py
@@ -523,7 +523,7 @@ class Section(dict):
         self._initialise()
         # we do this explicitly so that __setitem__ is used properly
         # (rather than just passing to ``dict.__init__``)
-        for entry, value in indict.iteritems():
+        for entry, value in indict.items():
             self[entry] = value
 
 
@@ -598,7 +598,7 @@ class Section(dict):
         ``unrepr`` must be set when setting a value to a dictionary, without
         creating a new sub-section.
         """
-        if not isinstance(key, string_type):
+        if not isinstance(key, (bytes, string_type)):
             raise ValueError('The key "%s" is not a string.' % key)
 
         # add the comment
@@ -1089,7 +1089,7 @@ class Section(dict):
 class ConfigObj(Section):
     """An object to read, create, and write config files."""
 
-    _keyword = re.compile(r'''^ # line start
+    _keyword = re.compile(br'''^ # line start
         (\s*)                   # indentation
         (                       # keyword
             (?:".*?")|          # double quotes
@@ -1102,7 +1102,7 @@ class ConfigObj(Section):
         ''',
         re.VERBOSE)
 
-    _sectionmarker = re.compile(r'''^
+    _sectionmarker = re.compile(br'''^
         (\s*)                     # 1: indentation
         ((?:\[\s*)+)              # 2: section marker open
         (                         # 3: section name open
@@ -1119,7 +1119,7 @@ class ConfigObj(Section):
     # or single values and comments
     # FIXME: this regex adds a '' to the end of comma terminated lists
     #   workaround in ``_handle_value``
-    _valueexp = re.compile(r'''^
+    _valueexp = re.compile(br'''^
         (?:
             (?:
                 (
@@ -1146,7 +1146,7 @@ class ConfigObj(Section):
         re.VERBOSE)
 
     # use findall to get the members of a list value
-    _listvalueexp = re.compile(r'''
+    _listvalueexp = re.compile(br'''
         (
             (?:".*?")|          # double quotes
             (?:'.*?')|          # single quotes
@@ -1158,7 +1158,7 @@ class ConfigObj(Section):
 
     # this regexp is used for the value
     # when lists are switched off
-    _nolistvalue = re.compile(r'''^
+    _nolistvalue = re.compile(br'''^
         (
             (?:".*?")|          # double quotes
             (?:'.*?')|          # single quotes
@@ -1170,10 +1170,10 @@ class ConfigObj(Section):
         re.VERBOSE)
 
     # regexes for finding triple quoted values on one line
-    _single_line_single = re.compile(r"^'''(.*?)'''\s*(#.*)?$")
-    _single_line_double = re.compile(r'^"""(.*?)"""\s*(#.*)?$')
-    _multi_line_single = re.compile(r"^(.*?)'''\s*(#.*)?$")
-    _multi_line_double = re.compile(r'^(.*?)"""\s*(#.*)?$')
+    _single_line_single = re.compile(br"^'''(.*?)'''\s*(#.*)?$")
+    _single_line_double = re.compile(br'^"""(.*?)"""\s*(#.*)?$')
+    _multi_line_single = re.compile(br"^(.*?)'''\s*(#.*)?$")
+    _multi_line_double = re.compile(br'^(.*?)"""\s*(#.*)?$')
 
     _triple_quote = {
         "'''": (_single_line_single, _multi_line_single),
@@ -1318,7 +1318,7 @@ class ConfigObj(Section):
                         break
                 break
 
-            infile = [line.rstrip('\r\n') for line in infile]
+            infile = [line.rstrip(b'\r\n') for line in infile]
 
         self._parse(infile)
         # if we had any errors, now is the time to raise them
@@ -1482,7 +1482,7 @@ class ConfigObj(Section):
                 return self._decode(infile, encoding)
 
         # No BOM discovered and no encoding specified, just return
-        if isinstance(infile, string_type):
+        if isinstance(infile, (bytes, string_type)):
             # infile read from a file will be a single string
             return infile.splitlines(True)
         return infile
@@ -1555,7 +1555,7 @@ class ConfigObj(Section):
             line = infile[cur_index]
             sline = line.strip()
             # do we have anything on the line ?
-            if not sline or sline.startswith('#'):
+            if not sline or sline.startswith(b'#'):
                 reset_comment = False
                 comment_list.append(line)
                 continue
@@ -1574,8 +1574,8 @@ class ConfigObj(Section):
                 (indent, sect_open, sect_name, sect_close, comment) = mat.groups()
                 if indent and (self.indent_type is None):
                     self.indent_type = indent
-                cur_depth = sect_open.count('[')
-                if cur_depth != sect_close.count(']'):
+                cur_depth = sect_open.count(b'[')
+                if cur_depth != sect_close.count(b']'):
                     self._handle_error("Cannot compute the section depth at line %s.",
                                        NestingError, infile, cur_index)
                     continue

--- a/easybuild/tools/configobj.py
+++ b/easybuild/tools/configobj.py
@@ -523,9 +523,8 @@ class Section(dict):
         self._initialise()
         # we do this explicitly so that __setitem__ is used properly
         # (rather than just passing to ``dict.__init__``)
-        for entry, value in indict.items():
-            self[entry] = value
-
+        for entry in indict:
+            self[entry] = indict[entry]
 
     def _initialise(self):
         # the sequence of scalar values in this Section

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -297,8 +297,7 @@ class EasyBuildOptions(GeneralOption):
                                   None, 'store', None, {'metavar': 'VERSION'}),
         })
 
-        longopts = opts.keys()
-        for longopt in longopts:
+        for longopt in list(opts.keys()):
             hlp = opts[longopt][0]
             hlp = "Try to %s (USE WITH CARE!)" % (hlp[0].lower() + hlp[1:])
             opts["try-%s" % longopt] = (hlp,) + opts[longopt][1:]

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -297,7 +297,7 @@ class EasyBuildOptions(GeneralOption):
                                   None, 'store', None, {'metavar': 'VERSION'}),
         })
 
-        for longopt in list(opts.keys()):
+        for longopt in list(opts):
             hlp = opts[longopt][0]
             hlp = "Try to %s (USE WITH CARE!)" % (hlp[0].lower() + hlp[1:])
             opts["try-%s" % longopt] = (hlp,) + opts[longopt][1:]

--- a/easybuild/tools/py2vs3/__init__.py
+++ b/easybuild/tools/py2vs3/__init__.py
@@ -29,3 +29,10 @@ if sys.version_info[0] >= 3:
     from easybuild.tools.py2vs3.py3 import *  # noqa
 else:
     from easybuild.tools.py2vs3.py2 import *  # noqa
+
+
+# based on six's 'with_metaclass' function
+# see also https://stackoverflow.com/questions/18513821/python-metaclass-understanding-the-with-metaclass
+def create_base_metaclass(base_class_name, metaclass, *bases):
+    """Create new class with specified metaclass based on specified base class(es)."""
+    return metaclass(base_class_name, bases, {})

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -208,7 +208,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
         read_size = 1024 * 8
 
     ec = proc.poll()
-    stdouterr = ''
+    stdouterr = b''
     while ec is None:
         # need to read from time to time.
         # - otherwise the stdout/stderr buffer gets filled and it all stops working

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -326,7 +326,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
     def test_configuration_variables(self):
         """Test usage of ConfigurationVariables."""
         # delete instance of ConfigurationVariables
-        ConfigurationVariables.__metaclass__._instances.pop(ConfigurationVariables, None)
+        ConfigurationVariables.__class__._instances.clear()
 
         # make sure ConfigurationVariables is a singleton class (only one available instance)
         cv1 = ConfigurationVariables()
@@ -338,7 +338,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
     def test_build_options(self):
         """Test usage of BuildOptions."""
         # delete instance of BuildOptions
-        BuildOptions.__metaclass__._instances.pop(BuildOptions, None)
+        BuildOptions.__class__._instances.clear()
 
         # make sure BuildOptions is a singleton class
         bo1 = BuildOptions()
@@ -348,7 +348,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
         self.assertTrue(bo1 is bo3)
 
         # test basic functionality
-        BuildOptions.__metaclass__._instances.pop(BuildOptions, None)
+        BuildOptions.__class__._instances.clear()
         bo = BuildOptions({
             'debug': False,
             'force': True
@@ -361,7 +361,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
         self.assertErrorRegex(AttributeError, '.*no attribute.*', lambda x: bo.__setitem__(*x), ('debug', True))
 
         # only valid keys can be set
-        BuildOptions.__metaclass__._instances.pop(BuildOptions, None)
+        BuildOptions.__class__._instances.clear()
         msg = "Encountered unknown keys .* \(known keys: .*"
         self.assertErrorRegex(KeyError, msg, BuildOptions, {'thisisclearlynotavalidbuildoption': 'FAIL'})
 

--- a/test/python3_testing.sh
+++ b/test/python3_testing.sh
@@ -5,3 +5,5 @@ for mod in `ls easybuild/base/*.py easybuild/tools/*py easybuild/main.py | egrep
     echo $test
     python3 -c "$test"
 done
+echo "set_up_configuration()"
+python3 -c "from easybuild.tools.options import set_up_configuration; set_up_configuration()"


### PR DESCRIPTION
Just to clarify: this involves changing a bunch of string values (`'...'`) to byte strings (`b'...')`.

In Python 2.6 and 2.7, `'...'` and `b'...'` are exactly the same thing, but in Python 3 there's an important distinction between `'...'` and `b'...'`, see for example https://eli.thegreenplace.net/2012/01/30/the-bytesstr-dichotomy-in-python-3.

In some cases, byte strings are produced in Python 3, and we need to take this into account when working on those values...