### PR TITLE
make --fix-deprecated-easyconfigs a bit less strict

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -2044,7 +2044,7 @@ def copy_patch_files(patch_specs, target_dir):
 def fix_deprecated_easyconfigs(paths):
     """Fix use of deprecated functionality in easyconfigs at specified locations."""
 
-    dummy_tc_regex = re.compile(r'^toolchain\s*=\s*{.*name.*dummy.*version.*}', re.M)
+    dummy_tc_regex = re.compile(r'^toolchain\s*=\s*{.*name.*dummy.*}', re.M)
 
     easyconfig_paths = []
     for path in paths:

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -2865,11 +2865,19 @@ class EasyConfigTest(EnhancedTestCase):
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         tc_regex = re.compile('^toolchain = .*', re.M)
 
-        for dummy_ver in ['dummy', '', '1.2.3']:
-            write_file(test_ec, tc_regex.sub("toolchain = {'name': 'dummy', 'version': '%s'}" % dummy_ver, toy_ectxt))
+        tc_strs = [
+            "{'name': 'dummy', 'version': 'dummy'}",
+            "{'name': 'dummy', 'version': ''}",
+            "{'name': 'dummy', 'version': '1.2.3'}",
+            "{'version': '', 'name': 'dummy'}",
+            "{'version': 'dummy', 'name': 'dummy'}",
+        ]
+
+        for tc_str in tc_strs:
+            write_file(test_ec, tc_regex.sub("toolchain = %s" % tc_str, toy_ectxt))
 
             test_ec_txt = read_file(test_ec)
-            regex = re.compile("^toolchain = {'name': 'dummy', .*$", re.M)
+            regex = re.compile("^toolchain = {.*'name': 'dummy'.*$", re.M)
             self.assertTrue(regex.search(test_ec_txt), "Pattern '%s' found in: %s" % (regex.pattern, test_ec_txt))
 
             self.mock_stderr(True)


### PR DESCRIPTION
Some existing easyconfigs don't have `name` and `version` in that order in the `toolchain` spec, so we need to be a bit more flexible in `--fix-deprecated-easyconfigs` (cfr. https://github.com/easybuilders/easybuild-easyconfigs/pull/8369).

