### PR TITLE
iterate over subdirectories in order in find_egg_dir_for of bootstrap script, to ensure oldest vsc-install is picked

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20190112.01 51b89475ffd0f7dd2bf713e7984e7b35a627196af06d03c2cf75f6bcda8c54c0"
+    - EB_BOOTSTRAP_EXPECTED="20190322.01 4b00b89b2317e2e44fc56d0223e10239c1b4efc50f81fcd39eb73895bccbe927"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -54,7 +54,7 @@ from distutils.version import LooseVersion
 from hashlib import md5
 
 
-EB_BOOTSTRAP_VERSION = '20190112.01'
+EB_BOOTSTRAP_VERSION = '20190322.01'
 
 # argparse preferrred, optparse deprecated >=2.7
 HAVE_ARGPARSE = False
@@ -173,19 +173,26 @@ def det_modules_path(install_path):
 def find_egg_dir_for(path, pkg):
     """Find full path of egg dir for given package."""
 
+    res = None
+
     for libdir in ['lib', 'lib64']:
         full_libpath = os.path.join(path, det_lib_path(libdir))
         eggdir_regex = re.compile('%s-[0-9a-z.]+-py[0-9.]+.egg' % pkg.replace('-', '_'))
-        subdirs = (os.path.exists(full_libpath) and os.listdir(full_libpath)) or []
+        subdirs = (os.path.exists(full_libpath) and sorted(os.listdir(full_libpath))) or []
         for subdir in subdirs:
             if eggdir_regex.match(subdir):
                 eggdir = os.path.join(full_libpath, subdir)
-                debug("Found egg dir for %s at %s" % (pkg, eggdir))
-                return eggdir
+                if res is None:
+                    debug("Found egg dir for %s at %s" % (pkg, eggdir))
+                    res = eggdir
+                else:
+                    debug("Found another egg dir for %s at %s (ignoring it)" % (pkg, eggdir))
 
     # no egg dir found
-    debug("Failed to determine egg dir path for %s in %s (subdirs: %s)" % (pkg, path, subdirs))
-    return None
+    if res is None:
+        debug("Failed to determine egg dir path for %s in %s (subdirs: %s)" % (pkg, path, subdirs))
+
+    return res
 
 
 def prep(path):
@@ -684,7 +691,8 @@ def stage2(tmpdir, templates, install_path, distribute_egg_dir, sourcepath):
             if res:
                 pkg_url_part = res.group(1)
             else:
-                error("Failed to determine PyPI package URL for %s: %s\n" % (pkg, pkg_simple))
+                error_msg = "Failed to determine PyPI package URL for %s using pattern '%s': %s\n"
+                error(error_msg % (pkg, pkg_url_part_regex.pattern, pkg_simple))
 
             pkg_url = 'https://pypi.python.org/' + pkg_url_part
             pkg_urls.append(pkg_url)


### PR DESCRIPTION
Testing of the bootstrap script is currently failing with (only) Python 2.7 because of a combo of a silly bug in the bootstrap script and the latest `vsc-install` checked into the `master` branch on GitHub (0.12.2) not being released yet on PyPI...

Two versions of `vsc-install` are being installed currently due to the `vsc-install < 0.11.4` workaround that was added in #2717: `vsc-install-0.11.3` and whichever is the latest version (which gets pulled in via `vsc-base`).

The 0.11.3 is supposed to take the upper hand, but that's currently not always the case apparently...

Depending on the order in which `vsc-install` installations are considered in the `find_egg_dir_for` in the bootstrap script, one or the other may be picked up. If the latest version is picked up, we're in trouble, especially if that version is not available on `PyPI` yet, since that results in an error like:

```
[[ERROR]] Failed to determine PyPI package URL for vsc-install: ...
```

The error has been improved here as well, to mention the pattern being searched for:

```
[[ERROR]] Failed to determine PyPI package URL for vsc-install using pattern '/(packages/[^#]+)/vsc-install-0.12.2.tar.gz#': 
```

Making sure that `find_egg_dir_for` considers the `vsc-install` installation in order (oldest first) fixes the problem.
In Python 2.7, `os.listdir` has a different default order than in Python 2.6, which explains why the problem only occurs there (at least in Travis).