### PR TITLE
ensure non-zero exit code for all test subsuites (+ fix trivial style issues)

### DIFF
--- a/test/framework/asyncprocess.py
+++ b/test/framework/asyncprocess.py
@@ -28,7 +28,6 @@ Unit tests for asyncprocess.py.
 @author: Toon Willems (Ghent University)
 """
 
-import os
 import sys
 import time
 from test.framework.utilities import EnhancedTestCase
@@ -65,9 +64,12 @@ class AsyncProcessTest(EnhancedTestCase):
         """cleanup"""
         super(AsyncProcessTest, self).tearDown()
 
+
 def suite():
     """ returns all the testcases in this module """
     return TestSuite([AsyncProcessTest()])
 
+
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -377,4 +377,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -34,15 +34,13 @@ import sys
 import tempfile
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
-from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
 
 import easybuild.tools.options as eboptions
 from easybuild.tools import run
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option, build_path, source_paths, install_path, get_repositorypath
 from easybuild.tools.config import BuildOptions, ConfigurationVariables
-from easybuild.tools.config import get_build_log_path, DEFAULT_PATH_SUBDIRS, init_build_options
-from easybuild.tools.environment import modify_env
+from easybuild.tools.config import DEFAULT_PATH_SUBDIRS, init_build_options
 from easybuild.tools.filetools import copy_dir, mkdir, write_file
 from easybuild.tools.options import CONFIG_ENV_VAR_PREFIX
 
@@ -576,7 +574,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
 def suite():
     return TestLoaderFiltered().loadTestsFromTestCase(EasyBuildConfigTest, sys.argv[1:])
 
+
 if __name__ == '__main__':
-    #logToScreen(enable=True)
-    #setLogLevelDebug()
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/containers.py
+++ b/test/framework/containers.py
@@ -402,4 +402,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -44,7 +44,7 @@ class DocsTest(EnhancedTestCase):
         gen_easyblocks_pkg = 'easybuild.easyblocks.generic'
         modules = import_available_modules(gen_easyblocks_pkg)
         common_params = {
-            'ConfigureMake' : ['configopts', 'buildopts', 'installopts'],
+            'ConfigureMake': ['configopts', 'buildopts', 'installopts'],
         }
         doc_functions = ['build_step', 'configure_step', 'test_step']
 
@@ -291,8 +291,7 @@ def suite():
     """ returns all test cases in this module """
     return TestLoaderFiltered().loadTestsFromTestCase(DocsTest, sys.argv[1:])
 
+
 if __name__ == '__main__':
-    # also check the setUp for debug
-    # logToScreen(enable=True)
-    # setLogLevelDebug()
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1570,4 +1570,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -40,7 +40,6 @@ import tempfile
 from distutils.version import LooseVersion
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
-from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
 
 import easybuild.tools.build_log
 import easybuild.framework.easyconfig as easyconfig
@@ -62,7 +61,7 @@ from easybuild.tools.config import module_classes
 from easybuild.tools.configobj import ConfigObj
 from easybuild.tools.docs import avail_easyconfig_constants, avail_easyconfig_templates
 from easybuild.tools.filetools import adjust_permissions, copy_file, mkdir, read_file, remove_file, symlink
-from easybuild.tools.filetools import which, write_file
+from easybuild.tools.filetools import write_file
 from easybuild.tools.module_naming_scheme.toolchain import det_toolchain_compilers, det_toolchain_mpi
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.options import parse_external_modules_metadata
@@ -142,7 +141,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(eb['name'], "pi")
         self.assertEqual(eb['version'], "3.14")
         self.assertEqual(eb['homepage'], "http://example.com")
-        self.assertEqual(eb['toolchain'], {"name":"dummy", "version": "dummy"})
+        self.assertEqual(eb['toolchain'], {"name": "dummy", "version": "dummy"})
         self.assertEqual(eb['description'], "test easyconfig")
 
     def test_validation(self):
@@ -521,51 +520,52 @@ class EasyConfigTest(EnhancedTestCase):
                "pi-3.15-GCC-4.6.3.eb",
                "pi-3.15-GCC-4.8.3.eb",
                "foo-1.2.3-GCC-4.6.3.eb"]
-        eb_files = [(fns[0], "\n".join([
-                        'easyblock = "ConfigureMake"',
-                        'name = "pi"',
-                        'version = "3.12"',
-                        'homepage = "http://example.com"',
-                        'description = "test easyconfig"',
-                        'toolchain = {"name": "dummy", "version": "dummy"}',
-                        'patches = %s' % patches
-                    ])),
-                    (fns[1], "\n".join([
-                        'easyblock = "ConfigureMake"',
-                        'name = "pi"',
-                        'version = "3.13"',
-                        'homepage = "http://example.com"',
-                        'description = "test easyconfig"',
-                        'toolchain = {"name": "%s", "version": "%s"}' % (tcname, tcver),
-                        'patches = %s' % patches
-                    ])),
-                    (fns[2], "\n".join([
-                        'easyblock = "ConfigureMake"',
-                        'name = "pi"',
-                        'version = "3.15"',
-                        'homepage = "http://example.com"',
-                        'description = "test easyconfig"',
-                        'toolchain = {"name": "%s", "version": "%s"}' % (tcname, tcver),
-                        'patches = %s' % patches
-                    ])),
-                    (fns[3], "\n".join([
-                        'easyblock = "ConfigureMake"',
-                        'name = "pi"',
-                        'version = "3.15"',
-                        'homepage = "http://example.com"',
-                        'description = "test easyconfig"',
-                        'toolchain = {"name": "%s", "version": "4.9.2"}' % tcname,
-                        'patches = %s' % patches
-                    ])),
-                    (fns[4], "\n".join([
-                        'easyblock = "ConfigureMake"',
-                        'name = "foo"',
-                        'version = "1.2.3"',
-                        'homepage = "http://example.com"',
-                        'description = "test easyconfig"',
-                        'toolchain = {"name": "%s", "version": "%s"}' % (tcname, tcver),
-                        'foo_extra1 = "bar"',
-                    ]))
+        eb_files = [
+            (fns[0], "\n".join([
+                'easyblock = "ConfigureMake"',
+                'name = "pi"',
+                'version = "3.12"',
+                'homepage = "http://example.com"',
+                'description = "test easyconfig"',
+                'toolchain = {"name": "dummy", "version": "dummy"}',
+                'patches = %s' % patches
+            ])),
+            (fns[1], "\n".join([
+                'easyblock = "ConfigureMake"',
+                'name = "pi"',
+                'version = "3.13"',
+                'homepage = "http://example.com"',
+                'description = "test easyconfig"',
+                'toolchain = {"name": "%s", "version": "%s"}' % (tcname, tcver),
+                'patches = %s' % patches
+            ])),
+            (fns[2], "\n".join([
+                'easyblock = "ConfigureMake"',
+                'name = "pi"',
+                'version = "3.15"',
+                'homepage = "http://example.com"',
+                'description = "test easyconfig"',
+                'toolchain = {"name": "%s", "version": "%s"}' % (tcname, tcver),
+                'patches = %s' % patches
+            ])),
+            (fns[3], "\n".join([
+                'easyblock = "ConfigureMake"',
+                'name = "pi"',
+                'version = "3.15"',
+                'homepage = "http://example.com"',
+                'description = "test easyconfig"',
+                'toolchain = {"name": "%s", "version": "4.9.2"}' % tcname,
+                'patches = %s' % patches
+            ])),
+            (fns[4], "\n".join([
+                'easyblock = "ConfigureMake"',
+                'name = "foo"',
+                'version = "1.2.3"',
+                'homepage = "http://example.com"',
+                'description = "test easyconfig"',
+                'toolchain = {"name": "%s", "version": "%s"}' % (tcname, tcver),
+                'foo_extra1 = "bar"',
+            ]))
         ]
 
         for (fn, txt) in eb_files:
@@ -573,7 +573,8 @@ class EasyConfigTest(EnhancedTestCase):
 
         # should crash when no suited easyconfig file (or template) is available
         specs = {'name': 'nosuchsoftware'}
-        error_regexp = ".*No easyconfig files found for software %s, and no templates available. I'm all out of ideas." % specs['name']
+        error_regexp = ".*No easyconfig files found for software %s, and no templates available. I'm all out of ideas."
+        error_regexp = error_regexp % specs['name']
         self.assertErrorRegex(EasyBuildError, error_regexp, obtain_ec_for, specs, [self.test_prefix], None)
 
         # should find matching easyconfig file
@@ -926,8 +927,8 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(eb['configopts'][1], configopts[1])
 
         # also buildopts and installopts as lists
-        buildopts = ['CC=foo' , 'CC=bar']
-        installopts = ['FOO=foo' , 'BAR=bar']
+        buildopts = ['CC=foo', 'CC=bar']
+        installopts = ['FOO=foo', 'BAR=bar']
         self.contents = orig_contents + '\n' + '\n'.join([
             "configopts = %s" % str(configopts),
             "buildopts = %s" % str(buildopts),
@@ -1034,7 +1035,8 @@ class EasyConfigTest(EnhancedTestCase):
             self.assertEqual(name, correct_name)
             self.assertEqual(easyblock, correct_easyblock)
 
-        self.assertEqual(fetch_parameters_from_easyconfig(read_file(toy_ec_file), ['description'])[0], "Toy C program, 100% toy.")
+        expected = "Toy C program, 100% toy."
+        self.assertEqual(fetch_parameters_from_easyconfig(read_file(toy_ec_file), ['description'])[0], expected)
 
         res = fetch_parameters_from_easyconfig("easyblock = 'ConfigureMake'  # test comment", ['easyblock'])
         self.assertEqual(res, ['ConfigureMake'])
@@ -1061,7 +1063,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         # also test deprecated default_fallback named argument
         self.assertErrorRegex(EasyBuildError, "DEPRECATED", get_easyblock_class, None, name='gzip',
-                                                                                 default_fallback=False)
+                              default_fallback=False)
 
         orig_value = easybuild.tools.build_log.CURRENT_VERSION
         easybuild.tools.build_log.CURRENT_VERSION = '3.9'
@@ -1191,8 +1193,10 @@ class EasyConfigTest(EnhancedTestCase):
             error_regex = "NO LONGER SUPPORTED since v%s.*'%s' is replaced by '%s'" % (ver, key, newkey)
             self.assertErrorRegex(EasyBuildError, error_regex, ec.get, key)
             self.assertErrorRegex(EasyBuildError, error_regex, lambda k: ec[k], key)
+
             def foo(key):
                 ec[key] = 'foo'
+
             self.assertErrorRegex(EasyBuildError, error_regex, foo, key)
 
     def test_deprecated_easyconfig_parameters(self):
@@ -1221,8 +1225,10 @@ class EasyConfigTest(EnhancedTestCase):
                 error_regex = "DEPRECATED.*since v%s.*'%s' is deprecated.*use '%s' instead" % (depr_ver, key, newkey)
                 self.assertErrorRegex(EasyBuildError, error_regex, ec.get, key)
                 self.assertErrorRegex(EasyBuildError, error_regex, lambda k: ec[k], key)
+
                 def foo(key):
                     ec[key] = 'foo'
+
                 self.assertErrorRegex(EasyBuildError, error_regex, foo, key)
             else:
                 # only deprecation warning, but key is replaced when getting/setting
@@ -1253,9 +1259,11 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertFalse('therenosucheasyconfigparameterlikethis' in ec)
         error_regex = "unknown easyconfig parameter"
         self.assertErrorRegex(EasyBuildError, error_regex, lambda k: ec[k], 'therenosucheasyconfigparameterlikethis')
+
         def set_ec_key(key):
             """Dummy function to set easyconfig parameter in 'ec' EasyConfig instance"""
             ec[key] = 'foobar'
+
         self.assertErrorRegex(EasyBuildError, error_regex, set_ec_key, 'therenosucheasyconfigparameterlikethis')
 
     def test_external_dependencies(self):
@@ -1413,12 +1421,12 @@ class EasyConfigTest(EnhancedTestCase):
     def test_quote_str(self):
         """Test quote_str function."""
         teststrings = {
-            'foo' : '"foo"',
-            'foo\'bar' : '"foo\'bar"',
-            'foo\'bar"baz' : '"""foo\'bar"baz"""',
-            "foo'bar\"baz" : '"""foo\'bar"baz"""',
-            "foo\nbar" : '"foo\nbar"',
-            'foo bar' : '"foo bar"'
+            'foo': '"foo"',
+            'foo\'bar': '"foo\'bar"',
+            'foo\'bar"baz': '"""foo\'bar"baz"""',
+            "foo'bar\"baz": '"""foo\'bar"baz"""',
+            "foo\nbar": '"foo\nbar"',
+            'foo bar': '"foo bar"'
         }
 
         for t in teststrings:
