### PR TITLE
only call 'scontrol release' when there's at least one job submitted

### DIFF
--- a/easybuild/tools/job/slurm.py
+++ b/easybuild/tools/job/slurm.py
@@ -137,7 +137,9 @@ class Slurm(JobBackend):
             if job.job_specs['hold']:
                 self.log.info("releasing user hold on job %s" % job.jobid)
                 job_ids.append(job.jobid)
-        run_cmd("scontrol release %s" % ' '.join(job_ids), trace=False)
+
+        if job_ids:
+            run_cmd("scontrol release %s" % ' '.join(job_ids), trace=False)
 
         submitted_jobs = '; '.join(["%s (%s): %s" % (job.name, job.module, job.jobid) for job in self._submitted])
         print_msg("List of submitted jobs (%d): %s" % (len(self._submitted), submitted_jobs), log=self.log)


### PR DESCRIPTION
Fix for following issue:

```
$ eb foo-1.2.3.eb --job
== temporary log file in case of crash /tmp/eb-7fOWcP/easybuild-KIt4oj.log
== foo/1.2.3 is already installed (module found), skipping
== No easyconfigs left to be built.
ERROR: cmd "scontrol release " exited with exit code 1 and output:
too few arguments for keyword:release
```