### PR TITLE
allow setting parallel to 0 or False to disable adding the -j argument

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1595,7 +1595,7 @@ class EasyBlock(object):
         """Set 'parallel' easyconfig parameter to determine how many cores can/should be used for parallel builds."""
         # set level of parallelism for build
         par = build_option('parallel')
-        if self.cfg['parallel']:
+        if self.cfg['parallel'] is not None:
             if par is None:
                 par = self.cfg['parallel']
                 self.log.debug("Desired parallelism specified via 'parallel' easyconfig parameter: %s", par)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1349,6 +1349,10 @@ class EasyBlockTest(EnhancedTestCase):
         os.close(handle)
         write_file(toy_ec2, toytxt + "\nparallel = 123\nmaxparallel = 67")
 
+        handle, toy_ec3 = tempfile.mkstemp(prefix='easyblock_test_file_', suffix='.eb')
+        os.close(handle)
+        write_file(toy_ec3, toytxt + "\nparallel = False")
+
         # default: parallellism is derived from # available cores + ulimit
         test_eb = EasyBlock(EasyConfig(toy_ec))
         test_eb.check_readiness_step()
@@ -1379,6 +1383,11 @@ class EasyBlockTest(EnhancedTestCase):
         test_eb = EasyBlock(EasyConfig(toy_ec2))
         test_eb.check_readiness_step()
         self.assertEqual(test_eb.cfg['parallel'], 67)
+
+        # make sure 'parallel = False' is not overriden
+        test_eb = EasyBlock(EasyConfig(toy_ec3))
+        test_eb.check_readiness_step()
+        self.assertEqual(test_eb.cfg['parallel'], False)
 
     def test_guess_start_dir(self):
         """Test guessing the start dir."""

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1368,6 +1368,11 @@ class EasyBlockTest(EnhancedTestCase):
         test_eb.check_readiness_step()
         self.assertEqual(test_eb.cfg['parallel'], 67)
 
+        # make sure 'parallel = False' is not overriden (no 'parallel' build option)
+        test_eb = EasyBlock(EasyConfig(toy_ec3))
+        test_eb.check_readiness_step()
+        self.assertEqual(test_eb.cfg['parallel'], False)
+
         # only 'parallel' build option specified
         init_config(build_options={'parallel': '97', 'validate': False})
         test_eb = EasyBlock(EasyConfig(toy_ec))
@@ -1384,10 +1389,10 @@ class EasyBlockTest(EnhancedTestCase):
         test_eb.check_readiness_step()
         self.assertEqual(test_eb.cfg['parallel'], 67)
 
-        # make sure 'parallel = False' is not overriden
+        # make sure 'parallel = False' is not overriden (with 'parallel' build option)
         test_eb = EasyBlock(EasyConfig(toy_ec3))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], False)
+        self.assertEqual(test_eb.cfg['parallel'], 0)
 
     def test_guess_start_dir(self):
         """Test guessing the start dir."""


### PR DESCRIPTION
motivation: `ConfigureMake`, `MakeCp`, etc. easyblocks allow setting `build_cmd` to something other than `make`, but without this change `-j PARALLEL` is always added anyway

this change is enough because `self.cfg['parallel']` is tested again in the `configuremake` build step, before adding `-j`