### PR TITLE
avoid printing of messages/warnings in framework test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,11 @@ script:
     # check GitHub configuration
     - eb --check-github --github-user=easybuild_test
     # run test suite
-    - python -O -m test.framework.suite
+    - python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
+    # try and make sure output of running tests is clean (no printed messages/warnings)
+    - ignore_patterns = "vsc\.install\.shared_setup|no GitHub token available|skipping SvnRepository test|python2.6/site-packages/urllib3/util/ssl_.py"
+    - prints_count=$(cat test_framework_suite.log | grep -v $ignore_patterns | grep -c '\.\n*[A-Za-z]')
+    - test $prints_count -eq 0 || (echo "Found $prints_count printed messages in output of test suite" && exit 1)
     # check bootstrap script version
     # version and SHA256 checksum are hardcoded below to avoid forgetting to update the version in the script along with contents
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ script:
     - python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
     # try and make sure output of running tests is clean (no printed messages/warnings)
     - IGNORE_PATTERNS="vsc\.install\.shared_setup|no GitHub token available|skipping SvnRepository test|lib/python2.6/site-packages"
-    - PRINTS_COUNT=$(cat test_framework_suite.log | egrep -v "${IGNORE_PATTERNS}" | grep -c '\.\n*[A-Za-z]')
+    - PRINTS_COUNT=$(cat test_framework_suite.log | egrep -v "${IGNORE_PATTERNS}" | grep -c '\.\n*[A-Za-z]' || true)
     - test "$PRINTS_COUNT" = "0" || (echo "Found $PRINTS_COUNT printed messages in output of test suite" && exit 1)
     # check bootstrap script version
     # version and SHA256 checksum are hardcoded below to avoid forgetting to update the version in the script along with contents

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,9 +101,9 @@ script:
     # run test suite
     - python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
     # try and make sure output of running tests is clean (no printed messages/warnings)
-    - ignore_patterns="vsc\.install\.shared_setup|no GitHub token available|skipping SvnRepository test|lib/python2.6/site-packages"
-    - prints_count=$(cat test_framework_suite.log | egrep -v "${ignore_patterns}" | grep -c '\.\n*[A-Za-z]')
-    - test $prints_count -eq 0 || (echo "Found $prints_count printed messages in output of test suite" && exit 1)
+    - IGNORE_PATTERNS="vsc\.install\.shared_setup|no GitHub token available|skipping SvnRepository test|lib/python2.6/site-packages"
+    - PRINTS_COUNT=$(cat test_framework_suite.log | egrep -v "${IGNORE_PATTERNS}" | grep -c '\.\n*[A-Za-z]')
+    - test "$PRINTS_COUNT" = "0" || (echo "Found $PRINTS_COUNT printed messages in output of test suite" && exit 1)
     # check bootstrap script version
     # version and SHA256 checksum are hardcoded below to avoid forgetting to update the version in the script along with contents
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ script:
     - IGNORE_PATTERNS="vsc\.install\.shared_setup|no GitHub token available|skipping SvnRepository test|lib/python2.6/site-packages|required Lmod as modules tool"
     # '|| true' is needed to avoid that Travis stops the job on non-zero exit of grep (i.e. when there are no matches)
     - PRINTED_MSG=$(egrep -v "${IGNORE_PATTERNS}" test_framework_suite.log | grep '\.\n*[A-Za-z]' || true)
-    - test -z "$PRINTED_MSG" || (echo "Found printed messages in output of test suite: $PRINTED_MSG" && exit 1)
+    - test "x$PRINTED_MSG" = "x" || (echo "Found printed messages in output of test suite\n${PRINTED_MSG}" && exit 1)
     # check bootstrap script version
     # version and SHA256 checksum are hardcoded below to avoid forgetting to update the version in the script along with contents
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ script:
     - python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
     # try and make sure output of running tests is clean (no printed messages/warnings)
     - ignore_patterns="vsc\.install\.shared_setup|no GitHub token available|skipping SvnRepository test|lib/python2.6/site-packages"
