### PR TITLE
add support for --container-base-config and --container-template-recipe + rename --container-base to --container-base-image

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -127,7 +127,7 @@ BUILD_OPTIONS_CMDLINE = {
     None: [
         'aggregate_regtest',
         'backup_modules',
-        'container_base',
+        'container_base_image',
         'container_image_format',
         'container_image_name',
         'container_tmpdir',

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -127,9 +127,11 @@ BUILD_OPTIONS_CMDLINE = {
     None: [
         'aggregate_regtest',
         'backup_modules',
+        'container_base_config',
         'container_base_image',
         'container_image_format',
         'container_image_name',
+        'container_template_recipe',
         'container_tmpdir',
         'download_timeout',
         'dump_test_report',

--- a/easybuild/tools/containers/base.py
+++ b/easybuild/tools/containers/base.py
@@ -47,9 +47,11 @@ class ContainerGenerator(object):
     RECIPE_FILE_NAME = None
 
     def __init__(self, easyconfigs):
+        self.container_base_config = build_option('container_base_config')
         self.container_base_image = build_option('container_base_image')
         self.container_build_image = build_option('container_build_image')
         self.container_path = container_path()
+        self.container_template_recipe = build_option('container_template_recipe')
         self.easyconfigs = easyconfigs
         self.image_format = build_option('container_image_format')
         self.img_name = build_option('container_image_name')

--- a/easybuild/tools/containers/base.py
+++ b/easybuild/tools/containers/base.py
@@ -47,7 +47,7 @@ class ContainerGenerator(object):
     RECIPE_FILE_NAME = None
 
     def __init__(self, easyconfigs):
-        self.container_base = build_option('container_base')
+        self.container_base_image = build_option('container_base_image')
         self.container_build_image = build_option('container_build_image')
         self.container_path = container_path()
         self.easyconfigs = easyconfigs

--- a/easybuild/tools/containers/docker.py
+++ b/easybuild/tools/containers/docker.py
@@ -103,14 +103,23 @@ class DockerContainer(ContainerGenerator):
     RECIPE_FILE_NAME = 'Dockerfile'
 
     def resolve_template(self):
-        return "\n\n".join([
-            DOCKER_TMPL_HEADER % {'container_base_image': self.container_base_image},
-            DOCKER_OS_INSTALL_DEPS_TMPLS[self.container_base_image],
-            DOCKER_INSTALL_EASYBUILD,
-            DOCKER_TMPL_FOOTER,
-        ])
+        """Return template container recipe."""
+
+        if self.container_base_config:
+            raise EasyBuildError("--container-base-config is not supported yet for Docker container images!")
+        elif self.container_template_recipe:
+            raise EasyBuildError("--container-template-recipe is not supported yet for Docker container images!")
+        else:
+            return "\n\n".join([
+                DOCKER_TMPL_HEADER % {'container_base_image': self.container_base_image},
+                DOCKER_OS_INSTALL_DEPS_TMPLS[self.container_base_image],
+                DOCKER_INSTALL_EASYBUILD,
+                DOCKER_TMPL_FOOTER,
+            ])
 
     def resolve_template_data(self):
+        """Return template data for container recipe."""
+
         os_deps = det_os_deps(self.easyconfigs)
 
         ec = self.easyconfigs[-1]['ec']

--- a/easybuild/tools/containers/docker.py
+++ b/easybuild/tools/containers/docker.py
@@ -39,7 +39,7 @@ from easybuild.tools.run import run_cmd
 
 
 DOCKER_TMPL_HEADER = """\
-FROM %(container_base)s
+FROM %(container_base_image)s
 LABEL maintainer=easybuild@lists.ugent.be
 """
 
@@ -104,8 +104,8 @@ class DockerContainer(ContainerGenerator):
 
     def resolve_template(self):
         return "\n\n".join([
-            DOCKER_TMPL_HEADER % {'container_base': self.container_base},
-            DOCKER_OS_INSTALL_DEPS_TMPLS[self.container_base],
+            DOCKER_TMPL_HEADER % {'container_base_image': self.container_base_image},
+            DOCKER_OS_INSTALL_DEPS_TMPLS[self.container_base_image],
             DOCKER_INSTALL_EASYBUILD,
             DOCKER_TMPL_FOOTER,
         ])
@@ -129,8 +129,8 @@ class DockerContainer(ContainerGenerator):
         }
 
     def validate(self):
-        if self.container_base not in DOCKER_OS_INSTALL_DEPS_TMPLS.keys():
-            raise EasyBuildError("Unsupported container base image '%s'" % self.container_base)
+        if self.container_base_image not in DOCKER_OS_INSTALL_DEPS_TMPLS.keys():
+            raise EasyBuildError("Unsupported container base image '%s'" % self.container_base_image)
         super(DockerContainer, self).validate()
 
     def build_image(self, dockerfile):

--- a/easybuild/tools/containers/singularity.py
+++ b/easybuild/tools/containers/singularity.py
@@ -89,7 +89,7 @@ class SingularityContainer(ContainerGenerator):
 
     def resolve_template_data(self):
 
-        base_specs = parse_container_base(self.container_base)
+        base_specs = parse_container_base(self.container_base_image)
 
         # extracting application name,version, version suffix, toolchain name, toolchain version from
         # easyconfig class
@@ -98,7 +98,7 @@ class SingularityContainer(ContainerGenerator):
 
         base_image, base_image_tag = None, None
 
-        # with localimage it only takes 2 arguments. --container-base localimage:/path/to/image
+        # with localimage it only takes 2 arguments. --container-base-image localimage:/path/to/image
         # checking if path to image is valid and verify image extension is '.img' or '.simg'
         if base_specs['bootstrap_agent'] == LOCALIMAGE:
             base_image = base_specs['arg1']
@@ -113,7 +113,7 @@ class SingularityContainer(ContainerGenerator):
                 raise EasyBuildError("Singularity base image at specified path does not exist: %s", base_image)
 
         # otherwise, bootstrap agent is 'docker' or 'shub'
-        # format --container-base {docker|shub}:<image>:<tag>
+        # format --container-base-image {docker|shub}:<image>:<tag>
         else:
             base_image = base_specs['arg1']
             # image tag is optional
@@ -202,22 +202,22 @@ class SingularityContainer(ContainerGenerator):
 
 
 def parse_container_base(base):
-    """Parse value passed to --container-base option."""
+    """Parse value passed to --container-base-image option."""
     if base:
         base_specs = base.split(':')
         if len(base_specs) > 3 or len(base_specs) <= 1:
             error_msg = '\n'.join([
-                "Invalid format for --container-base, must be one of the following:",
+                "Invalid format for --container-base-image, must be one of the following:",
                 '',
-                "--container-base localimage:/path/to/image",
-                "--container-base shub:<image>:<tag>",
-                "--container-base docker:<image>:<tag>",
+                "--container-base-image localimage:/path/to/image",
+                "--container-base-image shub:<image>:<tag>",
+                "--container-base-image docker:<image>:<tag>",
             ])
             raise EasyBuildError(error_msg)
     else:
-        raise EasyBuildError("--container-base must be specified")
+        raise EasyBuildError("--container-base-image must be specified")
 
-    # first argument to --container-base is the Singularity bootstrap agent (localimage, shub, docker)
+    # first argument to --container-base-image is the Singularity bootstrap agent (localimage, shub, docker)
     bootstrap_agent = base_specs[0]
 
     # check bootstrap type value and ensure it is localimage, shub, docker

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -665,10 +665,10 @@ class EasyBuildOptions(GeneralOption):
         descr = ("Container options", "Options related to generating container recipes & images")
 
         opts = OrderedDict({
-            'base': ("Base for container image. Examples (for Singularity): "
-                     "--container-base localimage:/path/to/image.img, "
-                     "--container-base shub:<image>:<tag>, "
-                     "--container-base docker:<image>:<tag> ", str, 'store', None),
+            'base-image': ("Base image to use for container image. Examples (for Singularity): "
+                           "--container-base-image localimage:/path/to/image.img, "
+                           "--container-base-image shub:<image>:<tag>, "
+                           "--container-base-image docker:<image>:<tag> ", str, 'store', None),
             'build-image': ("Build container image (requires sudo privileges!)", None, 'store_true', False),
             'image-format': ("Container image format", 'choice', 'store', None, CONT_IMAGE_FORMATS),
             'image-name': ("Custom name for container image (defaults to name of easyconfig)", None, 'store', None),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -665,6 +665,7 @@ class EasyBuildOptions(GeneralOption):
         descr = ("Container options", "Options related to generating container recipes & images")
 
         opts = OrderedDict({
+            'base-config': ("Configuration for container image", str, 'store', None),
             'base-image': ("Base image to use for container image. Examples (for Singularity): "
                            "--container-base-image localimage:/path/to/image.img, "
                            "--container-base-image shub:<image>:<tag>, "
@@ -672,6 +673,7 @@ class EasyBuildOptions(GeneralOption):
             'build-image': ("Build container image (requires sudo privileges!)", None, 'store_true', False),
             'image-format': ("Container image format", 'choice', 'store', None, CONT_IMAGE_FORMATS),
             'image-name': ("Custom name for container image (defaults to name of easyconfig)", None, 'store', None),
+            'template-recipe': ("Template recipe for container image", str, 'store', None),
             'tmpdir': ("Temporary directory where container image is built", None, 'store', None),
             'type': ("Type of container recipe/image to create", 'choice', 'store', DEFAULT_CONT_TYPE, CONT_TYPES),
         })

--- a/test/framework/containers.py
+++ b/test/framework/containers.py
@@ -74,13 +74,14 @@ class ContainersTest(EnhancedTestCase):
     """Tests for containers support"""
 
     def test_parse_container_base(self):
-        """Test parse_container_base function."""
+        """Test parse_container_basefunction."""
 
         for base_spec in [None, '']:
-            self.assertErrorRegex(EasyBuildError, "--container-base must be specified", parse_container_base, base_spec)
+            error_pattern = "--container-base-image must be specified"
+            self.assertErrorRegex(EasyBuildError, error_pattern, parse_container_base, base_spec)
 
         # format of base spec must be correct: <bootstrap_agent>:<arg> or <bootstrap_agent>:<arg1>:<arg2>
-        error_regex = "Invalid format for --container-base"
+        error_regex = "Invalid format for --container-base-image"
         for base_spec in ['foo', 'foo:bar:baz:sjee']:
             self.assertErrorRegex(EasyBuildError, error_regex, parse_container_base, base_spec)
 
@@ -133,13 +134,13 @@ class ContainersTest(EnhancedTestCase):
             '--experimental',
         ]
 
-        error_pattern = "--container-base must be specified"
+        error_pattern = "--container-base-image must be specified"
         self.assertErrorRegex(EasyBuildError, error_pattern, self.run_main, args, raise_error=True)
 
         # generating Singularity definition file with 'docker' or 'shub' bootstrap agents always works,
         # i.e. image label is not verified, image tag can be anything
         for cont_base in ['docker:test123', 'docker:test123:foo', 'shub:test123', 'shub:test123:foo']:
-            stdout, stderr = self.run_main(args + ['--container-base=%s' % cont_base])
+            stdout, stderr = self.run_main(args + ['--container-base-image=%s' % cont_base])
 
             self.assertFalse(stderr)
             regexs = ["^== Singularity definition file created at %s/containers/Singularity.toy-0.0" % self.test_prefix]
@@ -147,7 +148,7 @@ class ContainersTest(EnhancedTestCase):
 
             remove_file(os.path.join(self.test_prefix, 'containers', 'Singularity.toy-0.0'))
 
-        args.append("--container-base=shub:test123")
+        args.append("--container-base-image=shub:test123")
         self.run_main(args)
 
         # existing definition file is not overwritten without use of --force
@@ -169,7 +170,7 @@ class ContainersTest(EnhancedTestCase):
 
         # with 'localimage' bootstrap agent, specified image must exist
         test_img = os.path.join(self.test_prefix, 'test123.img')
-        args[-1] = "--container-base=localimage:%s" % test_img
+        args[-1] = "--container-base-image=localimage:%s" % test_img
         error_pattern = "Singularity base image at specified path does not exist"
         self.assertErrorRegex(EasyBuildError, error_pattern, self.run_main, args, raise_error=True)
 
@@ -192,7 +193,7 @@ class ContainersTest(EnhancedTestCase):
         # image extension must make sense when localimage is used
         for img_name in ['test123.foo', 'test123']:
             test_img = os.path.join(self.test_prefix, img_name)
-            args[-1] = "--container-base=localimage:%s" % test_img
+            args[-1] = "--container-base-image=localimage:%s" % test_img
             write_file(test_img, '')
             error_pattern = "Invalid image extension '.*' must be \.img or \.simg"
             self.assertErrorRegex(EasyBuildError, error_pattern, self.run_main, args, raise_error=True)
@@ -214,7 +215,7 @@ class ContainersTest(EnhancedTestCase):
             toy_ec,
             '-C',  # equivalent with --containerize
             '--experimental',
-            '--container-base=localimage:%s' % test_img,
+            '--container-base-image=localimage:%s' % test_img,
             '--container-build-image',
         ]
 
@@ -314,30 +315,30 @@ class ContainersTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError,
                               error_pattern,
                               self.run_main,
-                              base_args + ['--container-base=not-supported'],
+                              base_args + ['--container-base-image=not-supported'],
                               raise_error=True)
 
         for cont_base in ['ubuntu:16.04', 'centos:7']:
-            stdout, stderr = self.run_main(base_args + ['--container-base=%s' % cont_base])
+            stdout, stderr = self.run_main(base_args + ['--container-base-image=%s' % cont_base])
             self.assertFalse(stderr)
             regexs = ["^== Dockerfile definition file created at %s/containers/Dockerfile.toy-0.0" % self.test_prefix]
             self.check_regexs(regexs, stdout)
             remove_file(os.path.join(self.test_prefix, 'containers', 'Dockerfile.toy-0.0'))
 
-        self.run_main(base_args + ['--container-base=centos:7'])
+        self.run_main(base_args + ['--container-base-image=centos:7'])
 
         error_pattern = "Container recipe at %s/containers/Dockerfile.toy-0.0 already exists, " \
                         "not overwriting it without --force" % self.test_prefix
         self.assertErrorRegex(EasyBuildError,
                               error_pattern,
                               self.run_main,
-                              base_args + ['--container-base=centos:7'],
+                              base_args + ['--container-base-image=centos:7'],
                               raise_error=True)
 
         remove_file(os.path.join(self.test_prefix, 'containers', 'Dockerfile.toy-0.0'))
 
         base_args.insert(1, os.path.join(test_ecs, 'g', 'GCC', 'GCC-4.9.2.eb'))
-        self.run_main(base_args + ['--container-base=ubuntu:16.04'])
+        self.run_main(base_args + ['--container-base-image=ubuntu:16.04'])
         def_file = read_file(os.path.join(self.test_prefix, 'containers', 'Dockerfile.toy-0.0'))
         regexs = [
             "FROM ubuntu:16.04",
@@ -361,7 +362,7 @@ class ContainersTest(EnhancedTestCase):
             '-C',  # equivalent with --containerize
             '--experimental',
             '--container-type=docker',
-            '--container-base=ubuntu:16.04',
+            '--container-base-image=ubuntu:16.04',
             '--container-build-image',
         ]
 


### PR DESCRIPTION
The renaming of `--container-base` to `--container-base-image` should be OK since the container support is still experimental.

Note: this PR can be merged into `develop`, but will not be included in EasyBuild 3.9.1 anymore (which will be released soon from the `3.9.x` branch.