### PR TITLE
make check_conflicts aware of multi_deps

### DIFF
--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -47,6 +47,7 @@ from easybuild.tools.config import build_option
 from easybuild.tools.filetools import det_common_path_prefix, search_file
 from easybuild.tools.module_naming_scheme.easybuild_mns import EasyBuildMNS
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
+from easybuild.tools.utilities import flatten
 
 
 _log = fancylogger.getLogger('tools.robot', fname=False)
@@ -119,17 +120,30 @@ def check_conflicts(easyconfigs, modtool, check_inter_ec_conflicts=True):
     for node in ordered_ecs:
         node_key = mk_key(node)
 
+        parsed_build_deps = node['ec'].builddependencies()
+
+        # take into account listed multi-deps;
+        # these will be included in the list of build dependencies (see EasyConfig.handle_multi_deps),
+        # but should be filtered out since they're not real build dependencies
+        # we need to iterate over them when checking for conflicts...
+        if node['ec']['multi_deps']:
+            parsed_multi_deps = node['ec'].get_parsed_multi_deps()
+            parsed_build_deps = [d for d in parsed_build_deps if d not in flatten(parsed_multi_deps)]
+        else:
+            parsed_multi_deps = []
+
         # exclude external modules, since we can't check conflicts on them (we don't even know the software name)
-        build_deps = mk_dep_keys(node['ec'].builddependencies())
+        multi_deps = [mk_dep_keys(x) for x in parsed_multi_deps]
+        build_deps = mk_dep_keys(parsed_build_deps)
         deps = mk_dep_keys(node['ec'].all_dependencies)
 
-        # separate runtime deps from build deps
-        runtime_deps = [d for d in deps if d not in build_deps]
+        # separate runtime deps from build deps & multi deps
+        runtime_deps = [d for d in deps if d not in build_deps and d not in flatten(multi_deps)]
 
-        deps_for[node_key] = (build_deps, runtime_deps)
+        deps_for[node_key] = (build_deps, runtime_deps, multi_deps)
 
         # keep track of reverse deps too
-        for dep in deps:
+        for dep in deps + flatten(multi_deps):
             dep_of.setdefault(dep, set()).add(node_key)
 
     if check_inter_ec_conflicts:
@@ -137,25 +151,30 @@ def check_conflicts(easyconfigs, modtool, check_inter_ec_conflicts=True):
         # since we want to check for conflicts between specified easyconfigs too;
         # 'wrapper' easyconfigs are not included to avoid false conflicts being reported
         ec_keys = [k for k in [mk_key(e) for e in easyconfigs] if k not in wrapper_deps]
-        deps_for[(None, None)] = ([], ec_keys)
+        deps_for[(None, None)] = ([], ec_keys, [])
 
     # iteratively expand list of dependencies
     last_deps_for = None
     while deps_for != last_deps_for:
         last_deps_for = copy.deepcopy(deps_for)
         # (Automake, _), [], [(Autoconf, _), (GCC, _)]
-        for (key, (build_deps, runtime_deps)) in last_deps_for.items():
+        for (key, (build_deps, runtime_deps, multi_deps)) in last_deps_for.items():
             # extend runtime dependencies with non-build dependencies of own runtime dependencies
             # Autoconf
             for dep in runtime_deps:
                 # [], [M4, GCC]
-                deps_for[key][1].extend([d for d in deps_for[dep][1]])
+                deps_for[key][1].extend(deps_for[dep][1])
+
+            # extend multi deps with non-build dependencies of own runtime dependencies
+            for deplist in multi_deps:
+                for dep in deplist:
+                    deps_for[key][2].extend(deps_for[dep][1])
 
             # extend build dependencies with non-build dependencies of own build dependencies
             for dep in build_deps:
-                deps_for[key][0].extend([d for d in deps_for[dep][1]])
+                deps_for[key][0].extend(deps_for[dep][1])
 
-            deps_for[key] = (sorted(nub(deps_for[key][0])), sorted(nub(deps_for[key][1])))
+            deps_for[key] = (sorted(nub(deps_for[key][0])), sorted(nub(deps_for[key][1])), multi_deps)
 
             # also track reverse deps (except for ghost entry)
             if key != (None, None):
@@ -189,13 +208,22 @@ def check_conflicts(easyconfigs, modtool, check_inter_ec_conflicts=True):
 
     # for each of the easyconfigs, check whether the dependencies (incl. build deps) contain any conflicts
     res = False
-    for (key, (build_deps, runtime_deps)) in deps_for.items():
-        # also check whether module itself clashes with any of its dependencies
-        for i, dep1 in enumerate(build_deps + runtime_deps + [key]):
-            for dep2 in (build_deps + runtime_deps)[i+1:]:
-                # don't worry about conflicts between module itself and any of its build deps
-                if dep1 != key or dep2 not in build_deps:
-                    res |= check_conflict(key, dep1, dep2)
+    for (key, (build_deps, runtime_deps, multi_deps)) in deps_for.items():
+
+        # determine lists of runtime deps to iterate over
+        # only if multi_deps is used will we actually have more than one list of runtime deps...
+        if multi_deps:
+            lists_of_runtime_deps = [runtime_deps + x for x in multi_deps]
+        else:
+            lists_of_runtime_deps = [runtime_deps]
+
+        for runtime_deps in lists_of_runtime_deps:
+            # also check whether module itself clashes with any of its dependencies
+            for i, dep1 in enumerate(build_deps + runtime_deps + [key]):
+                for dep2 in (build_deps + runtime_deps)[i+1:]:
+                    # don't worry about conflicts between module itself and any of its build deps
+                    if dep1 != key or dep2 not in build_deps:
+                        res |= check_conflict(key, dep1, dep2)
 
     return res
 


### PR DESCRIPTION
The change in #2825 was only sufficient to resolve the traceback/crash, but it left `--check-conflicts` broken when an easyconfig that uses `multi_deps` was in play:

```
eb --check-conflicts SciPy-bundle-2019.03-foss-2019a.eb
== temporary log file in case of crash /tmp/eb-G2OTHq/easybuild-lr7N39.log
Conflict found for dependencies of SciPy-bundle-2019.03-foss-2019a: Python-2.7.15-GCCcore-8.2.0 vs Python-3.7.2-GCCcore-8.2.0
	Python-2.7.15-GCCcore-8.2.0 as dep of: SciPy-bundle-2019.03-foss-2019a
	Python-3.7.2-GCCcore-8.2.0 as dep of: SciPy-bundle-2019.03-foss-2019a
ERROR: One or more conflicts detected!
```

Fixed with the changes included here:

```
eb --check-conflicts SciPy-bundle-2019.03-foss-2019a.eb
== temporary log file in case of crash /tmp/eb-LlOL8r/easybuild-oDMiU2.log

No conflicts detected!

== Temporary log file(s) /tmp/eb-LlOL8r/easybuild-oDMiU2.log* have been removed.
== Temporary directory /tmp/eb-LlOL8r has been removed.
```