-    - prints_count=$(cat test_framework_suite.log | grep -v ${ignore_patterns} | grep -c '\.\n*[A-Za-z]')
+    - prints_count=$(cat test_framework_suite.log | grep -v "${ignore_patterns}" | grep -c '\.\n*[A-Za-z]')
     - test $prints_count -eq 0 || (echo "Found $prints_count printed messages in output of test suite" && exit 1)
     # check bootstrap script version
     # version and SHA256 checksum are hardcoded below to avoid forgetting to update the version in the script along with contents

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,8 +101,8 @@ script:
     # run test suite
     - python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
     # try and make sure output of running tests is clean (no printed messages/warnings)
-    - ignore_patterns = "vsc\.install\.shared_setup|no GitHub token available|skipping SvnRepository test|python2.6/site-packages/urllib3/util/ssl_.py"
-    - prints_count=$(cat test_framework_suite.log | grep -v $ignore_patterns | grep -c '\.\n*[A-Za-z]')
+    - ignore_patterns="vsc\.install\.shared_setup|no GitHub token available|skipping SvnRepository test|lib/python2.6/site-packages"
+    - prints_count=$(cat test_framework_suite.log | grep -v ${ignore_patterns} | grep -c '\.\n*[A-Za-z]')
     - test $prints_count -eq 0 || (echo "Found $prints_count printed messages in output of test suite" && exit 1)
     # check bootstrap script version
     # version and SHA256 checksum are hardcoded below to avoid forgetting to update the version in the script along with contents

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,8 +102,9 @@ script:
     - python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
     # try and make sure output of running tests is clean (no printed messages/warnings)
     - IGNORE_PATTERNS="vsc\.install\.shared_setup|no GitHub token available|skipping SvnRepository test|lib/python2.6/site-packages|required Lmod as modules tool"
-    - PRINTS_COUNT=$(cat test_framework_suite.log | egrep -v "${IGNORE_PATTERNS}" | grep -c '\.\n*[A-Za-z]' || true)
-    - test "$PRINTS_COUNT" = "0" || (echo "Found $PRINTS_COUNT printed messages in output of test suite" && exit 1)
+    # '|| true' is needed to avoid that Travis stops the job on non-zero exit of grep (i.e. when there are no matches)
+    - PRINTED_MSG=$(egrep -v "${IGNORE_PATTERNS}" test_framework_suite.log | grep '\.\n*[A-Za-z]' || true)
+    - test -z "$PRINTED_MSG" || (echo "Found printed messages in output of test suite: $PRINTED_MSG" && exit 1)
     # check bootstrap script version
     # version and SHA256 checksum are hardcoded below to avoid forgetting to update the version in the script along with contents
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ script:
     - python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
     # try and make sure output of running tests is clean (no printed messages/warnings)
     - ignore_patterns="vsc\.install\.shared_setup|no GitHub token available|skipping SvnRepository test|lib/python2.6/site-packages"
-    - prints_count=$(cat test_framework_suite.log | grep -v "${ignore_patterns}" | grep -c '\.\n*[A-Za-z]')
+    - prints_count=$(cat test_framework_suite.log | egrep -v "${ignore_patterns}" | grep -c '\.\n*[A-Za-z]')
     - test $prints_count -eq 0 || (echo "Found $prints_count printed messages in output of test suite" && exit 1)
     # check bootstrap script version
     # version and SHA256 checksum are hardcoded below to avoid forgetting to update the version in the script along with contents

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,7 +101,7 @@ script:
     # run test suite
     - python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
     # try and make sure output of running tests is clean (no printed messages/warnings)
-    - IGNORE_PATTERNS="vsc\.install\.shared_setup|no GitHub token available|skipping SvnRepository test|lib/python2.6/site-packages"
+    - IGNORE_PATTERNS="vsc\.install\.shared_setup|no GitHub token available|skipping SvnRepository test|lib/python2.6/site-packages|required Lmod as modules tool"
     - PRINTS_COUNT=$(cat test_framework_suite.log | egrep -v "${IGNORE_PATTERNS}" | grep -c '\.\n*[A-Za-z]' || true)
     - test "$PRINTS_COUNT" = "0" || (echo "Found $PRINTS_COUNT printed messages in output of test suite" && exit 1)
     # check bootstrap script version

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -941,6 +941,9 @@ class EasyConfig(object):
             ectxt = autopep8.fix_code(ectxt, options=autopep8_opts)
             self.log.debug("Dumped easyconfig after autopep8 reformatting: %s", ectxt)
 
