### PR TITLE
fix order of easyconfig parameters in output generated by 'eb --avail-easyconfig-params --output-format rst'

### DIFF
--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -228,10 +228,12 @@ def avail_easyconfig_params_rst(title, grouped_params):
         # group section title
         title = "%s parameters" % grpname
         table_titles = ["**Parameter name**", "**Description**", "**Default value**"]
+        keys = sorted(grouped_params[grpname].keys())
+        values = [grouped_params[grpname][key] for key in keys]
         table_values = [
-            ['``%s``' % name for name in grouped_params[grpname].keys()],  # parameter name
-            [x[0] for x in grouped_params[grpname].values()],  # description
-            [str(quote_str(x[1])) for x in grouped_params[grpname].values()]  # default value
+            ['``%s``' % name for name in keys],  # parameter name
+            [x[0] for x in values],  # description
+            [str(quote_str(x[1])) for x in values]  # default value
         ]
 
         doc.extend(rst_title_and_table(title, table_titles, table_values))

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -429,7 +429,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                     avail_arg,
                 ]
                 if fmt is not None:
-                    args.append(fmt)
+                    args.append('--output-format=%s' % fmt)
                 if custom is not None:
                     args.extend(['-e', custom])
 
@@ -449,14 +449,23 @@ class CommandLineOptionsTest(EnhancedTestCase):
                     msg = "Parameter type %s is featured in output of eb %s (args: %s): %s" % tup
                     self.assertTrue(regex.search(logtxt), msg)
 
+                ordered_params = ['name', 'toolchain', 'version', 'versionsuffix']
+                params = ordered_params + ['buildopts', 'sources', 'start_dir', 'dependencies', 'group',
+                                           'exts_list', 'moduleclass', 'buildstats'] + extra_params
+
                 # check a couple of easyconfig parameters
-                for param in ["name", "version", "toolchain", "versionsuffix", "buildopts", "sources", "start_dir",
-                              "dependencies", "group", "exts_list", "moduleclass", "buildstats"] + extra_params:
+                param_start = 0
+                for param in params:
                     # regex for parameter name (with optional '*') & description, matches both txt and rst formats
                     regex = re.compile("^[`]*%s(?:\*)?[`]*\s+\w+" % param, re.M)
                     tup = (param, avail_arg, args, regex.pattern, logtxt)
                     msg = "Parameter %s is listed with help in output of eb %s (args: %s, regex: %s): %s" % tup
-                    self.assertTrue(regex.search(logtxt), msg)
+                    res = regex.search(logtxt)
+                    self.assertTrue(res, msg)
+                    if param in ordered_params:
+                        # check whether this parameter is listed after previous one
+                        self.assertTrue(param_start < res.start(0), "%s is in expected order in: %s" % (param, logtxt))
+                        param_start = res.start(0)
 
             if os.path.exists(dummylogfn):
                 os.remove(dummylogfn)


### PR DESCRIPTION
Without this fix, the available easyconfig parameters are in no particular order, which affects the order in the auto-updated documentation at https://easybuild.readthedocs.io/en/latest/version-specific/easyconfig_parameters.html...