@@ -1543,7 +1551,7 @@ class EasyConfigTest(EnhancedTestCase):
     def test_dump_autopep8(self):
         """Test dump() with autopep8 usage enabled (only if autopep8 is available)."""
         try:
-            import autopep8
+            import autopep8  # noqa
             os.environ['EASYBUILD_DUMP_AUTOPEP8'] = '1'
             init_config()
             self.test_dump()
@@ -1643,7 +1651,7 @@ class EasyConfigTest(EnhancedTestCase):
             r'description = "foo description"',  # no templating for description
             r"sources = \[SOURCELOWER_TAR_GZ\]",
             # use of templates in *dependencies is disabled for now, since it can cause problems
-            #r"dependencies = \[\n    \('bar', '1.2.3', '%\(versionsuffix\)s'\),\n\]",
+            # r"dependencies = \[\n    \('bar', '1.2.3', '%\(versionsuffix\)s'\),\n\]",
             r"preconfigopts = '--opt1=%\(name\)s'",
             r"configopts = '--opt2=%\(version\)s'",
             r"sanity_check_paths = {\n    'files': \['files/%\(namelower\)s/foobar', 'files/x-test'\]",
@@ -1723,14 +1731,14 @@ class EasyConfigTest(EnhancedTestCase):
 
         # reverse dict of known template constants; template values (which are keys here) must be 'string-in-string
         templ_const = {
-            "template":'TEMPLATE_VALUE',
+            "template": 'TEMPLATE_VALUE',
             "%(name)s-%(version)s": 'NAME_VERSION',
         }
 
         templ_val = {
-            'foo':'name',
-            '0.0.1':'version',
-            '-test':'special_char',
+            'foo': 'name',
+            '0.0.1': 'version',
+            '-test': 'special_char',
         }
 
         self.assertEqual(to_template_str("template", templ_const, templ_val), 'TEMPLATE_VALUE')
@@ -1745,7 +1753,7 @@ class EasyConfigTest(EnhancedTestCase):
     def test_dep_graph(self):
         """Test for dep_graph."""
         try:
