### PR TITLE
fix UnicodeEncodeError raised from run_cmd with Python 2.7

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -118,7 +118,7 @@ def get_output_from_process(proc, read_size=None, asynchronous=False):
     # * in Python 2, .decode() returns a value of type 'unicode',
     #   but we really want a regular 'str' value (which is also why we use 'ignore' for encoding errors)
     # * in Python 3, .decode() returns a 'str' value when called on the 'bytes' value obtained from .read()
-    output = str(output.decode('utf-8', 'ignore'))
+    output = str(output.decode('ascii', 'ignore'))
 
     return output
 

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -97,6 +97,32 @@ def run_cmd_cache(func):
     return cache_aware_func
 
 
+def get_output_from_process(proc, read_size=None, asynchronous=False):
+    """
+    Get output from running process (that was opened with subprocess.Popen).
+
+    :param proc: process to get output from
+    :param read_size: number of bytes of output to read (if None: read all output)
+    :param asynchronous: get output asynchronously
+    """
+
+    if asynchronous:
+        output = recv_some(proc)
+    elif read_size:
+        output = proc.stdout.read(read_size)
+    else:
+        output = proc.stdout.read()
+
+    # need to be careful w.r.t. encoding since we want to obtain a string value,
+    # and the output may include non UTF-8 characters
+    # * in Python 2, .decode() returns a value of type 'unicode',
+    #   but we really want a regular 'str' value (which is also why we use 'ignore' for encoding errors)
+    # * in Python 3, .decode() returns a 'str' value when called on the 'bytes' value obtained from .read()
+    output = str(output.decode('utf-8', 'ignore'))
+
+    return output
+
+
 @run_cmd_cache
 def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True, log_output=False, path=None,
             force_in_dry_run=False, verbose=True, shell=True, trace=True, stream_output=None):
@@ -212,7 +238,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
     while ec is None:
         # need to read from time to time.
         # - otherwise the stdout/stderr buffer gets filled and it all stops working
-        output = proc.stdout.read(read_size).decode('utf-8', 'replace')
+        output = get_output_from_process(proc, read_size=read_size)
         if cmd_log:
             cmd_log.write(output)
         if stream_output:
@@ -221,7 +247,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
         ec = proc.poll()
 
     # read remaining data (all of it)
-    output = proc.stdout.read().decode('utf-8', 'replace')
+    output = get_output_from_process(proc)
     if cmd_log:
         cmd_log.write(output)
         cmd_log.close()
@@ -366,11 +392,11 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
         cmd_log.write("# output for interactive command: %s\n\n" % cmd)
 
     try:
-        p = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT, stdin=PIPE, close_fds=True, executable="/bin/bash")
+        proc = Popen(cmd, shell=True, stdout=PIPE, stderr=STDOUT, stdin=PIPE, close_fds=True, executable="/bin/bash")
     except OSError as err:
         raise EasyBuildError("run_cmd_qa init cmd %s failed:%s", cmd, err)
 
-    ec = p.poll()
+    ec = proc.poll()
     stdout_err = ''
     old_len_out = -1
     hit_count = 0
@@ -379,7 +405,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
         # need to read from time to time.
         # - otherwise the stdout/stderr buffer gets filled and it all stops working
         try:
-            out = recv_some(p).decode('utf-8', 'replace')
+            out = get_output_from_process(proc, asynchronous=True)
             if cmd_log:
                 cmd_log.write(out)
             stdout_err += out
@@ -399,7 +425,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
                 _log.debug("List of answers for question %s after cycling: %s", question.pattern, answers)
 
                 _log.debug("run_cmd_qa answer %s question %s out %s", fa, question.pattern, stdout_err[-50:])
-                send_all(p, fa)
+                send_all(proc, fa)
                 hit = True
                 break
         if not hit:
@@ -413,7 +439,7 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
                     _log.debug("List of answers for question %s after cycling: %s", question.pattern, answers)
 
                     _log.debug("run_cmd_qa answer %s std question %s out %s", fa, question.pattern, stdout_err[-50:])
-                    send_all(p, fa)
+                    send_all(proc, fa)
                     hit = True
                     break
             if not hit:
@@ -435,8 +461,8 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
         if hit_count > maxhits:
             # explicitly kill the child process before exiting
             try:
