### PR TITLE
Use pid in backup name candidate to reduce risk of two processes colliding.

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1303,7 +1303,7 @@ def find_backup_name_candidate(src_file):
     timestamp = datetime.datetime.now()
     dst_file = '%s_%s_%s' % (src_file, timestamp.strftime('%Y%m%d%H%M%S'), os.getpid())
     while os.path.exists(dst_file):
-        _log.debug("Backup of %s at %s_%s already found at %s, trying again in a second...", src_file, timestamp, os.getpid())
+        _log.debug("Backup of %s at %s already found at %s, trying again in a second...", src_file, dst_file, timestamp)
         time.sleep(1)
         timestamp = datetime.datetime.now()
         dst_file = '%s_%s_%s' % (src_file, timestamp.strftime('%Y%m%d%H%M%S'), os.getpid())

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1301,12 +1301,12 @@ def find_backup_name_candidate(src_file):
 
     # e.g. 20170817234510 on Aug 17th 2017 at 23:45:10
     timestamp = datetime.datetime.now()
-    dst_file = '%s_%s' % (src_file, timestamp.strftime('%Y%m%d%H%M%S'))
+    dst_file = '%s_%s_%s' % (src_file, timestamp.strftime('%Y%m%d%H%M%S'), os.getpid())
     while os.path.exists(dst_file):
-        _log.debug("Backup of %s at %s already found at %s, trying again in a second...", src_file, timestamp)
+        _log.debug("Backup of %s at %s_%s already found at %s, trying again in a second...", src_file, timestamp, os.getpid())
         time.sleep(1)
         timestamp = datetime.datetime.now()
-        dst_file = '%s_%s' % (src_file, timestamp.strftime('%Y%m%d%H%M%S'))
+        dst_file = '%s_%s_%s' % (src_file, timestamp.strftime('%Y%m%d%H%M%S'), os.getpid())
 
     return dst_file
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1607,7 +1607,7 @@ class FileToolsTest(EnhancedTestCase):
         ft.write_file(test_file, 'foo')
 
         # timestamp should be exactly 14 digits (year, month, day, hours, minutes, seconds)
-        regex = re.compile('^test\.txt_[0-9]{14}$')
+        regex = re.compile('^test\.txt_[0-9]{14}_[0-9]+$')
 
         res = ft.find_backup_name_candidate(test_file)
         self.assertTrue(os.path.samefile(os.path.dirname(res), self.test_prefix))

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1607,7 +1607,7 @@ class FileToolsTest(EnhancedTestCase):
         ft.write_file(test_file, 'foo')
 
         # timestamp should be exactly 14 digits (year, month, day, hours, minutes, seconds)
-        regex = re.compile('^test\.txt_[0-9]{14}_[0-9]+$')
+        regex = re.compile(r'^test\.txt_[0-9]{14}_[0-9]+$')
 
         res = ft.find_backup_name_candidate(test_file)
         self.assertTrue(os.path.samefile(os.path.dirname(res), self.test_prefix))

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3644,7 +3644,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         patterns = [
             "^== injecting sha256 checksums in .*/test\.eb$",
             "^== fetching sources & patches for test\.eb\.\.\.$",
-            "^== backup of easyconfig file saved to .*/test\.eb\.bak_[0-9]+\.\.\.$",
+            "^== backup of easyconfig file saved to .*/test\.eb\.bak_[0-9]+_[0-9]+\.\.\.$",
             "^== injecting sha256 checksums for sources & patches in test\.eb\.\.\.$",
             "^== \* toy-0.0\.tar\.gz: %s$" % toy_source_sha256,
             "^== \* toy-0\.0_fix-silly-typo-in-printf-statement\.patch: %s$" % toy_patch_sha256,
@@ -3750,7 +3750,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         patterns = [
             "^== injecting md5 checksums in .*/test\.eb$",
             "^== fetching sources & patches for test\.eb\.\.\.$",
-            "^== backup of easyconfig file saved to .*/test\.eb\.bak_[0-9]+\.\.\.$",
+            "^== backup of easyconfig file saved to .*/test\.eb\.bak_[0-9]+_[0-9]+\.\.\.$",
             "^== injecting md5 checksums for sources & patches in test\.eb\.\.\.$",
             "^== \* toy-0.0\.tar\.gz: be662daa971a640e40be5c804d9d7d10$",
             "^== \* toy-0\.0_fix-silly-typo-in-printf-statement\.patch: e6785e1a721fc8bf79892e3ef41557c0$",

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1420,7 +1420,7 @@ class ToyBuildTest(EnhancedTestCase):
         # check that backup module is hidden (required for Tcl syntax)
         self.assertTrue(os.path.basename(first_toy_mod_backup).startswith('.'))
 
-        toy_mod_bak = ".*/toy/\.0\.0-deps\.bak_[0-9]+_[0-9]+"
+        toy_mod_bak = r".*/toy/\.0\.0-deps\.bak_[0-9]+_[0-9]+"
         regex = re.compile("^== backup of existing module file stored at %s" % toy_mod_bak, re.M)
         self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
         regex = re.compile("^== comparing module file with backup %s; no differences found$" % toy_mod_bak, re.M)
@@ -1483,7 +1483,7 @@ class ToyBuildTest(EnhancedTestCase):
             self.assertTrue('.bak_' in os.path.basename(first_toy_lua_mod_backup))
             self.assertFalse(os.path.basename(first_toy_lua_mod_backup).startswith('.'))
 
-            toy_mod_bak = ".*/toy/0\.0-deps\.bak_[0-9]+_[0-9]+"
+            toy_mod_bak = r".*/toy/0\.0-deps\.bak_[0-9]+_[0-9]+"
             regex = re.compile("^== backup of existing module file stored at %s" % toy_mod_bak, re.M)
             self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
             regex = re.compile("^== comparing module file with backup %s; no differences found$" % toy_mod_bak, re.M)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1420,7 +1420,7 @@ class ToyBuildTest(EnhancedTestCase):
         # check that backup module is hidden (required for Tcl syntax)
         self.assertTrue(os.path.basename(first_toy_mod_backup).startswith('.'))
 
-        toy_mod_bak = ".*/toy/\.0\.0-deps\.bak_[0-9]*"
+        toy_mod_bak = ".*/toy/\.0\.0-deps\.bak_[0-9]+_[0-9]+"
         regex = re.compile("^== backup of existing module file stored at %s" % toy_mod_bak, re.M)
         self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
         regex = re.compile("^== comparing module file with backup %s; no differences found$" % toy_mod_bak, re.M)
@@ -1483,7 +1483,7 @@ class ToyBuildTest(EnhancedTestCase):
             self.assertTrue('.bak_' in os.path.basename(first_toy_lua_mod_backup))
             self.assertFalse(os.path.basename(first_toy_lua_mod_backup).startswith('.'))
 
-            toy_mod_bak = ".*/toy/0\.0-deps\.bak_[0-9]*"
+            toy_mod_bak = ".*/toy/0\.0-deps\.bak_[0-9]+_[0-9]+"
             regex = re.compile("^== backup of existing module file stored at %s" % toy_mod_bak, re.M)
             self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
             regex = re.compile("^== comparing module file with backup %s; no differences found$" % toy_mod_bak, re.M)


### PR DESCRIPTION
The reprod dir quite often clashes between two builds when submitting build jobs to cluster.