### PR TITLE
also consider 'python3' in 'eb' script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,6 +114,8 @@ script:
     # to run tests on an *installed* version of the EasyBuild framework;
     # this is done to catch possible packaging issues
     - cd $HOME
+    # eb --version with verbose output from 'eb' command (to show selection of 'python' command to use)
+    - EB_VERBOSE=1 eb --version
     # check GitHub configuration
     - eb --check-github --github-user=easybuild_test
     # run test suite

--- a/eb
+++ b/eb
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##
-# Copyright 2009-2014 Ghent University
+# Copyright 2009-2019 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -33,39 +33,48 @@
 # @author: Pieter De Baets (Ghent University)
 # @author: Jens Timmerman (Ghent University)
 
-# Python 2.6 or more recent 2.x required
-REQ_MAJ_PYVER=2
-REQ_MIN_PYVER=6
-REQ_PYVER=${REQ_MAJ_PYVER}.${REQ_MIN_PYVER}
+# Python 2.6+ or 3.5+ required
+REQ_MIN_PY2VER=6
+REQ_MIN_PY3VER=5
 
-PYTHON=python$REQ_MAJ_PYVER
-which $PYTHON &> /dev/null
-if [ $? -ne 0 ]
-then
-    PYTHON=python
-    which $PYTHON &> /dev/null
-    if [ $? -ne 0 ]
-    then
-        echo "ERROR: $PYTHON not available in \$PATH?"
-        exit 1
+
+function verbose() {
+    if [ ! -z ${EB_VERBOSE} ]; then echo ">> $1"; fi
+}
+
+PYTHON=
+for python_cmd in 'python2' 'python3' 'python'; do
+
+    verbose "Considering '$python_cmd'..."
+
+    which $python_cmd &> /dev/null
+    if [ $? -eq 0 ]; then
+
+        # make sure Python version being used is compatible
+        pyver=`$python_cmd -V 2>&1 | cut -f2 -d' '`
+        pyver_maj=`echo $pyver | cut -f1 -d'.'`
+        pyver_min=`echo $pyver | cut -f2 -d'.'`
+
+        if [ $pyver_maj -eq 2 ] && [ $pyver_min -ge $REQ_MIN_PY2VER ]; then
+            verbose "'$python_cmd' version: $pyver, which matches Python 2 version requirement (>= 2.$REQ_MIN_PY2VER)"
+            PYTHON=$python_cmd
+            break
+        elif [ $pyver_maj -eq 3 ] && [ $pyver_min -ge $REQ_MIN_PY3VER ]; then
+            verbose "'$python_cmd' version: $pyver, which matches Python 3 version requirement (>= 3.$REQ_MIN_PY3VER)"
+            PYTHON=$python_cmd
+            break
+        fi
+    else
+        verbose "No '$python_cmd' found in \$PATH, skipping..."
     fi
-fi
+done
 
-# make sure Python version being used is compatible
-pyver=`$PYTHON -V 2>&1 | cut -f2 -d' '`
-pyver_maj=`echo $pyver | cut -f1 -d'.'`
-pyver_min=`echo $pyver | cut -f2 -d'.'`
-
-if [ $pyver_maj -ne $REQ_MAJ_PYVER ]
-then
-    echo "ERROR: EasyBuild is currently only compatible with Python v${REQ_MAJ_PYVER}.x, found v${pyver}" 1>&2
-    exit 2
-fi
-
-if [ $pyver_min -lt $REQ_MIN_PYVER ]
-then
-    echo "ERROR: EasyBuild requires Python v${REQ_PYVER} or a more recent v${REQ_MAJ_PYVER}.x, found v${pyver}." 1>&2
-    exit 3
+if [ -z $PYTHON ]; then
+    echo -n "ERROR: No compatible 'python' command found via \$PATH " >&2
+    echo "(EasyBuild requires Python 2.${REQ_MIN_PY2VER}+ or 3.${REQ_MIN_PY3VER}+)" >&2
+    exit 1
+else
+    verbose "Selected Python command: $python_cmd (`which $python_cmd`)"
 fi
 
 # enable optimization, unless $PYTHONOPTIMIZE is defined (use "export PYTHONOPTIMIZE=0" to disable optimization)
@@ -81,4 +90,5 @@ then
     export FANCYLOGGER_IGNORE_MPI4PY=1
 fi
 
+verbose "$PYTHON -m easybuild.main $@"
 $PYTHON -m easybuild.main "$@"

--- a/eb
+++ b/eb
@@ -43,7 +43,7 @@ function verbose() {
 }
 
 PYTHON=
-for python_cmd in 'python2' 'python3' 'python'; do
+for python_cmd in ${EB_PYTHON} 'python2' 'python3' 'python'; do
 
     verbose "Considering '$python_cmd'..."
 


### PR DESCRIPTION
Before these changes, the `eb` script was already considering `python2` prior to `python`.

Now it also considers `python3`, after considering `python2` but before considering `python`.

In addition, you can specify a specific `python*` command to use via the `$EB_PYTHON` environment variable.

Verbose output of the procedure to pick a `python*` command to use can be obtained by setting `$EB_VERBOSE`:

```
$ EB_VERBOSE=1 eb --version
>> Considering 'python2'...
>> No 'python2' found in $PATH, skipping...
>> Considering 'python3'...
>> 'python3' version: 3.7.2, which matches Python 3 version requirement (>= 3.5)
>> Selected Python command: python3 (/usr/local/bin/python3)
>> python3 -m easybuild.main --version
This is EasyBuild 4.0.0.dev0 (framework: 4.0.0.dev0, easyblocks: 4.0.0.dev0) on host boegels-MBP.
```

```
$ EB_PYTHON=python EB_VERBOSE=1 eb --version
>> Considering 'python'...
>> 'python' version: 2.7.10, which matches Python 2 version requirement (>= 2.6)
>> Selected Python command: python (/usr/bin/python)
>> python -m easybuild.main --version
This is EasyBuild 4.0.0.dev0 (framework: 4.0.0.dev0, easyblocks: 4.0.0.dev0) on host boegels-MBP.
```

```
$ EB_PYTHON=/usr/bin/python2.7 EB_VERBOSE=1 eb --version
>> Considering '/usr/bin/python2.7'...
>> '/usr/bin/python2.7' version: 2.7.10, which matches Python 2 version requirement (>= 2.6)
>> Selected Python command: /usr/bin/python2.7 (/usr/bin/python2.7)
>> /usr/bin/python2.7 -m easybuild.main --version
This is EasyBuild 4.0.0.dev0 (framework: 4.0.0.dev0, easyblocks: 4.0.0.dev0) on host boegels-MBP.
```