### PR TITLE
update template values after updating iterative easyconfig parameters

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1555,6 +1555,9 @@ class EasyBlock(object):
                 self.cfg[opt] = ''  # empty list => empty option as next value
             self.log.debug("Next value for %s: %s" % (opt, str(self.cfg[opt])))
 
+        # re-generate template values, which may be affected by changed parameters we're iterating over
+        self.cfg.generate_template_values()
+
         # re-enable templating before self.cfg values are used
         self.cfg.enable_templating = prev_enable_templating
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -2769,7 +2769,7 @@ class EasyConfigTest(EnhancedTestCase):
         # first listed build dep should be SWIG
         self.assertEqual(builddeps[0]['name'], 'SWIG')
         self.assertEqual(builddeps[0]['version'], '3.0.12')
-        # template %(pyver)s values should be resolved correctly based 1st item in multi_deps
+        # template %(pyver)s values should be resolved correctly based on 1st item in multi_deps
         self.assertEqual(builddeps[0]['versionsuffix'], '-Python-3.7.2')
         self.assertEqual(builddeps[0]['full_mod_name'], 'SWIG/3.0.12-Python-3.7.2')
 
@@ -2783,7 +2783,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         self.assertEqual(builddeps[0]['name'], 'SWIG')
         self.assertEqual(builddeps[0]['version'], '3.0.12')
-        # template %(pyver)s values should be resolved correctly based 1st item in multi_deps
+        # template %(pyver)s values should be resolved correctly based on 2nd item in multi_deps
         self.assertEqual(builddeps[0]['versionsuffix'], '-Python-2.7.15')
         self.assertEqual(builddeps[0]['full_mod_name'], 'SWIG/3.0.12-Python-2.7.15')
 


### PR DESCRIPTION
This solves a bug reported by @micket, where templates like `%(pyver)s` were not getting resolved in `builddependencies` when using `multi_deps`.

Example use case:

```python
multi_deps = {'Python': ['3.7.2', '2.7.15']}
builddependencies = [('SWIG', '3.0.12', '-Python-%(pyver)s')]
```

`SWIG` can't be installed multi-Python via `multi_deps` since it's not a traditional Python package.