### PR TITLE
avoid TypeError when checking gompi/iccifort/iimpi/intel versions for deprecation

### DIFF
--- a/easybuild/toolchains/gompi.py
+++ b/easybuild/toolchains/gompi.py
@@ -40,8 +40,13 @@ class Gompi(GccToolchain, OpenMPI):
 
     def is_deprecated(self):
         """Return whether or not this toolchain is deprecated."""
+        # need to transform a version like '2016a' with something that is safe to compare with '2000'
+        # comparing subversions that include letters causes TypeErrors in Python 3
+        # 'a' is assumed to be equivalent with '.01' (January), and 'b' with '.07' (June) (good enough for this purpose)
+        version = self.version.replace('a', '.01').replace('b', '.07')
+
         # deprecate oldest gompi toolchains (versions 1.x)
-        if LooseVersion(self.version) < LooseVersion('2000'):
+        if LooseVersion(version) < LooseVersion('2000'):
             deprecated = True
         else:
             deprecated = False

--- a/easybuild/toolchains/iccifort.py
+++ b/easybuild/toolchains/iccifort.py
@@ -45,8 +45,14 @@ class IccIfort(IntelIccIfort):
 
     def is_deprecated(self):
         """Return whether or not this toolchain is deprecated."""
+
+        # need to transform a version like '2016a' with something that is safe to compare with '2016.01'
+        # comparing subversions that include letters causes TypeErrors in Python 3
+        # 'a' is assumed to be equivalent with '.01' (January), and 'b' with '.07' (June) (good enough for this purpose)
+        version = self.version.replace('a', '.01').replace('b', '.07')
+
         # iccifort toolchains older than iccifort/2016.1.150-* are deprecated
-        if LooseVersion(self.version) < LooseVersion('2016.1'):
+        if LooseVersion(version) < LooseVersion('2016.1'):
             deprecated = True
         else:
             deprecated = False

--- a/easybuild/toolchains/iimpi.py
+++ b/easybuild/toolchains/iimpi.py
@@ -43,9 +43,14 @@ class Iimpi(IccIfort, IntelMPI):
 
     def is_deprecated(self):
         """Return whether or not this toolchain is deprecated."""
+        # need to transform a version like '2016a' with something that is safe to compare with '8.0', '2000', '2016.01'
+        # comparing subversions that include letters causes TypeErrors in Python 3
+        # 'a' is assumed to be equivalent with '.01' (January), and 'b' with '.07' (June) (good enough for this purpose)
+        version = self.version.replace('a', '.01').replace('b', '.07')
+
         # iimpi toolchains older than iimpi/2016.01 are deprecated
         # iimpi 8.1.5 is an exception, since it used in intel/2016a (which is not deprecated yet)
-        iimpi_ver = LooseVersion(self.version)
+        iimpi_ver = LooseVersion(version)
         if iimpi_ver < LooseVersion('8.0'):
             deprecated = True
         elif iimpi_ver > LooseVersion('2000') and iimpi_ver < LooseVersion('2016.01'):

--- a/easybuild/toolchains/intel.py
+++ b/easybuild/toolchains/intel.py
@@ -47,11 +47,15 @@ class Intel(Iimpi, IntelMKL, IntelFFTW):
 
     def is_deprecated(self):
         """Return whether or not this toolchain is deprecated."""
+        # need to transform a version like '2016a' with something that is safe to compare with '2016.01'
+        # comparing subversions that include letters causes TypeErrors in Python 3
+        # 'a' is assumed to be equivalent with '.01' (January), and 'b' with '.07' (June) (good enough for this purpose)
+        version = self.version.replace('a', '.01').replace('b', '.07')
+
         # intel toolchains older than intel/2016a are deprecated
         # take into account that intel/2016.x is always < intel/2016a according to LooseVersion;
         # intel/2016.01 & co are not deprecated yet...
-        intel_ver = LooseVersion(self.version)
-        if intel_ver < LooseVersion('2016a') and intel_ver < LooseVersion('2016.01'):
+        if LooseVersion(version) < LooseVersion('2016.01'):
             deprecated = True
         else:
             deprecated = False


### PR DESCRIPTION
Example error that is fixed with this change:

```
Traceback (most recent call last):
  ...
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 390, in __init__
    self.check_deprecated(self.path)
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 571, in check_deprecated
    if self.toolchain.is_deprecated():
  File "/Volumes/work/easybuild-framework/easybuild/toolchains/iimpi.py", line 51, in is_deprecated
    elif iimpi_ver > LooseVersion('2000') and iimpi_ver < LooseVersion('2016.01'):
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/version.py", line 52, in __lt__
    c = self._cmp(other)
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/version.py", line 337, in _cmp
    if self.version < other.version:
TypeError: '<' not supported between instances of 'str' and 'int'
```