-            import pygraph
+            import pygraph  # noqa
 
             test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
             build_options = {
@@ -2445,7 +2453,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    # also check the setUp for debug
-    # logToScreen(enable=True)
-    # setLogLevelDebug()
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/easyconfigformat.py
+++ b/test/framework/easyconfigformat.py
@@ -33,8 +33,6 @@ from easybuild.framework.easyconfig.format.format import FORMAT_VERSION_HEADER_T
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
 
-from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
-
 
 class EasyConfigFormatTest(EnhancedTestCase):
     """Test the parser"""
@@ -54,6 +52,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    # logToScreen(enable=True)
-    # setLogLevelDebug()
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -31,7 +31,6 @@ import os
 import sys
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
-from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
 
 import easybuild.tools.build_log
 from easybuild.framework.easyconfig.format.format import Dependency
@@ -206,6 +205,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    # logToScreen(enable=True)
-    # setLogLevelDebug()
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/easyconfigversion.py
+++ b/test/framework/easyconfigversion.py
@@ -32,7 +32,6 @@ import sys
 
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
-from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
 
 from easybuild.framework.easyconfig.format.version import VersionOperator, ToolchainVersionOperator
 from easybuild.framework.easyconfig.format.version import OrderedVersionOperators
@@ -98,8 +97,8 @@ class EasyConfigVersion(EnhancedTestCase):
             ('> 3', '< 2', (False, False)),  # no overlap
             ('> 3', '== 3', (False, False)),  # no overlap
             ('< 3', '> 2', (True, True)),  # overlap, and conflict (region between 2 and 3 is ambiguous)
-            ('>= 3', '== 3' , (True, True)),  # overlap, and conflict (boundary 3 is ambigous)
-            ('> 3', '>= 3' , (True, False)),  # overlap, no conflict ('> 3' is more strict then '>= 3')
+            ('>= 3', '== 3', (True, True)),  # overlap, and conflict (boundary 3 is ambigous)
+            ('> 3', '>= 3', (True, False)),  # overlap, no conflict ('> 3' is more strict then '>= 3')
 
             # suffix
             ('> 2', '> 1', (True, False)),  # suffix both equal (both None), ordering like above
@@ -118,8 +117,8 @@ class EasyConfigVersion(EnhancedTestCase):
         """Test strict greater then ordering"""
         left_gt_right = [
             ('> 2', '> 1'),  # True, order by strictness equals order by boundaries for gt/ge
-            ('< 8' , '< 10'),  # True, order by strictness equals inversed order by boundaries for lt/le
-            ('== 4' , '> 3'),  # equality is more strict then inequality, but this order by boundaries
+            ('< 8', '< 10'),  # True, order by strictness equals inversed order by boundaries for lt/le
+            ('== 4', '> 3'),  # equality is more strict then inequality, but this order by boundaries
             ('> 3', '== 2'),  # there is no overlap, so just order the intervals according their boundaries
             ('== 1', '> 1'),  # no overlap, same boundaries, order by operator
             ('== 1', '< 1'),  # no overlap, same boundaries, order by operator
@@ -199,7 +198,6 @@ class EasyConfigVersion(EnhancedTestCase):
 
     def test_toolchain_versop_test(self):
         """Test the ToolchainVersionOperator test"""
-        top = ToolchainVersionOperator()
         _, tcs = search_toolchain('')
         tc_names = [x.NAME for x in tcs]
         for tc in tc_names:  # test all known toolchain names
@@ -274,6 +272,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    # logToScreen(enable=True)
-    # setLogLevelDebug()
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/ebconfigobj.py
+++ b/test/framework/ebconfigobj.py
@@ -27,20 +27,14 @@ Unit tests for easyconfig/format/format EBConfigObj
 
 @author: Stijn De Weirdt (Ghent University)
 """
-import os
-import re
 import sys
 
 from easybuild.framework.easyconfig.format.format import EBConfigObj
-from easybuild.framework.easyconfig.format.version import VersionOperator, ToolchainVersionOperator
-from easybuild.framework.easyconfig.format.version import OrderedVersionOperators
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.configobj import ConfigObj
 from easybuild.tools.toolchain.utilities import search_toolchain
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
-
-from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
 
 
 class TestEBConfigObj(EnhancedTestCase):
@@ -66,10 +60,10 @@ class TestEBConfigObj(EnhancedTestCase):
         data = [
             ('versions=1', {'version': '1'}),
             # == is usable
-            ('toolchains=%s == 1' % self.tc_first, {'toolchain':{'name': self.tc_first, 'version': '1'}}),
+            ('toolchains=%s == 1' % self.tc_first, {'toolchain': {'name': self.tc_first, 'version': '1'}}),
         ]
 
-        for val, res in  data:
+        for val, res in data:
             configobj_txt = ['[SUPPORTED]', val]
             co = ConfigObj(configobj_txt)
             cov = EBConfigObj(co)
@@ -88,7 +82,7 @@ class TestEBConfigObj(EnhancedTestCase):
             ('toolchains=%s > 1' % self.tc_first, {}),
         ]
 
-        for val, res in  data:
+        for val, res in data:
             configobj_txt = ['[SUPPORTED]', val]
             co = ConfigObj(configobj_txt)
             self.assertErrorRegex(EasyBuildError,
@@ -146,10 +140,7 @@ class TestEBConfigObj(EnhancedTestCase):
             '[> 1]',
             '[[< 2]]',  # although this makes sense, it's considered a conflict
         ]
-        for txt in [
-            txt_wrong_versions,
-            txt_conflict_nested_versions,
-            ]:
+        for txt in [txt_wrong_versions, txt_conflict_nested_versions]:
             co = ConfigObj(txt)
             cov = EBConfigObj(co)
             self.assertErrorRegex(EasyBuildError, r'conflict', cov.squash,
@@ -167,7 +158,7 @@ class TestEBConfigObj(EnhancedTestCase):
         txt = [
             '[SUPPORTED]',
             'versions = 1.0, 0.0, 1.1, 1.6, 2.1',
-            'toolchains = %s,%s' % (tc_section_first, tc_tmpl % tc_last),
+            'toolchains = %s,%s' % (tc_section_first, tc_section_last),
             '[DEFAULT]',
             'y=a',
             '[> 1.0]',
@@ -189,17 +180,17 @@ class TestEBConfigObj(EnhancedTestCase):
 
         # tests
         tests = [
-            (tc_last, '1.0', {'y':'a'}),
-            (tc_last, '1.1', {'y':'b', 'x':'1'}),
+            (tc_last, '1.0', {'y': 'a'}),
+            (tc_last, '1.1', {'y': 'b', 'x': '1'}),
             (tc_last, '1.5', {}),  # not a supported version
-            (tc_last, '1.6', {'y':'c', 'x':'2', 'z':'3'}),  # nested
-            (tc_last, '2.1', {'y':'d', 'x':'3', 'z':'3'}),  # values from most precise versop
+            (tc_last, '1.6', {'y': 'c', 'x': '2', 'z': '3'}),  # nested
+            (tc_last, '2.1', {'y': 'd', 'x': '3', 'z': '3'}),  # values from most precise versop
 
-            (tc_first, '1.0', {'y':'z1'}),  # toolchain section, not default
-            (tc_first, '1.1', {'y':'b', 'x':'1'}),  # the version section precedes the toolchain section
+            (tc_first, '1.0', {'y': 'z1'}),  # toolchain section, not default
+            (tc_first, '1.1', {'y': 'b', 'x': '1'}),  # the version section precedes the toolchain section
             (tc_first, '1.5', {}),  # not a supported version
-            (tc_first, '1.6', {'y':'z2', 'x':'2', 'z':'3'}),  # nested
-            (tc_first, '2.1', {'y':'d', 'x':'3', 'z':'3'}),  # values from most precise versop
+            (tc_first, '1.6', {'y': 'z2', 'x': '2', 'z': '3'}),  # nested
+            (tc_first, '2.1', {'y': 'd', 'x': '3', 'z': '3'}),  # values from most precise versop
         ]
         for tc, version, res in tests:
             co = ConfigObj(txt)
@@ -236,7 +227,7 @@ class TestEBConfigObj(EnhancedTestCase):
             ('3.0', {'versionprefix': 'production-', 'versionsuffix': '-mature'}),
         ]
 
-        for version, res in  data:
+        for version, res in data:
             # yes, redo this for each test, even if it's static text
             # some of the data is modified in place
             co = ConfigObj(txt)
@@ -268,7 +259,7 @@ class TestEBConfigObj(EnhancedTestCase):
 
         # default tc is cgoolf -> cgoolf > 0.0.0
         res = cov.get_specs_for(version='2.3.4', tcname=self.tc_first, tcversion='1.0.0')
-        self.assertEqual(res, {'foo':'bar'})
+        self.assertEqual(res, {'foo': 'bar'})
 
 
 def suite():
@@ -277,6 +268,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    # logToScreen(enable=True)
-    # setLogLevelDebug()
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/environment.py
+++ b/test/framework/environment.py
@@ -76,5 +76,7 @@ def suite():
     """ returns all the testcases in this module """
     return TestLoaderFiltered().loadTestsFromTestCase(EnvironmentTest, sys.argv[1:])
 
+
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -41,7 +41,6 @@ import tempfile
 import urllib2
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
-from urllib2 import URLError
 
 import easybuild.tools.filetools as ft
 from easybuild.tools.build_log import EasyBuildError
@@ -195,18 +194,18 @@ class FileToolsTest(EnhancedTestCase):
         # put a directory 'foo' in place (should be ignored by 'which')
         foo = os.path.join(self.test_prefix, 'foo')
         ft.mkdir(foo)
-        ft.adjust_permissions(foo, stat.S_IRUSR|stat.S_IXUSR)
+        ft.adjust_permissions(foo, stat.S_IRUSR | stat.S_IXUSR)
         # put executable file 'bar' in place
         bar = os.path.join(self.test_prefix, 'bar')
         ft.write_file(bar, '#!/bin/bash')
-        ft.adjust_permissions(bar, stat.S_IRUSR|stat.S_IXUSR)
+        ft.adjust_permissions(bar, stat.S_IRUSR | stat.S_IXUSR)
         self.assertEqual(ft.which('foo'), None)
         self.assertTrue(os.path.samefile(ft.which('bar'), bar))
 
         # add another location to 'bar', which should only return the first location by default
         barbis = os.path.join(self.test_prefix, 'more', 'bar')
         ft.write_file(barbis, '#!/bin/bash')
-        ft.adjust_permissions(barbis, stat.S_IRUSR|stat.S_IXUSR)
+        ft.adjust_permissions(barbis, stat.S_IRUSR | stat.S_IXUSR)
         os.environ['PATH'] = '%s:%s' % (os.environ['PATH'], os.path.dirname(barbis))
         self.assertTrue(os.path.samefile(ft.which('bar'), bar))
 
@@ -227,7 +226,8 @@ class FileToolsTest(EnhancedTestCase):
             'md5': '7167b64b1ca062b9674ffef46f9325db',
             'sha1': 'db05b79e09a4cc67e9dd30b313b5488813db3190',
             'sha256': '1c49562c4b404f3120a3fa0926c8d09c99ef80e470f7de03ffdfa14047960ea5',
-            'sha512': '7610f6ce5e91e56e350d25c917490e4815f7986469fafa41056698aec256733eb7297da8b547d5e74b851d7c4e475900cec4744df0f887ae5c05bf1757c224b4',
+            'sha512': '7610f6ce5e91e56e350d25c917490e4815f7986469fafa41056698aec256733e'
+                      'b7297da8b547d5e74b851d7c4e475900cec4744df0f887ae5c05bf1757c224b4',
         }
 
         # make sure checksums computation/verification is correct
@@ -501,7 +501,7 @@ class FileToolsTest(EnhancedTestCase):
 
         # creating the symlink
         link = os.path.join(self.test_prefix, 'test.link')
-        ft.symlink(fp, link) # test if is symlink is valid is done elsewhere
+        ft.symlink(fp, link)  # test if is symlink is valid is done elsewhere
 
         # Attempting to remove a valid symlink
         ft.remove_file(link)
@@ -947,7 +947,7 @@ class FileToolsTest(EnhancedTestCase):
         # test default behaviour:
         # recursive, add permissions, relative to existing permissions, both files and dirs, skip symlinks
         # add user execution, group write permissions
-        ft.adjust_permissions(self.test_prefix, stat.S_IXUSR|stat.S_IWGRP)
+        ft.adjust_permissions(self.test_prefix, stat.S_IXUSR | stat.S_IWGRP)
 
         # foo file: rwxrw-r--
         foo_perms = os.stat(os.path.join(self.test_prefix, 'foo'))[stat.ST_MODE]
@@ -985,7 +985,7 @@ class FileToolsTest(EnhancedTestCase):
             ft.symlink(test_files[-1], os.path.join(testdir, 'symlink%s' % idx))
 
         # by default, 50% of failures are allowed (to be robust against failures to change permissions)
-        perms = stat.S_IRUSR|stat.S_IWUSR|stat.S_IXUSR
+        perms = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
 
         ft.adjust_permissions(testdir, perms, recursive=True, ignore_errors=True)
 
@@ -1456,7 +1456,7 @@ class FileToolsTest(EnhancedTestCase):
         # check error handling (after creating a permission problem with removing files/dirs)
         ft.write_file(testfile, 'bar')
         ft.mkdir(test_dir)
-        ft.adjust_permissions(self.test_prefix, stat.S_IWUSR|stat.S_IWGRP|stat.S_IWOTH, add=False)
+        ft.adjust_permissions(self.test_prefix, stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH, add=False)
         self.assertErrorRegex(EasyBuildError, "Failed to remove", ft.remove_file, testfile)
         self.assertErrorRegex(EasyBuildError, "Failed to remove", ft.remove, testfile)
         self.assertErrorRegex(EasyBuildError, "Failed to remove", ft.remove_dir, test_dir)
@@ -1670,14 +1670,14 @@ class FileToolsTest(EnhancedTestCase):
         target_dir = os.path.join(self.test_prefix, 'target')
 
         try:
-            res = ft.get_source_tarball_from_git('test.tar.gz', target_dir, git_config)
+            ft.get_source_tarball_from_git('test.tar.gz', target_dir, git_config)
             # (only) tarball is created in specified target dir
             self.assertTrue(os.path.isfile(os.path.join(target_dir, 'test.tar.gz')))
             self.assertEqual(os.listdir(target_dir), ['test.tar.gz'])
 
             del git_config['tag']
             git_config['commit'] = '8456f86'
-            res = ft.get_source_tarball_from_git('test2.tar.gz', target_dir, git_config)
+            ft.get_source_tarball_from_git('test2.tar.gz', target_dir, git_config)
             self.assertTrue(os.path.isfile(os.path.join(target_dir, 'test2.tar.gz')))
             self.assertEqual(sorted(os.listdir(target_dir)), ['test.tar.gz', 'test2.tar.gz'])
 
@@ -1807,5 +1807,7 @@ def suite():
     """ returns all the testcases in this module """
     return TestLoaderFiltered().loadTestsFromTestCase(FileToolsTest, sys.argv[1:])
 
+
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/format_convert.py
+++ b/test/framework/format_convert.py
@@ -76,7 +76,7 @@ class ConvertTest(EnhancedTestCase):
         self.assertEqual(DictOfStrings.SEPARATOR_KEY_VALUE, ':')
 
         # start with simple one because the conversion to string is ordered
-        dest = {'a':'b'}
+        dest = {'a': 'b'}
         txt = DictOfStrings.SEPARATOR_KEY_VALUE.join(dest.items()[0])
 
         res = DictOfStrings(txt)
@@ -88,7 +88,7 @@ class ConvertTest(EnhancedTestCase):
             KEYLESS_ENTRIES = ['first']
             __str__ = DictOfStrings.__str__
 
-        dest2 = {'first':'first_value'}
+        dest2 = {'first': 'first_value'}
         dest2.update(dest)
         txt2 = DictOfStrings.SEPARATOR_DICT.join([dest2['first'], txt])
         res = Tmp(txt2)
@@ -99,9 +99,8 @@ class ConvertTest(EnhancedTestCase):
         txt2 = txt.replace(DictOfStrings.SEPARATOR_KEY_VALUE, DictOfStrings.SEPARATOR_KEY_VALUE + ' ')
         res = ListOfStrings(txt2.replace(DictOfStrings.SEPARATOR_DICT, DictOfStrings.SEPARATOR_DICT + ' '))
 
-
         # more complex one
-        dest = {'a':'b', 'c':'d'}
+        dest = {'a': 'b', 'c': 'd'}
         tmp = [DictOfStrings.SEPARATOR_KEY_VALUE.join(item) for item in dest.items()]
         txt = DictOfStrings.SEPARATOR_DICT.join(tmp)
 
@@ -122,7 +121,7 @@ class ConvertTest(EnhancedTestCase):
         self.assertEqual(ListOfStringsAndDictOfStrings.SEPARATOR_KEY_VALUE, ':')
 
         txt = "a,b,c:d"
-        dest = ['a', 'b', {'c':'d'}]
+        dest = ['a', 'b', {'c': 'd'}]
 
         res = ListOfStringsAndDictOfStrings(txt)
         self.assertEqual(res, dest)
@@ -138,7 +137,7 @@ class ConvertTest(EnhancedTestCase):
 
         # larger test
         txt = "a,b,c:d;e:f,g,h,i:j"
-        dest = ['a', 'b', {'c':'d', 'e': 'f'}, 'g', 'h', {'i': 'j'}]
+        dest = ['a', 'b', {'c': 'd', 'e': 'f'}, 'g', 'h', {'i': 'j'}]
 
         res = ListOfStringsAndDictOfStrings(txt)
         self.assertEqual(res, dest)
@@ -158,13 +157,13 @@ class ConvertTest(EnhancedTestCase):
         tc_versop = ToolchainVersionOperator(tc_versop_str)
 
         txt = Dependency.SEPARATOR_DEP.join([versop_str])
-        dest = {'versop':versop}
+        dest = {'versop': versop}
         res = Dependency(txt)
         self.assertEqual(dest, res)
         self.assertEqual(str(res), txt)
 
         txt = Dependency.SEPARATOR_DEP.join([versop_str, tc_versop_str])
-        dest = {'versop':versop, 'tc_versop':tc_versop}
+        dest = {'versop': versop, 'tc_versop': tc_versop}
         res = Dependency(txt)
         self.assertEqual(dest, res)
         self.assertEqual(str(res), txt)
@@ -174,13 +173,13 @@ class ConvertTest(EnhancedTestCase):
 
         # filename;level:<int>;dest:<string>
         dest = {
-            'filename':'/some/path',
-            'level':1,
-            'dest':'somedir',
+            'filename': '/some/path',
+            'level': 1,
+            'dest': 'somedir',
         }
         newdest = {
-            'sep':DictOfStrings.SEPARATOR_DICT,
-            'dsep':DictOfStrings.SEPARATOR_KEY_VALUE,
+            'sep': DictOfStrings.SEPARATOR_DICT,
+            'dsep': DictOfStrings.SEPARATOR_KEY_VALUE,
         }
         newdest.update(dest)
         txt = "%(filename)s%(sep)slevel%(dsep)s%(level)s%(sep)sdest%(dsep)s%(dest)s" % newdest
@@ -192,19 +191,19 @@ class ConvertTest(EnhancedTestCase):
         """Test Patches"""
 
         dest = [
-            {'filename':'fn1',
+            {'filename': 'fn1',
              'level': 1,
              },
-            {'filename':'fn2'
+            {'filename': 'fn2'
              },
-            {'filename':'fn3',
-             'dest':'somedir',
+            {'filename': 'fn3',
+             'dest': 'somedir',
              }
         ]
         newdest = {
-            'lsep':ListOfStrings.SEPARATOR_LIST,
-            'sep':DictOfStrings.SEPARATOR_DICT,
-            'dsep':DictOfStrings.SEPARATOR_KEY_VALUE,
+            'lsep': ListOfStrings.SEPARATOR_LIST,
+            'sep': DictOfStrings.SEPARATOR_DICT,
+            'dsep': DictOfStrings.SEPARATOR_KEY_VALUE,
         }
 
         tmpl = [
@@ -231,6 +230,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    # logToScreen(enable=True)
-    # setLogLevelDebug()
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/general.py
+++ b/test/framework/general.py
@@ -137,5 +137,7 @@ def suite():
     """ returns all the testcases in this module """
     return TestLoaderFiltered().loadTestsFromTestCase(GeneralTest, sys.argv[1:])
 
+
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -552,4 +552,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/hooks.py
+++ b/test/framework/hooks.py
@@ -189,5 +189,7 @@ def suite():
     """ returns all the testcases in this module """
     return TestLoaderFiltered().loadTestsFromTestCase(HooksTest, sys.argv[1:])
 
+
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/include.py
+++ b/test/framework/include.py
@@ -150,8 +150,6 @@ class IncludeTest(EnhancedTestCase):
 
     def test_include_mns(self):
         """Test include_module_naming_schemes()."""
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        test_mns = os.path.join(testdir, 'sandbox', 'easybuild', 'module_naming_scheme')
 
         my_mns = os.path.join(self.test_prefix, 'my_mns')
         mkdir(my_mns)
@@ -253,5 +251,7 @@ def suite():
     """ returns all the testcases in this module """
     return TestLoaderFiltered().loadTestsFromTestCase(IncludeTest, sys.argv[1:])
 
+
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/lib.py
+++ b/test/framework/lib.py
@@ -127,4 +127,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/license.py
+++ b/test/framework/license.py
@@ -72,6 +72,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    # logToScreen(enable=True)
-    # setLogLevelDebug()
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -34,13 +34,9 @@ import sys
 import tempfile
 from distutils.version import LooseVersion
 from unittest import TextTestRunner, TestSuite
-from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
-from vsc.utils.missing import nub
-
 from easybuild.framework.easyconfig.tools import process_easyconfig
 from easybuild.tools import config
 from easybuild.tools.filetools import mkdir, read_file, write_file
-from easybuild.tools.modules import curr_module_paths
 from easybuild.tools.module_generator import ModuleGeneratorLua, ModuleGeneratorTcl, dependencies_for
 from easybuild.tools.module_naming_scheme.utilities import is_valid_module_name
 from easybuild.framework.easyblock import EasyBlock
@@ -49,6 +45,7 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.modules import EnvironmentModulesC, Lmod
 from easybuild.tools.utilities import quote_str
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, find_full_path, init_config
+
 
 class ModuleGeneratorTest(EnhancedTestCase):
     """Tests for module_generator module."""
@@ -233,7 +230,6 @@ class ModuleGeneratorTest(EnhancedTestCase):
 
         self.assertTrue(full_module_name in self.modtool.loaded_modules())
         self.modtool.purge()
-
 
     def test_load(self):
         """Test load part in generated module file."""
@@ -491,7 +487,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
             res = self.modgen.append_paths('key', ['1234@example.com'], expand_relpaths=False)
             self.assertEqual('append_path("key", "1234@example.com")\n', res)
 
-        self.assertErrorRegex(EasyBuildError, "Absolute path %s/foo passed to update_paths " \
+        self.assertErrorRegex(EasyBuildError, "Absolute path %s/foo passed to update_paths "
                                               "which only expects relative paths." % self.modgen.app.installdir,
                               self.modgen.append_paths, "key2", ["bar", "%s/foo" % self.modgen.app.installdir])
 
@@ -539,7 +535,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
             res = self.modgen.prepend_paths('key', ['1234@example.com'], expand_relpaths=False)
             self.assertEqual('prepend_path("key", "1234@example.com")\n', res)
 
-        self.assertErrorRegex(EasyBuildError, "Absolute path %s/foo passed to update_paths " \
+        self.assertErrorRegex(EasyBuildError, "Absolute path %s/foo passed to update_paths "
                                               "which only expects relative paths." % self.modgen.app.installdir,
                               self.modgen.prepend_paths, "key2", ["bar", "%s/foo" % self.modgen.app.installdir])
 
@@ -949,7 +945,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
 
         def test_ec(ecfile, short_modname, mod_subdir, modpath_exts, user_modpath_exts, init_modpaths):
             """Test whether active module naming scheme returns expected values."""
-            ec = EasyConfig(glob.glob(os.path.join(ecs_dir, '*','*', ecfile))[0])
+            ec = EasyConfig(glob.glob(os.path.join(ecs_dir, '*', '*', ecfile))[0])
             self.assertEqual(ActiveMNS().det_full_module_name(ec), os.path.join(mod_subdir, short_modname))
             self.assertEqual(ActiveMNS().det_short_module_name(ec), short_modname)
             self.assertEqual(ActiveMNS().det_module_subdir(ec), mod_subdir)
@@ -1103,6 +1099,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    #logToScreen(enable=True)
-    #setLogLevelDebug()
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -1071,4 +1071,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/modulestool.py
+++ b/test/framework/modulestool.py
@@ -31,19 +31,16 @@ import os
 import re
 import stat
 import sys
-import tempfile
 from vsc.utils import fancylogger
 
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
 from distutils.version import StrictVersion
 
-import easybuild.tools.options as eboptions
-from easybuild.tools import config, modules
+from easybuild.tools import modules
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import build_option
 from easybuild.tools.filetools import which, write_file
-from easybuild.tools.modules import modules_tool, Lmod
+from easybuild.tools.modules import Lmod
 from test.framework.utilities import init_config
 
 
@@ -183,7 +180,7 @@ class ModulesToolTest(EnhancedTestCase):
                 'echo "os.environ[\'FOO\'] = \'foo\'"',
             ])
             write_file(fake_path, fake_lmod_txt)
-            os.chmod(fake_path, stat.S_IRUSR|stat.S_IXUSR)
+            os.chmod(fake_path, stat.S_IRUSR | stat.S_IXUSR)
             os.environ['LMOD_CMD'] = fake_path
             init_config(build_options=build_options)
             lmod = Lmod(testing=True)
@@ -218,5 +215,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
-
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -129,8 +129,10 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertTrue(re.search(' -h ', outtxt), "Only short options included in short help")
         self.assertTrue(re.search("show short help message and exit", outtxt), "Documentation included in short help")
         self.assertEqual(re.search("--short-help ", outtxt), None, "Long options not included in short help")
-        self.assertEqual(re.search("Software search and build options", outtxt), None, "Not all option groups included in short help (1)")
-        self.assertEqual(re.search("Regression test options", outtxt), None, "Not all option groups included in short help (2)")
+        self.assertEqual(re.search("Software search and build options", outtxt), None,
+                         "Not all option groups included in short help (1)")
+        self.assertEqual(re.search("Regression test options", outtxt), None,
+                         "Not all option groups included in short help (2)")
 
     def test_help_long(self):
         """Test long help message."""
@@ -144,10 +146,14 @@ class CommandLineOptionsTest(EnhancedTestCase):
                                )
         outtxt = topt.parser.help_to_file.getvalue()
 
-        self.assertTrue(re.search("-H OUTPUT_FORMAT, --help=OUTPUT_FORMAT", outtxt), "Long documentation expanded in long help")
-        self.assertTrue(re.search("show short help message and exit", outtxt), "Documentation included in long help")
-        self.assertTrue(re.search("Software search and build options", outtxt), "Not all option groups included in short help (1)")
-        self.assertTrue(re.search("Regression test options", outtxt), "Not all option groups included in short help (2)")
+        self.assertTrue(re.search("-H OUTPUT_FORMAT, --help=OUTPUT_FORMAT", outtxt),
+                        "Long documentation expanded in long help")
+        self.assertTrue(re.search("show short help message and exit", outtxt),
+                        "Documentation included in long help")
+        self.assertTrue(re.search("Software search and build options", outtxt),
+                        "Not all option groups included in short help (1)")
+        self.assertTrue(re.search("Regression test options", outtxt),
+                        "Not all option groups included in short help (2)")
 
     def test_no_args(self):
         """Test using no arguments."""
@@ -161,6 +167,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     def test_debug(self):
         """Test enabling debug logging."""
+        error_tmpl = "%s log messages are included when using %s: %s"
         for debug_arg in ['-d', '--debug']:
             args = [
                 'nosuchfile.eb',
@@ -170,7 +177,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
             for log_msg_type in ['DEBUG', 'INFO', 'ERROR']:
                 res = re.search(' %s ' % log_msg_type, outtxt)
-                self.assertTrue(res, "%s log messages are included when using %s: %s" % (log_msg_type, debug_arg, outtxt))
+                self.assertTrue(res, error_tmpl % (log_msg_type, debug_arg, outtxt))
 
     def test_info(self):
         """Test enabling info logging."""
@@ -182,9 +189,10 @@ class CommandLineOptionsTest(EnhancedTestCase):
                    ]
             outtxt = self.eb_main(args)
 
+            error_tmpl = "%s log messages are included when using %s ( out: %s)"
             for log_msg_type in ['INFO', 'ERROR']:
                 res = re.search(' %s ' % log_msg_type, outtxt)
-                self.assertTrue(res, "%s log messages are included when using %s ( out: %s)" % (log_msg_type, info_arg, outtxt))
+                self.assertTrue(res, error_tmpl % (log_msg_type, info_arg, outtxt))
 
             for log_msg_type in ['DEBUG']:
                 res = re.search(' %s ' % log_msg_type, outtxt)
@@ -193,20 +201,17 @@ class CommandLineOptionsTest(EnhancedTestCase):
     def test_quiet(self):
         """Test enabling quiet logging (errors only)."""
         for quiet_arg in ['--quiet']:
-            args = [
-                    'nosuchfile.eb',
-                    quiet_arg,
-                   ]
-            outtxt = self.eb_main(args)
+            args = ['nosuchfile.eb', quiet_arg]
+            out = self.eb_main(args)
 
             for log_msg_type in ['ERROR']:
-                res = re.search(' %s ' % log_msg_type, outtxt)
-                msg = "%s log messages are included when using %s (outtxt: %s)" % (log_msg_type, quiet_arg, outtxt)
+                res = re.search(' %s ' % log_msg_type, out)
+                msg = "%s log messages are included when using %s (out: %s)" % (log_msg_type, quiet_arg, out)
                 self.assertTrue(res, msg)
 
             for log_msg_type in ['DEBUG', 'INFO']:
-                res = re.search(' %s ' % log_msg_type, outtxt)
-                msg = "%s log messages are *not* included when using %s (outtxt: %s)" % (log_msg_type, quiet_arg, outtxt)
+                res = re.search(' %s ' % log_msg_type, out)
+                msg = "%s log messages are *not* included when using %s (out: %s)" % (log_msg_type, quiet_arg, out)
                 self.assertTrue(not res, msg)
 
     def test_force(self):
@@ -222,10 +227,12 @@ class CommandLineOptionsTest(EnhancedTestCase):
                ]
         outtxt, error_thrown = self.eb_main(args, return_error=True)
 
-        self.assertTrue(not error_thrown, "No error is thrown if software is already installed (error_thrown: %s)" % error_thrown)
+        error_msg = "No error is thrown if software is already installed (error_thrown: %s)" % error_thrown
+        self.assertTrue(not error_thrown, error_msg)
 
         already_msg = "GCC/4.6.3 is already installed"
-        self.assertTrue(re.search(already_msg, outtxt), "Already installed message without --force, outtxt: %s" % outtxt)
+        error_msg = "Already installed message without --force, outtxt: %s" % outtxt
+        self.assertTrue(re.search(already_msg, outtxt), error_msg)
 
         # clear log file
         write_file(self.logfile, '')
@@ -373,7 +380,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
             error_msg = "Log messages are printed to stdout when %s is used (stdout: %s)" % (stdout_arg, stdout)
             self.assertTrue(len(stdout) > 100, error_msg)
 
-
         topdir = os.path.dirname(os.path.abspath(__file__))
         toy_ecfile = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
         self.logfile = None
@@ -416,7 +422,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                 if custom is not None:
                     args.extend(['-e', custom])
 
-                outtxt = self.eb_main(args, logfile=dummylogfn, verbose=True)
+                self.eb_main(args, logfile=dummylogfn, verbose=True)
                 logtxt = read_file(self.logfile)
 
                 # check whether all parameter types are listed
@@ -462,7 +468,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                 '--list-toolchains',
                 '--unittest-file=%s' % self.logfile,
                ]
-        outtxt = self.eb_main(args, logfile=dummylogfn)
+        self.eb_main(args, logfile=dummylogfn)
 
         info_msg = r"INFO List of known toolchains \(toolchainname: module\[,module\.\.\.\]\):"
         logtxt = read_file(self.logfile)
@@ -500,7 +506,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                     '--avail-%s' % name,
                     '--unittest-file=%s' % self.logfile,
                    ]
-            outtxt = self.eb_main(args, logfile=dummylogfn)
+            self.eb_main(args, logfile=dummylogfn)
             logtxt = read_file(self.logfile)
 
             words = name.replace('-', ' ')
@@ -536,7 +542,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--avail-cfgfile-constants',
             '--unittest-file=%s' % self.logfile,
         ]
-        outtxt = self.eb_main(args, logfile=dummylogfn)
+        self.eb_main(args, logfile=dummylogfn)
         logtxt = read_file(self.logfile)
         cfgfile_constants = {
             'DEFAULT_ROBOT_PATHS': os.path.join(tmpdir, 'easybuild', 'easyconfigs'),
@@ -1336,19 +1342,19 @@ class CommandLineOptionsTest(EnhancedTestCase):
         log = fancylogger.getLogger()
 
         # force it to False
-        topt = EasyBuildOptions(
+        EasyBuildOptions(
             go_args=['--disable-experimental'],
         )
         try:
             log.experimental('x')
             # sanity check, should never be reached if it works.
-            self.assertTrue(False, "Experimental logging should be disabled by setting the --disable-experimental option")
+            self.assertTrue(False, "Experimental logging should be disabled by setting --disable-experimental option")
         except easybuild.tools.build_log.EasyBuildError, err:
             # check error message
             self.assertTrue('Experimental functionality.' in str(err))
 
         # toggle experimental
-        topt = EasyBuildOptions(
+        EasyBuildOptions(
             go_args=['--experimental'],
         )
         try:
@@ -1373,7 +1379,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         log = fancylogger.getLogger()
 
         # force it to lower version using 0.x, which should no result in any raised error (only deprecation logging)
-        topt = EasyBuildOptions(
+        EasyBuildOptions(
             go_args=['--deprecated=0.%s' % orig_value],
         )
         stderr = None
@@ -1382,14 +1388,14 @@ class CommandLineOptionsTest(EnhancedTestCase):
             log.deprecated('x', str(orig_value))
             stderr = self.get_stderr()
             self.mock_stderr(False)
-        except easybuild.tools.build_log.EasyBuildError, err:
+        except easybuild.tools.build_log.EasyBuildError:
             self.assertTrue(False, 'Deprecated logging should work')
 
         stderr_regex = re.compile("^\nWARNING: Deprecated functionality, will no longer work in")
         self.assertTrue(stderr_regex.search(stderr), "Pattern '%s' found in: %s" % (stderr_regex.pattern, stderr))
 
         # force it to current version, which should result in deprecation
-        topt = EasyBuildOptions(
+        EasyBuildOptions(
             go_args=['--deprecated=%s' % orig_value],
         )
         try:
@@ -1400,7 +1406,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             self.assertTrue('DEPRECATED' in str(err2))
 
         # force higher version by prefixing it with 1, which should result in deprecation errors
-        topt = EasyBuildOptions(
+        EasyBuildOptions(
             go_args=['--deprecated=1%s' % orig_value],
         )
         try:
@@ -1416,7 +1422,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
     def test_allow_modules_tool_mismatch(self):
         """Test allowing mismatch of modules tool with 'module' function."""
         # make sure MockModulesTool is available
-        from test.framework.modulestool import MockModulesTool
+        from test.framework.modulestool import MockModulesTool  # noqa
 
         # trigger that main() creates new instance of ModulesTool
         self.modtool = None
@@ -1528,7 +1534,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         for extra_arg in ['--try-software=foo', '--try-toolchain=gompi', '--try-toolchain=gomp,2018a,-a-suffix']:
             allargs = args + [extra_arg]
-            self.assertErrorRegex(EasyBuildError, "problems validating the options", self.eb_main, allargs, raise_error=True)
+            self.assertErrorRegex(EasyBuildError, "problems validating the options",
+                                  self.eb_main, allargs, raise_error=True)
 
         # no --try used, so no tweaked easyconfig files are generated
         allargs = args + ['--software-version=1.2.3', '--toolchain=gompi,2018a']
@@ -2215,7 +2222,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args = [
             '--avail-module-naming-schemes',
         ]
-        logtxt, _= run_cmd("cd %s; eb %s" % (self.test_prefix, ' '.join(args)), simple=False)
+        logtxt, _ = run_cmd("cd %s; eb %s" % (self.test_prefix, ' '.join(args)), simple=False)
         self.assertFalse(mns_regex.search(logtxt), "Unexpected pattern '%s' found in: %s" % (mns_regex.pattern, logtxt))
 
         # include extra test MNS
@@ -2233,7 +2240,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--avail-module-naming-schemes',
             '--include-module-naming-schemes=%s/*.py' % self.test_prefix,
         ]
-        logtxt, _= run_cmd("cd %s; eb %s" % (self.test_prefix, ' '.join(args)), simple=False)
+        logtxt, _ = run_cmd("cd %s; eb %s" % (self.test_prefix, ' '.join(args)), simple=False)
         self.assertTrue(mns_regex.search(logtxt), "Pattern '%s' *not* found in: %s" % (mns_regex.pattern, logtxt))
 
     def test_use_included_module_naming_scheme(self):
@@ -2293,7 +2300,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args = [
             '--list-toolchains',
         ]
-        logtxt, _= run_cmd("cd %s; eb %s" % (self.test_prefix, ' '.join(args)), simple=False)
+        logtxt, _ = run_cmd("cd %s; eb %s" % (self.test_prefix, ' '.join(args)), simple=False)
         self.assertFalse(tc_regex.search(logtxt), "Pattern '%s' *not* found in: %s" % (tc_regex.pattern, logtxt))
 
         # include extra test toolchain
@@ -2316,7 +2323,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--include-toolchains=%s/*.py,%s/*/*.py' % (self.test_prefix, self.test_prefix),
             '--list-toolchains',
         ]
-        logtxt, _= run_cmd("cd %s; eb %s" % (self.test_prefix, ' '.join(args)), simple=False)
+        logtxt, _ = run_cmd("cd %s; eb %s" % (self.test_prefix, ' '.join(args)), simple=False)
         self.assertTrue(tc_regex.search(logtxt), "Pattern '%s' found in: %s" % (tc_regex.pattern, logtxt))
 
     def test_cleanup_tmpdir(self):
@@ -2425,7 +2432,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
             shutil.rmtree(mytmpdir)
             modify_env(os.environ, self.orig_environ)
             tempfile.tempdir = None
-
 
         orig_tmpdir = tempfile.gettempdir()
         cand_tmpdirs = [
@@ -2776,7 +2782,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             r".*/toy-0.0-gompi-2018a-test.eb\s*\|",
             r"^\s*1 file(s?) changed",
             "^== pushing branch 'develop' to remote '.*' \(git@github.com:easybuilders/easybuild-easyconfigs.git\)",
-            r"^Updated easybuilders/easybuild-easyconfigs PR #2237 by pushing to branch easybuilders/develop \[DRY RUN\]",
+            r"^Updated easybuilders/easybuild-easyconfigs PR #2237 "
+            "by pushing to branch easybuilders/develop \[DRY RUN\]",
         ]
         self._assert_regexs(regexs, txt)
 
@@ -3281,7 +3288,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             args = ['toy-0.0.eb', '--force', '--debug']
             if zip_logs:
                 args.append(zip_logs)
-            out = self.eb_main(args, do_build=True)
+            self.eb_main(args, do_build=True)
 
             logs = glob.glob(os.path.join(toy_eb_install_dir, 'easybuild-toy-0.0*log*'))
             self.assertEqual(len(logs), 1, "Found exactly 1 log file in %s: %s" % (toy_eb_install_dir, logs))
@@ -3422,9 +3429,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # Check the parsing itself
         gcc_generic_flags = "march=x86-64 -mtune=generic"
         test_cases = [
-            ('',''),
-            ('xHost','xHost'),
-            ('GENERIC','GENERIC'),
+            ('', ''),
+            ('xHost', 'xHost'),
+            ('GENERIC', 'GENERIC'),
             ('Intel:xHost', {'Intel': 'xHost'}),
             ('Intel:GENERIC', {'Intel': 'GENERIC'}),
             ('Intel:xHost;GCC:%s' % gcc_generic_flags, {'Intel': 'xHost', 'GCC': gcc_generic_flags}),
@@ -3439,10 +3446,10 @@ class CommandLineOptionsTest(EnhancedTestCase):
     def test_check_contrib_style(self):
         """Test style checks performed by --check-contrib + dedicated --check-style option."""
         try:
-            import pycodestyle
+            import pycodestyle  # noqa
         except ImportError:
             try:
-                import pep8
+                import pep8  # noqa
             except ImportError:
                 print "Skipping test_check_contrib_style, since pycodestyle or pep8 is not available"
                 return
@@ -3519,7 +3526,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
             r"^>> One or more SHA256 checksums checks FAILED!",
         ]
         for pattern in patterns:
-            regex = re.compile(pattern, re.M)
             self.assertTrue(re.search(pattern, stdout, re.M), "Pattern '%s' found in: %s" % (pattern, stdout))
 
     def test_allow_use_as_root(self):
@@ -3878,5 +3884,7 @@ def suite():
     """ returns all the testcases in this module """
     return TestLoaderFiltered().loadTestsFromTestCase(CommandLineOptionsTest, sys.argv[1:])
 
+
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/package.py
+++ b/test/framework/package.py
@@ -267,4 +267,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/parallelbuild.py
+++ b/test/framework/parallelbuild.py
@@ -34,7 +34,6 @@ import sys
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
 
-import easybuild.tools.job.slurm as slurm
 from easybuild.framework.easyconfig.tools import process_easyconfig
 from easybuild.tools import config
 from easybuild.tools.filetools import adjust_permissions, mkdir, remove_dir, which, write_file
@@ -362,4 +361,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/repository.py
+++ b/test/framework/repository.py
@@ -74,7 +74,7 @@ class RepositoryTest(EnhancedTestCase):
         """Test using GitRepository."""
         # only run this test if git Python module is available
         try:
-            from git import GitCommandError
+            from git import GitCommandError  # noqa
         except ImportError:
             print "(skipping GitRepository test)"
             return
@@ -116,7 +116,7 @@ class RepositoryTest(EnhancedTestCase):
         """Test using SvnRepository."""
         # only run this test if pysvn Python module is available
         try:
-            from pysvn import ClientError
+            from pysvn import ClientError  # noqa
         except ImportError:
             print "(skipping SvnRepository test)"
             return
@@ -137,7 +137,7 @@ class RepositoryTest(EnhancedTestCase):
         """Test using HgRepository."""
         # only run this test if pysvn Python module is available
         try:
-            import hglib
+            import hglib  # noqa
         except ImportError:
             print "(skipping HgRepository test)"
             return
@@ -193,8 +193,10 @@ class RepositoryTest(EnhancedTestCase):
             path = repo.add_easyconfig(toy_yeb_file, 'test', '1.0', {'time': 1.23}, None)
             check_ec(path, [{'time': 1.23}])
 
-            path = repo.add_easyconfig(toy_yeb_file, 'test', '1.0', {'time': 1.23, 'size': 123}, [{'time': 0.9, 'size': 2}])
-            check_ec(path, [{'time': 0.9, 'size': 2}, {'time': 1.23, 'size': 123}])
+            stats1 = {'time': 1.23, 'size': 123}
+            stats2 = [{'time': 0.9, 'size': 2}]
+            path = repo.add_easyconfig(toy_yeb_file, 'test', '1.0', stats1, stats2)
+            check_ec(path, stats2 + [stats1])
 
             easybuild.tools.build_log.EXPERIMENTAL = orig_experimental
         else:
@@ -206,10 +208,12 @@ class RepositoryTest(EnhancedTestCase):
 
         shutil.rmtree(self.path, True)
 
+
 def suite():
     """ returns all the testcases in this module """
     return TestLoaderFiltered().loadTestsFromTestCase(RepositoryTest, sys.argv[1:])
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -1452,4 +1452,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -395,4 +395,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/scripts.py
+++ b/test/framework/scripts.py
@@ -226,4 +226,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/style.py
+++ b/test/framework/style.py
@@ -37,10 +37,10 @@ from vsc.utils import fancylogger
 from easybuild.framework.easyconfig.style import _eb_check_trailing_whitespace, check_easyconfigs_style
 
 try:
-    import pycodestyle
+    import pycodestyle  # noqa
 except ImportError:
     try:
-        import pep8
+        import pep8  # noqa
     except ImportError:
         pass
 
@@ -102,4 +102,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -31,7 +31,6 @@ Unit tests for systemtools.py
 import re
 import sys
 
-from os.path import exists as orig_os_path_exists
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
 
@@ -316,9 +315,11 @@ def mocked_run_cmd(cmd, **kwargs):
     else:
         return run_cmd(cmd, **kwargs)
 
+
 def mocked_uname():
     """Mocked version of platform.uname, with specified contents for known machine names."""
     return ('Linux', 'localhost', '3.16', '3.16', MACHINE_NAME, '')
+
 
 class SystemToolsTest(EnhancedTestCase):
     """ very basis FileRepository test, we don't want git / svn dependency """
@@ -355,8 +356,10 @@ class SystemToolsTest(EnhancedTestCase):
         """Test getting core count (mocked for Linux)."""
         st.get_os_type = lambda: st.LINUX
         orig_sched_getaffinity = st.sched_getaffinity
+
         class MockedSchedGetaffinity(object):
             cpus = [1L, 1L, 0L, 0L, 1L, 1L, 0L, 0L, 1L, 1L, 0L, 0L]
+
         st.sched_getaffinity = lambda: MockedSchedGetaffinity()
         self.assertEqual(get_avail_core_count(), 6)
         st.sched_getaffinity = orig_sched_getaffinity
@@ -627,12 +630,12 @@ class SystemToolsTest(EnhancedTestCase):
         ext = get_shared_lib_ext()
         self.assertTrue(ext in ['dylib', 'so'])
 
-    def test_shared_lib_ext_native(self):
+    def test_shared_lib_ext_linux(self):
         """Test getting extension for shared libraries (mocked for Linux)."""
         st.get_os_type = lambda: st.LINUX
         self.assertEqual(get_shared_lib_ext(), 'so')
 
-    def test_shared_lib_ext_native(self):
+    def test_shared_lib_ext_darwin(self):
         """Test getting extension for shared libraries (mocked for Darwin)."""
         st.get_os_type = lambda: st.DARWIN
         self.assertEqual(get_shared_lib_ext(), 'dylib')
@@ -675,7 +678,7 @@ class SystemToolsTest(EnhancedTestCase):
     def test_gcc_version_native(self):
         """Test getting gcc version."""
         gcc_version = get_gcc_version()
-        self.assertTrue(isinstance(gcc_version, basestring) or gcc_version == None)
+        self.assertTrue(isinstance(gcc_version, basestring) or gcc_version is None)
 
     def test_gcc_version_linux(self):
         """Test getting gcc version (mocked for Linux)."""
@@ -771,5 +774,7 @@ def suite():
     """ returns all the testcases in this module """
     return TestLoaderFiltered().loadTestsFromTestCase(SystemToolsTest, sys.argv[1:])
 
+
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1553,4 +1553,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/toolchainvariables.py
+++ b/test/framework/toolchainvariables.py
@@ -125,10 +125,10 @@ class ToolchainVariablesTest(EnhancedTestCase):
         # e.g. numpy and mkl blas
         # -Wl:-Bstatic,-Wl:--start-group,mkl_intel_lp64,mkl_intel_thread,mkl_core,-Wl:--end-group,-Wl:-Bdynamic,iomp5
         kwargs = {
-                  'prefix':'',
-                  'prefix_begin_end':'-Wl:',
-                  'separator':',',
-                  'separator_begin_end':',',
+                  'prefix': '',
+                  'prefix_begin_end': '-Wl:',
+                  'separator': ',',
+                  'separator_begin_end': ',',
                   }
         copy_blas_2.try_function_on_element('change', kwargs=kwargs)
         copy_blas_2.SEPARATOR = ','
@@ -167,5 +167,7 @@ def suite():
     """ return all the tests"""
     return TestLoaderFiltered().loadTestsFromTestCase(ToolchainVariablesTest, sys.argv[1:])
 
+
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -40,13 +40,10 @@ from distutils.version import LooseVersion
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from test.framework.package import mock_fpm
 from unittest import TextTestRunner
-from vsc.utils.fancylogger import setLogLevelDebug, logToScreen
 
 import easybuild.tools.hooks  # so we can reset cached hooks
 import easybuild.tools.module_naming_scheme  # required to dynamically load test module naming scheme(s)
 from easybuild.framework.easyconfig.easyconfig import EasyConfig
-from easybuild.framework.easyconfig.format.one import EB_FORMAT_EXTENSION
-from easybuild.framework.easyconfig.format.yeb import YEB_FORMAT_EXTENSION
 from easybuild.framework.easyconfig.parser import EasyConfigParser
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import get_module_syntax, get_repositorypath
@@ -260,7 +257,8 @@ class ToyBuildTest(EnhancedTestCase):
             self.assertTrue(re.search(r'^puts stderr "oh hai!"$', toy_module_txt, re.M))
         elif get_module_syntax() == 'Lua':
             self.assertTrue(re.search(r'^setenv\("FOO", "bar"\)', toy_module_txt, re.M))
-            self.assertTrue(re.search(r'^prepend_path\("SOMEPATH", pathJoin\(root, "foo/bar"\)\)$', toy_module_txt, re.M))
+            pattern = r'^prepend_path\("SOMEPATH", pathJoin\(root, "foo/bar"\)\)$'
+            self.assertTrue(re.search(pattern, toy_module_txt, re.M))
             self.assertTrue(re.search(r'^prepend_path\("SOMEPATH", pathJoin\(root, "baz"\)\)$', toy_module_txt, re.M))
             self.assertTrue(re.search(r'^prepend_path\("SOMEPATH", root\)$', toy_module_txt, re.M))
             mod_load_msg = r'^if mode\(\) == "load" then\n\s*io.stderr:write\(%s\)$' % modloadmsg_regex_lua
@@ -331,7 +329,8 @@ class ToyBuildTest(EnhancedTestCase):
     def test_toy_build_with_blocks(self):
         """Test a toy build with multiple blocks."""
         orig_sys_path = sys.path[:]
-        # add directory in which easyconfig file can be found to Python search path, since we're not specifying it full path below
+        # add directory in which easyconfig file can be found to Python search path,
+        # since we're not specifying it full path below
         tmpdir = tempfile.mkdtemp()
         # note get_paths_for expects easybuild/easyconfigs subdir
         ecs_path = os.path.join(tmpdir, "easybuild", "easyconfigs")
@@ -643,10 +642,8 @@ class ToyBuildTest(EnhancedTestCase):
                 self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
 
         write_file(test_ec, read_file(toy_ec) + "\ngroup = ('%s', 'custom message', 'extra item')\n" % group_name)
-        error_pattern = "Failed to get application instance.*: Found group spec in tuple format that is not a 2-tuple:"
         self.assertErrorRegex(SystemExit, '.*', self.eb_main, args, do_build=True,
                               raise_error=True, raise_systemexit=True)
-
 
     def test_allow_system_deps(self):
         """Test allow_system_deps easyconfig parameter."""
@@ -940,7 +937,8 @@ class ToyBuildTest(EnhancedTestCase):
 
             for modname in ['GCC', 'OpenMPI']:
                 regex = re.compile('load.*' + modname, re.M)
-                self.assertFalse(regex.search(toy_modtxt), "Pattern '%s' not found in: %s" % (regex.pattern, toy_modtxt))
+                self.assertFalse(regex.search(toy_modtxt),
+                                 "Pattern '%s' not found in: %s" % (regex.pattern, toy_modtxt))
 
     def test_toy_advanced(self):
         """Test toy build with extensions and non-dummy toolchain."""
@@ -1372,11 +1370,11 @@ class ToyBuildTest(EnhancedTestCase):
         args = common_args + ['--module-syntax=Tcl']
 
         # install module once (without --module-only), so it can be backed up
-        outtxt = self.eb_main(args, do_build=True, raise_error=True)
+        self.eb_main(args, do_build=True, raise_error=True)
         self.assertTrue(os.path.exists(toy_mod))
 
         # forced reinstall, no backup of module file because --backup-modules (or --module-only) is not used
-        outtxt = self.eb_main(args, do_build=True, raise_error=True)
+        self.eb_main(args, do_build=True, raise_error=True)
         self.assertTrue(os.path.exists(toy_mod))
         toy_mod_backups = glob.glob(os.path.join(toy_mod_dir, '.' + toy_mod_fn + '.bak_*'))
         self.assertEqual(len(toy_mod_backups), 0)
@@ -1384,7 +1382,7 @@ class ToyBuildTest(EnhancedTestCase):
         self.mock_stderr(True)
         self.mock_stdout(True)
         # note: no need to specificy --backup-modules, enabled automatically under --module-only
-        outtxt = self.eb_main(args + ['--module-only'], do_build=True, raise_error=True)
+        self.eb_main(args + ['--module-only'], do_build=True, raise_error=True)
         stderr = self.get_stderr()
         stdout = self.get_stdout()
         self.mock_stderr(False)
@@ -1835,7 +1833,7 @@ class ToyBuildTest(EnhancedTestCase):
 
         # also test use of --rpath-filter
         args.extend(['--rpath-filter=/test.*,/foo/bar.*', '--disable-cleanup-tmpdir'])
-        outtxt = self.test_toy_build(extra_args=args, raise_error=True)
+        self.test_toy_build(extra_args=args, raise_error=True)
 
         # check whether rpath filter was set correctly
         rpath_filter_paths = grab_gcc_rpath_wrapper_filter_arg().split(',')
@@ -2004,7 +2002,7 @@ def suite():
     """ return all the tests in this file """
     return TestLoaderFiltered().loadTestsFromTestCase(ToyBuildTest, sys.argv[1:])
 
+
 if __name__ == '__main__':
-    #logToScreen(enable=True)
-    #setLogLevelDebug()
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/tweak.py
+++ b/test/framework/tweak.py
@@ -318,4 +318,5 @@ def suite():
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/type_checking.py
+++ b/test/framework/type_checking.py
@@ -297,7 +297,7 @@ class TypeCheckingTest(EnhancedTestCase):
                               to_dependency, {'toolchain': 'lib, 1.2.8', 'versionsuffix': 'suff'})
         # too many values
         dep_spec = {'lib': '1.2.8', 'foo': '1.3', 'toolchain': 'lib, 1.2.8', 'versionsuffix': 'suff'}
-        self.assertErrorRegex(EasyBuildError, "Found unexpected \(key, value\) pair: .*", to_dependency, dep_spec)
+        self.assertErrorRegex(EasyBuildError, r"Found unexpected \(key, value\) pair: .*", to_dependency, dep_spec)
 
     def test_to_dependencies(self):
         """Test to_dependencies function."""

--- a/test/framework/type_checking.py
+++ b/test/framework/type_checking.py
@@ -257,18 +257,19 @@ class TypeCheckingTest(EnhancedTestCase):
         lib_dict.update({'versionsuffix': ''})
 
         # to_dependency doesn't touch values of non-dict type
-        self.assertEqual(to_dependency(('foo', '1.3')), ('foo','1.3'))
-        self.assertEqual(to_dependency(('foo', '1.3', '-suff', ('GCC', '4.8.2'))), ('foo', '1.3', '-suff', ('GCC','4.8.2')))
+        self.assertEqual(to_dependency(('foo', '1.3')), ('foo', '1.3'))
+        expected = ('foo', '1.3', '-suff', ('GCC', '4.8.2'))
+        self.assertEqual(to_dependency(('foo', '1.3', '-suff', ('GCC', '4.8.2'))), expected)
         self.assertEqual(to_dependency('foo/1.3'), 'foo/1.3')
 
-        self.assertEqual(to_dependency({'name':'fftw/3.3.4.2', 'external_module': True}),
-            {
-                'external_module': True,
-                'full_mod_name': 'fftw/3.3.4.2',
-                'name': None,
-                'short_mod_name': 'fftw/3.3.4.2',
-                'version': None,
-            })
+        expected = {
+            'external_module': True,
+            'full_mod_name': 'fftw/3.3.4.2',
+            'name': None,
+            'short_mod_name': 'fftw/3.3.4.2',
+            'version': None,
+        }
+        self.assertEqual(to_dependency({'name': 'fftw/3.3.4.2', 'external_module': True}), expected)
 
         foo_dict = {
             'name': 'foo',
@@ -293,10 +294,10 @@ class TypeCheckingTest(EnhancedTestCase):
 
         # no name/version
         self.assertErrorRegex(EasyBuildError, "Can not parse dependency without name and version: .*",
-            to_dependency, {'toolchain': 'lib, 1.2.8', 'versionsuffix': 'suff'})
+                              to_dependency, {'toolchain': 'lib, 1.2.8', 'versionsuffix': 'suff'})
         # too many values
-        self.assertErrorRegex(EasyBuildError, "Found unexpected \(key, value\) pair: .*",
-            to_dependency, {'lib': '1.2.8', 'foo':'1.3', 'toolchain': 'lib, 1.2.8', 'versionsuffix': 'suff'})
+        dep_spec = {'lib': '1.2.8', 'foo': '1.3', 'toolchain': 'lib, 1.2.8', 'versionsuffix': 'suff'}
+        self.assertErrorRegex(EasyBuildError, "Found unexpected \(key, value\) pair: .*", to_dependency, dep_spec)
 
     def test_to_dependencies(self):
         """Test to_dependencies function."""
@@ -317,7 +318,7 @@ class TypeCheckingTest(EnhancedTestCase):
             'foo/1.2.3',
             ('foo', '1.2.3'),
             ('bar', '4.5.6', '-test'),
-            ('foobar', '1.3.5', '', ('GCC','4.7.2')),
+            ('foobar', '1.3.5', '', ('GCC', '4.7.2')),
             {'name': 'toy', 'version': '0.0'},
             {'name': 'toy', 'version': '0.0', 'versionsuffix': '-bleh'},
             {'name': 'toy', 'version': '0.0', 'toolchain': {'name': 'gompi', 'version': '2015a'}},
@@ -381,7 +382,7 @@ class TypeCheckingTest(EnhancedTestCase):
         self.assertFalse(is_value_of_type(dependencies, DEPENDENCIES))
 
         # wrong keys (name/version is strictly required)
-        self.assertFalse(is_value_of_type([{'a':'b', 'c':'d'}], DEPENDENCIES))
+        self.assertFalse(is_value_of_type([{'a': 'b', 'c': 'd'}], DEPENDENCIES))
 
         # not a list
         self.assertFalse(is_value_of_type({'name': 'intel', 'version': '2015a'}, DEPENDENCIES))
@@ -424,7 +425,7 @@ class TypeCheckingTest(EnhancedTestCase):
         """Test as_hashable function."""
         hashable_value = (
             ('one', (1,)),
-            ('two', (1,2)),
+            ('two', (1, 2)),
         )
         self.assertEqual(as_hashable({'one': [1], 'two': [1, 2]}), hashable_value)
 
@@ -587,10 +588,12 @@ class TypeCheckingTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, error_msg, ensure_iterable_license_specs, (42,))
         self.assertErrorRegex(EasyBuildError, error_msg, ensure_iterable_license_specs, (42, 'foo'))
 
