### PR TITLE
use temporary checkout of repository as robot path for --new-pr and --update-pr to determine locations for patch files

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -709,7 +709,7 @@ def _easyconfigs_pr_common(paths, ecs, start_branch=None, pr_branch=None, start_
 
     # figure out to which software name patches relate, and copy them to the right place
     if paths['patch_files']:
-        patch_specs = det_patch_specs(paths['patch_files'], file_info)
+        patch_specs = det_patch_specs(paths['patch_files'], file_info, extra_robot_paths=[target_dir])
 
         print_msg("copying patch files to %s..." % target_dir)
         patch_info = copy_patch_files(patch_specs, target_dir)
@@ -831,7 +831,7 @@ def is_patch_for(patch_name, ec):
     return res
 
 
-def det_patch_specs(patch_paths, file_info):
+def det_patch_specs(patch_paths, file_info, extra_robot_paths=None):
     """ Determine software names for patch files """
     print_msg("determining software names for patch files...")
     patch_specs = []
@@ -851,7 +851,7 @@ def det_patch_specs(patch_paths, file_info):
             # fall back on scanning all eb files for patches
             print("Matching easyconfig for %s not found on the first try:" % patch_path,)
             print("scanning all easyconfigs to determine where patch file belongs (this may take a while)...")
-            soft_name = find_software_name_for_patch(patch_file)
+            soft_name = find_software_name_for_patch(patch_file, extra_robot_paths=extra_robot_paths)
             if soft_name:
                 patch_specs.append((patch_path, soft_name))
             else:
@@ -861,7 +861,7 @@ def det_patch_specs(patch_paths, file_info):
     return patch_specs
 
 
-def find_software_name_for_patch(patch_name):
+def find_software_name_for_patch(patch_name, extra_robot_paths=None):
     """
     Scan all easyconfigs in the robot path(s) to determine which software a patch file belongs to
 
@@ -869,7 +869,7 @@ def find_software_name_for_patch(patch_name):
     :return: name of the software that this patch file belongs to (if found)
     """
 
-    robot_paths = build_option('robot_path')
+    robot_paths = (extra_robot_paths or []) + build_option('robot_path')
     soft_name = None
 
     all_ecs = []

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -709,7 +709,7 @@ def _easyconfigs_pr_common(paths, ecs, start_branch=None, pr_branch=None, start_
 
     # figure out to which software name patches relate, and copy them to the right place
     if paths['patch_files']:
-        patch_specs = det_patch_specs(paths['patch_files'], file_info, extra_robot_paths=[target_dir])
+        patch_specs = det_patch_specs(paths['patch_files'], file_info, [target_dir])
 
         print_msg("copying patch files to %s..." % target_dir)
         patch_info = copy_patch_files(patch_specs, target_dir)
@@ -831,7 +831,7 @@ def is_patch_for(patch_name, ec):
     return res
 
 
-def det_patch_specs(patch_paths, file_info, extra_robot_paths=None):
+def det_patch_specs(patch_paths, file_info, ec_dirs):
     """ Determine software names for patch files """
     print_msg("determining software names for patch files...")
     patch_specs = []
@@ -851,7 +851,7 @@ def det_patch_specs(patch_paths, file_info, extra_robot_paths=None):
             # fall back on scanning all eb files for patches
             print("Matching easyconfig for %s not found on the first try:" % patch_path)
             print("scanning all easyconfigs to determine where patch file belongs (this may take a while)...")
-            soft_name = find_software_name_for_patch(patch_file, extra_robot_paths=extra_robot_paths)
+            soft_name = find_software_name_for_patch(patch_file, ec_dirs)
             if soft_name:
                 patch_specs.append((patch_path, soft_name))
             else:
@@ -861,20 +861,20 @@ def det_patch_specs(patch_paths, file_info, extra_robot_paths=None):
     return patch_specs
 
 
-def find_software_name_for_patch(patch_name, extra_robot_paths=None):
+def find_software_name_for_patch(patch_name, ec_dirs):
     """
     Scan all easyconfigs in the robot path(s) to determine which software a patch file belongs to
 
     :param patch_name: name of the patch file
+    :param ecs_dirs: list of directories to consider when looking for easyconfigs
     :return: name of the software that this patch file belongs to (if found)
     """
 
-    robot_paths = (extra_robot_paths or []) + build_option('robot_path')
     soft_name = None
 
     all_ecs = []
-    for robot_path in robot_paths:
-        for (dirpath, _, filenames) in os.walk(robot_path):
+    for ec_dir in ec_dirs:
+        for (dirpath, _, filenames) in os.walk(ec_dir):
             for fn in filenames:
                 if fn != 'TEMPLATE.eb':
                     path = os.path.join(dirpath, fn)

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -876,7 +876,7 @@ def find_software_name_for_patch(patch_name, ec_dirs):
     for ec_dir in ec_dirs:
         for (dirpath, _, filenames) in os.walk(ec_dir):
             for fn in filenames:
-                if fn != 'TEMPLATE.eb':
+                if fn != 'TEMPLATE.eb' and not fn.endswith('.py'):
                     path = os.path.join(dirpath, fn)
                     rawtxt = read_file(path)
                     if 'patches' in rawtxt:

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -401,13 +401,12 @@ class GithubTest(EnhancedTestCase):
             'minimal_toolchains': True,
             'use_existing_modules': True,
             'external_modules_metadata': ConfigObj(),
-            'robot_path': [ec_path],
             'silent': True,
             'valid_module_classes': module_classes(),
             'validate': False,
         })
         self.mock_stdout(True)
-        ec = gh.find_software_name_for_patch('toy-0.0_fix-silly-typo-in-printf-statement.patch')
+        ec = gh.find_software_name_for_patch('toy-0.0_fix-silly-typo-in-printf-statement.patch', [ec_path])
         txt = self.get_stdout()
         self.mock_stdout(False)
 
@@ -525,9 +524,6 @@ class GithubTest(EnhancedTestCase):
     def test_det_patch_specs(self):
         """Test for det_patch_specs function."""
 
-        # robot_path build option is used by find_software_name_for_patch, which is called by det_patch_specs
-        init_config(build_options={'robot_path': []})
-
         patch_paths = [os.path.join(self.test_prefix, p) for p in ['1.patch', '2.patch', '3.patch']]
         file_info = {'ecs': [
                 {'name': 'A', 'patches': ['1.patch']},
@@ -536,12 +532,12 @@ class GithubTest(EnhancedTestCase):
         }
         error_pattern = "Failed to determine software name to which patch file .*/2.patch relates"
         self.mock_stdout(True)
-        self.assertErrorRegex(EasyBuildError, error_pattern, gh.det_patch_specs, patch_paths, file_info)
+        self.assertErrorRegex(EasyBuildError, error_pattern, gh.det_patch_specs, patch_paths, file_info, [])
         self.mock_stdout(False)
 
         file_info['ecs'].append({'name': 'C', 'patches': [('3.patch', 'subdir'), '2.patch']})
         self.mock_stdout(True)
-        res = gh.det_patch_specs(patch_paths, file_info)
+        res = gh.det_patch_specs(patch_paths, file_info, [])
         self.mock_stdout(False)
 
         self.assertEqual(len(res), 3)


### PR DESCRIPTION
… so only that is considered when figuring out to which easyconfig the specified patch files belong to

~~Marked `WIP` since need to check whether not considering the easyconfigs in the local robot path makes sense...~~ Removed the `WIP`, there's no point in checking easyconfigs in the local robot path imho.