### PR TITLE
take into account possible 'system' version when checking toolchain versions for deprecation

### DIFF
--- a/easybuild/toolchains/gompi.py
+++ b/easybuild/toolchains/gompi.py
@@ -28,6 +28,7 @@ EasyBuild support for gompi compiler toolchain (includes GCC and OpenMPI).
 :author: Kenneth Hoste (Ghent University)
 """
 from distutils.version import LooseVersion
+import re
 
 from easybuild.toolchains.gcc import GccToolchain
 from easybuild.toolchains.mpi.openmpi import OpenMPI
@@ -46,7 +47,8 @@ class Gompi(GccToolchain, OpenMPI):
         version = self.version.replace('a', '.01').replace('b', '.07')
 
         # deprecate oldest gompi toolchains (versions 1.x)
-        if LooseVersion(version) < LooseVersion('2000'):
+        # make sure a non-symbolic version (e.g., 'system') is used before making comparisons using LooseVersion
+        if re.match('^[0-9]', version) and LooseVersion(version) < LooseVersion('2000'):
             deprecated = True
         else:
             deprecated = False

--- a/easybuild/toolchains/iccifort.py
+++ b/easybuild/toolchains/iccifort.py
@@ -29,6 +29,7 @@ EasyBuild support for Intel compilers toolchain (icc, ifort)
 :author: Kenneth Hoste (Ghent University)
 """
 from distutils.version import LooseVersion
+import re
 
 from easybuild.toolchains.compiler.inteliccifort import IntelIccIfort
 from easybuild.toolchains.gcccore import GCCcore
@@ -52,7 +53,8 @@ class IccIfort(IntelIccIfort):
         version = self.version.replace('a', '.01').replace('b', '.07')
 
         # iccifort toolchains older than iccifort/2016.1.150-* are deprecated
-        if LooseVersion(version) < LooseVersion('2016.1'):
+        # make sure a non-symbolic version (e.g., 'system') is used before making comparisons using LooseVersion
+        if re.match('^[0-9]', version) and LooseVersion(version) < LooseVersion('2016.1'):
             deprecated = True
         else:
             deprecated = False

--- a/easybuild/toolchains/iimpi.py
+++ b/easybuild/toolchains/iimpi.py
@@ -29,6 +29,7 @@ EasyBuild support for intel compiler toolchain (includes Intel compilers (icc, i
 :author: Kenneth Hoste (Ghent University)
 """
 from distutils.version import LooseVersion
+import re
 
 from easybuild.toolchains.iccifort import IccIfort
 from easybuild.toolchains.mpi.intelmpi import IntelMPI
@@ -48,14 +49,15 @@ class Iimpi(IccIfort, IntelMPI):
         # 'a' is assumed to be equivalent with '.01' (January), and 'b' with '.07' (June) (good enough for this purpose)
         version = self.version.replace('a', '.01').replace('b', '.07')
 
-        # iimpi toolchains older than iimpi/2016.01 are deprecated
-        # iimpi 8.1.5 is an exception, since it used in intel/2016a (which is not deprecated yet)
-        iimpi_ver = LooseVersion(version)
-        if iimpi_ver < LooseVersion('8.0'):
-            deprecated = True
-        elif iimpi_ver > LooseVersion('2000') and iimpi_ver < LooseVersion('2016.01'):
-            deprecated = True
-        else:
-            deprecated = False
+        deprecated = False
+        # make sure a non-symbolic version (e.g., 'system') is used before making comparisons using LooseVersion
+        if re.match('^[0-9]', version):
+            iimpi_ver = LooseVersion(version)
+            # iimpi toolchains older than iimpi/2016.01 are deprecated
+            # iimpi 8.1.5 is an exception, since it used in intel/2016a (which is not deprecated yet)
+            if iimpi_ver < LooseVersion('8.0'):
+                deprecated = True
+            elif iimpi_ver > LooseVersion('2000') and iimpi_ver < LooseVersion('2016.01'):
+                deprecated = True
 
         return deprecated

--- a/easybuild/toolchains/intel.py
+++ b/easybuild/toolchains/intel.py
@@ -30,6 +30,7 @@ Intel Math Kernel Library (MKL), and Intel FFTW wrappers).
 :author: Kenneth Hoste (Ghent University)
 """
 from distutils.version import LooseVersion
+import re
 
 from easybuild.toolchains.iimpi import Iimpi
 from easybuild.toolchains.iimkl import Iimkl
@@ -55,7 +56,8 @@ class Intel(Iimpi, IntelMKL, IntelFFTW):
         # intel toolchains older than intel/2016a are deprecated
         # take into account that intel/2016.x is always < intel/2016a according to LooseVersion;
         # intel/2016.01 & co are not deprecated yet...
-        if LooseVersion(version) < LooseVersion('2016.01'):
+        # make sure a non-symbolic version (e.g., 'system') is used before making comparisons using LooseVersion
+        if re.match('^[0-9]', version) and LooseVersion(version) < LooseVersion('2016.01'):
             deprecated = True
         else:
             deprecated = False


### PR DESCRIPTION
(follow-up for #2792)

Fixes problem that occurs with `impi-system-iccifort-system-GCC-system-2.29.eb`:

```
== temporary log file in case of crash /Users/kehoste/work/TMP/eb-bdxowi2b/easybuild-y4dxr7j9.log
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Volumes/work/easybuild-framework/easybuild/main.py", line 454, in <module>
    main()
  File "/Volumes/work/easybuild-framework/easybuild/main.py", line 321, in main
    easyconfigs, generated_ecs = parse_easyconfigs(paths, validate=not options.inject_checksums)
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyconfig/tools.py", line 389, in parse_easyconfigs
    easyconfigs.extend(process_easyconfig(ec_file, **kwargs))
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 1489, in process_easyconfig
    ec = EasyConfig(spec, build_specs=build_specs, validate=validate, hidden=hidden)
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 390, in __init__
    self.check_deprecated(self.path)
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 571, in check_deprecated
    if self.toolchain.is_deprecated():
  File "/Volumes/work/easybuild-framework/easybuild/toolchains/iccifort.py", line 55, in is_deprecated
    if LooseVersion(version) < LooseVersion('2016.1'):
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/version.py", line 52, in __lt__
    c = self._cmp(other)
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/distutils/version.py", line 337, in _cmp
    if self.version < other.version:
TypeError: '<' not supported between instances of 'str' and 'int'