### PR TITLE
replace -Wl,--enable-new-dtags compiler option with -Wl,--disable-new-dtags in RPATH wrapper script

### DIFF
--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -103,8 +103,8 @@ while idx < len(args):
     # --enable-new-dtags is not removed but replaced to prevent issues when linker flag is forwarded from the compiler
     # to the linker with an extra prefixed flag (either -Xlinker or -Wl,).
     # In that case, the compiler would erroneously pass the next random argument to the linker.
-    elif arg == '--enable-new-dtags':
-        cmd_args.append('--disable-new-dtags')
+    elif arg == flag_prefix + '--enable-new-dtags':
+        cmd_args.append(flag_prefix + '--disable-new-dtags')
     else:
         cmd_args.append(arg)
 

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1163,6 +1163,21 @@ class ToolchainTest(EnhancedTestCase):
         ]
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
+        # compiler command, -Wl,--enable-new-dtags should be replaced with -Wl,--disable-new-dtags
+        out, ec = run_cmd("%s gcc '' '%s' -Wl,--enable-new-dtags foo.c" % (script, rpath_inc), simple=False)
+        self.assertEqual(ec, 0)
+        cmd_args = [
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,--disable-new-dtags'",
+            "'-Wl,--disable-new-dtags'",
+            "'foo.c'",
+        ]
+        self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
+
         # test passing no arguments
         out, ec = run_cmd("%s gcc '' '%s'" % (script, rpath_inc), simple=False)
         self.assertEqual(ec, 0)


### PR DESCRIPTION
implementation of proposed fix for problem reported in #2820 by @casparvl