### PR TITLE
correctly resolve template values used for extensions

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -483,9 +483,6 @@ class EasyBlock(object):
                     # since it may use template values like %(name)s & %(version)s
                     ext_options = copy.deepcopy(self.cfg.get_ref('exts_default_options'))
 
-                    # set default template for name of source file
-                    ext_options.setdefault('source_tmpl', '%(name)s-%(version)s.tar.gz')
-
                     if len(ext) == 3:
                         if isinstance(ext_options, dict):
                             ext_options.update(ext[2])
@@ -506,11 +503,13 @@ class EasyBlock(object):
                     template_values.update(template_constant_dict(ext_src))
 
                     # resolve templates in extension options
-                    ext_src['options'] = ext_options = resolve_template(ext_options, template_values)
+                    ext_options = resolve_template(ext_options, template_values)
 
                     checksums = ext_options.get('checksums', [])
 
-                    fn = ext_options['source_tmpl']
+                    # use default template for name of source file if none is specified
+                    default_source_tmpl = resolve_template('%(name)s-%(version)s.tar.gz', template_values)
+                    fn = ext_options.get('source_tmpl', default_source_tmpl)
 
                     if ext_options.get('nosource', None):
                         exts_sources.append(ext_src)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -514,7 +514,7 @@ class EasyBlock(object):
                     if ext_options.get('nosource', None):
                         exts_sources.append(ext_src)
                     else:
-                        source_urls = [url for url in ext_options.get('source_urls', [])]
+                        source_urls = ext_options.get('source_urls', [])
                         force_download = build_option('force_download') in [FORCE_DOWNLOAD_ALL, FORCE_DOWNLOAD_SOURCES]
                         src_fn = self.obtain_file(fn, extension=True, urls=source_urls, force_download=force_download)
 

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -36,8 +36,9 @@ The Extension class should serve as a base class for all extensions.
 import copy
 import os
 
+from easybuild.framework.easyconfig.easyconfig import resolve_template
+from easybuild.framework.easyconfig.templates import template_constant_dict
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import build_option, build_path
 from easybuild.tools.filetools import change_dir
 from easybuild.tools.run import run_cmd
 
@@ -60,17 +61,22 @@ class Extension(object):
         self.ext = copy.deepcopy(ext)
         self.dry_run = self.master.dry_run
 
-        if not 'name' in self.ext:
+        if 'name' not in self.ext:
             raise EasyBuildError("'name' is missing in supplied class instance 'ext'.")
+
+        name, version = self.ext['name'], self.ext.get('version', None)
 
         # parent sanity check paths/commands are not relevant for extension
         self.cfg['sanity_check_commands'] = []
         self.cfg['sanity_check_paths'] = []
 
+        # construct dict with template values that can be used
+        self.cfg.template_values.update(template_constant_dict({'name': name, 'version': version}))
+
         # list of source/patch files: we use an empty list as default value like in EasyBlock
-        self.src = self.ext.get('src', [])
-        self.patches = self.ext.get('patches', [])
-        self.options = copy.deepcopy(self.ext.get('options', {}))
+        self.src = resolve_template(self.ext.get('src', []), self.cfg.template_values)
+        self.patches = resolve_template(self.ext.get('patches', []), self.cfg.template_values)
+        self.options = resolve_template(copy.deepcopy(self.ext.get('options', {})), self.cfg.template_values)
 
         if extra_params:
             self.cfg.extend_params(extra_params, overwrite=False)
@@ -81,12 +87,12 @@ class Extension(object):
         # this allows to specify custom easyconfig parameters on a per-extension basis
         for key in self.options:
             if key in self.cfg:
-                self.cfg[key] = self.options[key]
+                self.cfg[key] = resolve_template(self.options[key], self.cfg.template_values)
                 self.log.debug("Customising known easyconfig parameter '%s' for extension %s/%s: %s",
-                               key, self.ext['name'], self.ext['version'], self.cfg[key])
+                               key, name, version, self.cfg[key])
             else:
                 self.log.debug("Skipping unknown custom easyconfig parameter '%s' for extension %s/%s: %s",
-                               key, self.ext['name'], self.ext['version'], self.options[key])
+                               key, name, version, self.options[key])
 
         self.sanity_check_fail_msgs = []
 


### PR DESCRIPTION
This fixes a long-standing issue where using templates in `exts_list` either did not work at all, or where incorrect values were being used (i.e. the ones inherited by the 'parent').

fixes #1445, #1597, #1138