### PR TITLE
fix problem with list of iterative easyconfig parameters being determined too early + reset toolchain variables on iterations

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1484,8 +1484,7 @@ class EasyBlock(object):
         prev_enable_templating = self.cfg.enable_templating
         self.cfg.enable_templating = False
 
-        # tell easyconfig we are iterating (used by dependencies() and builddependencies())
-        self.cfg.iterating = True
+        self.cfg.start_iterating()
 
         # handle configure/build/install options that are specified as lists (+ perhaps builddependencies)
         # set first element to be used, keep track of list in self.iter_opts
@@ -1523,8 +1522,7 @@ class EasyBlock(object):
             self.cfg[opt] = self.iter_opts[opt]
             self.log.debug("Restored value of '%s' that was iterated over: %s", opt, self.cfg[opt])
 
-        # tell easyconfig we are no longer iterating (used by dependencies() and builddependencies())
-        self.cfg.iterating = False
+        self.cfg.stop_iterating()
 
         # re-enable templating before self.cfg values are used
         self.cfg.enable_templating = prev_enable_templating

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1853,6 +1853,10 @@ class EasyBlock(object):
             '$ORIGIN/../lib64',
         ]
 
+        if self.iter_idx > 0:
+            # reset toolchain for iterative runs before preparing it again
+            self.toolchain.reset()
+
         # prepare toolchain: load toolchain module and dependencies, set up build environment
         self.toolchain.prepare(self.cfg['onlytcmod'], deps=self.cfg.dependencies(), silent=self.silent,
                                rpath_filter_dirs=self.rpath_filter_dirs, rpath_include_dirs=self.rpath_include_dirs)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -542,8 +542,9 @@ class EasyConfig(object):
 
         # create a list of all options that are actually going to be iterated over
         # builddependencies are always a list, need to look deeper down below
-        self.iterate_options = [opt for opt in ITERATE_OPTIONS
-                                if opt != 'builddependencies' and isinstance(self[opt], (list, tuple))]
+
+        # list of all options to iterate over
+        self.iterate_options = []
         self.iterating = False
 
         # parse dependency specifications
@@ -679,14 +680,19 @@ class EasyConfig(object):
         # when lists are used, they should be all of same length
         # list of length 1 are treated as if it were strings in EasyBlock
         opt_counts = []
-        for opt in self.iterate_options:
+        for opt in ITERATE_OPTIONS:
+
+            # only when builddependencies is a list of lists are we iterating over them
+            if opt == 'builddependencies' and not all(isinstance(e, list) for e in self[opt]):
+                continue
 
             # anticipate changes in available easyconfig parameters (e.g. makeopts -> buildopts?)
             if self.get(opt, None) is None:
                 raise EasyBuildError("%s not available in self.cfg (anymore)?!", opt)
 
             # keep track of list, supply first element as first option to handle
-            opt_counts.append((opt, len(self[opt])))
+            if isinstance(self[opt], (list, tuple)):
+                opt_counts.append((opt, len(self[opt])))
 
         # make sure that options that specify lists have the same length
         list_opt_lengths = [length for (opt, length) in opt_counts if length > 1]
@@ -694,6 +700,26 @@ class EasyConfig(object):
             raise EasyBuildError("Build option lists for iterated build should have same length: %s", opt_counts)
 
         return True
+
+    def start_iterating(self):
+        """Start iterative mode."""
+
+        for opt in ITERATE_OPTIONS:
+            # builddpendencies is already handled, see __init__
+            if opt == 'builddependencies':
+                continue
+
+            # list of values indicates that this is a value to iterate over
+            if isinstance(self[opt], (list, tuple)):
+                self.iterate_options.append(opt)
+
+        # keep track of when we're iterating (used by builddependencies())
+        self.iterating = True
+
+    def stop_iterating(self):
+        """Stop iterative mode."""
+
+        self.iterating = False
 
     def filter_hidden_deps(self):
         """

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -172,11 +172,15 @@ class Toolchain(object):
             self.options = self.OPTIONS_CLASS()
 
         if not hasattr(self, 'variables'):
-            self.variables = self.VARIABLES_CLASS()
-            if hasattr(self, 'LINKER_TOGGLE_START_STOP_GROUP'):
-                self.variables.LINKER_TOGGLE_START_STOP_GROUP = self.LINKER_TOGGLE_START_STOP_GROUP
-            if hasattr(self, 'LINKER_TOGGLE_STATIC_DYNAMIC'):
-                self.variables.LINKER_TOGGLE_STATIC_DYNAMIC = self.LINKER_TOGGLE_STATIC_DYNAMIC
+            self.variables_init()
+
+    def variables_init(self):
+        """Initialise toolchain variables."""
+        self.variables = self.VARIABLES_CLASS()
+        if hasattr(self, 'LINKER_TOGGLE_START_STOP_GROUP'):
+            self.variables.LINKER_TOGGLE_START_STOP_GROUP = self.LINKER_TOGGLE_START_STOP_GROUP
+        if hasattr(self, 'LINKER_TOGGLE_STATIC_DYNAMIC'):
+            self.variables.LINKER_TOGGLE_STATIC_DYNAMIC = self.LINKER_TOGGLE_STATIC_DYNAMIC
 
     def _init_class_constants(self, class_constants):
         """Initialise class 'constants'."""
@@ -686,6 +690,10 @@ class Toolchain(object):
     def is_deprecated(self):
         """Return whether or not this toolchain is deprecated."""
         return False
+
+    def reset(self):
+        """Reset this toolchain instance."""
+        self.variables_init()
 
     def prepare(self, onlymod=None, deps=None, silent=False, loadmod=True,
                 rpath_filter_dirs=None, rpath_include_dirs=None):


### PR DESCRIPTION
follow-up for changes made in #2741

Without this, building FFTW is broken with:

```
ERROR: Traceback (most recent call last):
  File "/tmp/lib/python2.6/site-packages/easybuild_framework-3.9.0.dev0-py2.7.egg/easybuild/main.py", line 112, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/tmp/lib/python2.7/site-packages/easybuild_framework-3.9.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2880, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/tmp/lib/python2.7/site-packages/easybuild_easyblocks-3.9.0.dev0-py2.7.egg/easybuild/easyblocks/f/fftw.py", line 213, in run_all_steps
    return super(EB_FFTW, self).run_all_steps(*args, **kwargs)
  File "/tmp/lib/python2.7/site-packages/easybuild_framework-3.9.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2790, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/tmp/lib/python2.7/site-packages/easybuild_framework-3.9.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 2663, in run_step
    step_method(self)()
  File "/tmp/lib/python2.7/site-packages/easybuild_easyblocks-3.9.0.dev0-py2.7.egg/easybuild/easyblocks/generic/configuremake.py", line 260, in configure_step
    self.cfg['configopts'],
TypeError: sequence item 5: expected string, list found
```