+        if not ectxt.endswith('\n'):
+            ectxt += '\n'
+
         write_file(fp, ectxt, always_overwrite=always_overwrite, backup=backup, verbose=backup)
 
         self.enable_templating = orig_enable_templating
@@ -1679,7 +1682,7 @@ def robot_find_subtoolchain_for_dep(dep, modtool, parent_tc=None, parent_first=F
         warning_msg = "Failed to determine toolchain hierarchy for %(name)s/%(version)s when determining " % parent_tc
         warning_msg += "subtoolchain for dependency '%s': %s" % (dep['name'], err)
         _log.warning(warning_msg)
-        print_warning(warning_msg)
+        print_warning(warning_msg, silent=build_option('silent'))
         toolchain_hierarchy = []
 
     # start with subtoolchains first, i.e. first (dummy or) compiler-only toolchain, etc.,

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -100,7 +100,8 @@ def tweak(easyconfigs, build_specs, modtool, targetdirs=None):
         # Make sure there are no more build_specs, as combining --try-toolchain* with other options is currently not
         # supported
         if any(key not in ['toolchain_name', 'toolchain_version', 'toolchain'] for key in keys):
-            print_warning("Combining --try-toolchain* with other build options is not fully supported: using regex")
+            warning_msg = "Combining --try-toolchain* with other build options is not fully supported: using regex"
+            print_warning(warning_msg, silent=build_option('silent'))
             revert_to_regex = True
 
         if not revert_to_regex:
@@ -743,7 +744,7 @@ def match_minimum_tc_specs(source_tc_spec, target_tc_hierarchy):
     # Warn if we are changing compiler families, this is very likely to cause problems
     if target_compiler_family != source_tc_spec['comp_family']:
         print_warning("Your request will result in a compiler family switch (%s to %s). Here be dragons!" %
-                      (source_tc_spec['comp_family'], target_compiler_family))
+                      (source_tc_spec['comp_family'], target_compiler_family), silent=build_option('silent'))
 
     return minimal_matching_toolchain
 

--- a/easybuild/toolchains/mpi/openmpi.py
+++ b/easybuild/toolchains/mpi/openmpi.py
@@ -35,6 +35,7 @@ from distutils.version import LooseVersion
 
 import easybuild.tools.environment as env
 from easybuild.tools.build_log import print_warning
+from easybuild.tools.config import build_option
 from easybuild.tools.toolchain.constants import COMPILER_VARIABLES, MPI_COMPILER_VARIABLES
 from easybuild.tools.toolchain.mpi import Mpi
 from easybuild.tools.toolchain.variables import CommandFlagList
@@ -84,7 +85,7 @@ class OpenMPI(Mpi):
                 env.setvar('TMPDIR', tmpdir)
                 warn_msg = "Long $TMPDIR path may cause problems with OpenMPI 2.x, using shorter path: %s" % tmpdir
                 self.log.warning(warn_msg)
-                print_warning(warn_msg)
+                print_warning(warn_msg, silent=build_option('silent'))
 
     def _set_mpi_compiler_variables(self):
         """Define MPI wrapper commands (depends on OpenMPI version) and add OMPI_* variables to set."""

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -136,8 +136,7 @@ class EasyBuildLog(fancylogger.FancyLogger):
         def log_callback_warning_and_print(msg):
             """Log warning message, and also print it to stderr."""
             self.warning(msg)
-            if not silent:
-                sys.stderr.write('\nWARNING: ' + msg + '\n\n')
+            print_warning(msg, silent=silent)
 
         kwargs['log_callback'] = log_callback_warning_and_print
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -447,7 +447,6 @@ def pypi_source_urls(pkg_name):
     tmpdir = tempfile.mkdtemp()
     urls_html = os.path.join(tmpdir, '%s_urls.html' % pkg_name)
     if download_file(os.path.basename(urls_html), simple_url, urls_html) is None:
