### PR TITLE
fix UnicodeDecodeError on command output using 'replace' mode in run_cmd & run_cmd_qa

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -212,7 +212,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
     while ec is None:
         # need to read from time to time.
         # - otherwise the stdout/stderr buffer gets filled and it all stops working
-        output = proc.stdout.read(read_size).decode()
+        output = proc.stdout.read(read_size).decode(errors='replace')
         if cmd_log:
             cmd_log.write(output)
         if stream_output:
@@ -221,7 +221,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
         ec = proc.poll()
 
     # read remaining data (all of it)
-    output = proc.stdout.read().decode()
+    output = proc.stdout.read().decode(errors='replace')
     if cmd_log:
         cmd_log.write(output)
         cmd_log.close()
@@ -379,7 +379,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
         # need to read from time to time.
         # - otherwise the stdout/stderr buffer gets filled and it all stops working
         try:
-            out = recv_some(p).decode()
+            out = recv_some(p).decode(errors='replace')
             if cmd_log:
                 cmd_log.write(out)
             stdout_err += out
@@ -450,7 +450,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
     # Process stopped. Read all remaining data
     try:
         if p.stdout:
-            out = p.stdout.read().decode()
+            out = p.stdout.read().decode(errors='replace')
             stdout_err += out
             if cmd_log:
                 cmd_log.write(out)

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -212,7 +212,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
     while ec is None:
         # need to read from time to time.
         # - otherwise the stdout/stderr buffer gets filled and it all stops working
-        output = proc.stdout.read(read_size).decode(errors='replace')
+        output = proc.stdout.read(read_size).decode('utf-8', 'replace')
         if cmd_log:
             cmd_log.write(output)
         if stream_output:
@@ -221,7 +221,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
         ec = proc.poll()
 
     # read remaining data (all of it)
-    output = proc.stdout.read().decode(errors='replace')
+    output = proc.stdout.read().decode('utf-8', 'replace')
     if cmd_log:
         cmd_log.write(output)
         cmd_log.close()
@@ -379,7 +379,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
         # need to read from time to time.
         # - otherwise the stdout/stderr buffer gets filled and it all stops working
         try:
-            out = recv_some(p).decode(errors='replace')
+            out = recv_some(p).decode('utf-8', 'replace')
             if cmd_log:
                 cmd_log.write(out)
             stdout_err += out
@@ -450,7 +450,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
     # Process stopped. Read all remaining data
     try:
         if p.stdout:
-            out = p.stdout.read().decode(errors='replace')
+            out = p.stdout.read().decode('utf-8', 'replace')
             stdout_err += out
             if cmd_log:
                 cmd_log.write(out)

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -77,7 +77,7 @@ class RunTest(EnhancedTestCase):
 
         (out, ec) = run_cmd(cmd)
         self.assertEqual(ec, 0)
-        self.assertEqual(out, "foo � bar")
+        self.assertTrue(out.startswith('foo ') and out.endswith(' bar'))
 
     def test_run_cmd_log(self):
         """Test logging of executed commands."""
@@ -213,7 +213,8 @@ class RunTest(EnhancedTestCase):
 
         (out, ec) = run_cmd_qa(cmd, qa)
         self.assertEqual(ec, 0)
-        self.assertEqual(out, "question\nanswer\nfoo � bar")
+        self.assertTrue(out.startswith("question\nanswer\nfoo "))
+        self.assertTrue(out.endswith('bar'))
 
     def test_run_cmd_qa_log_all(self):
         """Test run_cmd_qa with log_output enabled"""


### PR DESCRIPTION
Fix for following error I ran into when building `GCCcore/7.3.0` using `eb` on top of Python 3.6:

```
== 2019-03-01 21:27:11,214 run.py:174 DEBUG run_cmd: running cmd  make -j 8  (in /home/kehoste/py3/build/GCCcore/7.3.0/dummy-/gcc-7.3.0/stage1_obj)
== 2019-03-01 21:27:11,214 run.py:193 INFO running cmd:  make -j 8
== 2019-03-01 21:31:02,063 build_log.py:164 ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:124 in __init__): Traceback (most recent call last):
  File "/home/kehoste/easybuild-framework/easybuild/main.py", line 112, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/home/kehoste/easybuild-framework/easybuild/framework/easyblock.py", line 2861, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/home/kehoste/easybuild-framework/easybuild/framework/easyblock.py", line 2771, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/home/kehoste/easybuild-framework/easybuild/framework/easyblock.py", line 2637, in run_step
    step_method(self)()
  File "/home/kehoste/easybuild-easyblocks/easybuild/easyblocks/g/gcc.py", line 408, in build_step
    run_cmd(cmd, log_all=True, simple=True)
  File "/home/kehoste/easybuild-framework/easybuild/tools/run.py", line 88, in cache_aware_func
    res = func(cmd, *args, **kwargs)
  File "/home/kehoste/easybuild-framework/easybuild/tools/run.py", line 215, in run_cmd
    output = proc.stdout.read(read_size).decode()
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2 in position 8191: unexpected end of data
 (at easybuild/main.py:145 in build_and_install_software)
```

The `make` output includes weird characters that have to be dealt with.

I was able to reproduce the problem in the tests by running `cat` on a file that contains similar characters, which are now being replaced with '`�`'