### PR TITLE
only import from pkg_resources (provided by setuptools) to check GC3Pie version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,10 +113,10 @@ script:
     - export PYTHONPATH=/tmp/$TRAVIS_JOB_ID/lib/python$TRAVIS_PYTHON_VERSION/site-packages
     # install easybuild-framework to unique temporary location using prepared sdist tarball
     - mkdir -p $PYTHONPATH; easy_install --prefix /tmp/$TRAVIS_JOB_ID $TRAVIS_BUILD_DIR/dist/easybuild-framework*tar.gz
-    # make sure there are no "import setuptools" or "import pkg_resources" statements,
+    # make sure there are no (top-level) "import setuptools" or "import pkg_resources" statements,
     # since EasyBuild should not have a runtime requirement on setuptools
-    - SETUPTOOLS_IMPORTS=$(egrep -RI '^(from|import) pkg_resources|^(from|import) setuptools' easybuild/ || true)
-    - test "x$SETUPTOOLS_IMPORTS" = "x" || (echo "Found setuptools imports in easybuild/:\n${SETUPTOOLS_IMPORTS}" && exit 1)
+    - SETUPTOOLS_IMPORTS=$(egrep -RI '^(from|import)[ \t]*pkg_resources|^(from|import)[ \t]*setuptools' easybuild/ || true)
+    - test "x$SETUPTOOLS_IMPORTS" = "x" || (echo "Found setuptools and/or pkg_resources imports in easybuild/:\n${SETUPTOOLS_IMPORTS}" && exit 1)
     # move outside of checkout of easybuild-framework repository,
     # to run tests on an *installed* version of the EasyBuild framework;
     # this is done to catch possible packaging issues

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,11 +113,10 @@ script:
     - export PYTHONPATH=/tmp/$TRAVIS_JOB_ID/lib/python$TRAVIS_PYTHON_VERSION/site-packages
     # install easybuild-framework to unique temporary location using prepared sdist tarball
     - mkdir -p $PYTHONPATH; easy_install --prefix /tmp/$TRAVIS_JOB_ID $TRAVIS_BUILD_DIR/dist/easybuild-framework*tar.gz
-    # actively break "import setuptools" and "import pkg_resources",
+    # make sure there are no "import setuptools" or "import pkg_resources" statements,
     # since EasyBuild should not have a runtime requirement on setuptools
-    - echo 'raise ImportError("setuptools should no longer be relied on")' > /tmp/$TRAVIS_JOB_ID/setuptools.py
-    - echo 'raise ImportError("setuptools is not available")' > /tmp/$TRAVIS_JOB_ID/pkg_resources.py
-    - export PYTHONPATH=/tmp/$TRAVIS_JOB_ID:$PYTHONPATH
+    - SETUPTOOLS_IMPORTS=$(egrep -RI '^(from|import) pkg_resources|^(from|import) setuptools' easybuild/ || true)
+    - test "x$SETUPTOOLS_IMPORTS" = "x" || (echo "Found setuptools imports in easybuild/:\n${SETUPTOOLS_IMPORTS}" && exit 1)
     # move outside of checkout of easybuild-framework repository,
     # to run tests on an *installed* version of the EasyBuild framework;
     # this is done to catch possible packaging issues

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,8 +113,10 @@ script:
     - export PYTHONPATH=/tmp/$TRAVIS_JOB_ID/lib/python$TRAVIS_PYTHON_VERSION/site-packages
     # install easybuild-framework to unique temporary location using prepared sdist tarball
     - mkdir -p $PYTHONPATH; easy_install --prefix /tmp/$TRAVIS_JOB_ID $TRAVIS_BUILD_DIR/dist/easybuild-framework*tar.gz
-    # actively break "import setuptools", since EasyBuild should not have a runtime requirement on setuptools
-    - echo 'raise NotImplementedError("setuptools is not available")' > /tmp/$TRAVIS_JOB_ID/setuptools.py
+    # actively break "import setuptools" and "import pkg_resources",
+    # since EasyBuild should not have a runtime requirement on setuptools
+    - echo 'raise ImportError("setuptools should no longer be relied on")' > /tmp/$TRAVIS_JOB_ID/setuptools.py
+    - echo 'raise ImportError("setuptools is not available")' > /tmp/$TRAVIS_JOB_ID/pkg_resources.py
     - export PYTHONPATH=/tmp/$TRAVIS_JOB_ID:$PYTHONPATH
     # move outside of checkout of easybuild-framework repository,
     # to run tests on an *installed* version of the EasyBuild framework;

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,7 @@ script:
     - mkdir -p $PYTHONPATH; easy_install --prefix /tmp/$TRAVIS_JOB_ID $TRAVIS_BUILD_DIR/dist/easybuild-framework*tar.gz
     # make sure there are no (top-level) "import setuptools" or "import pkg_resources" statements,
     # since EasyBuild should not have a runtime requirement on setuptools
