### PR TITLE
configure Lmod w.r.t. spider cache in generated Singularity container recipes + also install OS pkgs for OpenSSL & IB libs

### DIFF
--- a/easybuild/tools/containers/singularity.py
+++ b/easybuild/tools/containers/singularity.py
@@ -99,7 +99,11 @@ eval "$@"
 
 %%environment
 source /etc/profile
+# avoid picking up modules from outside of container
+module unuse $MODULEPATH
+# pick up modules installed in /app
 module use /app/modules/all
+# load module(s) corresponding to installed software
 module load %(mod_names)s
 
 %%labels

--- a/easybuild/tools/containers/singularity.py
+++ b/easybuild/tools/containers/singularity.py
@@ -235,6 +235,8 @@ class SingularityContainer(ContainerGenerator):
                 'python-pip',
                 # additional packages that EasyBuild relies on (for now)
                 'gcc-c++',  # C/C++ components of GCC (gcc, g++)
+                ('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel'),  # for OpenMPI
+                ('openssl-devel', 'libssl-dev', 'libopenssl-devel'),  # for CMake, Python, ...
                 'perl-Data-Dumper',  # required for GCC build
                 # required for Automake build, see https://github.com/easybuilders/easybuild-easyconfigs/issues/1822
                 'perl-Thread-Queue',

--- a/easybuild/tools/containers/singularity.py
+++ b/easybuild/tools/containers/singularity.py
@@ -83,9 +83,6 @@ Bootstrap: %(bootstrap)s
 
 %(post_commands)s
 
-# change to 'easybuild' user
-su - easybuild
-
 # install Lmod RC file
 cat > /etc/lmodrc.lua << EOF
 scDescriptT = {
@@ -95,6 +92,12 @@ scDescriptT = {
   },
 }
 EOF
+
+# change to 'easybuild' user
+su - easybuild
+
+# verbose commands
+set -v
 
 # use EasyBuild to install specified software
 eb %(easyconfigs)s --robot --installpath=/app/ --prefix=/scratch --tmpdir=/scratch/tmp
@@ -117,6 +120,8 @@ eval "$@"
 source /etc/profile
 # increase threshold time for Lmod to write cache in $HOME (which we don't want to do)
 export LMOD_SHORT_TIME=86400
+# purge any modules that may be loaded outside container
+module --force purge
 # avoid picking up modules from outside of container
 module unuse $MODULEPATH
 # pick up modules installed in /app


### PR DESCRIPTION
Updating the Lmod cache is important w.r.t. avoiding that the auto-generated Lmod user cache which is stored in `$HOME/.lmod.d` gets picked up, since that can lead to very confusing output from "`module avail`" when switching between container images...