### PR TITLE
ensure correct value type in data field of Request object in Python 2/3

### DIFF
--- a/easybuild/base/rest.py
+++ b/easybuild/base/rest.py
@@ -39,7 +39,7 @@ import json
 from functools import partial
 
 from easybuild.base import fancylogger
-from easybuild.tools.py2vs3 import HTTPSHandler, Request, build_opener, json_loads, urlencode
+from easybuild.tools.py2vs3 import HTTPSHandler, Request, build_opener, json_loads, string_type, urlencode
 
 
 class Client(object):
@@ -193,6 +193,13 @@ class Client(object):
             sep = '/'
         else:
             sep = ''
+
+        # value passed to 'data' must be a 'bytes' value (not 'str') in Python 3.x, but a string value in Python 2
+        # hence, we encode the value obtained (if needed)
+        # this doesn't affect the value type in Python 2, and makes it a 'bytes' value in Python 3
+        if isinstance(body, string_type):
+            body = body.encode('utf-8')
+
         request = Request(self.url + sep + url, data=body)
         for header, value in headers.items():
             request.add_header(header, value)

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -28,6 +28,7 @@ Unit tests for talking to GitHub.
 @author: Jens Timmerman (Ghent University)
 @author: Kenneth Hoste (Ghent University)
 """
+import base64
 import os
 import random
 import re
@@ -562,8 +563,9 @@ class GithubTest(EnhancedTestCase):
 
         status, body = client.repos['hpcugent']['testrepository'].contents.a_directory['a_file.txt'].get()
         self.assertEqual(status, 200)
-        # dGhpcyBpcyBhIGxpbmUgb2YgdGV4dAo= == 'this is a line of text' in base64 encoding
-        self.assertEqual(body['content'].strip(), u"dGhpcyBpcyBhIGxpbmUgb2YgdGV4dAo=")
+        # base64.b64encode requires & produces a 'bytes' value in Python 3,
+        # but we need a string value hence the .decode() (also works in Python 2)
+        self.assertEqual(body['content'].strip(), base64.b64encode(b'this is a line of text\n').decode())
 
         status, headers = client.head()
         self.assertEqual(status, 200)


### PR DESCRIPTION
Without this fix, the added test fails as below when using Python 3.

This is relevant for features like `--upload-test-report`.

```
ERROR: test_restclient (__main__.GithubTest)
Test use of RestClient.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Volumes/work/easybuild-framework/test/framework/github.py", line 575, in test_restclient
    status, body = client.user.emails.post(body='test@example.com')
  File "/Volumes/work/easybuild-framework/easybuild/base/rest.py", line 136, in post
    return self.request(self.POST, url, json.dumps(body), headers, content_type='application/json')
  File "/Volumes/work/easybuild-framework/easybuild/base/rest.py", line 167, in request
    conn = self.get_connection(method, url, body, headers)
  File "/Volumes/work/easybuild-framework/easybuild/base/rest.py", line 201, in get_connection
    connection = self.opener.open(request)
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 523, in open
    req = meth(req)
  File "/usr/local/Cellar/python/3.7.2/Frameworks/Python.framework/Versions/3.7/lib/python3.7/urllib/request.py", line 1247, in do_request_
    raise TypeError(msg)
TypeError: POST data should be bytes, an iterable of bytes, or a file object. It cannot be of type str.
```