-    - SETUPTOOLS_IMPORTS=$(egrep -RI '^(from|import)[ \t]*pkg_resources|^(from|import)[ \t]*setuptools' easybuild/ || true)
+    - SETUPTOOLS_IMPORTS=$(egrep -RI '^(from|import)[ ]*pkg_resources|^(from|import)[ ]*setuptools' easybuild/ || true)
     - test "x$SETUPTOOLS_IMPORTS" = "x" || (echo "Found setuptools and/or pkg_resources imports in easybuild/:\n${SETUPTOOLS_IMPORTS}" && exit 1)
     # move outside of checkout of easybuild-framework repository,
     # to run tests on an *installed* version of the EasyBuild framework;

--- a/easybuild/tools/job/gc3pie.py
+++ b/easybuild/tools/job/gc3pie.py
@@ -33,10 +33,8 @@ from distutils.version import LooseVersion
 from time import gmtime, strftime
 import time
 
-from pkg_resources import get_distribution, DistributionNotFound
-
 from easybuild.base import fancylogger
-from easybuild.tools.build_log import EasyBuildError, print_msg
+from easybuild.tools.build_log import EasyBuildError, print_msg, print_warning
 from easybuild.tools.config import JOB_DEPS_TYPE_ABORT_ON_ERROR, JOB_DEPS_TYPE_ALWAYS_RUN, build_option
 from easybuild.tools.job.backend import JobBackend
 from easybuild.tools.utilities import only_if_module_is_available
@@ -98,15 +96,20 @@ class GC3Pie(JobBackend):
     @only_if_module_is_available('gc3libs', pkgname='gc3pie')
     def _check_version(self):
         """Check whether GC3Pie version complies with required version."""
-        try:
-            pkg = get_distribution('gc3pie')
-        except DistributionNotFound as err:
-            raise EasyBuildError(
-                "Cannot load GC3Pie package: %s" % err)
 
-        if LooseVersion(pkg.version) < LooseVersion(self.REQ_VERSION):
-            raise EasyBuildError("Found GC3Pie version %s, but version %s or more recent is required",
-                                 pkg.version, self.REQ_VERSION)
+        try:
+            from pkg_resources import get_distribution, DistributionNotFound
+            pkg = get_distribution('gc3pie')
+
+            if LooseVersion(pkg.version) < LooseVersion(self.REQ_VERSION):
+                raise EasyBuildError("Found GC3Pie version %s, but version %s or more recent is required",
+                                     pkg.version, self.REQ_VERSION)
+
+        except ImportError as err:
+            print_warning("Failed to check required GC3Pie version (>= %s)", self.REQ_VERSION)
+
+        except DistributionNotFound as err:
+            raise EasyBuildError("Cannot load GC3Pie package: %s", err)
 
     def init(self):
         """

--- a/easybuild/tools/job/gc3pie.py
+++ b/easybuild/tools/job/gc3pie.py
@@ -105,7 +105,7 @@ class GC3Pie(JobBackend):
                 raise EasyBuildError("Found GC3Pie version %s, but version %s or more recent is required",
                                      pkg.version, self.REQ_VERSION)
 
-        except ImportError as err:
+        except ImportError:
             print_warning("Failed to check required GC3Pie version (>= %s)", self.REQ_VERSION)
 
         except DistributionNotFound as err:

--- a/easybuild/tools/version.py
+++ b/easybuild/tools/version.py
@@ -43,7 +43,7 @@ from socket import gethostname
 # recent setuptools versions will *TRANSFORM* something like 'X.Y.Zdev' into 'X.Y.Z.dev0', with a warning like
 #   UserWarning: Normalizing '2.4.0dev' to '2.4.0.dev0'
 # This causes problems further up the dependency chain...
-VERSION = LooseVersion('3.9.1.dev0')
+VERSION = LooseVersion('4.0.0.dev0')
 UNKNOWN = 'UNKNOWN'
 
 


### PR DESCRIPTION
Since `setuptools` is a requirement for GC3Pie, this will work out fine in practice. It allows us to avoid requiring `setuptools` for EasyBuild itself...