### PR TITLE
make test for dep_graph function robust against changing order of lines in resulting dot file

### DIFF
--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1768,7 +1768,13 @@ class EasyConfigTest(EnhancedTestCase):
             # 3 nodes should be there: 'GCC/6.4.0-2.28 (EXT)', 'toy', and 'intel/2018a'
             # and 2 edges: 'toy -> intel' and 'toy -> "GCC/6.4.0-2.28 (EXT)"'
             dottxt = read_file(dot_file)
-            self.assertEqual(dottxt, EXPECTED_DOTTXT_TOY_DEPS)
+
+            self.assertTrue(dottxt.startswith('digraph graphname {'))
+
+            # compare sorted output, since order of lines can change
+            ordered_dottxt = '\n'.join(sorted(dottxt.split('\n')))
+            ordered_expected = '\n'.join(sorted(EXPECTED_DOTTXT_TOY_DEPS.split('\n')))
+            self.assertEqual(ordered_dottxt, ordered_expected)
 
         except ImportError:
             print "Skipping test_dep_graph, since pygraph is not available"


### PR DESCRIPTION
In some circumstances, the order of lines in the `*.dot` file created via `dep_graph` is slightly different, e.g.:

```
digraph graphname {
toy;
"GCC/6.4.0-2.28 (EXT)";
intel;
toy -> intel;
toy -> "GCC/6.4.0-2.28 (EXT)";
}
```

vs

```
digraph graphname {
toy;
intel;
"GCC/6.4.0-2.28 (EXT)";
toy -> intel;
toy -> "GCC/6.4.0-2.28 (EXT)";
}
```

The difference doesn't matter though, since it represents the same dependency graph.