### PR TITLE
list build dependencies *before* runtime dependencies, so dependencies listed via multi_deps are loaded first in toolchain environment

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -871,10 +871,11 @@ class EasyConfig(object):
 
         :param build_only: only return build dependencies, discard others
         """
-        if build_only:
-            deps = self.builddependencies()
-        else:
-            deps = self['dependencies'] + self.builddependencies()
+        deps = self.builddependencies()
+
+        if not build_only:
+            # use += rather than .extend to get a new list rather than updating list of build deps in place...
+            deps += self['dependencies']
 
         # if filter-deps option is provided we "clean" the list of dependencies for
         # each processed easyconfig to remove the unwanted dependencies

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -678,6 +678,20 @@ class EasyConfigTest(EnhancedTestCase):
         })
         parsed_deps = [
             {
+                'name': 'testbuildonly',
+                'version': '4.9.3-2.25',
+                'versionsuffix': '',
+                'toolchain': ec['toolchain'],
+                'toolchain_inherited': True,
+                'dummy': False,
+                'short_mod_name': 'testbuildonly/.4.9.3-2.25-GCC-4.8.3',
+                'full_mod_name': 'testbuildonly/.4.9.3-2.25-GCC-4.8.3',
+                'build_only': True,
+                'hidden': True,
+                'external_module': False,
+                'external_module_metadata': {},
+            },
+            {
                 'name': 'foo',
                 'version': '1.2.3',
                 'versionsuffix': '',
@@ -715,20 +729,6 @@ class EasyConfigTest(EnhancedTestCase):
                 'short_mod_name': 'test/.3.2.1-GCC-4.8.3',
                 'full_mod_name': 'test/.3.2.1-GCC-4.8.3',
                 'build_only': False,
-                'hidden': True,
-                'external_module': False,
-                'external_module_metadata': {},
-            },
-            {
-                'name': 'testbuildonly',
-                'version': '4.9.3-2.25',
-                'versionsuffix': '',
-                'toolchain': ec['toolchain'],
-                'toolchain_inherited': True,
-                'dummy': False,
-                'short_mod_name': 'testbuildonly/.4.9.3-2.25-GCC-4.8.3',
-                'full_mod_name': 'testbuildonly/.4.9.3-2.25-GCC-4.8.3',
-                'build_only': True,
                 'hidden': True,
                 'external_module': False,
                 'external_module_metadata': {},
@@ -1310,12 +1310,12 @@ class EasyConfigTest(EnhancedTestCase):
 
         deps = ec.dependencies()
         self.assertEqual(len(deps), 7)
-        correct_deps = ['intel/2018a', 'GCC/6.4.0-2.28', 'foobar/1.2.3', 'test/9.7.5', 'pi/3.14', 'hidden/.1.2.3',
-                        'somebuilddep/0.1']
+        correct_deps = ['somebuilddep/0.1', 'intel/2018a', 'GCC/6.4.0-2.28', 'foobar/1.2.3', 'test/9.7.5', 'pi/3.14',
+                        'hidden/.1.2.3']
         self.assertEqual([d['short_mod_name'] for d in deps], correct_deps)
         self.assertEqual([d['full_mod_name'] for d in deps], correct_deps)
-        self.assertEqual([d['external_module'] for d in deps], [False, True, True, True, True, True, True])
-        self.assertEqual([d['hidden'] for d in deps], [False, False, False, False, False, True, False])
+        self.assertEqual([d['external_module'] for d in deps], [True, False, True, True, True, True, True])
+        self.assertEqual([d['hidden'] for d in deps], [False, False, False, False, False, False, True])
 
         metadata = os.path.join(self.test_prefix, 'external_modules_metadata.cfg')
         metadatatxt = '\n'.join([
@@ -1339,32 +1339,32 @@ class EasyConfigTest(EnhancedTestCase):
         }
         init_config(build_options=build_options)
         ec = EasyConfig(toy_ec)
-        self.assertEqual(ec.dependencies()[2]['short_mod_name'], 'foobar/1.2.3')
-        self.assertEqual(ec.dependencies()[2]['external_module'], True)
+        self.assertEqual(ec.dependencies()[3]['short_mod_name'], 'foobar/1.2.3')
+        self.assertEqual(ec.dependencies()[3]['external_module'], True)
         metadata = {
             'name': ['foo', 'bar'],
             'version': ['1.2.3', '3.2.1'],
             'prefix': '/foo/bar',
         }
-        self.assertEqual(ec.dependencies()[2]['external_module_metadata'], metadata)
+        self.assertEqual(ec.dependencies()[3]['external_module_metadata'], metadata)
 
-        self.assertEqual(ec.dependencies()[3]['short_mod_name'], 'test/9.7.5')
-        self.assertEqual(ec.dependencies()[3]['external_module'], True)
+        self.assertEqual(ec.dependencies()[4]['short_mod_name'], 'test/9.7.5')
+        self.assertEqual(ec.dependencies()[4]['external_module'], True)
         metadata = {
             'name': ['test'],
             'version': ['9.7.5'],
             'prefix': 'TEST_INC/..',
         }
-        self.assertEqual(ec.dependencies()[3]['external_module_metadata'], metadata)
+        self.assertEqual(ec.dependencies()[4]['external_module_metadata'], metadata)
 
-        self.assertEqual(ec.dependencies()[4]['short_mod_name'], 'pi/3.14')
-        self.assertEqual(ec.dependencies()[4]['external_module'], True)
+        self.assertEqual(ec.dependencies()[5]['short_mod_name'], 'pi/3.14')
+        self.assertEqual(ec.dependencies()[5]['external_module'], True)
         metadata = {
             'name': ['PI'],
             'version': ['3.14'],
             'prefix': 'PI_PREFIX',
         }
-        self.assertEqual(ec.dependencies()[4]['external_module_metadata'], metadata)
+        self.assertEqual(ec.dependencies()[5]['external_module_metadata'], metadata)
 
         # check whether $EBROOT*/$EBVERSION* environment variables are defined correctly for external modules
         os.environ['PI_PREFIX'] = '/test/prefix/PI'


### PR DESCRIPTION
While working on an easyconfig file that required `SciPy-bundle` as a dependency and where multiple `Python` versions were specified via `multi_deps`, I noticed a problem we have overlooked in #2828.

When `Python` is included in `multi_deps`, the installation procedure is performed iteratively, once for every listed `Python` version. Internally, this is done via `builddependencies` (to ensure no (strict) runtime dependency on a particular `Python` version is introduced in the generated module file).

If this is combined with a dependency like `SciPy-bundle` by which a `Python` version gets loaded by default if none is loaded yet (since `multi_deps_load_default` was enabled when installing `SciPy-bundle`), a version conflict arises when the `SciPy-bundle` module (which in turns loads the module for `Python` `3.7.2` (for example)) was loaded first, and a(nother) `Python` version was loaded afterwards...

For example, with:

```python
toolchain = {'name': 'foss', 'version': '2019a'}

multi_deps = {'Python': ['3.7.2', '2.7.15']}

dependencies = [('SciPy-bundle', '2019.03')]
```

the problem occurs when the `Python/2.7.15-GCCcore-8.2.0` module is being loaded for the 2nd iteration of the installation, since at that point the `SciPy-bundle/2019.03-foss-2019a` module was already loaded, which in turns resulted in loading `Python/3.7.2-GCCcore-8.2.0` by default since no `Python` module was loaded yet at this point...

The problem is easily fixed by simply switching the order of build dependencies vs (runtime) dependencies to ensure that build dependencies are loaded *first* (after the toolchain is loaded)...

In practice this most likely rarely matters in contexts where `multi_deps` is not involved, so this change should be safe to make.

We ran into a similar issue with the sanity check step while implementing the support for `multi_deps_load_default` in #2828, see https://github.com/easybuilders/easybuild-framework/pull/2828/files#diff-a1bcbbc1aab6b59688b219f298fddb56R1344