### PR TITLE
don't specify --ntasks-per-node when submitting Slurm jobs

### DIFF
--- a/easybuild/tools/job/slurm.py
+++ b/easybuild/tools/job/slurm.py
@@ -184,6 +184,5 @@ class SlurmJob(object):
         if cores:
             self.job_specs['nodes'] = 1
             self.job_specs['ntasks'] = cores
-            self.job_specs['ntasks-per-node'] = cores
         else:
             self.log.warn("Number of cores to request not specified, falling back to whatever Slurm does by default")

--- a/test/framework/parallelbuild.py
+++ b/test/framework/parallelbuild.py
@@ -347,7 +347,6 @@ class ParallelBuildTest(EnhancedTestCase):
             'job-name': 'gzip-1.5-foss-2018a',
             'nodes': 1,
             'ntasks': 3,
-            'ntasks-per-node': 3,
             'output': 'gzip-1.5-foss-2018a-%j.out',
             'time': 300,  # 60*5 (unit is minutes)
             'wrap': "echo '%s'" % test_ec,


### PR DESCRIPTION
Currently, jobs to a `Slurm` backend are being submitted with "`sbatch --nodes 1 --ntasks 5 --ntasks-per-node 5`" when "`eb --job --job-cores 5`" is used.

That works fine, until you change your mind after the jobs were submitted and you want to increase the number of cores using `scontrol update job=<jobid> NumTasks=10 NumCPUS=10`.

The `--ntasks-per-node 5` that was used at submission time can not be changed afterwards, and thus it prevents you from increasing the number of requested cores for that job (if you do try to increase the number of cores/tasks, the job gets stuck due to `BadConstraints`).

I see no need for using `--ntasks-per-node` at all, so let's just remove it...
Afaik, this shouldn't cause any problems.