### PR TITLE
fix broken tests with Python 3.x + also test with Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,9 @@ matrix:
       env: ENV_MOD_TCL_VERSION=1.147 TEST_EASYBUILD_MODULES_TOOL=EnvironmentModulesTcl TEST_EASYBUILD_MODULE_SYNTAX=Tcl
     - python: 3.6
       env: ENV_MOD_VERSION=4.1.4 TEST_EASYBUILD_MODULE_SYNTAX=Tcl TEST_EASYBUILD_MODULES_TOOL=EnvironmentModules  # Tmod 4.1.4 is used in RHEL8
-    # also test most common configuration with Python 3.7
+    # also test most common configuration with Python 3.5 and 3.7
+    - python: 3.5
+      env: LMOD_VERSION=7.8.5
     - python: 3.7
       dist: xenial
       env: LMOD_VERSION=7.8.5

--- a/easybuild/base/generaloption.py
+++ b/easybuild/base/generaloption.py
@@ -773,7 +773,7 @@ class ExtOptionParser(OptionParser):
                 logmethod = self.error_env_option_method
             else:
                 logmethod = self.log.debug
-            logmethod(msg, len(candidates), self.envvar_prefix, ','.join(candidates))
+            logmethod(msg, len(candidates), self.envvar_prefix, ','.join(sorted(candidates)))
 
         self.log.debug("Environment variable options with prefix %s: %s",
                        self.envvar_prefix, self.environment_arguments)

--- a/easybuild/base/rest.py
+++ b/easybuild/base/rest.py
@@ -35,11 +35,8 @@ based on https://github.com/jpaugh/agithub/commit/1e2575825b165c1cb7cbd85c22e256
 :author: Jens Timmerman
 """
 import base64
+import json
 from functools import partial
-try:
-    import json
-except ImportError:
-    import simplejson as json
 
 from easybuild.base import fancylogger
 from easybuild.tools.py2vs3 import HTTPSHandler, Request, build_opener, urlencode

--- a/easybuild/base/rest.py
+++ b/easybuild/base/rest.py
@@ -39,7 +39,7 @@ import json
 from functools import partial
 
 from easybuild.base import fancylogger
-from easybuild.tools.py2vs3 import HTTPSHandler, Request, build_opener, urlencode
+from easybuild.tools.py2vs3 import HTTPSHandler, Request, build_opener, json_loads, urlencode
 
 
 class Client(object):
@@ -171,7 +171,7 @@ class Client(object):
         else:
             body = conn.read()
             try:
-                pybody = json.loads(body)
+                pybody = json_loads(body)
             except ValueError:
                 pybody = body
         fancylogger.getLogger().debug('reponse len: %s ', len(pybody))

--- a/easybuild/base/testing.py
+++ b/easybuild/base/testing.py
@@ -153,7 +153,7 @@ class TestCase(OrigTestCase):
         try:
             call(*args, **kwargs)
             str_kwargs = ['='.join([k, str(v)]) for (k, v) in kwargs.items()]
-            str_args = ', '.join(map(str, args) + str_kwargs)
+            str_args = ', '.join(list(map(str, args)) + str_kwargs)
             self.assertTrue(False, "Expected errors with %s(%s) call should occur" % (call.__name__, str_args))
         except error as err:
             msg = self.convert_exception_to_str(err)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -56,6 +56,7 @@ from easybuild.base import fancylogger
 from easybuild.framework.easyconfig import EASYCONFIGS_PKG_SUBDIR
 from easybuild.framework.easyconfig.easyconfig import ITERATE_OPTIONS, EasyConfig, ActiveMNS, get_easyblock_class
 from easybuild.framework.easyconfig.easyconfig import get_module_path, letter_dir_for, resolve_template
+from easybuild.framework.easyconfig.format.format import SANITY_CHECK_PATHS_DIRS, SANITY_CHECK_PATHS_FILES
 from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconfig
 from easybuild.framework.easyconfig.style import MAX_LINE_LENGTH
 from easybuild.framework.easyconfig.tools import get_paths_for
@@ -2147,9 +2148,9 @@ class EasyBlock(object):
         # supported/required keys in for sanity check paths, along with function used to check the paths
         path_keys_and_check = {
             # files must exist and not be a directory
-            'files': ('file', lambda fp: os.path.exists(fp) and not os.path.isdir(fp)),
+            SANITY_CHECK_PATHS_FILES: ('file', lambda fp: os.path.exists(fp) and not os.path.isdir(fp)),
             # directories must exist and be non-empty
-            'dirs': ("(non-empty) directory", lambda dp: os.path.isdir(dp) and os.listdir(dp)),
+            SANITY_CHECK_PATHS_DIRS: ("(non-empty) directory", lambda dp: os.path.isdir(dp) and os.listdir(dp)),
         }
 
         # prepare sanity check paths
@@ -2162,7 +2163,7 @@ class EasyBlock(object):
                 paths = {}
                 for key in path_keys_and_check:
                     paths.setdefault(key, [])
-                paths.update({'dirs': ['bin', ('lib', 'lib64')]})
+                paths.update({SANITY_CHECK_PATHS_DIRS: ['bin', ('lib', 'lib64')]})
                 self.log.info("Using default sanity check paths: %s" % paths)
         else:
             self.log.info("Using specified sanity check paths: %s" % paths)
@@ -2285,7 +2286,9 @@ class EasyBlock(object):
             return ' or '.join("'%s'" % x for x in xs)
 
         # check sanity check paths
-        for key, (typ, check_fn) in path_keys_and_check.items():
+        for key in [SANITY_CHECK_PATHS_FILES, SANITY_CHECK_PATHS_DIRS]:
+
+            (typ, check_fn) = path_keys_and_check[key]
 
             for xs in paths[key]:
                 if isinstance(xs, string_type):

--- a/easybuild/framework/easyconfig/format/format.py
+++ b/easybuild/framework/easyconfig/format/format.py
@@ -71,6 +71,8 @@ GROUPED_PARAMS = [
 ]
 LAST_PARAMS = ['sanity_check_paths', 'moduleclass']
 
+SANITY_CHECK_PATHS_DIRS = 'dirs'
+SANITY_CHECK_PATHS_FILES = 'files'
 
 _log = fancylogger.getLogger('easyconfig.format.format', fname=False)
 

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -30,15 +30,15 @@ This is the original pure python code, to be exec'ed rather then parsed
 :author: Stijn De Weirdt (Ghent University)
 :author: Kenneth Hoste (Ghent University)
 """
