### PR TITLE
put fake 'vsc' namespace in place that produces an error on import

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -71,7 +71,7 @@ from easybuild.tools.docs import avail_cfgfile_constants, avail_easyconfig_const
 from easybuild.tools.docs import avail_toolchain_opts, avail_easyconfig_params, avail_easyconfig_templates
 from easybuild.tools.docs import list_easyblocks, list_toolchains
 from easybuild.tools.environment import restore_env, unset_env_vars
-from easybuild.tools.filetools import CHECKSUM_TYPE_SHA256, CHECKSUM_TYPES
+from easybuild.tools.filetools import CHECKSUM_TYPE_SHA256, CHECKSUM_TYPES, install_fake_vsc
 from easybuild.tools.github import GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO
 from easybuild.tools.github import GITHUB_PR_DIRECTION_DESC, GITHUB_PR_ORDER_CREATED, GITHUB_PR_STATE_OPEN
 from easybuild.tools.github import GITHUB_PR_STATES, GITHUB_PR_ORDERS, GITHUB_PR_DIRECTIONS
@@ -1310,6 +1310,9 @@ def set_up_configuration(args=None, logfile=None, testing=False, silent=False):
     # initialise the EasyBuild configuration & build options
     init(options, config_options_dict)
     init_build_options(build_options=build_options, cmdline_options=options)
+
+    # set up fake 'vsc' Python package, to catch easyblocks/scripts that still import from vsc.* namespace
+    install_fake_vsc()
 
     return eb_go, (build_specs, log, logfile, robot_path, search_query, tmpdir, try_to_generate, tweaked_ecs_paths)
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1805,6 +1805,30 @@ class FileToolsTest(EnhancedTestCase):
         ]:
             self.assertFalse(ft.is_sha256_checksum(not_a_sha256_checksum))
 
+    def test_fake_vsc(self):
+        """Test whether importing from 'vsc.*' namespace results in an error after calling install_fake_vsc."""
+
+        ft.install_fake_vsc()
+
+        self.mock_stderr(True)
+        self.mock_stdout(True)
+        try:
+            import vsc  # noqa
+            self.assertTrue(False, "'import vsc' results in an error")
+        except SystemExit:
+            pass
+
+        stderr = self.get_stderr()
+        stdout = self.get_stdout()
+        self.mock_stderr(False)
+        self.mock_stdout(False)
+
+        self.assertEqual(stdout, '')
+
+        error_pattern = r"Detected import from 'vsc' namespace in .*/test/framework/filetools.py \(line [0-9]+\)"
+        regex = re.compile(r"^\nERROR: %s" % error_pattern)
+        self.assertTrue(regex.search(stderr), "Pattern '%s' found in: %s" % (regex.pattern, stderr))
+
 
 def suite():
     """ returns all the testcases in this module """


### PR DESCRIPTION
Since we ingested `vsc-base` & `vsc-install` into the EasyBuild framework (cfr. #2708) we should actively prevent imports from the `vsc.*` namespace, since it can cause problems (see for example #2745).

This injects a fake `vsc` namespace early on, that catches any `import vsc.*` or `from vsc.* import ...` statements, and exits with a clear error, for example:

```
$ eb GCCcore-6.3.0.eb
== temporary log file in case of crash /tmp/eb-c1eTh9/easybuild-yR5zsp.log

ERROR: Detected import from 'vsc' namespace in /Users/kehoste/work/easybuild-easyblocks/easybuild/easyblocks/g/gcc.py (line 42)
vsc-base & vsc-install were ingested into the EasyBuild framework in EasyBuild v4.0
The functionality you need may be available in the 'easybuild.base.*' namespace.
```