### PR TITLE
add support for specifying non-image based bootstrap agents in Singularity container recipes via --container-base-config

### DIFF
--- a/easybuild/tools/containers/singularity.py
+++ b/easybuild/tools/containers/singularity.py
@@ -162,7 +162,7 @@ class SingularityContainer(ContainerGenerator):
                 raise EasyBuildError("Unknown key for base container configuration: %s", key)
 
         # make sure correct bootstrap agent is specified
-        bootstrap = template_data['bootstrap']
+        bootstrap = template_data.get('bootstrap')
         if bootstrap:
             if bootstrap not in SINGULARITY_BOOTSTRAP_AGENTS:
                 raise EasyBuildError("Unknown value specified for 'bootstrap' keyword: %s (known: %s)",

--- a/easybuild/tools/containers/singularity.py
+++ b/easybuild/tools/containers/singularity.py
@@ -49,13 +49,18 @@ LIBRARY = 'library'  # Sylabs Container Library
 LOCALIMAGE = 'localimage'  # local image file
 SHUB = 'shub'  # image hosted on Singularity Hub
 YUM = 'yum'  # yum-based systems like CentOS
-ZYPPER = 'zypper'  # zypper-based systems like CentOS
+ZYPPER = 'zypper'  # zypper-based systems like openSUSE
 
 # valid bootstrap agents for 'bootstrap' keyword in --container-base-config
 SINGULARITY_BOOTSTRAP_AGENTS = [ARCH, BUSYBOX, DEBOOTSTRAP, DOCKER, LIBRARY, LOCALIMAGE, SHUB, YUM, ZYPPER]
 
 # valid bootstrap agents for --container-base-image value
 SINGULARITY_BOOTSTRAP_AGENTS_IMAGE = [DOCKER, LIBRARY, LOCALIMAGE, SHUB]
+
+SINGULARITY_INCLUDE_DEFAULTS = {
+    YUM: 'yum',
+    ZYPPER: 'zypper',
+}
 
 SINGULARITY_MIRRORURL_DEFAULTS = {
     BUSYBOX: 'https://www.busybox.net/downloads/binaries/%{OSVERSION}/busybox-x86_64',
@@ -171,7 +176,7 @@ class SingularityContainer(ContainerGenerator):
                                  bootstrap)
 
         # use default value for mirror URI if none was specified
-        if bootstrap in [BUSYBOX, DEBOOTSTRAP, YUM, ZYPPER] and template_data.get('mirrorurl') is None:
+        if bootstrap in SINGULARITY_MIRRORURL_DEFAULTS and template_data.get('mirrorurl') is None:
             template_data['mirrorurl'] = SINGULARITY_MIRRORURL_DEFAULTS[bootstrap]
 
         # check whether OS version is specified if required
@@ -179,6 +184,10 @@ class SingularityContainer(ContainerGenerator):
         if mirrorurl and '%{OSVERSION}' in mirrorurl and template_data.get('osversion') is None:
             raise EasyBuildError("Keyword 'osversion' is required in container base config when '%%{OSVERSION}' "
                                  "is used in mirror URI: %s", mirrorurl)
+
+        # use default value for list of included OS packages if nothing else was specified
+        if bootstrap in SINGULARITY_INCLUDE_DEFAULTS and template_data.get('include') is None:
+            template_data['include'] = SINGULARITY_INCLUDE_DEFAULTS[bootstrap]
 
         return template_data
 

--- a/easybuild/tools/containers/singularity.py
+++ b/easybuild/tools/containers/singularity.py
@@ -41,15 +41,32 @@ from easybuild.tools.run import run_cmd
 from easybuild.tools.containers.base import ContainerGenerator
 
 
-DOCKER = 'docker'
-LOCALIMAGE = 'localimage'
-SHUB = 'shub'
-SINGULARITY_BOOTSTRAP_TYPES = [DOCKER, LOCALIMAGE, SHUB]
+ARCH = 'arch'  # Arch Linux
+BUSYBOX = 'busybox'  # BusyBox Linux
+DEBOOTSTRAP = 'debootstrap'  # apt-based systems like Ubuntu/Debian
+DOCKER = 'docker'  # image hosted on Docker Hub
+LIBRARY = 'library'  # Sylabs Container Library
+LOCALIMAGE = 'localimage'  # local image file
+SHUB = 'shub'  # image hosted on Singularity Hub
+YUM = 'yum'  # yum-based systems like CentOS
+ZYPPER = 'zypper'  # zypper-based systems like CentOS
 
+# valid bootstrap agents for 'bootstrap' keyword in --container-base-config
+SINGULARITY_BOOTSTRAP_AGENTS = [ARCH, BUSYBOX, DEBOOTSTRAP, DOCKER, LIBRARY, LOCALIMAGE, SHUB, YUM, ZYPPER]
+
+# valid bootstrap agents for --container-base-image value
+SINGULARITY_BOOTSTRAP_AGENTS_IMAGE = [DOCKER, LIBRARY, LOCALIMAGE, SHUB]
+
+SINGULARITY_MIRRORURL_DEFAULTS = {
+    BUSYBOX: 'https://www.busybox.net/downloads/binaries/%{OSVERSION}/busybox-x86_64',
+    DEBOOTSTRAP: 'http://us.archive.ubuntu.com/ubuntu/',
+    YUM: 'http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/x86_64/',
+    ZYPPER: 'http://download.opensuse.org/distribution/leap/%{OSVERSION}/repo/oss/',
+}
 
 SINGULARITY_TEMPLATE = """
 Bootstrap: %(bootstrap)s
-From: %(from)s
+%(bootstrap_config)s
 
 %%post
 %(install_os_deps)s
@@ -115,26 +132,59 @@ class SingularityContainer(ContainerGenerator):
 
         template_data = {}
 
-        base_config_keys = ['bootstrap', 'from']
+        base_config_known_keys = [
+            # bootstrap agent to use
+            # see https://www.sylabs.io/guides/latest/user-guide/definition_files.html#header
+            'bootstrap',
+            # argument for bootstrap agents; only valid for: docker, library, localimage, shub
+            'from',
+            # list of additional OS packages to include; only valid with debootstrap, yum, zypper
+            'include',
+            # URI to use to download OS; only valid with busybox, debootstrap, yum, zypper
+            'mirrorurl',
+            # OS 'version' to use; only valid with busybox, debootstrap, yum, zypper
+            # only required if value for %(mirrorurl)s contains %{OSVERSION}s
+            'osversion',
+        ]
 
         # configuration for base container is assumed to have <key>=<value>[,<key>=<value>] format
         config_items = self.container_base_config.split(',')
         for item in config_items:
             key, value = item.split('=', 1)
-            if key in base_config_keys:
+            if key in base_config_known_keys:
                 template_data[key] = value
             else:
                 raise EasyBuildError("Unknown key for base container configuration: %s", key)
 
-        if sorted(base_config_keys) != sorted(template_data.keys()):
-            raise EasyBuildError("Not all keys for base configuration were specified! Found %s, expected %s",
-                                 ', '.join(sorted(base_config_keys)), ', '.join(sorted(template_data.keys())))
+        # make sure correct bootstrap agent is specified
+        bootstrap = template_data['bootstrap']
+        if bootstrap:
+            if bootstrap not in SINGULARITY_BOOTSTRAP_AGENTS:
+                raise EasyBuildError("Unknown value specified for 'bootstrap' keyword: %s (known: %s)",
+                                     bootstrap, ', '.join(SINGULARITY_BOOTSTRAP_AGENTS))
+        else:
+            raise EasyBuildError("Keyword 'bootstrap' is required in container base config")
+
+        # make sure 'from' is specified when required
+        if bootstrap in SINGULARITY_BOOTSTRAP_AGENTS_IMAGE and template_data.get('from') is None:
+            raise EasyBuildError("Keyword 'from' is required in container base config when using bootstrap agent '%s'",
+                                 bootstrap)
+
+        # use default value for mirror URI if none was specified
+        if bootstrap in [BUSYBOX, DEBOOTSTRAP, YUM, ZYPPER] and template_data.get('mirrorurl') is None:
+            template_data['mirrorurl'] = SINGULARITY_MIRRORURL_DEFAULTS[bootstrap]
+
+        # check whether OS version is specified if required
+        mirrorurl = template_data.get('mirrorurl')
+        if mirrorurl and '%{OSVERSION}' in mirrorurl and template_data.get('osversion') is None:
+            raise EasyBuildError("Keyword 'osversion' is required in container base config when '%%{OSVERSION}' "
+                                 "is used in mirror URI: %s", mirrorurl)
 
         return template_data
 
     def resolve_template_data_base_image(self):
         """Return template data for container recipe based on what is passed to --container-base-image."""
-        base_specs = parse_container_base(self.container_base_image)
+        base_specs = parse_container_base_image(self.container_base_image)
 
         # extracting application name,version, version suffix, toolchain name, toolchain version from
         # easyconfig class
@@ -157,8 +207,8 @@ class SingularityContainer(ContainerGenerator):
             else:
                 raise EasyBuildError("Singularity base image at specified path does not exist: %s", base_image)
 
-        # otherwise, bootstrap agent is 'docker' or 'shub'
-        # format --container-base-image {docker|shub}:<image>:<tag>
+        # otherwise, bootstrap agent is 'docker', 'library' or 'shub'
+        # format --container-base-image {docker|library|shub}:<image>:<tag>
         else:
             base_image = base_specs['arg1']
             # image tag is optional
@@ -190,6 +240,13 @@ class SingularityContainer(ContainerGenerator):
         else:
             raise EasyBuildError("Either --container-base-config or --container-base-image must be specified!")
 
+        # puzzle together specs for bootstrap agent
+        bootstrap_config_lines = []
+        for key in ['From', 'OSVersion', 'MirrorURL', 'Include']:
+            if key.lower() in template_data:
+                bootstrap_config_lines.append('%s: %s' % (key, template_data[key.lower()]))
+        template_data['bootstrap_config'] = '\n'.join(bootstrap_config_lines)
+
         # if there is osdependencies in easyconfig then add them to Singularity recipe
         install_os_deps = ''
         for ec in self.easyconfigs:
@@ -213,6 +270,7 @@ class SingularityContainer(ContainerGenerator):
         return template_data
 
     def build_image(self, recipe_path):
+        """Build container image by calling out to 'sudo singularity build'."""
 
         cont_path = container_path()
         def_file = os.path.basename(recipe_path)
@@ -276,7 +334,7 @@ class SingularityContainer(ContainerGenerator):
         print_msg("Singularity image created at %s" % img_path, log=self.log)
 
 
-def parse_container_base(base):
+def parse_container_base_image(base):
     """Parse value passed to --container-base-image option."""
     if base:
         base_specs = base.split(':')
@@ -284,21 +342,22 @@ def parse_container_base(base):
             error_msg = '\n'.join([
                 "Invalid format for --container-base-image, must be one of the following:",
                 '',
+                "--container-base-image library:<entity>/<collection>/<container>:<tag>",
                 "--container-base-image localimage:/path/to/image",
-                "--container-base-image shub:<image>:<tag>",
-                "--container-base-image docker:<image>:<tag>",
+                "--container-base-image shub:<registry>/<username>/<container-name>:<tag>@digest",
+                "--container-base-image docker:<registry>/<namespace>/<container>:<tag>@<digest>",
             ])
             raise EasyBuildError(error_msg)
     else:
         raise EasyBuildError("--container-base-image must be specified")
 
-    # first argument to --container-base-image is the Singularity bootstrap agent (localimage, shub, docker)
+    # first argument to --container-base-image is the Singularity bootstrap agent (library, localimage, shub, docker)
     bootstrap_agent = base_specs[0]
 
-    # check bootstrap type value and ensure it is localimage, shub, docker
-    if bootstrap_agent not in SINGULARITY_BOOTSTRAP_TYPES:
-        known_bootstrap_agents = ', '.join(SINGULARITY_BOOTSTRAP_TYPES)
-        raise EasyBuildError("Bootstrap agent in container base spec must be one of: %s" % known_bootstrap_agents)
+    # check bootstrap type value and ensure it is library, localimage, shub, docker
+    if bootstrap_agent not in SINGULARITY_BOOTSTRAP_AGENTS_IMAGE:
+        known_bootstrap_agents = ', '.join(SINGULARITY_BOOTSTRAP_AGENTS_IMAGE)
+        raise EasyBuildError("Bootstrap agent in container base image spec must be one of: %s" % known_bootstrap_agents)
 
     res = {'bootstrap_agent': bootstrap_agent}
 

--- a/test/framework/containers.py
+++ b/test/framework/containers.py
@@ -221,6 +221,10 @@ class ContainersTest(EnhancedTestCase):
             '--experimental',
         ]
 
+        args.extend(['--container-base-config', 'osversion=7.6.1810'])
+        error_pattern = r"Keyword 'bootstrap' is required in container base config"
+        self.assertErrorRegex(EasyBuildError, error_pattern, self.run_main, args, raise_error=True)
+
         args.extend(['--container-base-config', 'bootstrap=foobar'])
         error_pattern = r"Unknown value specified for 'bootstrap' keyword: foobar \(known: arch, busybox, debootstrap, "
         self.assertErrorRegex(EasyBuildError, error_pattern, self.run_main, args, raise_error=True)

--- a/test/framework/containers.py
+++ b/test/framework/containers.py
@@ -238,7 +238,8 @@ class ContainersTest(EnhancedTestCase):
             "Bootstrap: yum",
             "OSVersion: 7.6.1810",
             "MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/x86_64/",
-            '',
+            "Include: yum",
+            '\n',
         ])
         self.assertTrue(txt.startswith(expected), "Container recipe starts with '%s':\n\n%s" % (expected, txt))
 
@@ -253,21 +254,23 @@ class ContainersTest(EnhancedTestCase):
             "Bootstrap: yum",
             "OSVersion: 7.6.1810",
             "MirrorURL: https://example.com",
-            '',
+            "Include: yum",
+            '\n',
         ])
         self.assertTrue(txt.startswith(expected), "Container recipe starts with '%s':\n\n%s" % (expected, txt))
 
         remove_file(test_container_recipe)
 
         # osversion is not required when %{OSVERSION} is nost used in mirror URL
-        args[-1] = 'bootstrap=yum,mirrorurl=https://example.com'
+        args[-1] = 'bootstrap=yum,mirrorurl=https://example.com,include=test123'
         stdout, stderr = self.run_main(args, raise_error=True)
 
         txt = read_file(test_container_recipe)
         expected = '\n'.join([
             "Bootstrap: yum",
             "MirrorURL: https://example.com",
-            '',
+            "Include: test123",
+            '\n',
         ])
         self.assertTrue(txt.startswith(expected), "Container recipe starts with '%s':\n\n%s" % (expected, txt))
 


### PR DESCRIPTION
Things that work now that did not before:

```
eb -C --container-base-config bootstrap=yum,osversion=7.6.1810 --experimental bzip2-1.0.6.eb
```

This is only partially useful for now, since the assumption is still that EasyBuild is installed in the container image (which it won't be if you start from a minimal OS), along with `pip`, Lmod, etc., and that an `easybuild` user exists that has write access to `/app/` and `/scratch/`.
I plan to fix that in a follow-up PR, but I prefer keeping the scope of PRs limited to make them easier to review/merge.

This fixes #2901 along the way too (cc @ArangoGutierrez):

```
eb -C --container-base-config bootstrap=library,from=sylabsed/examples/lolcow:latest --experimental bzip2-1.0.6.eb
```

When an existing image is being pulled from a repository like Singularity Hub (`shub`), Sylabs Container Library (`library`) or Docker Hub (`docker`), or if a local container image (`localimage`) is used as base, the assumptions w.r.t. EasyBuild, Lmod and the `easybuild` user are probably going to stand (for now)...