+
 def suite():
     """ returns all the testcases in this module """
     return TestLoaderFiltered().loadTestsFromTestCase(TypeCheckingTest, sys.argv[1:])
 
 
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/type_checking.py
+++ b/test/framework/type_checking.py
@@ -257,10 +257,13 @@ class TypeCheckingTest(EnhancedTestCase):
         lib_dict.update({'versionsuffix': ''})
 
         # to_dependency doesn't touch values of non-dict type
-        self.assertEqual(to_dependency(('foo', '1.3')), ('foo', '1.3'))
-        expected = ('foo', '1.3', '-suff', ('GCC', '4.8.2'))
-        self.assertEqual(to_dependency(('foo', '1.3', '-suff', ('GCC', '4.8.2'))), expected)
-        self.assertEqual(to_dependency('foo/1.3'), 'foo/1.3')
+        dep_specs = [
+            ('foo', '1.3'),
+            ('foo', '1.3', '-suff', ('GCC', '4.8.2')),
+            'foo/1.3',
+        ]
+        for dep_spec in dep_specs:
+            self.assertEqual(to_dependency(dep_spec), dep_spec)
 
         expected = {
             'external_module': True,

--- a/test/framework/variables.py
+++ b/test/framework/variables.py
@@ -42,7 +42,7 @@ class VariablesTest(EnhancedTestCase):
 
     def test_variables(self):
         class TestVariables(Variables):
-            MAP_CLASS = {'FOO':CommaList}
+            MAP_CLASS = {'FOO': CommaList}
 
         v = TestVariables()
         self.assertEqual(str(v), "{}")
@@ -58,7 +58,7 @@ class VariablesTest(EnhancedTestCase):
         v.nappend('BAR', 20)
         self.assertEqual(str(v['BAR']), "0 1 2 10 11 20")
 
-        v.nappend_el('BAR', 30, idx= -2)
+        v.nappend_el('BAR', 30, idx=-2)
         self.assertEqual(str(v), "{'BAR': [[0, 1, 2], [10, 11, 30], [20]]}")
         self.assertEqual(str(v['BAR']), '0 1 2 10 11 30 20')
 
@@ -89,9 +89,12 @@ class VariablesTest(EnhancedTestCase):
         v.join('FOOBAR', 'BAR')
         self.assertEqual(v['FOOBAR'], [])
 
+
 def suite():
     """ return all the tests"""
     return TestLoaderFiltered().loadTestsFromTestCase(VariablesTest, sys.argv[1:])
 
+
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/yeb.py
+++ b/test/framework/yeb.py
@@ -35,11 +35,11 @@ from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_
 from unittest import TextTestRunner
 
 import easybuild.tools.build_log
-from easybuild.framework.easyconfig.easyconfig import ActiveMNS, EasyConfig
+from easybuild.framework.easyconfig.easyconfig import EasyConfig
 from easybuild.framework.easyconfig.format.yeb import is_yeb_format
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import module_classes
-from easybuild.tools.filetools import read_file, write_file
+from easybuild.tools.filetools import read_file
 
 
 try:
@@ -122,7 +122,6 @@ class YebTest(EnhancedTestCase):
         self.assertFalse(is_yeb_format(test_eb, None))
         self.assertFalse(is_yeb_format(None, raw_eb))
 
-
     def test_join(self):
         """ Test yaml_join function """
         # skip test if yaml module was not loaded
@@ -141,11 +140,10 @@ class YebTest(EnhancedTestCase):
         ]
 
         # import here for testing yaml_join separately
