### PR TITLE
Preserve interpreter options when fixing script shebang

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2167,9 +2167,12 @@ class EasyBlock(object):
                     paths = glob.glob(os.path.join(self.installdir, glob_pattern))
                     self.log.info("Fixing '%s' shebang to '%s' for files that match '%s': %s",
                                   lang, shebang, glob_pattern, paths)
-                    regex = r'^#!.*/%s[0-9.]*$' % lang
+                    # Use a regex group to capture any option passed to the interpreter
+                    # in the original shebang to preserve them in the new one.
+                    regex = r'^#!.*/%s[0-9.]?([^\.]*)$' % lang
+                    replace = r'%s\1' % shebang
                     for path in paths:
-                        apply_regex_substitutions(path, [(regex, shebang)], backup=False)
+                        apply_regex_substitutions(path, [(regex, replace)], backup=False)
 
     def post_install_step(self):
         """

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2167,12 +2167,9 @@ class EasyBlock(object):
                     paths = glob.glob(os.path.join(self.installdir, glob_pattern))
                     self.log.info("Fixing '%s' shebang to '%s' for files that match '%s': %s",
                                   lang, shebang, glob_pattern, paths)
-                    # Use a regex group to capture any option passed to the interpreter
-                    # in the original shebang to preserve them in the new one.
-                    regex = r'^#!.*/%s[0-9.]?([^\.]*)$' % lang
-                    replace = r'%s\1' % shebang
+                    regex = r'^#!.*/%s[0-9.]*' % lang
                     for path in paths:
-                        apply_regex_substitutions(path, [(regex, replace)], backup=False)
+                        apply_regex_substitutions(path, [(regex, shebang)], backup=False)
 
     def post_install_step(self):
         """

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2261,12 +2261,12 @@ class ToyBuildTest(EnhancedTestCase):
         for perlbin in ['t1.pl', 't2.pl', 't3.pl', 't4.pl']:
             perlbin_path = os.path.join(toy_bindir, perlbin)
             perlbin_txt = read_file(perlbin_path)
-            if perlbin != 't4.pl':
-                self.assertTrue(perl_shebang_regex.match(perlbin_txt),
-                                "Pattern '%s' found in %s: %s" % (perl_shebang_regex.pattern, perlbin_path, perlbin_txt))
+            if perlbin == 't4.pl':
+                regex = perl_opt_shebang_regex
             else:
-                self.assertTrue(perl_opt_shebang_regex.match(perlbin_txt),
-                                "Pattern '%s' found in %s: %s" % (perl_shebang_regex.pattern, perlbin_path, perlbin_txt))
+                regex = perl_shebang_regex
+            self.assertTrue(regex.match(perlbin_txt),
+                            "Pattern '%s' found in %s: %s" % (regex.pattern, perlbin_path, perlbin_txt))
 
 def suite():
     """ return all the tests in this file """

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2237,6 +2237,7 @@ class ToyBuildTest(EnhancedTestCase):
             "   'echo \"#!/usr/bin/perl\\n# test\" > %(installdir)s/bin/t1.pl',",
             "   'echo \"#!/software/Perl/5.28.1-GCCcore-7.3.0/bin/perl5\\n# test\" > %(installdir)s/bin/t2.pl',",
             "   'echo \"#!/usr/bin/env perl\\n# test\" > %(installdir)s/bin/t3.pl',",
+            "   'echo \"#!/usr/bin/perl -w\\n# test\" > %(installdir)s/bin/t4.pl',",
             "]",
             "fix_python_shebang_for = ['bin/t1.py', 'bin/*.py', 'nosuchdir/*.py']",
             "fix_perl_shebang_for = 'bin/*.pl'",
@@ -2256,12 +2257,16 @@ class ToyBuildTest(EnhancedTestCase):
 
         # no re.M, this should match at start of file!
         perl_shebang_regex = re.compile(r'^#!/usr/bin/env perl\n# test$')
-        for perlbin in ['t1.pl', 't2.pl', 't3.pl']:
+        perl_opt_shebang_regex = re.compile(r'^#!/usr/bin/env perl -w\n# test$')
+        for perlbin in ['t1.pl', 't2.pl', 't3.pl', 't4.pl']:
             perlbin_path = os.path.join(toy_bindir, perlbin)
             perlbin_txt = read_file(perlbin_path)
-            self.assertTrue(perl_shebang_regex.match(perlbin_txt),
-                            "Pattern '%s' found in %s: %s" % (perl_shebang_regex.pattern, perlbin_path, perlbin_txt))
-
+            if perlbin != 't4.pl':
+                self.assertTrue(perl_shebang_regex.match(perlbin_txt),
+                                "Pattern '%s' found in %s: %s" % (perl_shebang_regex.pattern, perlbin_path, perlbin_txt))
+            else:
+                self.assertTrue(perl_opt_shebang_regex.match(perlbin_txt),
+                                "Pattern '%s' found in %s: %s" % (perl_shebang_regex.pattern, perlbin_path, perlbin_txt))
 
 def suite():
     """ return all the tests in this file """


### PR DESCRIPTION
With the current implementation, the shebang is not fixed if anything is specified after the path, as in `#!/usr/bin/perl -w`.
The proposed solution captures whatever follows the interpreter path and adds it back into the new shebang. If nothing is specified, nothing is added, making it fully backwards compatible.