### PR TITLE
take into account that builddependencies is always a list in EasyBlock.det_iter_cnt

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1529,8 +1529,18 @@ class EasyBlock(object):
 
     def det_iter_cnt(self):
         """Determine iteration count based on configure/build/install options that may be lists."""
-        iter_cnt = max([1] + [len(self.cfg[opt]) for opt in ITERATE_OPTIONS
-                              if isinstance(self.cfg[opt], (list, tuple))])
+        iter_opt_lens = [len(self.cfg[opt]) for opt in ITERATE_OPTIONS
+                         if opt not in ['builddependencies'] and isinstance(self.cfg[opt], (list, tuple))]
+
+        # we need to take into account that builddependencies is always a list
+        # we're only iteraing over it if it's a list of lists
+        builddeps = self.cfg['builddependencies']
+        if all(isinstance(x, list) for x in builddeps):
+            iter_opt_lens.append(len(builddeps))
+
+        iter_cnt = max([1] + iter_opt_lens)
+        self.log.info("Number of iterations to perform for central part of installation procedure: %s", iter_cnt)
+
         return iter_cnt
 
     def set_parallel(self):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1529,16 +1529,16 @@ class EasyBlock(object):
 
     def det_iter_cnt(self):
         """Determine iteration count based on configure/build/install options that may be lists."""
-        iter_opt_lens = [len(self.cfg[opt]) for opt in ITERATE_OPTIONS
-                         if opt not in ['builddependencies'] and isinstance(self.cfg[opt], (list, tuple))]
+        iter_opt_counts = [len(self.cfg[opt]) for opt in ITERATE_OPTIONS
+                           if opt not in ['builddependencies'] and isinstance(self.cfg[opt], (list, tuple))]
 
         # we need to take into account that builddependencies is always a list
-        # we're only iteraing over it if it's a list of lists
+        # we're only iterating over it if it's a list of lists
         builddeps = self.cfg['builddependencies']
         if all(isinstance(x, list) for x in builddeps):
-            iter_opt_lens.append(len(builddeps))
+            iter_opt_counts.append(len(builddeps))
 
-        iter_cnt = max([1] + iter_opt_lens)
+        iter_cnt = max([1] + iter_opt_counts)
         self.log.info("Number of iterations to perform for central part of installation procedure: %s", iter_cnt)
 
         return iter_cnt


### PR DESCRIPTION
@bartoldeman: we overlooked this in #2741

It's only problematic if there is more than one build dependency listed, but it's an important bug to fix...