-                os.killpg(p.pid, signal.SIGKILL)
-                os.kill(p.pid, signal.SIGKILL)
+                os.killpg(proc.pid, signal.SIGKILL)
+                os.kill(proc.pid, signal.SIGKILL)
             except OSError as err:
                 _log.debug("run_cmd_qa exception caught when killing child process: %s", err)
             _log.debug("run_cmd_qa: full stdouterr: %s", stdout_err)
@@ -445,12 +471,12 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
 
         # the sleep below is required to avoid exiting on unknown 'questions' too early (see above)
         time.sleep(1)
-        ec = p.poll()
+        ec = proc.poll()
 
     # Process stopped. Read all remaining data
     try:
-        if p.stdout:
-            out = p.stdout.read().decode('utf-8', 'replace')
+        if proc.stdout:
+            out = get_output_from_process(proc)
             stdout_err += out
             if cmd_log:
                 cmd_log.write(out)

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -66,8 +66,8 @@ class RunTest(EnhancedTestCase):
     def test_get_output_from_process(self):
         """Test for get_output_from_process utility function."""
 
-        def get_proc(cmd, async=False):
-            if async:
+        def get_proc(cmd, asynchronous=False):
+            if asynchronous:
                 proc = asyncprocess.Popen(cmd, shell=True, stdout=asyncprocess.PIPE, stderr=asyncprocess.STDOUT,
                                           stdin=asyncprocess.PIPE, close_fds=True, executable='/bin/bash')
             else:
@@ -106,14 +106,14 @@ class RunTest(EnhancedTestCase):
         # can also get output asynchronously (read_size is *ignored* in that case)
         async_cmd = "echo hello; read reply; echo $reply"
 
-        proc = get_proc(async_cmd, async=True)
+        proc = get_proc(async_cmd, asynchronous=True)
         out = get_output_from_process(proc, asynchronous=True)
         self.assertEqual(out, 'hello\n')
         asyncprocess.send_all(proc, 'test123\n')
         out = get_output_from_process(proc)
         self.assertEqual(out, 'test123\n')
 
-        proc = get_proc(async_cmd, async=True)
+        proc = get_proc(async_cmd, asynchronous=True)
         out = get_output_from_process(proc, asynchronous=True, read_size=1)
         # read_size is ignored when getting output asynchronously, we're getting more than 1 byte!
         self.assertEqual(out, 'hello\n')

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -72,14 +72,16 @@ class RunTest(EnhancedTestCase):
         # test running command that emits non-UTF-8 characters
         # this is constructed to reproduce errors like:
         # UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2
-        test_file = os.path.join(self.test_prefix, 'foo.txt')
-        write_file(test_file, b"foo \xe2 bar")
-        cmd = "cat %s" % test_file
+        # UnicodeEncodeError: 'ascii' codec can't encode character u'\u2018'
+        for text in [b"foo \xe2 bar", b"foo \u2018 bar"]:
+            test_file = os.path.join(self.test_prefix, 'foo.txt')
+            write_file(test_file, text)
+            cmd = "cat %s" % test_file
 
-        (out, ec) = run_cmd(cmd)
-        self.assertEqual(ec, 0)
-        self.assertTrue(out.startswith('foo ') and out.endswith(' bar'))
-        self.assertEqual(type(out), str)
+            (out, ec) = run_cmd(cmd)
+            self.assertEqual(ec, 0)
+            self.assertTrue(out.startswith('foo ') and out.endswith(' bar'))
+            self.assertEqual(type(out), str)
 
     def test_run_cmd_log(self):
         """Test logging of executed commands."""
@@ -166,14 +168,16 @@ class RunTest(EnhancedTestCase):
         # test running command that emits non-UTF-8 characters
         # this is constructed to reproduce errors like:
         # UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2
-        test_file = os.path.join(self.test_prefix, 'foo.txt')
-        write_file(test_file, b"foo \xe2 bar")
-        cmd = "cat %s" % test_file
+        # UnicodeEncodeError: 'ascii' codec can't encode character u'\u2018' (‘)
+        for text in [b"foo \xe2 bar", "foo ‘ bar"]:
+            test_file = os.path.join(self.test_prefix, 'foo.txt')
+            write_file(test_file, text)
+            cmd = "cat %s" % test_file
 
