### PR TITLE
silence printed deprecation warnings for easyconfigs/toolchains based on 'silent' build option

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -574,9 +574,14 @@ class EasyConfig(object):
             depr_msgs.append("toolchain '%(name)s/%(version)s' is marked as deprecated" % self['toolchain'])
 
         if depr_msgs:
+            depr_msg = ', '.join(depr_msgs)
+
             depr_maj_ver = int(str(VERSION).split('.')[0]) + 1
+            depr_ver = '%s.0' % depr_maj_ver
+
             more_info_depr_ec = " (see also http://easybuild.readthedocs.org/en/latest/Deprecated-easyconfigs.html)"
-            self.log.deprecated(', '.join(depr_msgs), '%s.0' % depr_maj_ver, more_info=more_info_depr_ec)
+
+            self.log.deprecated(depr_msg, depr_ver, more_info=more_info_depr_ec, silent=build_option('silent'))
 
     def validate(self, check_osdeps=True):
         """

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -121,7 +121,7 @@ class EasyBuildLog(fancylogger.FancyLogger):
             msg = common_msg + " (use --experimental option to enable): " + msg
             raise EasyBuildError(msg, *args)
 
-    def deprecated(self, msg, ver, max_ver=None, more_info=None, *args, **kwargs):
+    def deprecated(self, msg, ver, max_ver=None, more_info=None, silent=False, *args, **kwargs):
         """
         Print deprecation warning or raise an exception, depending on specified version(s)
 
@@ -130,12 +130,14 @@ class EasyBuildLog(fancylogger.FancyLogger):
                     else: version to check against max_ver to determine warning vs exception
         :param max_ver: version threshold for warning vs exception (compared to 'ver')
         :param more_info: additional message with instructions where to get more information
+        :param silent: stay silent (don't *print* deprecation warnings, only log them)
         """
         # provide log_callback function that both logs a warning and prints to stderr
         def log_callback_warning_and_print(msg):
             """Log warning message, and also print it to stderr."""
             self.warning(msg)
-            sys.stderr.write('\nWARNING: ' + msg + '\n\n')
+            if not silent:
+                sys.stderr.write('\nWARNING: ' + msg + '\n\n')
 
         kwargs['log_callback'] = log_callback_warning_and_print
 

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -109,6 +109,7 @@ class BuildLogTest(EnhancedTestCase):
         log.deprecated("anotherwarning", newer_ver)
         log.deprecated("onemorewarning", '1.0', '2.0')
         log.deprecated("lastwarning", '1.0', max_ver='2.0')
+        log.deprecated("thisisnotprinted", '1.0', max_ver='2.0', silent=True)
         log.error("kaput")
         log.error("err: %s", 'msg: %s')
         stderr = self.get_stderr()
@@ -138,6 +139,7 @@ class BuildLogTest(EnhancedTestCase):
             r"%s.test_easybuildlog \[WARNING\] :: Deprecated functionality.*anotherwarning.*" % root,
             r"%s.test_easybuildlog \[WARNING\] :: Deprecated functionality.*onemorewarning.*" % root,
             r"%s.test_easybuildlog \[WARNING\] :: Deprecated functionality.*lastwarning.*" % root,
+            r"%s.test_easybuildlog \[WARNING\] :: Deprecated functionality.*thisisnotprinted.*" % root,
             r"%s.test_easybuildlog \[ERROR\] :: EasyBuild crashed with an error \(at .* in .*\): kaput" % root,
             root + r".test_easybuildlog \[ERROR\] :: EasyBuild crashed with an error \(at .* in .*\): err: msg: %s",
             r"%s.test_easybuildlog \[ERROR\] :: .*EasyBuild encountered an exception \(at .* in .*\): oops" % root,


### PR DESCRIPTION
This should get rid of the stream of `WARNING: Deprecated functionality` messages being printed in the easyconfigs tests, while still printing them during normal use of `eb`.