-        print("Failed to download %s to determine available PyPI URLs for %s" % (simple_url, pkg_name))
         _log.debug("Failed to download %s to determine available PyPI URLs for %s", simple_url, pkg_name)
         res = []
     else:

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -222,7 +222,7 @@ def write_file(path, txt, append=False, forced=False, backup=False, always_overw
             backed_up_fp = back_up_file(path)
             _log.info("Existing file %s backed up to %s", path, backed_up_fp)
             if verbose:
-                print_msg("Backup of %s created at %s" % (path, backed_up_fp))
+                print_msg("Backup of %s created at %s" % (path, backed_up_fp), silent=build_option('silent'))
 
     # note: we can't use try-except-finally, because Python 2.4 doesn't support it as a single block
     try:

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -832,10 +832,10 @@ class ModulesTool(object):
                 elif action == IGNORE:
                     self.log.info(msg + ", but ignoring as configured")
                 elif action == UNSET:
-                    print_warning(msg + "; unsetting them")
+                    print_warning(msg + "; unsetting them", silent=build_option('silent'))
                     unset_env_vars(eb_module_keys)
                 else:
-                    print_warning(msg + msg_control)
+                    print_warning(msg + msg_control, silent=build_option('silent'))
 
             if loaded_eb_modules:
                 opt = '--detect-loaded-modules={%s}' % ','.join(LOADED_MODULES_ACTIONS)
@@ -863,21 +863,21 @@ class ModulesTool(object):
 
                 elif action == PURGE:
                     msg = "Found non-allowed loaded (EasyBuild-generated) modules (%s), running 'module purge'"
-                    print_warning(msg % ', '.join(loaded_eb_modules))
+                    print_warning(msg % ', '.join(loaded_eb_modules), silent=build_option('silent'))
 
                     self.log.info(msg)
                     self.purge()
 
                 elif action == UNLOAD:
                     msg = "Unloading non-allowed loaded (EasyBuild-generated) modules: %s"
-                    print_warning(msg % ', '.join(loaded_eb_modules))
+                    print_warning(msg % ', '.join(loaded_eb_modules), silent=build_option('silent'))
 
                     self.log.info(msg)
                     self.unload(loaded_eb_modules[::-1])
 
                 else:
                     # default behaviour is just to print out a warning and continue
-                    print_warning(verbose_msg)
+                    print_warning(verbose_msg, silent=build_option('silent'))
 
     def read_module_file(self, mod_name):
         """

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -367,6 +367,8 @@ class EasyBlockTest(EnhancedTestCase):
 
     def test_make_module_extra(self):
         """Test for make_module_extra."""
+        init_config(build_options={'silent': True})
+
         self.contents = '\n'.join([
             'easyblock = "ConfigureMake"',
             'name = "pi"',
@@ -456,6 +458,8 @@ class EasyBlockTest(EnhancedTestCase):
 
     def test_make_module_dep(self):
         """Test for make_module_dep"""
+        init_config(build_options={'silent': True})
+
         self.contents = '\n'.join([
             'easyblock = "ConfigureMake"',
             'name = "pi"',
@@ -545,6 +549,7 @@ class EasyBlockTest(EnhancedTestCase):
         build_options = {
             'check_osdeps': False,
             'robot_path': [test_ecs_path],
+            'silent': True,
             'valid_stops': all_stops,
             'validate': False,
         }
@@ -625,6 +630,8 @@ class EasyBlockTest(EnhancedTestCase):
 
     def test_extensions_step(self):
         """Test the extensions_step"""
+        init_config(build_options={'silent': True})
+
         self.contents = '\n'.join([
             'easyblock = "ConfigureMake"',
             'name = "pi"',
@@ -660,6 +667,8 @@ class EasyBlockTest(EnhancedTestCase):
 
     def test_skip_extensions_step(self):
         """Test the skip_extensions_step"""
+        init_config(build_options={'silent': True})
+
         self.contents = '\n'.join([
             'easyblock = "ConfigureMake"',
             'name = "pi"',
@@ -1134,7 +1143,7 @@ class EasyBlockTest(EnhancedTestCase):
 
     def test_check_readiness(self):
         """Test check_readiness method."""
-        init_config(build_options={'validate': False})
+        init_config(build_options={'validate': False, 'silent': True})
 
         # check that check_readiness step works (adding dependencies, etc.)
         ec_file = 'OpenMPI-2.1.2-GCC-6.4.0-2.28.eb'
@@ -1257,6 +1266,8 @@ class EasyBlockTest(EnhancedTestCase):
 
     def test_extensions_sanity_check(self):
         """Test sanity check aspect of extensions."""
+        init_config(build_options={'silent': True})
+
         test_ecs_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'easyconfigs', 'test_ecs')
         toy_ec_fn = os.path.join(test_ecs_dir, 't', 'toy', 'toy-0.0-gompi-2018a-test.eb')
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -60,8 +60,8 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import module_classes
 from easybuild.tools.configobj import ConfigObj
 from easybuild.tools.docs import avail_easyconfig_constants, avail_easyconfig_templates
-from easybuild.tools.filetools import adjust_permissions, copy_file, mkdir, read_file, remove_file, symlink
-from easybuild.tools.filetools import write_file
+from easybuild.tools.filetools import adjust_permissions, change_dir, copy_file, mkdir, read_file, remove_file
+from easybuild.tools.filetools import symlink, write_file
 from easybuild.tools.module_naming_scheme.toolchain import det_toolchain_compilers, det_toolchain_mpi
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.options import parse_external_modules_metadata
@@ -201,6 +201,8 @@ class EasyConfigTest(EnhancedTestCase):
 
     def test_dependency(self):
         """ test all possible ways of specifying dependencies """
+        init_config(build_options={'silent': True})
+
         self.contents = '\n'.join([
             'easyblock = "ConfigureMake"',
             'name = "pi"',
@@ -271,6 +273,8 @@ class EasyConfigTest(EnhancedTestCase):
 
     def test_extra_options(self):
         """ extra_options should allow other variables to be stored """
+        init_config(build_options={'silent': True})
+
         self.contents = '\n'.join([
             'easyblock = "ConfigureMake"',
             'name = "pi"',
@@ -509,6 +513,9 @@ class EasyConfigTest(EnhancedTestCase):
 
     def test_obtain_easyconfig(self):
         """test obtaining an easyconfig file given certain specifications"""
+        init_config(build_options={'silent': True})
+
+        change_dir(self.test_prefix)
 
         tcname = 'GCC'
         tcver = '4.6.3'
@@ -1067,7 +1074,9 @@ class EasyConfigTest(EnhancedTestCase):
 
         orig_value = easybuild.tools.build_log.CURRENT_VERSION
         easybuild.tools.build_log.CURRENT_VERSION = '3.9'
+        self.mock_stderr(True)
         self.assertEqual(get_easyblock_class(None, name='gzip', default_fallback=False), None)
+        self.mock_stderr(False)
         easybuild.tools.build_log.CURRENT_VERSION = orig_value
 
     def test_letter_dir(self):
@@ -1719,7 +1728,7 @@ class EasyConfigTest(EnhancedTestCase):
             regex = re.compile(pattern, re.M)
             self.assertTrue(regex.search(ectxt), "Pattern '%s' found in: %s" % (regex.pattern, ectxt))
 
-        self.assertTrue(ectxt.endswith("# trailing comment"))
+        self.assertTrue(ectxt.endswith("# trailing comment\n"))
 
         # reparsing the dumped easyconfig file should work
         EasyConfig(testec)
@@ -1909,6 +1918,8 @@ class EasyConfigTest(EnhancedTestCase):
 
     def test_copy(self):
         """Test copy method of EasyConfig object."""
+        init_config(build_options={'silent': True})
+
         test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         ec1 = EasyConfig(os.path.join(test_easyconfigs, 't', 'toy', 'toy-0.0.eb'))
 
@@ -1940,6 +1951,7 @@ class EasyConfigTest(EnhancedTestCase):
 
     def test_copy_easyconfigs(self):
         """Test copy_easyconfigs function."""
+        init_config(build_options={'silent': True})
         test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
 
         target_dir = os.path.join(self.test_prefix, 'copied_ecs')
@@ -2437,6 +2449,7 @@ class EasyConfigTest(EnhancedTestCase):
 
     def test_filename(self):
         """Test filename method of EasyConfig class."""
+        init_config(build_options={'silent': True})
         test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
 
         test_ecs = [

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -149,7 +149,13 @@ class GithubTest(EnhancedTestCase):
 
         expected = "PR #1: a pr"
 
+        self.mock_stdout(True)
         output = gh.list_prs(parameters, per_page=1, github_user=GITHUB_TEST_ACCOUNT)
+        stdout = self.get_stdout()
+        self.mock_stdout(False)
+
+        self.assertTrue(stdout.startswith("== Listing PRs with parameters: "))
+
         self.assertEqual(expected, output)
 
     def test_reasons_for_closing(self):

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -402,6 +402,7 @@ class GithubTest(EnhancedTestCase):
             'use_existing_modules': True,
             'external_modules_metadata': ConfigObj(),
             'robot_path': [ec_path],
+            'silent': True,
             'valid_module_classes': module_classes(),
             'validate': False,
         })

--- a/test/framework/lib.py
+++ b/test/framework/lib.py
@@ -54,7 +54,8 @@ class EasyBuildLibTest(EnhancedTestCase):
         super(EasyBuildLibTest, self).setUp()
 
         # make sure BuildOptions instance is re-created
-        del BuildOptions._instances[BuildOptions]
+        if BuildOptions in BuildOptions._instances:
+            del BuildOptions._instances[BuildOptions]
 
         self.tmpdir = tempfile.mkdtemp()
 

--- a/test/framework/lib.py
+++ b/test/framework/lib.py
@@ -69,7 +69,8 @@ class EasyBuildLibTest(EnhancedTestCase):
         """Utility function to set up EasyBuild configuration."""
 
         # wipe BuildOption singleton instance, so it gets re-created when set_up_configuration is called
-        del BuildOptions._instances[BuildOptions]
+        if BuildOptions in BuildOptions._instances:
+            del BuildOptions._instances[BuildOptions]
 
         self.assertFalse(BuildOptions in BuildOptions._instances)
         set_up_configuration(silent=True)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -261,7 +261,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.eb_main(args, do_build=True)
 
         args.append('--skip')
+        self.mock_stdout(True)
         outtxt = self.eb_main(args, do_build=True, verbose=True)
+        self.mock_stdout(False)
 
         found_msg = "Module toy/0.0 found.\n[^\n]+Going to skip actual main build"
         found = re.search(found_msg, outtxt, re.M)

--- a/test/framework/package.py
+++ b/test/framework/package.py
@@ -179,6 +179,8 @@ class PackageTest(EnhancedTestCase):
 
     def test_active_pns(self):
         """Test use of ActivePNS."""
+        init_config(build_options={'silent': True})
+
         topdir = os.path.dirname(os.path.abspath(__file__))
         test_easyconfigs = os.path.join(topdir, 'easyconfigs', 'test_ecs')
         test_ec = os.path.join(test_easyconfigs, 'o', 'OpenMPI', 'OpenMPI-2.1.2-GCC-6.4.0-2.28.eb')

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -1419,7 +1419,7 @@ class RobotTest(EnhancedTestCase):
 
         # we must allow use of deprecated toolchain in this case
         self.allow_deprecated_behaviour()
-        init_config()
+        init_config(build_options={'silent': True})
 
         test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
 
@@ -1439,6 +1439,7 @@ class RobotTest(EnhancedTestCase):
         init_config(build_options={
             'consider_archived_easyconfigs': True,
             'robot_path': [test_ecs],
+            'silent': True,
         })
         res = resolve_dependencies(ecs, self.modtool, retain_all_deps=True)
         self.assertEqual([ec['full_mod_name'] for ec in res], ['intel/2012a', 'gzip/1.5-intel-2012a'])

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -122,23 +122,13 @@ tests = [gen, bl, o, r, ef, ev, ebco, ep, e, mg, m, mt, f, run, a, robot, b, v, 
          tw, p, i, pkg, d, env, et, y, st, h, ct, lib]
 
 SUITE = unittest.TestSuite([x.suite() for x in tests])
-
-# uses XMLTestRunner if possible, so we can output an XML file that can be supplied to Jenkins
-xml_msg = ""
-try:
-    import xmlrunner  # requires unittest-xml-reporting package
-    xml_dir = 'test-reports'
-    res = xmlrunner.XMLTestRunner(output=xml_dir, verbosity=1).run(SUITE)
-    xml_msg = ", XML output of tests available in %s directory" % xml_dir
-except ImportError, err:
-    sys.stderr.write("WARNING: xmlrunner module not available, falling back to using unittest...\n\n")
-    res = unittest.TextTestRunner().run(SUITE)
+res = unittest.TextTestRunner().run(SUITE)
 
 fancylogger.logToFile(log_fn, enable=False)
 
 if not res.wasSuccessful():
     sys.stderr.write("ERROR: Not all tests were successful.\n")
-    print "Log available at %s" % log_fn, xml_msg
+    print "Log available at %s" % log_fn
     sys.exit(2)
 else:
     for fn in glob.glob('%s*' % log_fn):

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -63,6 +63,8 @@ class ToolchainTest(EnhancedTestCase):
         self.orig_get_cpu_model = st.get_cpu_model
         self.orig_get_cpu_vendor = st.get_cpu_vendor
 
+        init_config(build_options={'silent': True})
+
     def tearDown(self):
         """Cleanup after toolchain test."""
         st.get_cpu_architecture = self.orig_get_cpu_architecture
@@ -312,8 +314,7 @@ class ToolchainTest(EnhancedTestCase):
         """Test whether overriding the optarch flag works."""
         flag_vars = ['CFLAGS', 'CXXFLAGS', 'FCFLAGS', 'FFLAGS', 'F90FLAGS']
         for optarch_var in ['march=lovelylovelysandybridge', None]:
-            build_options = {'optarch': optarch_var}
-            init_config(build_options=build_options)
+            init_config(build_options={'optarch': optarch_var, 'silent': True})
             for enable in [True, False]:
                 tc = self.get_toolchain('foss', version='2018a')
                 tc.set_options({'optarch': enable})
@@ -337,8 +338,7 @@ class ToolchainTest(EnhancedTestCase):
         """Test whether --optarch=GENERIC works as intended."""
         for generic in [False, True]:
             if generic:
-                build_options = {'optarch': 'GENERIC'}
-                init_config(build_options=build_options)
+                init_config(build_options={'optarch': 'GENERIC', 'silent': True})
             flag_vars = ['CFLAGS', 'CXXFLAGS', 'FCFLAGS', 'FFLAGS', 'F90FLAGS']
             tcs = {
                 'gompi': ('2018a', "-march=x86-64 -mtune=generic"),
@@ -410,8 +410,7 @@ class ToolchainTest(EnhancedTestCase):
             optarch_var['Intel'] = intel_flags
             optarch_var['GCC'] = gcc_flags
             optarch_var['GCCcore'] = gcccore_flags
-            build_options = {'optarch': optarch_var}
-            init_config(build_options=build_options)
+            init_config(build_options={'optarch': optarch_var, 'silent': True})
             tc = self.get_toolchain(toolchain, version=toolchain_ver)
             tc.set_options({'optarch': enable})
             tc.prepare()
@@ -774,7 +773,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertTrue(mpi_cmd_for_re.match(tc.mpi_cmd_for('test', 4)))
 
         # test specifying custom template for MPI commands
-        init_config(build_options={'mpi_cmd_template': "mpiexec -np %(nr_ranks)s -- %(cmd)s"})
+        init_config(build_options={'mpi_cmd_template': "mpiexec -np %(nr_ranks)s -- %(cmd)s", 'silent': True})
         self.assertEqual(tc.mpi_cmd_for('test123', '7'), "mpiexec -np 7 -- test123")
 
     def test_prepare_deps(self):
@@ -933,7 +932,7 @@ class ToolchainTest(EnhancedTestCase):
         """Test independency of toolchain instances."""
 
         # tweaking --optarch is required for Cray toolchains (craypre-<optarch> module must be available)
-        init_config(build_options={'optarch': 'test'})
+        init_config(build_options={'optarch': 'test', 'silent': True})
 
         tc_cflags = {
             'CrayCCE': "-O2 -homp -craype-verbose",
@@ -1366,7 +1365,7 @@ class ToolchainTest(EnhancedTestCase):
         os.environ['PATH'] = '%s:%s' % (os.path.join(self.test_prefix, 'fake'), os.getenv('PATH', ''))
 
         # enable --rpath and prepare toolchain
-        init_config(build_options={'rpath': True, 'rpath_filter': ['/ba.*']})
+        init_config(build_options={'rpath': True, 'rpath_filter': ['/ba.*'], 'silent': True})
         tc = self.get_toolchain('gompi', version='2018a')
 
         # preparing RPATH wrappers requires --experimental, need to bypass that here
@@ -1466,6 +1465,9 @@ class ToolchainTest(EnhancedTestCase):
 
     def test_prepare_openmpi_tmpdir(self):
         """Test handling of long $TMPDIR path for OpenMPI 2.x"""
+
+        # this test relies on warnings being printed
+        init_config(build_options={'silent': False})
 
         def prep():
             """Helper function: create & prepare toolchain"""

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -606,7 +606,10 @@ class ToyBuildTest(EnhancedTestCase):
                 write_file(test_ec, read_file(toy_ec) + "\ngroup = '%s'\n" % group)
             else:
                 write_file(test_ec, read_file(toy_ec) + "\ngroup = %s\n" % str(group))
+
+            self.mock_stdout(True)
             outtxt = self.eb_main(args, logfile=dummylogfn, do_build=True, raise_error=True, raise_systemexit=True)
+            self.mock_stdout(False)
 
             if get_module_syntax() == 'Tcl':
                 pattern = "Can't generate robust check in TCL modules for users belonging to group %s." % group_name
@@ -1510,7 +1513,9 @@ class ToyBuildTest(EnhancedTestCase):
         self.test_toy_build(['--packagepath=%s' % pkgpath])
         self.assertFalse(os.path.exists(pkgpath), "%s is not created without use of --package" % pkgpath)
 
+        self.mock_stdout(True)
         self.test_toy_build(extra_args=['--package', '--skip'], verify=False)
+        self.mock_stdout(False)
 
         toypkg = os.path.join(pkgpath, 'toy-0.0-eb-%s.1.rpm' % EASYBUILD_VERSION)
         self.assertTrue(os.path.exists(toypkg), "%s is there" % toypkg)

--- a/test/framework/tweak.py
+++ b/test/framework/tweak.py
@@ -70,6 +70,8 @@ class TweakTest(EnhancedTestCase):
 
     def test_obtain_ec_for(self):
         """Test obtain_ec_for function."""
+        init_config(build_options={'silent': True})
+
         test_easyconfigs_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         # find existing easyconfigs
         specs = {
@@ -144,8 +146,7 @@ class TweakTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, error_pattern, tweak_one, toy_ec, tweaked_toy_ec, {'version': '1.2.3'})
 
         # existing file does get overwritten when --force is used
-        build_options = {'force': True}
-        init_config(build_options=build_options)
+        init_config(build_options={'force': True, 'silent': True})
         write_file(tweaked_toy_ec, '')
         tweak_one(toy_ec, tweaked_toy_ec, {'version': '1.2.3'})
         tweaked_toy_ec_parsed = EasyConfigParser(tweaked_toy_ec).get_config_dict()
@@ -187,8 +188,9 @@ class TweakTest(EnhancedTestCase):
         """Test matching a toolchain to lowest possible in a hierarchy"""
         test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         init_config(build_options={
-            'valid_module_classes': module_classes(),
             'robot_path': test_easyconfigs,
+            'silent': True,
+            'valid_module_classes': module_classes(),
         })
         get_toolchain_hierarchy.clear()
         foss_hierarchy = get_toolchain_hierarchy({'name': 'foss', 'version': '2018a'}, incl_capabilities=True)
@@ -247,8 +249,9 @@ class TweakTest(EnhancedTestCase):
         """Test mapping between two toolchain hierarchies"""
         test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         init_config(build_options={
-            'valid_module_classes': module_classes(),
             'robot_path': test_easyconfigs,
+            'silent': True,
+            'valid_module_classes': module_classes(),
         })
         get_toolchain_hierarchy.clear()
         foss_tc = {'name': 'foss', 'version': '2018a'}
@@ -290,8 +293,9 @@ class TweakTest(EnhancedTestCase):
         """Test mapping of easyconfig to target hierarchy"""
         test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         init_config(build_options={
-            'valid_module_classes': module_classes(),
             'robot_path': test_easyconfigs,
+            'silent': True,
+            'valid_module_classes': module_classes(),
         })
         get_toolchain_hierarchy.clear()
 

--- a/test/framework/yeb.py
+++ b/test/framework/yeb.py
@@ -71,6 +71,7 @@ class YebTest(EnhancedTestCase):
         build_options = {
             'check_osdeps': False,
             'external_modules_metadata': {},
+            'silent': True,
             'valid_module_classes': module_classes(),
         }
         init_config(build_options=build_options)


### PR DESCRIPTION
The `silent` build option is only set to `True` when the tests are run (and since there's no direct option for it, it can't be controlled easily during normal use of `eb`)

fixes complaint made in #2771