### PR TITLE
prepend location of test easyblocks to $PYTHONPATH to test_generate_software_list, rather than append

### DIFF
--- a/test/framework/scripts.py
+++ b/test/framework/scripts.py
@@ -66,7 +66,7 @@ class ScriptsTest(EnhancedTestCase):
         test_dir = os.path.abspath(os.path.dirname(__file__))
         eb_blocks_path = os.path.join(test_dir, 'sandbox')
         pythonpath = os.environ.get('PYTHONPATH', os.path.dirname(test_dir))
-        os.environ['PYTHONPATH'] = os.pathsep.join([pythonpath, eb_blocks_path])
+        os.environ['PYTHONPATH'] = os.pathsep.join([eb_blocks_path, pythonpath])
 
         testdir = os.path.dirname(__file__)
         topdir = os.path.dirname(os.path.dirname(testdir))


### PR DESCRIPTION
`test_generate_software_list` fails when `easybuild-easyblocks` repo is also included in `$PYTHONPATH`