### PR TITLE
fix test account for GitHub-related tests

### DIFF
--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -51,7 +51,7 @@ except ImportError, err:
 
 
 # test account, for which a token may be available
-GITHUB_TEST_ACCOUNT = 'easybuild_testxxx'
+GITHUB_TEST_ACCOUNT = 'easybuild_test'
 # the user & repo to use in this test (https://github.com/hpcugent/testrepository)
 GITHUB_USER = "hpcugent"
 GITHUB_REPO = "testrepository"


### PR DESCRIPTION
This slipped in unintended with #2700, and it effectively disabled the tests for the GitHub integration features. The tests still pass though, so no damage done luckily...