### PR TITLE
Add multi_deps information to generated module, help and whatis sections.

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -541,7 +541,8 @@ class ModuleGenerator(object):
 
         # Multi deps (if any)
         multi_deps = self._generate_multi_deps_list()
-        lines.extend(self._generate_section("This module is compatible with the following modules, one of each is required", '\n'.join(multi_deps)))
+        section_txt = "This module is compatible with the following modules, one of each is required"
+        lines.extend(self._generate_section(section_txt, '\n'.join(multi_deps)))
 
         # Extensions (if any)
         extensions = self._generate_extension_list()
@@ -560,7 +561,6 @@ class ModuleGenerator(object):
                 txt = ''
                 vlist = self.app.cfg['multi_deps'].get(key)
                 for idx in range(len(vlist)):
-                    found = False
                     for deplist in self.app.cfg.multi_deps:
                         for dep in deplist:
                             if dep['name'] == key and dep['version'] == vlist[idx]:

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -539,11 +539,39 @@ class ModuleGenerator(object):
                 else:
                     lines.append(" - %s contact: %s" % (contacts_type.capitalize(), contacts))
 
+        # Multi deps (if any)
+        multi_deps = self._generate_multi_deps_list()
+        lines.extend(self._generate_section("This module is compatible with the following modules, one of each is required", '\n'.join(multi_deps)))
+
         # Extensions (if any)
         extensions = self._generate_extension_list()
         lines.extend(self._generate_section("Included extensions", '\n'.join(wrap(extensions, 78))))
 
         return '\n'.join(lines)
+
+    def _generate_multi_deps_list(self):
+        """
+        Generate a string with a comma-separated list of multi_deps.
+        """
+        multi_deps = []
+        if self.app.cfg['multi_deps']:
+            for key in sorted(self.app.cfg['multi_deps'].keys()):
+                mod_list = []
+                txt = ''
+                vlist = self.app.cfg['multi_deps'].get(key)
+                for idx in range(len(vlist)):
+                    found = False
+                    for deplist in self.app.cfg.multi_deps:
+                        for dep in deplist:
+                            if dep['name'] == key and dep['version'] == vlist[idx]:
+                                modname = dep['short_mod_name']
+                                if idx == 0:
+                                    modname += ' (default)'
+                                mod_list.append(modname)
+                txt += ', '.join(mod_list)
+                multi_deps.append(txt)
+
+        return multi_deps
 
     def _generate_section(self, sec_name, sec_txt, strip=False):
         """
@@ -567,6 +595,11 @@ class ModuleGenerator(object):
                 "Description: %s" % self.app.cfg['description'],
                 "Homepage: %s" % self.app.cfg['homepage']
             ]
+
+            multi_deps = self._generate_multi_deps_list()
+            if multi_deps:
+                whatis.append("Compatible modules: %s" % ', '.join(multi_deps))
+
             extensions = self._generate_extension_list()
             if extensions:
                 whatis.append("Extensions: %s" % extensions)

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -541,8 +541,11 @@ class ModuleGenerator(object):
 
         # Multi deps (if any)
         multi_deps = self._generate_multi_deps_list()
-        section_txt = "This module is compatible with the following modules, one of each is required"
-        lines.extend(self._generate_section(section_txt, '\n'.join(multi_deps)))
+        if multi_deps:
+            compatible_modules_txt = '\n'.join([
+                "This module is compatible with the following modules, one of each line is required:",
+            ] + ['* %s' % d for d in multi_deps])
+            lines.extend(self._generate_section("Compatible modules", compatible_modules_txt))
 
         # Extensions (if any)
         extensions = self._generate_extension_list()

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2086,6 +2086,20 @@ class ToyBuildTest(EnhancedTestCase):
 
         self.assertTrue(expected in toy_mod_txt, "Pattern '%s' should be found in: %s" % (expected, toy_mod_txt))
 
+        # also check relevant parts of "module help" and whatis bits
+        expected_descr = '\n'.join([
+            "Compatible modules",
+            "==================",
+            "This module is compatible with the following modules, one of each line is required:",
+            "* GCC/4.6.3 (default), GCC/7.3.0-2.30",
+        ])
+        error_msg_descr = "Pattern '%s' should be found in: %s" % (expected_descr, toy_mod_txt)
+        self.assertTrue(expected_descr in toy_mod_txt, error_msg_descr)
+
+        expected_whatis = "whatis([==[Compatible modules: GCC/4.6.3 (default), GCC/7.3.0-2.30]==])"
+        error_msg_whatis = "Pattern '%s' should be found in: %s" % (expected_whatis, toy_mod_txt)
+        self.assertTrue(expected_whatis in toy_mod_txt, error_msg_whatis)
+
         def check_toy_load(depends_on=False):
             # by default, toy/0.0 should load GCC/4.6.3 (first listed GCC version in multi_deps)
             self.modtool.load(['toy/0.0'])
@@ -2156,6 +2170,8 @@ class ToyBuildTest(EnhancedTestCase):
         toy_mod_txt = read_file(toy_mod_file)
 
         self.assertFalse(expected in toy_mod_txt, "Pattern '%s' should not be found in: %s" % (expected, toy_mod_txt))
+        self.assertTrue(expected_descr in toy_mod_txt, error_msg_descr)
+        self.assertTrue(expected_whatis in toy_mod_txt, error_msg_whatis)
 
         self.modtool.load(['toy/0.0'])
         loaded_mod_names = [x['mod_name'] for x in self.modtool.list()]
@@ -2196,6 +2212,8 @@ class ToyBuildTest(EnhancedTestCase):
                 ])
 
             self.assertTrue(expected in toy_mod_txt, "Pattern '%s' should be found in: %s" % (expected, toy_mod_txt))
+            self.assertTrue(expected_descr in toy_mod_txt, error_msg_descr)
+            self.assertTrue(expected_whatis in toy_mod_txt, error_msg_whatis)
 
             check_toy_load(depends_on=True)
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2096,7 +2096,11 @@ class ToyBuildTest(EnhancedTestCase):
         error_msg_descr = "Pattern '%s' should be found in: %s" % (expected_descr, toy_mod_txt)
         self.assertTrue(expected_descr in toy_mod_txt, error_msg_descr)
 
-        expected_whatis = "whatis([==[Compatible modules: GCC/4.6.3 (default), GCC/7.3.0-2.30]==])"
+        if get_module_syntax() == 'Lua':
+            expected_whatis = "whatis([==[Compatible modules: GCC/4.6.3 (default), GCC/7.3.0-2.30]==])"
+        else:
+            expected_whatis = "module-whatis {Compatible modules: GCC/4.6.3 (default), GCC/7.3.0-2.30}"
+
         error_msg_whatis = "Pattern '%s' should be found in: %s" % (expected_whatis, toy_mod_txt)
         self.assertTrue(expected_whatis in toy_mod_txt, error_msg_whatis)
 


### PR DESCRIPTION
For a easyconfig with:
```
multi_deps = {
    'Python': ['3.7.2', '2.7.15'],
    'Tcl': ['8.6.8', '8.6.9'],
}
```
this will produce a module file containing:
```
This module is compatible with the following modules, one of each is required
=============================================================================
Python/3.7.2 (default), Python/2.7.15
Tcl/8.6.8 (default), Tcl/8.6.9
```
in the help section and
```
whatis([==[Compatible modules: Python/3.7.2 (default), Python/2.7.15, Tcl/8.6.8 (default), Tcl/8.6.9]==])
```

Is this what you where looking for, Joachim?

This is intended to solve, https://github.com/easybuilders/easybuild-framework/issues/2860