### PR TITLE
Lower required version in slurm job backend to 16.05

### DIFF
--- a/easybuild/tools/job/slurm.py
+++ b/easybuild/tools/job/slurm.py
@@ -46,7 +46,8 @@ class Slurm(JobBackend):
     Manage SLURM server communication and create `SlurmJob` objects.
     """
 
-    REQ_VERSION = '17'
+    # Oldest version tested, may also work with earlier releases
+    REQ_VERSION = '16.05'
 
     def __init__(self, *args, **kwargs):
         """Constructor."""
@@ -161,8 +162,9 @@ class SlurmJob(object):
         self.job_specs = {
             'job-name': self.name,
             # pattern for output file for submitted job;
-            # SLURM replaces %x with job name, %j with job ID (see https://slurm.schedmd.com/sbatch.html#lbAF)
-            'output': '%x-%j.out',
+            # SLURM replaces %j with job ID (see https://slurm.schedmd.com/sbatch.html#lbAH)
+            # %x (job name) replacement needs SLURM >= 17.02.1, thus we add name ourselves
+            'output': '%s-%%j.out' % self.name,
             'wrap': self.script,
         }
 

--- a/test/framework/parallelbuild.py
+++ b/test/framework/parallelbuild.py
@@ -348,7 +348,7 @@ class ParallelBuildTest(EnhancedTestCase):
             'nodes': 1,
             'ntasks': 3,
             'ntasks-per-node': 3,
-            'output': '%x-%j.out',
+            'output': 'gzip-1.5-foss-2018a-%j.out',
             'time': 300,  # 60*5 (unit is minutes)
             'wrap': "echo '%s'" % test_ec,
         }


### PR DESCRIPTION
This has been tested on our test cluster running SLURM 16.05.9 and works like a charm.  It is also quite likely that earlier releases may work as well, but testing this is up to someone with an even more ancient setup ;-)