-import copy
 import os
 import re
 import tempfile
 
 from easybuild.base import fancylogger
 from easybuild.framework.easyconfig.format.format import DEPENDENCY_PARAMETERS, EXCLUDED_KEYS_REPLACE_TEMPLATES
-from easybuild.framework.easyconfig.format.format import FORMAT_DEFAULT_VERSION, GROUPED_PARAMS
-from easybuild.framework.easyconfig.format.format import LAST_PARAMS, get_format_version
+from easybuild.framework.easyconfig.format.format import FORMAT_DEFAULT_VERSION, GROUPED_PARAMS, LAST_PARAMS
+from easybuild.framework.easyconfig.format.format import SANITY_CHECK_PATHS_DIRS, SANITY_CHECK_PATHS_FILES
+from easybuild.framework.easyconfig.format.format import get_format_version
 from easybuild.framework.easyconfig.format.pyheaderconfigobj import EasyConfigFormatConfigObj
 from easybuild.framework.easyconfig.format.version import EasyVersion
 from easybuild.framework.easyconfig.templates import to_template_str
@@ -55,7 +55,7 @@ REFORMAT_FORCED_PARAMS = ['sanity_check_paths'] + DEPENDENCY_PARAMETERS
 REFORMAT_SKIPPED_PARAMS = ['toolchain', 'toolchainopts']
 REFORMAT_THRESHOLD_LENGTH = 100  # only reformat lines that would be longer than this amount of characters
 REFORMAT_ORDERED_ITEM_KEYS = {
-    'sanity_check_paths': ['files', 'dirs'],
+    'sanity_check_paths': [SANITY_CHECK_PATHS_FILES, SANITY_CHECK_PATHS_DIRS],
 }
 
 

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -380,7 +380,7 @@ def to_dependency(dep):
                 raise EasyBuildError("Unexpected format for dependency marked as external module: %s", dep)
 
         else:
