### PR TITLE
stick to vsc-base<2.9.0 in bootstrap script to avoid requiring 'future' dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20190322.01 4b00b89b2317e2e44fc56d0223e10239c1b4efc50f81fcd39eb73895bccbe927"
+    - EB_BOOTSTRAP_EXPECTED="20190521.01 c769811d1dd5b1447b9bc07b704a7c1e2a43eca5ff3853615ef1d6818d2119d3"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -54,7 +54,7 @@ from distutils.version import LooseVersion
 from hashlib import md5
 
 
-EB_BOOTSTRAP_VERSION = '20190322.01'
+EB_BOOTSTRAP_VERSION = '20190521.01'
 
 # argparse preferrred, optparse deprecated >=2.7
 HAVE_ARGPARSE = False
@@ -528,14 +528,18 @@ def stage1(tmpdir, sourcepath, distribute_egg_dir, forcedversion):
 
         # install vsc-base again at the end, to avoid that the one available on the system is used instead
         post_vsc_base = cmd[:]
-        post_vsc_base[-1] = VSC_BASE
+        post_vsc_base[-1] = VSC_BASE + '<2.9.0'
 
     if not print_debug:
         cmd.insert(0, '--quiet')
 
     # install vsc-install version prior to 0.11.4, where mock was introduced as a dependency
     # workaround for problem reported in https://github.com/easybuilders/easybuild-framework/issues/2712
-    run_easy_install(cmd[:-1] + [VSC_INSTALL + '<0.11.4'])
+    # also stick to vsc-base < 2.9.0 to avoid requiring 'future' Python package as dependency
+    for pkg in [VSC_INSTALL + '<0.11.4', VSC_BASE + '<2.9.0']:
+        precmd = cmd[:-1] + [pkg]
+        info("running pre-install command 'easy_install %s'" % (' '.join(precmd)))
+        run_easy_install(precmd)
 
     info("installing EasyBuild with 'easy_install %s'" % (' '.join(cmd)))
     run_easy_install(cmd)


### PR DESCRIPTION
`vsc-base` 2.9.0 and newer require `future` now

Since there are no updates in `vsc-base` that are relevant for EasyBuild and we ingested `vsc-base` into this repository in the `4.x` in preparation of EasyBuild 4.0 (cfr. #2708), we can stick to `vsc-base` 2.8.4 for now which doesn't add this additional requirement.

This is similar to what we did for `vsc-install` in #2717...