-        from easybuild.framework.easyconfig.format.yeb import yaml_join
+        from easybuild.framework.easyconfig.format.yeb import yaml_join  # noqa
         loaded = yaml.load('\n'.join(stream))
         for key in ['fb1', 'fb2', 'fb3']:
             self.assertEqual(loaded.get(key), 'foobar')
-
 
     def test_bad_toolchain_format(self):
         """ Test alternate toolchain format name,version """
@@ -157,7 +155,8 @@ class YebTest(EnhancedTestCase):
         testdir = os.path.dirname(os.path.abspath(__file__))
         test_easyconfigs = os.path.join(testdir, 'easyconfigs', 'yeb')
         expected = r'Can not convert list .* to toolchain dict. Expected 2 or 3 elements'
-        self.assertErrorRegex(EasyBuildError, expected, EasyConfig, os.path.join(test_easyconfigs, 'bzip-bad-toolchain.yeb'))
+        self.assertErrorRegex(EasyBuildError, expected, EasyConfig,
+                              os.path.join(test_easyconfigs, 'bzip-bad-toolchain.yeb'))
 
     def test_external_module_toolchain(self):
         """Test specifying external (build) dependencies in yaml format."""
@@ -183,9 +182,12 @@ class YebTest(EnhancedTestCase):
         self.assertEqual(ec.dependencies()[1]['full_mod_name'], 'fftw/3.3.4.0')
         self.assertEqual(ec.dependencies()[1]['external_module_metadata'], metadata)
 
+
 def suite():
     """ returns all the testcases in this module """
     return TestLoaderFiltered().loadTestsFromTestCase(YebTest, sys.argv[1:])
 
+
 if __name__ == '__main__':
-    TextTestRunner(verbosity=1).run(suite())
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))


### PR DESCRIPTION
Running a test subsuite always results in a zero exit code (suggesting success), regardless of whether any tests failed or not, which is stupid/annoying.

I fixed a whole bunch of style issues in the test modules while I was fixing this, which makes this PR look scary, but the changes are all trivial...

No tests were harmed in the process, and all changes are limited to `test/*`