### PR TITLE
 add support for marking extensions with 'only_if_missing', such that they're skipped automatically if already installed

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1426,7 +1426,7 @@ class EasyBlock(object):
 
         # only consider actually skipping extensions when --skip is used,
         # or when one or more individual extensions are marked 'only_if_missing'
-        do_skip = self.skip or any(ext['options'].get('only_if_missing', False) for ext in self.exts)
+        do_skip = self.skip or any(ext.get('options', {}).get('only_if_missing', False) for ext in self.exts)
 
         if do_skip:
             # obtaining untemplated reference value is required here to support legacy string templates like name/version
@@ -1444,17 +1444,16 @@ class EasyBlock(object):
             res = []
             for ext in self.exts:
                 name = ext['name']
+                options = ext.get('options', {})
 
                 # at this point either --skip is being used, *or* one or more extensions are marked 'only_if_missing'
-                if not (self.skip or ext['options'].get('only_if_missing', False)):
+                if not (self.skip or options.get('only_if_missing', False)):
                     self.log.debug("Not considering extension %s for skipping...", name)
                     res.append(ext)
                     continue
 
-                if 'options' in ext and 'modulename' in ext['options']:
-                    modname = ext['options']['modulename']
-                else:
-                    modname = name
+                modname = options.get('modulename', name)
+
                 tmpldict = {
                     'ext_name': modname,
                     'ext_version': ext.get('version'),

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1423,49 +1423,65 @@ class EasyBlock(object):
         - use this to detect existing extensions and to remove them from self.exts
         - based on initial R version
         """
-        # obtaining untemplated reference value is required here to support legacy string templates like name/version
-        exts_filter = self.cfg.get_ref('exts_filter')
 
-        if not exts_filter or len(exts_filter) == 0:
-            raise EasyBuildError("Skipping of extensions, but no exts_filter set in easyconfig")
-        elif isinstance(exts_filter, basestring) or len(exts_filter) != 2:
-            raise EasyBuildError('exts_filter should be a list or tuple of ("command","input")')
-        cmdtmpl = exts_filter[0]
-        cmdinputtmpl = exts_filter[1]
+        # only consider actually skipping extensions when --skip is used,
+        # or when one or more individual extensions are marked 'only_if_missing'
+        do_skip = self.skip or any(ext['options'].get('only_if_missing', False) for ext in self.exts)
 
-        res = []
-        for ext in self.exts:
-            name = ext['name']
-            if 'options' in ext and 'modulename' in ext['options']:
-                modname = ext['options']['modulename']
-            else:
-                modname = name
-            tmpldict = {
-                'ext_name': modname,
-                'ext_version': ext.get('version'),
-                'src': ext.get('source'),
-            }
+        if do_skip:
+            # obtaining untemplated reference value is required here to support legacy string templates like name/version
+            exts_filter = self.cfg.get_ref('exts_filter')
 
-            try:
-                cmd = cmdtmpl % tmpldict
-            except KeyError as err:
-                msg = "KeyError occurred on completing extension filter template: %s; "
-                msg += "'name'/'version' keys are no longer supported, should use 'ext_name'/'ext_version' instead"
-                self.log.nosupport(msg % err, '2.0')
+            if not exts_filter or len(exts_filter) == 0:
+                raise EasyBuildError("Skipping of extensions, but no exts_filter set in easyconfig")
 
-            if cmdinputtmpl:
-                stdin = cmdinputtmpl % tmpldict
-                (cmdstdouterr, ec) = run_cmd(cmd, log_all=False, log_ok=False, simple=False, inp=stdin, regexp=False)
-            else:
-                (cmdstdouterr, ec) = run_cmd(cmd, log_all=False, log_ok=False, simple=False, regexp=False)
-            self.log.info("exts_filter result %s %s", cmdstdouterr, ec)
-            if ec:
-                self.log.info("Not skipping %s" % name)
-                self.log.debug("exit code: %s, stdout/err: %s" % (ec, cmdstdouterr))
-                res.append(ext)
-            else:
-                self.log.info("Skipping %s" % name)
-        self.exts = res
+            elif isinstance(exts_filter, basestring) or len(exts_filter) != 2:
+                raise EasyBuildError('exts_filter should be a list or tuple of ("command","input")')
+
+            cmdtmpl = exts_filter[0]
+            cmdinputtmpl = exts_filter[1]
+
+            res = []
+            for ext in self.exts:
+                name = ext['name']
+
+                # at this point either --skip is being used, *or* one or more extensions are marked 'only_if_missing'
+                if not (self.skip or ext['options'].get('only_if_missing', False)):
+                    self.log.debug("Not considering extension %s for skipping...", name)
+                    res.append(ext)
+                    continue
+
+                if 'options' in ext and 'modulename' in ext['options']:
+                    modname = ext['options']['modulename']
+                else:
+                    modname = name
+                tmpldict = {
+                    'ext_name': modname,
+                    'ext_version': ext.get('version'),
+                    'src': ext.get('source'),
+                }
+
+                try:
+                    cmd = cmdtmpl % tmpldict
+                except KeyError as err:
+                    msg = "KeyError occurred on completing extension filter template: %s; "
+                    msg += "'name'/'version' keys are no longer supported, should use 'ext_name'/'ext_version' instead"
+                    self.log.nosupport(msg % err, '2.0')
+
+                if cmdinputtmpl:
+                    stdin = cmdinputtmpl % tmpldict
+                    (cmdstdouterr, ec) = run_cmd(cmd, log_all=False, log_ok=False, simple=False, inp=stdin, regexp=False)
+                else:
+                    (cmdstdouterr, ec) = run_cmd(cmd, log_all=False, log_ok=False, simple=False, regexp=False)
+                self.log.info("exts_filter result %s %s", cmdstdouterr, ec)
+                if ec:
+                    self.log.info("Not skipping %s" % name)
+                    self.log.debug("exit code: %s, stdout/err: %s" % (ec, cmdstdouterr))
+                    res.append(ext)
+                else:
+                    self.log.info("Skipping %s" % name)
+
+            self.exts = res
 
     #
     # MISCELLANEOUS UTILITY FUNCTIONS
@@ -1999,8 +2015,7 @@ class EasyBlock(object):
 
         self.exts_all = self.exts[:]  # retain a copy of all extensions, regardless of filtering/skipping
 
-        if self.skip:
-            self.skip_extensions()
+        self.skip_extensions()
 
         # actually install extensions
         self.log.debug("Installing extensions")

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -695,6 +695,7 @@ class EasyBlockTest(EnhancedTestCase):
         eb.extensions_step(fetch=True)
 
         # test for proper error message when skip is set, but no exts_filter is set
+        eb.skip = True
         self.assertRaises(EasyBuildError, eb.skip_extensions)
         self.assertErrorRegex(EasyBuildError, "no exts_filter set", eb.skip_extensions)
 


### PR DESCRIPTION
This may come in useful to automatically skip Python packages that are available in Python 3.x but not in Python 2.x, for multi-Python installations.

My use case for this was `numba`, which requires `funcsigs` and `singledispatch` only when built on top of Python 2.x, but this approach doesn't cover that because of simple `improt singledispatch` is not enough to skip the installation for `singledispatch` (since it actually lives in `functools.singledispatch` in Python 3.x); see also https://github.com/easybuilders/easybuild-easyconfigs/pull/8164 .

Nevertheless, this could be useful in other contexts...