-            dep_keys = dep.keys()
+            dep_keys = list(dep.keys())
 
             # need to handle name/version keys first, to avoid relying on order in which keys are processed...
             for key in ['name', 'version']:

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -33,6 +33,7 @@ from distutils.util import strtobool
 
 from easybuild.base import fancylogger
 from easybuild.framework.easyconfig.format.format import DEPENDENCY_PARAMETERS
+from easybuild.framework.easyconfig.format.format import SANITY_CHECK_PATHS_DIRS, SANITY_CHECK_PATHS_FILES
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.py2vs3 import string_type
 
@@ -490,11 +491,11 @@ TUPLE_OF_STRINGS = (tuple, as_hashable({'elem_types': [str]}))
 STRING_OR_TUPLE_LIST = (list, as_hashable({'elem_types': [str, TUPLE_OF_STRINGS]}))
 SANITY_CHECK_PATHS_DICT = (dict, as_hashable({
     'elem_types': {
-        'files': [STRING_OR_TUPLE_LIST],
-        'dirs': [STRING_OR_TUPLE_LIST],
+        SANITY_CHECK_PATHS_FILES: [STRING_OR_TUPLE_LIST],
+        SANITY_CHECK_PATHS_DIRS: [STRING_OR_TUPLE_LIST],
     },
     'opt_keys': [],
-    'req_keys': ['files', 'dirs'],
+    'req_keys': [SANITY_CHECK_PATHS_FILES, SANITY_CHECK_PATHS_DIRS],
 }))
 CHECKSUMS = (list, as_hashable({'elem_types': [STRING_OR_TUPLE_LIST]}))
 

--- a/easybuild/tools/py2vs3/py2.py
+++ b/easybuild/tools/py2vs3/py2.py
@@ -31,6 +31,7 @@ Implementations for Python 2.
 """
 # these are not used here, but imported from here in other places
 import ConfigParser as configparser  # noqa
+import json
 import subprocess
 import urllib2 as std_urllib  # noqa
 from string import letters as ascii_letters  # noqa
@@ -51,6 +52,9 @@ reload = reload
 
 # string type that can be used in 'isinstance' calls
 string_type = basestring
+
+# trivial wrapper for json.loads (Python 3 version is less trivial)
+json_loads = json.loads
 
 
 def subprocess_popen_text(cmd, **kwargs):

--- a/easybuild/tools/py2vs3/py3.py
+++ b/easybuild/tools/py2vs3/py3.py
@@ -31,7 +31,9 @@ Implementations for Python 3.
 """
 # these are not used here, but imported from here in other places
 import configparser  # noqa
+import json
 import subprocess
+import sys
 import urllib.request as std_urllib  # noqa
 from collections import OrderedDict  # noqa
 from io import StringIO  # noqa
@@ -45,6 +47,18 @@ from importlib import reload  # noqa
 
 # string type that can be used in 'isinstance' calls
 string_type = str
+
+
+def json_loads(body):
+    """Wrapper for json.loads that takes into account that Python versions older than 3.6 require a string value."""
+
+    if isinstance(body, bytes) and sys.version_info[0] == 3 and sys.version_info[1] < 6:
+        # decode bytes string as regular string with UTF-8 encoding for Python 3.5.x and older
+        # only Python 3.6 and newer have support for passing bytes string to json.loads
+        # cfr. https://docs.python.org/2/library/json.html#json.loads
+        body = body.decode('utf-8', 'ignore')
+
+    return json.loads(body)
 
 
 def subprocess_popen_text(cmd, **kwargs):

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -1,4 +1,5 @@
 # #
+# -*- coding: utf-8 -*-
 # Copyright 2012-2019 Ghent University
 #
 # This file is part of EasyBuild,


### PR DESCRIPTION
* add wrapper for `json.loads` since in Python 3.5 the provided value *must* be a string
* fix couple of issues related to order of lists and keys in dicts, to make tests pass consistently also with Python 3.5
* fix problem when using Python 3 introduced in #2804 (`.keys()` returns an iterator, not a list)