### PR TITLE
disable checking of read/exec permissions when checking for availability of 'sudo' command

### DIFF
--- a/easybuild/tools/containers/utils.py
+++ b/easybuild/tools/containers/utils.py
@@ -59,7 +59,7 @@ def check_tool(tool_name, min_tool_version=None):
     """
     if tool_name == 'sudo':
         # disable checking of permissions for 'sudo' command,
-        # since read permissions are never available for 'sudo' executable
+        # since read permissions may not be available for 'sudo' executable (e.g. on CentOS)
         tool_path = which(tool_name, check_perms=False)
     else:
         tool_path = which(tool_name)

--- a/easybuild/tools/containers/utils.py
+++ b/easybuild/tools/containers/utils.py
@@ -57,7 +57,13 @@ def check_tool(tool_name, min_tool_version=None):
     This function is a predicate check for the existence of tool_name on the system PATH.
     If min_tool_version is not None, it will check that the version has an equal or higher value.
     """
-    tool_path = which(tool_name)
+    if tool_name == 'sudo':
+        # disable checking of permissions for 'sudo' command,
+        # since read permissions are never available for 'sudo' executable
+        tool_path = which(tool_name, check_perms=False)
+    else:
+        tool_path = which(tool_name)
+
     if not tool_path:
         return False
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -376,7 +376,7 @@ def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False, forced
     return find_base_dir()
 
 
-def which(cmd, retain_all=False):
+def which(cmd, retain_all=False, check_perms=True):
     """
     Return (first) path in $PATH for specified command, or None if command is not found
 
@@ -389,9 +389,14 @@ def which(cmd, retain_all=False):
     paths = os.environ.get('PATH', '').split(os.pathsep)
     for path in paths:
         cmd_path = os.path.join(path, cmd)
-        # only accept path is command is there, and both readable and executable
-        if os.access(cmd_path, os.R_OK | os.X_OK) and os.path.isfile(cmd_path):
-            _log.info("Command %s found at %s" % (cmd, cmd_path))
+        # only accept path if command is there
+        if os.path.isfile(cmd_path):
+            _log.info("Command %s found at %s", cmd, cmd_path)
+            if check_perms:
+                # check if read/executable permissions are available
+                if not os.access(cmd_path, os.R_OK | os.X_OK):
+                    _log.info("No read/exec permissions for %s, so continuing search...", cmd_path)
+                    continue
             if retain_all:
                 res.append(cmd_path)
             else:

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -380,7 +380,9 @@ def which(cmd, retain_all=False, check_perms=True):
     """
     Return (first) path in $PATH for specified command, or None if command is not found
 
-    :param retain_all: returns *all* locations to the specified command in $PATH, not just the first one"""
+    :param retain_all: returns *all* locations to the specified command in $PATH, not just the first one
+    :param check_perms: check whether candidate path has read/exec permissions before accepting it as a match
+    """
     if retain_all:
         res = []
     else:

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -215,6 +215,25 @@ class FileToolsTest(EnhancedTestCase):
         self.assertTrue(os.path.samefile(res[0], bar))
         self.assertTrue(os.path.samefile(res[1], barbis))
 
+        # both read/exec permissions must be available
+        # if read permissions are removed for first hit, second hit is found instead
+        ft.adjust_permissions(bar, stat.S_IRUSR, add=False)
+        self.assertTrue(os.path.samefile(ft.which('bar'), barbis))
+
+        # likewise for read permissions
+        ft.adjust_permissions(bar, stat.S_IRUSR, add=True)
+        self.assertTrue(os.path.samefile(ft.which('bar'), bar))
+
+        ft.adjust_permissions(bar, stat.S_IXUSR, add=False)
+        self.assertTrue(os.path.samefile(ft.which('bar'), barbis))
+
+        # if read permission on other 'bar' are also removed, nothing is found anymore
+        ft.adjust_permissions(barbis, stat.S_IRUSR, add=False)
+        self.assertEqual(ft.which('bar'), None)
+
+        # checking of read/exec permissions can be disabled via 'check_perms'
+        self.assertTrue(os.path.samefile(ft.which('bar', check_perms=False), bar))
+
     def test_checksums(self):
         """Test checksum functionality."""
         fh, fp = tempfile.mkstemp()


### PR DESCRIPTION
On CentOS7:
```
$ which sudo
/usr/bin/sudo
$ file /usr/bin/sudo
/usr/bin/sudo: setuid executable, regular file, no read permission
$ ls -l /usr/bin/sudo
---s--x--x. 1 root root 147392 Oct 31  2018 /usr/bin/sudo
```

Without this, using `--container-build-image` fails with:

```
ERROR: sudo not found on your system
```