-        (out, ec) = run_cmd(cmd, log_output=True)
-        self.assertEqual(ec, 0)
-        self.assertTrue(out.startswith('foo ') and out.endswith(' bar'))
-        self.assertEqual(type(out), str)
+            (out, ec) = run_cmd(cmd, log_output=True)
+            self.assertEqual(ec, 0)
+            self.assertTrue(out.startswith('foo ') and out.endswith(' bar'))
+            self.assertEqual(type(out), str)
 
     def test_run_cmd_trace(self):
         """Test run_cmd under --trace"""

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -67,6 +67,7 @@ class RunTest(EnhancedTestCase):
         self.assertEqual(out, "hello\n")
         # no reason echo hello could fail
         self.assertEqual(ec, 0)
+        self.assertEqual(type(out), str)
 
         # test running command that emits non-UTF-8 characters
         # this is constructed to reproduce errors like:
@@ -78,6 +79,7 @@ class RunTest(EnhancedTestCase):
         (out, ec) = run_cmd(cmd)
         self.assertEqual(ec, 0)
         self.assertTrue(out.startswith('foo ') and out.endswith(' bar'))
+        self.assertEqual(type(out), str)
 
     def test_run_cmd_log(self):
         """Test logging of executed commands."""
@@ -149,6 +151,7 @@ class RunTest(EnhancedTestCase):
         """Test run_cmd with log_output enabled"""
         (out, ec) = run_cmd("seq 1 100", log_output=True)
         self.assertEqual(ec, 0)
+        self.assertEqual(type(out), str)
         self.assertTrue(out.startswith("1\n2\n"))
         self.assertTrue(out.endswith("99\n100\n"))
 
@@ -159,6 +162,18 @@ class RunTest(EnhancedTestCase):
         run_cmd_log_lines = run_cmd_log_txt.split('\n')
         self.assertEqual(run_cmd_log_lines[2:5], ['1', '2', '3'])
         self.assertEqual(run_cmd_log_lines[-4:-1], ['98', '99', '100'])
+
+        # test running command that emits non-UTF-8 characters
+        # this is constructed to reproduce errors like:
+        # UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2
+        test_file = os.path.join(self.test_prefix, 'foo.txt')
+        write_file(test_file, b"foo \xe2 bar")
+        cmd = "cat %s" % test_file
+
+        (out, ec) = run_cmd(cmd, log_output=True)
+        self.assertEqual(ec, 0)
+        self.assertTrue(out.startswith('foo ') and out.endswith(' bar'))
+        self.assertEqual(type(out), str)
 
     def test_run_cmd_trace(self):
         """Test run_cmd under --trace"""


### PR DESCRIPTION
Fix for this issues that occurred when installing `libreadline` on top of Python 2.7.5 when using `4.x` branch and `eb --trace libreadline-7.0-GCCcore-7.3.0.eb`:

```
== installing...
  >> running command:
	[started at: 2019-03-06 08:33:27]
	[output logged in /tmp/eb-Tmn2Kx/easybuild-run_cmd-6ll1rS.log]
	make install
ERROR: Traceback (most recent call last):
  File "/home/kehoste/easybuild-framework/easybuild/main.py", line 112, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/home/kehoste/easybuild-framework/easybuild/framework/easyblock.py", line 2861, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/home/kehoste/easybuild-framework/easybuild/framework/easyblock.py", line 2771, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/home/kehoste/easybuild-framework/easybuild/framework/easyblock.py", line 2637, in run_step
    step_method(self)()
  File "/home/kehoste/easybuild-easyblocks/easybuild/easyblocks/generic/configuremake.py", line 294, in install_step
    (out, _) = run_cmd(cmd, log_all=True, simple=False)
  File "/home/kehoste/easybuild-framework/easybuild/tools/run.py", line 88, in cache_aware_func
    res = func(cmd, *args, **kwargs)
  File "/home/kehoste/easybuild-framework/easybuild/tools/run.py", line 217, in run_cmd
    cmd_log.write(output)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 4570-4572: ordinal not in range(128)
```

This problem was reproduced in the tests before fixing the issue...