### PR TITLE
Replace deps by hidden deps instead of removing them from the lists.

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -697,16 +697,15 @@ class EasyConfig(object):
                         # see comments in resolve_template
                         enable_templating = self.enable_templating
                         self.enable_templating = False
-
                         # track whether this hidden dep is listed as a build dep
                         orig_hidden_dep = self['hiddendependencies'][hidden_idx]
                         if key == 'builddependencies':
                             orig_hidden_dep['build_only'] = True
                         # actual replacement
                         self[key][idx] = orig_hidden_dep
-                        replaced = True
-
                         self.enable_templating = enable_templating
+
+                        replaced = True
                         if dep_mod_name == visible_mod_name:
                             msg = "Replaced (build)dependency matching hidden dependency %s"
                         else:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -174,7 +174,7 @@ def det_subtoolchain_version(current_tc, subtoolchain_name, optional_toolchains,
 
 @toolchain_hierarchy_cache
 def get_toolchain_hierarchy(parent_toolchain, incl_capabilities=False):
-    """
+    r"""
     Determine list of subtoolchains for specified parent toolchain.
     Result starts with the most minimal subtoolchains first, ends with specified toolchain.
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -684,7 +684,8 @@ class EasyConfig(object):
 
         faulty_deps = []
 
-        # templating must be temporarily disabled to obtain modifiable and original lists
+        # templating must be temporarily disabled to obtain reference to original list ('orig_hiddendeps'),
+        # so its elements can be changed in place
         # see comments in resolve_template
         enable_templating = self.enable_templating
         self.enable_templating = False

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -225,13 +225,7 @@ class FormatOneZero(EasyConfigFormatConfigObj):
         for group in keyset:
             printed = False
             for key in group:
-                val = copy.deepcopy(ecfg[key])
-                # include hidden deps back in list of (build)dependencies, they were filtered out via filter_hidden_deps
-                if key == 'dependencies':
-                    val.extend([d for d in ecfg['hiddendependencies'] if not d['build_only']])
-                elif key == 'builddependencies':
-                    val.extend([d for d in ecfg['hiddendependencies'] if d['build_only']])
-
+                val = ecfg[key]
                 if val != default_values[key]:
                     # dependency easyconfig parameters were parsed, so these need special care to 'unparse' them
                     if key in DEPENDENCY_PARAMETERS:

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1399,7 +1399,7 @@ class EasyConfigTest(EnhancedTestCase):
         ec_file = os.path.join(test_dir, 'easyconfigs', 'test_ecs', 'g', 'gzip', 'gzip-1.4-GCC-4.6.3.eb')
         ec = EasyConfig(ec_file)
         self.assertEqual(ec['hiddendependencies'][0]['full_mod_name'], 'toy/.0.0-deps')
-        self.assertEqual(ec['dependencies'], [])
+        self.assertEqual(ec['dependencies'][0]['full_mod_name'], 'toy/.0.0-deps')
 
         build_options = {
             'hide_deps': ['toy'],
@@ -1408,7 +1408,7 @@ class EasyConfigTest(EnhancedTestCase):
         init_config(build_options=build_options)
         ec = EasyConfig(ec_file)
         self.assertEqual(ec['hiddendependencies'][0]['full_mod_name'], 'toy/.0.0-deps')
-        self.assertEqual(ec['dependencies'], [])
+        self.assertEqual(ec['dependencies'][0]['full_mod_name'], 'toy/.0.0-deps')
 
     def test_quote_str(self):
         """Test quote_str function."""


### PR DESCRIPTION
This a cleanup so that hidden deps do not need to be re-added when
dumping the easyconfig. The build only needs to consider
builddependencies and dependencies, with integrated hidden
dependencies.