### PR TITLE
Remove shebang options - Improve apply_regex_substitution log output

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2167,7 +2167,7 @@ class EasyBlock(object):
                     paths = glob.glob(os.path.join(self.installdir, glob_pattern))
                     self.log.info("Fixing '%s' shebang to '%s' for files that match '%s': %s",
                                   lang, shebang, glob_pattern, paths)
-                    regex = r'^#!.*/%s[0-9.]*' % lang
+                    regex = r'^#!.*/%s[0-9.]*\s+.*' % lang
                     for path in paths:
                         apply_regex_substitutions(path, [(regex, shebang)], backup=False)
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2167,7 +2167,7 @@ class EasyBlock(object):
                     paths = glob.glob(os.path.join(self.installdir, glob_pattern))
                     self.log.info("Fixing '%s' shebang to '%s' for files that match '%s': %s",
                                   lang, shebang, glob_pattern, paths)
-                    regex = r'^#!.*/%s[0-9.]*\s+.*' % lang
+                    regex = r'^#!.*/%s[0-9.]*.*$' % lang
                     for path in paths:
                         apply_regex_substitutions(path, [(regex, shebang)], backup=False)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1041,13 +1041,11 @@ def apply_regex_substitutions(path, regex_subs, backup='.orig.eb'):
             backup_ext = ''
 
         try:
-            counter = 0
-            for line in fileinput.input(path, inplace=1, backup=backup_ext):
-                counter += 1
+            for line_id, line in enumerate(fileinput.input(path, inplace=1, backup=backup_ext)):
                 for regex, subtxt in regex_subs:
                     match = regex.search(line)
                     if match:
-                        _log.info("Replacing line %d in %s: '%s' -> '%s'", counter, path, match.group(0), subtxt)
+                        _log.info("Replacing line %d in %s: '%s' -> '%s'", (line_id + 1), path, match.group(0), subtxt)
                     line = regex.sub(subtxt, line)
                 sys.stdout.write(line)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1029,7 +1029,7 @@ def apply_regex_substitutions(path, regex_subs, backup='.orig.eb'):
             dry_run_msg("  * regex pattern '%s', replacement string '%s'" % (regex, subtxt))
 
     else:
-        _log.debug("Applying following regex substitutions to %s: %s", path, regex_subs)
+        _log.info("Applying following regex substitutions to %s: %s", path, regex_subs)
 
         for i, (regex, subtxt) in enumerate(regex_subs):
             regex_subs[i] = (re.compile(regex), subtxt)
@@ -1041,8 +1041,13 @@ def apply_regex_substitutions(path, regex_subs, backup='.orig.eb'):
             backup_ext = ''
 
         try:
+            counter = 0
             for line in fileinput.input(path, inplace=1, backup=backup_ext):
+                counter += 1
                 for regex, subtxt in regex_subs:
+                    match = regex.search(line)
+                    if match:
+                        _log.info("Replacing line %d in %s: '%s' -> '%s'", counter, path, match.group(0), subtxt)
                     line = regex.sub(subtxt, line)
                 sys.stdout.write(line)
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2261,7 +2261,7 @@ class ToyBuildTest(EnhancedTestCase):
             perlbin_path = os.path.join(toy_bindir, perlbin)
             perlbin_txt = read_file(perlbin_path)
             self.assertTrue(perl_shebang_regex.match(perlbin_txt),
-                            "Pattern '%s' found in %s: %s" % (regex.pattern, perlbin_path, perlbin_txt))
+                            "Pattern '%s' found in %s: %s" % (perl_shebang_regex.pattern, perlbin_path, perlbin_txt))
 
 def suite():
     """ return all the tests in this file """

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2257,15 +2257,10 @@ class ToyBuildTest(EnhancedTestCase):
 
         # no re.M, this should match at start of file!
         perl_shebang_regex = re.compile(r'^#!/usr/bin/env perl\n# test$')
-        perl_opt_shebang_regex = re.compile(r'^#!/usr/bin/env perl -w\n# test$')
         for perlbin in ['t1.pl', 't2.pl', 't3.pl', 't4.pl']:
             perlbin_path = os.path.join(toy_bindir, perlbin)
             perlbin_txt = read_file(perlbin_path)
-            if perlbin == 't4.pl':
-                regex = perl_opt_shebang_regex
-            else:
-                regex = perl_shebang_regex
-            self.assertTrue(regex.match(perlbin_txt),
+            self.assertTrue(perl_shebang_regex.match(perlbin_txt),
                             "Pattern '%s' found in %s: %s" % (regex.pattern, perlbin_path, perlbin_txt))
 
 def suite():


### PR DESCRIPTION
The problem with the changes in #2905 is that with coreutils < 0.30 everything that follows the first word in the shebang is treated as a single argument. Hence something like `#!/usr/bin/env perl -w` fails with:
```
/usr/bin/env: 'perl -w': No such file or directory
```
This fix removes any flag from the shebang.

Changes to `filetools.py` are also proposed to provide a complete log of the strings replaced by `apply_regex_substitutions`. The log output will be:
```
INFO Fixing 'perl' shebang to '#!/usr/bin/env perl' for files that match 'bin/SVDetect': ['/opt/easybuild/software/Compiler/GCC/6.4.0-2.28/SVDetect/0.8b-Perl-5.26.0/bin/SVDetect']
INFO Applying following regex substitutions to /opt/easybuild/software/Compiler/GCC/6.4.0-2.28/SVDetect/0.8b-Perl-5.26.0/bin/SVDetect: [('^#!.*/perl[0-9.]*\\s+.*', '#!/usr/bin/env perl')]
INFO Replacing line 1 in /opt/easybuild/software/Compiler/GCC/6.4.0-2.28/SVDetect/0.8b-Perl-5.26.0/scripts/BAM_preprocessingPairs.pl: '#!/usr/bin/perl -w' -> '#!/usr/bin/env perl'
```