### PR TITLE
ensure check_conflicts uses flattened list of build dependencies for easyconfigs that use multi_deps

### DIFF
--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -120,7 +120,7 @@ def check_conflicts(easyconfigs, modtool, check_inter_ec_conflicts=True):
         node_key = mk_key(node)
 
         # exclude external modules, since we can't check conflicts on them (we don't even know the software name)
-        build_deps = mk_dep_keys(node['builddependencies'])
+        build_deps = mk_dep_keys(node['ec'].builddependencies())
         deps = mk_dep_keys(node['ec'].all_dependencies)
 
         # separate runtime deps from build deps


### PR DESCRIPTION
@vanzod Please merge ASAP, since this is making the easyconfig tests fail after https://github.com/easybuilders/easybuild-easyconfigs/pull/7921 got merged.

I'll follow up later with a dedicated test for this bug.

This problem was introduced in #2813, and makes `--check-conflicts` fail as soon as an easyconfig file that uses `multi_deps` is picked up, for example:

```
eb --check-conflicts SciPy-bundle-2019.03-foss-2019a.eb
== temporary log file in case of crash /tmp/eb-K0_31k/easybuild-jpxQWc.log
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Volumes/work/easybuild-framework/easybuild/main.py", line 454, in <module>
    main()
  File "/Volumes/work/easybuild-framework/easybuild/main.py", line 386, in main
    if check_conflicts(easyconfigs, modtool):
  File "/Volumes/work/easybuild-framework/easybuild/tools/robot.py", line 123, in check_conflicts
    build_deps = mk_dep_keys(node['builddependencies'])
  File "/Volumes/work/easybuild-framework/easybuild/tools/robot.py", line 109, in mk_dep_keys
    if not dep.get('external_module', False):
AttributeError: 'list' object has no attribute 'get'