### PR TITLE
warn if non-single-letter local variables not named 'local_*' or '_*' are used + enhance --fix-deprecated-easyconfigs to rename them

### DIFF
--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -198,6 +198,10 @@ DEFAULT_CONFIG = {
     'whatis': [None, "List of brief (one line) description entries for the software", MODULES],
 
     # OTHER easyconfig parameters
+    # 'block' must be a known easyconfig parameter in case strict local variable naming is enabled;
+    # see also retrieve_blocks_in_spec function
+    'block': [None, "List of other 'block' sections on which this block depends "
+                    "(only relevant in easyconfigs with subblocks)", OTHER],
     'buildstats': [None, "A list of dicts with build statistics", OTHER],
     'deprecated': [False, "String specifying reason why this easyconfig file is deprecated "
                           "and will be archived in the next major release of EasyBuild", OTHER],

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -469,8 +469,12 @@ class EasyConfig(object):
 
         if self.unknown_keys:
             cnt = len(self.unknown_keys)
+            if self.path:
+                in_fn = "in %s" % os.path.basename(self.path)
+            else:
+                in_fn = ''
             unknown_keys_msg = ', '.join(sorted(self.unknown_keys))
-            msg = "Use of %d unknown easyconfig parameters detected: %s\n" % (cnt, unknown_keys_msg)
+            msg = "Use of %d unknown easyconfig parameters detected %s: %s\n" % (cnt, in_fn, unknown_keys_msg)
             msg += "If these are just local variables please rename them to start with '%s', " % LOCAL_VAR_PREFIX
             msg += "or try using --fix-deprecated-easyconfigs to do this automatically."
             if strict_local_var_naming:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -137,7 +137,7 @@ def is_local_var_name(name):
     elif name in ['__builtins__']:
         res = True
     # single letters are acceptable names for local variables
-    elif len(name) == 1 and re.match('^[a-zA-Z]$', name):
+    elif re.match('^[a-zA-Z]$', name):
         res = True
 
     return res
@@ -171,7 +171,7 @@ def triage_easyconfig_params(variables, ec):
         # validations are skipped, just set in the config
         if key in ec:
             ec_params[key] = variables[key]
-            _log.info("setting config option %s: value %s (type: %s)", key, ec_params[key], type(ec_params[key]))
+            _log.debug("setting config option %s: value %s (type: %s)", key, ec_params[key], type(ec_params[key]))
         elif key in REPLACED_PARAMETERS:
             _log.nosupport("Easyconfig parameter '%s' is replaced by '%s'" % (key, REPLACED_PARAMETERS[key]), '2.0')
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -2130,7 +2130,7 @@ def fix_deprecated_easyconfigs(paths):
         # fix use of local variables with a name other than a single letter or 'local_*'
         ec = EasyConfig(path, strict_local_var_naming=False)
         for key in ec.unknown_keys:
-            regexp = re.compile('(^|\W)' + key + '(\W|$)', re.M)
+            regexp = re.compile(r'(^|\W)' + key + r'(\W|$)', re.M)
             ectxt = regexp.sub(LOCAL_VAR_PREFIX + key, ectxt)
 
         if fixed:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -2130,8 +2130,8 @@ def fix_deprecated_easyconfigs(paths):
         # fix use of local variables with a name other than a single letter or 'local_*'
         ec = EasyConfig(path, strict_local_var_naming=False)
         for key in ec.unknown_keys:
-            regexp = re.compile(key, re.M)  # FIXME avoid replacing partial matches!
-            ectxt = regexp.sub('local_' + key, ectxt)
+            regexp = re.compile('(^|\W)' + key + '(\W|$)', re.M)
+            ectxt = regexp.sub(LOCAL_VAR_PREFIX + key, ectxt)
 
         if fixed:
             fixed_cnt += 1

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -2130,8 +2130,9 @@ def fix_deprecated_easyconfigs(paths):
         # fix use of local variables with a name other than a single letter or 'local_*'
         ec = EasyConfig(path, strict_local_var_naming=False)
         for key in ec.unknown_keys:
-            regexp = re.compile(r'(^|\W)' + key + r'(\W|$)', re.M)
+            regexp = re.compile(r'\b(%s)\b' % key)
             ectxt = regexp.sub(LOCAL_VAR_PREFIX + key, ectxt)
+            fixed = True
 
         if fixed:
             fixed_cnt += 1

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -145,7 +145,7 @@ def triage_easyconfig_params(variables, ec):
         # to catch mistakes (using unknown easyconfig parameters),
         # and to protect against using a local variable name that may later become a known easyconfig parameter,
         # we require that non-single letter names of local variables start with 'local_'
-        elif key.startswith(LOCAL_VAR_PREFIX):
+        elif key.startswith(LOCAL_VAR_PREFIX) or key.startswith('_'):
             _log.debug("Ignoring local variable '%s' (value: %s)", key, variables[key])
 
         # __builtins__ is always defined as a 'local' variables

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -533,10 +533,13 @@ class EasyConfig(object):
             # anything is considered to be a local variable in the easyconfig file;
             # to catch mistakes (using unknown easyconfig parameters),
             # and to protect against using a local variable name that may later become a known easyconfig parameter,
-            # we require that names of local variables start with 'local_'
+            # we require that non-single letter names of local variables start with 'local_'
             elif key.startswith(LOCAL_VAR_PREFIX):
                 self.log.debug("Ignoring local variable '%s' (value: %s)", key, local_vars[key])
-            elif key not in ['__builtins__']:
+
+            # __builtins__ is always defined as a 'local' variables
+            # single-letter local variable names are allowed (mainly for use in list comprehensions)
+            elif len(key) > 1 and key not in ['__builtins__']:
                 unknown_keys.append(key)
 
         if unknown_keys:

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -230,6 +230,7 @@ BUILD_OPTIONS_CMDLINE = {
         'set_gid_bit',
         'skip_test_cases',
         'sticky_bit',
+        'strict_local_var_naming',
         'trace',
         'upload_test_report',
         'update_modules_tool_cache',

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -437,9 +437,10 @@ def init_build_options(build_options=None, cmdline_options=None):
 
         auto_ignore_osdeps_options = [cmdline_options.check_conflicts, cmdline_options.containerize,
                                       cmdline_options.dep_graph, cmdline_options.dry_run,
-                                      cmdline_options.dry_run_short, cmdline_options.extended_dry_run,
-                                      cmdline_options.dump_env_script, cmdline_options.missing_modules,
-                                      cmdline_options.new_pr, cmdline_options.preview_pr, cmdline_options.update_pr]
+                                      cmdline_options.dry_run_short, cmdline_options.dump_env_script,
+                                      cmdline_options.extended_dry_run, cmdline_options.fix_deprecated_easyconfigs,
+                                      cmdline_options.missing_modules, cmdline_options.new_pr,
+                                      cmdline_options.preview_pr, cmdline_options.update_pr]
         if any(auto_ignore_osdeps_options):
             _log.info("Auto-enabling ignoring of OS dependencies")
             cmdline_options.ignore_osdeps = True

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -662,6 +662,9 @@ class EasyBuildOptions(GeneralOption):
                                            None, 'store_true', False),
             'inject-checksums': ("Inject checksums of specified type for sources/patches into easyconfig file(s)",
                                  'choice', 'store_or_None', CHECKSUM_TYPE_SHA256, CHECKSUM_TYPES),
+            'strict-local-var-naming': ("Enforce specific naming scheme for local variables in easyconfig files, "
+                                        "where only single-letter or names that start with 'local_' or '_' "
+                                        "are allowed", None, 'store_true', False),
         })
         self.log.debug("easyconfig_options: descr %s opts %s" % (descr, opts))
         self.add_group_parser(opts, descr, prefix='')

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -161,7 +161,8 @@ class Toolchain(object):
             raise EasyBuildError("Toolchain init: no name provided")
         self.name = name
         if self.name == DUMMY_TOOLCHAIN_NAME:
-            self.log.deprecated("Use of 'dummy' toolchain is deprecated, use 'system' toolchain instead", '5.0')
+            self.log.deprecated("Use of 'dummy' toolchain is deprecated, use 'system' toolchain instead", '5.0',
+                                silent=build_option('silent'))
             self.name = SYSTEM_TOOLCHAIN_NAME
 
         if version is None:

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -49,7 +49,7 @@ from easybuild.framework.easyconfig.easyconfig import ActiveMNS, EasyConfig, cre
 from easybuild.framework.easyconfig.easyconfig import det_subtoolchain_version, fix_deprecated_easyconfigs
 from easybuild.framework.easyconfig.easyconfig import is_generic_easyblock, get_easyblock_class, get_module_path
 from easybuild.framework.easyconfig.easyconfig import letter_dir_for, process_easyconfig, resolve_template
-from easybuild.framework.easyconfig.easyconfig import verify_easyconfig_filename
+from easybuild.framework.easyconfig.easyconfig import triage_easyconfig_params, verify_easyconfig_filename
 from easybuild.framework.easyconfig.licenses import License, LicenseGPLv3
 from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconfig
 from easybuild.framework.easyconfig.templates import template_constant_dict, to_template_str
@@ -2992,6 +2992,34 @@ class EasyConfigTest(EnhancedTestCase):
             'dirs': [],
         }
         self.assertEqual(ec['sanity_check_paths'], expected_sanity_check_paths)
+
+    def test_triage_easyconfig_params(self):
+        """Test for triage_easyconfig_params function."""
+        variables = {
+            'foobar': 'foobar',
+            'local_foo': 'test123',
+            '_bar': 'bar',
+            'name': 'example',
+            'version': '1.2.3',
+            'toolchain': {'name': 'system', 'version': 'system'},
+            'homepage': 'https://example.com',
+            'bleh': "just a local var",
+        }
+        ec = {
+            'name': None,
+            'version': None,
+            'homepage': None,
+            'toolchain': None,
+        }
+        ec_params, unknown_keys = triage_easyconfig_params(variables, ec)
+        expected = {
+            'name': 'example',
+            'version': '1.2.3',
+            'homepage': 'https://example.com',
+            'toolchain': {'name': 'system', 'version': 'system'},
+        }
+        self.assertEqual(ec_params, expected)
+        self.assertEqual(sorted(unknown_keys), ['bleh', 'foobar'])
 
     def test_local_vars_detection(self):
         """Test detection of using unknown easyconfig parameters that are likely local variables."""

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -2941,6 +2941,7 @@ class EasyConfigTest(EnhancedTestCase):
 
     def test_local_vars_detection(self):
         """Test detection of using unknown easyconfig parameters that are likely local variables."""
+
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         test_ectxt = '\n'.join([
             "easyblock = 'ConfigureMake'",
@@ -2956,9 +2957,17 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, expected_error, EasyConfig, test_ec)
 
         # all unknown keys are detected at once, and reported alphabetically
-        write_file(test_ec, 'zzz_test = ["one", "two"]\n' + test_ectxt + '\nan_unknown_key = 123')
+        # single-letter local variables are not a problem
+        test_ectxt = '\n'.join([
+            'zzz_test = ["one", "two"]',
+            test_ectxt,
+            'a = "blah"',
+            'test_list = [x for x in ["1", "2", "3"]]',
+            'an_unknown_key = 123',
+        ])
+        write_file(test_ec, test_ectxt)
 
-        expected_error = "Use of 3 unknown easyconfig parameters detected: an_unknown_key, foobar, zzz_test"
+        expected_error = "Use of 4 unknown easyconfig parameters detected: an_unknown_key, foobar, test_list, zzz_test"
         self.assertErrorRegex(EasyBuildError, expected_error, EasyConfig, test_ec)
 
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3005,10 +3005,12 @@ class EasyConfigTest(EnhancedTestCase):
             "description = 'test'",
             "toolchain = SYSTEM",
             "foobar = 'xxx'",
+            "_foo = 'foo'",  # not reported
+            "local_bar = 'bar'",  # not reported
         ])
         write_file(test_ec, test_ectxt)
         expected_error = "Use of 1 unknown easyconfig parameters detected: foobar"
-        self.assertErrorRegex(EasyBuildError, expected_error, EasyConfig, test_ec)
+        self.assertErrorRegex(EasyBuildError, expected_error, EasyConfig, test_ec, strict_local_var_naming=True)
 
         # all unknown keys are detected at once, and reported alphabetically
         # single-letter local variables are not a problem
@@ -3016,13 +3018,15 @@ class EasyConfigTest(EnhancedTestCase):
             'zzz_test = ["one", "two"]',
             test_ectxt,
             'a = "blah"',
+            'local_foo = "foo"',  # matches local variable naming scheme, so not reported!
             'test_list = [x for x in ["1", "2", "3"]]',
+            '_bar = "bar"',  # matches local variable naming scheme, so not reported!
             'an_unknown_key = 123',
         ])
         write_file(test_ec, test_ectxt)
 
         expected_error = "Use of 4 unknown easyconfig parameters detected: an_unknown_key, foobar, test_list, zzz_test"
-        self.assertErrorRegex(EasyBuildError, expected_error, EasyConfig, test_ec)
+        self.assertErrorRegex(EasyBuildError, expected_error, EasyConfig, test_ec, strict_local_var_naming=True)
 
 
 def suite():

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -2939,6 +2939,28 @@ class EasyConfigTest(EnhancedTestCase):
         }
         self.assertEqual(ec['sanity_check_paths'], expected_sanity_check_paths)
 
+    def test_local_vars_detection(self):
+        """Test detection of using unknown easyconfig parameters that are likely local variables."""
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        test_ectxt = '\n'.join([
+            "easyblock = 'ConfigureMake'",
+            "name = 'test'",
+            "version = '1.2.3'",
+            "homepage = 'https://example.com'",
+            "description = 'test'",
+            "toolchain = SYSTEM",
+            "foobar = 'xxx'",
+        ])
+        write_file(test_ec, test_ectxt)
+        expected_error = "Use of 1 unknown easyconfig parameters detected: foobar"
+        self.assertErrorRegex(EasyBuildError, expected_error, EasyConfig, test_ec)
+
+        # all unknown keys are detected at once, and reported alphabetically
+        write_file(test_ec, 'zzz_test = ["one", "two"]\n' + test_ectxt + '\nan_unknown_key = 123')
+
+        expected_error = "Use of 3 unknown easyconfig parameters detected: an_unknown_key, foobar, zzz_test"
+        self.assertErrorRegex(EasyBuildError, expected_error, EasyConfig, test_ec)
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -2876,7 +2876,7 @@ class EasyConfigTest(EnhancedTestCase):
         # purposely define configopts via local variable 'foo', which has value that also contains 'foo' substring;
         # that way, we can check whether only the 'foo' variable name is replaced with 'local_foo'
         test_ectxt = regex.sub(r'foo = "--foobar --barfoo --barfoobaz"\nconfigopts = foo\n\n\1', toy_ec_txt)
-        regex = re.compile('^(toolchain\s*=.*)$', re.M)
+        regex = re.compile(r'^(toolchain\s*=.*)$', re.M)
         test_ectxt = regex.sub(r'\1\n\nsome_list = [x + "1" for x in ["one", "two", "three"]]', test_ectxt)
 
         # test fixing the use of 'dummy' toolchain to SYSTEM

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1344,6 +1344,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         easyconfig.parser.DEPRECATED_PARAMETERS = orig_deprecated_parameters
         reload(easyconfig.parser)
+        reload(easyconfig.easyconfig)
         easyconfig.easyconfig.EasyConfig = orig_EasyConfig
         easyconfig.easyconfig.ActiveMNS = orig_ActiveMNS
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -2889,7 +2889,7 @@ class EasyConfigTest(EnhancedTestCase):
             "{'version': 'dummy', 'name': 'dummy'}",
         ]
 
-        unknown_params_error_pattern = "Use of 2 unknown easyconfig parameters detected: foo, some_list"
+        unknown_params_error_pattern = "Use of 2 unknown easyconfig parameters detected in test.eb: foo, some_list"
 
         for tc_str in tc_strs:
             # first check if names of local variables get fixed if 'dummy' toolchain is not used
@@ -2933,7 +2933,7 @@ class EasyConfigTest(EnhancedTestCase):
             self.assertFalse(stdout)
 
             warnings = [
-                "WARNING: Use of 2 unknown easyconfig parameters detected: foo, some_list",
+                "WARNING: Use of 2 unknown easyconfig parameters detected in test.eb: foo, some_list",
                 "Use of 'dummy' toolchain is deprecated, use 'system' toolchain instead",
             ]
             for warning in warnings:
@@ -3072,7 +3072,7 @@ class EasyConfigTest(EnhancedTestCase):
             "local_bar = 'bar'",  # not reported
         ])
         write_file(test_ec, test_ectxt)
-        expected_error = "Use of 1 unknown easyconfig parameters detected: foobar"
+        expected_error = "Use of 1 unknown easyconfig parameters detected in test.eb: foobar"
         self.assertErrorRegex(EasyBuildError, expected_error, EasyConfig, test_ec, strict_local_var_naming=True)
 
         # all unknown keys are detected at once, and reported alphabetically
@@ -3088,7 +3088,8 @@ class EasyConfigTest(EnhancedTestCase):
         ])
         write_file(test_ec, test_ectxt)
 
-        expected_error = "Use of 4 unknown easyconfig parameters detected: an_unknown_key, foobar, test_list, zzz_test"
+        expected_error = "Use of 4 unknown easyconfig parameters detected in test.eb: "
+        expected_error += "an_unknown_key, foobar, test_list, zzz_test"
         self.assertErrorRegex(EasyBuildError, expected_error, EasyConfig, test_ec, strict_local_var_naming=True)
 
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3028,6 +3028,7 @@ class EasyConfigTest(EnhancedTestCase):
             'toolchain': {'name': 'system', 'version': 'system'},
             'homepage': 'https://example.com',
             'bleh': "just a local var",
+            'x': "single letter local var",
         }
         ec = {
             'name': None,
@@ -3044,6 +3045,16 @@ class EasyConfigTest(EnhancedTestCase):
         }
         self.assertEqual(ec_params, expected)
         self.assertEqual(sorted(unknown_keys), ['bleh', 'foobar'])
+
+        # check behaviour when easyconfig parameters that use a name indicating a local variable were defined
+        ec.update({
+            'x': None,
+            'local_foo': None,
+            '_foo': None,
+            '_': None,
+        })
+        error = "Found 4 easyconfig parameters that are considered local variables: _, _foo, local_foo, x"
+        self.assertErrorRegex(EasyBuildError, error, triage_easyconfig_params, variables, ec)
 
     def test_local_vars_detection(self):
         """Test detection of using unknown easyconfig parameters that are likely local variables."""

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -2868,6 +2868,12 @@ class EasyConfigTest(EnhancedTestCase):
         test_ec = os.path.join(self.test_prefix, 'test.eb')
 
         test_ectxt = toy_ec_txt
+        # inject local variables with names that need to be tweaked (or not for single-letter ones)
+        regex = re.compile('^(sanity_check_paths)', re.M)
+        test_ectxt = regex.sub(r'foobar = "foobar"\n\n\1', toy_ec_txt)
+        regex = re.compile('^(toolchain\s*=.*)$', re.M)
+        test_ectxt = regex.sub(r'\1\n\nsome_list = [x + "1" for x in ["one", "two", "three"]]', test_ectxt)
+        print test_ectxt
 
         # test fixing the use of 'dummy' toolchain to SYSTEM
         tc_regex = re.compile('^toolchain = .*', re.M)
@@ -2886,6 +2892,10 @@ class EasyConfigTest(EnhancedTestCase):
             regex = re.compile("^toolchain = {.*'name': 'dummy'.*$", re.M)
             self.assertTrue(regex.search(test_ec_txt), "Pattern '%s' found in: %s" % (regex.pattern, test_ec_txt))
 
+            # easyconfig doesn't parse because of local variables with name other than 'local_*'
+            error_pattern = "Use of 2 unknown easyconfig parameters detected: foobar, some_list"
+            self.assertErrorRegex(EasyBuildError, error_pattern, EasyConfig, test_ec)
+
             self.mock_stderr(True)
             self.mock_stdout(True)
             fix_deprecated_easyconfigs([toy_ec, test_ec, gzip_ec])
@@ -2901,6 +2911,11 @@ class EasyConfigTest(EnhancedTestCase):
             self.assertEqual(gzip_ec_txt, read_file(gzip_ec))
             self.assertEqual(toy_ec_txt, read_file(toy_ec))
             self.assertTrue(test_ec_txt != read_file(test_ec))
+
+            # original easyconfig is backed up automatically
+            test_ecs = sorted([f for f in os.listdir(self.test_prefix) if f.startswith('test.eb')])
+            self.assertEqual(len(test_ecs), 2)
+            self.assertEqual(test_ec_txt, read_file(os.path.join(self.test_prefix, test_ecs[1])))
 
             # parsing works now, toolchain is replaced with system toolchain
             ec = EasyConfig(test_ec)

--- a/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.3-GCC-4.8.2-serial.eb
+++ b/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.3-GCC-4.8.2-serial.eb
@@ -14,13 +14,13 @@ toolchainopts = {'optarch': True, 'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage]
 
-common_configopts = "--enable-threads --enable-openmp --with-pic"
+local_common_configopts = "--enable-threads --enable-openmp --with-pic"
 
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
-    common_configopts + " --enable-long-double --enable-mpi",
-    common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+    local_common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    local_common_configopts + " --enable-long-double --enable-mpi",
+    local_common_configopts + " --enable-quad-precision",
+    local_common_configopts + " --enable-sse2 --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.7-GCC-6.4.0-2.28-serial.eb
+++ b/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.7-GCC-6.4.0-2.28-serial.eb
@@ -14,13 +14,13 @@ toolchainopts = {'optarch': True, 'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage]
 
-common_configopts = "--enable-openmp --with-pic"
+local_common_configopts = "--enable-openmp --with-pic"
 
 configopts = [
-    common_configopts + " --enable-single --enable-sse2",
-    common_configopts + " --enable-long-double",
-    common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2",  # default as last
+    local_common_configopts + " --enable-single --enable-sse2",
+    local_common_configopts + " --enable-long-double",
+    local_common_configopts + " --enable-quad-precision",
+    local_common_configopts + " --enable-sse2",  # default as last
 ]
 
 sanity_check_paths = {

--- a/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.7-gompi-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.7-gompi-2018a.eb
@@ -13,13 +13,13 @@ toolchainopts = {'optarch': True, 'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage]
 
-common_configopts = "--enable-openmp --with-pic"
+local_common_configopts = "--enable-openmp --with-pic"
 
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
-    common_configopts + " --enable-long-double --enable-mpi",
-    common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+    local_common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    local_common_configopts + " --enable-long-double --enable-mpi",
+    local_common_configopts + " --enable-quad-precision",
+    local_common_configopts + " --enable-sse2 --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.7-gompic-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.7-gompic-2018a.eb
@@ -13,13 +13,13 @@ toolchainopts = {'optarch': True, 'pic': True}
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = [homepage]
 
-common_configopts = "--enable-threads --enable-openmp --with-pic"
+local_common_configopts = "--enable-threads --enable-openmp --with-pic"
 
 configopts = [
-    common_configopts + " --enable-single --enable-sse2 --enable-mpi",
-    common_configopts + " --enable-long-double --enable-mpi",
-    common_configopts + " --enable-quad-precision",
-    common_configopts + " --enable-sse2 --enable-mpi",  # default as last
+    local_common_configopts + " --enable-single --enable-sse2 --enable-mpi",
+    local_common_configopts + " --enable-long-double --enable-mpi",
+    local_common_configopts + " --enable-quad-precision",
+    local_common_configopts + " --enable-sse2 --enable-mpi",  # default as last
 ]
 
 sanity_check_paths = {

--- a/test/framework/easyconfigs/test_ecs/f/foss/foss-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/f/foss/foss-2018a.eb
@@ -9,27 +9,23 @@ OpenMPI for MPI support, OpenBLAS (BLAS and LAPACK support), FFTW and ScaLAPACK.
 
 toolchain = SYSTEM
 
-comp_name = 'GCC'
-comp_version = '6.4.0-2.28'
-comp = (comp_name, comp_version)
+local_comp = ('GCC', '6.4.0-2.28')
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.20'
 
 # toolchain used to build foss dependencies
-comp_mpi_tc_name = 'gompi'
-comp_mpi_tc_ver = "%s" % version
-comp_mpi_tc = (comp_mpi_tc_name, comp_mpi_tc_ver)
+local_comp_mpi_tc = ('gompi', version)
 
 # compiler toolchain dependencies
 # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
 # because of toolchain preperation functions
 dependencies = [
-    comp,
-    ('OpenMPI', '2.1.2', '', comp),  # part of gompi-2018a
-    (blaslib, blasver, '', comp),
-    ('FFTW', '3.3.7', '', comp_mpi_tc),
-    ('ScaLAPACK', '2.0.2', '-%s-%s' % (blaslib, blasver), comp_mpi_tc)
+    local_comp,
+    ('OpenMPI', '2.1.2', '', local_comp),  # part of gompi-2018a
+    (local_blaslib, local_blasver, '', local_comp),
+    ('FFTW', '3.3.7', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', '-%s-%s' % (local_blaslib, local_blasver), local_comp_mpi_tc)
 ]
 
 moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/f/fosscuda/fosscuda-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/f/fosscuda/fosscuda-2018a.eb
@@ -9,29 +9,25 @@ description = """GCC based compiler toolchain __with CUDA support__, and includi
 
 toolchain = SYSTEM
 
-comp_name = 'GCC'
-comp_ver = '6.4.0-2.28'
-comp = (comp_name, comp_ver)
+local_comp = ('GCC', '6.4.0-2.28')
 
 # toolchain used to build fosscuda dependencies
-comp_mpi_tc_name = 'gompic'
-comp_mpi_tc_ver = version
-comp_mpi_tc = (comp_mpi_tc_name, comp_mpi_tc_ver)
+local_comp_mpi_tc = ('gompic', version)
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
-blas = '-%s-%s' % (blaslib, blasver)
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.20'
+local_blas = '-%s-%s' % (local_blaslib, local_blasver)
 
 # compiler toolchain dependencies
 # we need GCC and OpenMPI as explicit dependencies instead of gompi toolchain
 # because of toolchain preperation functions
 dependencies = [
-    comp,  # part of gompic
-    ('CUDA', '9.1.85', '', comp),  # part of gompic
+    local_comp,  # part of gompic
+    ('CUDA', '9.1.85', '', local_comp),  # part of gompic
     ('OpenMPI', '2.1.2', '', ('gcccuda', version)),  # part of gompic
-    (blaslib, blasver, '', comp),
-    ('FFTW', '3.3.7', '', comp_mpi_tc),
-    ('ScaLAPACK', '2.0.2', blas, comp_mpi_tc),
+    (local_blaslib, local_blasver, '', local_comp),
+    ('FFTW', '3.3.7', '', local_comp_mpi_tc),
+    ('ScaLAPACK', '2.0.2', local_blas, local_comp_mpi_tc),
 ]
 
 moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/g/GCC/GCC-4.6.3.eb
+++ b/test/framework/easyconfigs/test_ecs/g/GCC/GCC-4.6.3.eb
@@ -25,7 +25,8 @@ source_urls = [
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+# commented out 'languages' setting since dummy GCC easyblock doesn't define this as a known easyconfig parameter
+# languages = ['c', 'c++', 'fortran', 'lto']
 
 # compiler class
 moduleclass = 'compiler'

--- a/test/framework/easyconfigs/test_ecs/g/GCC/GCC-4.6.4.eb
+++ b/test/framework/easyconfigs/test_ecs/g/GCC/GCC-4.6.4.eb
@@ -23,7 +23,8 @@ sources = [
     'mpc-1.0.1.tar.gz',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+# commented out 'languages' setting since dummy GCC easyblock doesn't define this as a known easyconfig parameter
+# languages = ['c', 'c++', 'fortran', 'lto']
 
 patches = ['mpfr-3.1.0-changes_fix.patch']
 

--- a/test/framework/easyconfigs/test_ecs/g/GCC/GCC-4.8.2.eb
+++ b/test/framework/easyconfigs/test_ecs/g/GCC/GCC-4.8.2.eb
@@ -23,7 +23,8 @@ sources = [
     'mpc-1.0.1.tar.gz',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+# commented out 'languages' setting since dummy GCC easyblock doesn't define this as a known easyconfig parameter
+# languages = ['c', 'c++', 'fortran', 'lto']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/test/framework/easyconfigs/test_ecs/g/GCC/GCC-4.8.3.eb
+++ b/test/framework/easyconfigs/test_ecs/g/GCC/GCC-4.8.3.eb
@@ -23,7 +23,8 @@ sources = [
     'mpc-1.0.1.tar.gz',
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+# commented out 'languages' setting since dummy GCC easyblock doesn't define this as a known easyconfig parameter
+# languages = ['c', 'c++', 'fortran', 'lto']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/test/framework/easyconfigs/test_ecs/g/GCC/GCC-4.9.2.eb
+++ b/test/framework/easyconfigs/test_ecs/g/GCC/GCC-4.9.2.eb
@@ -17,18 +17,19 @@ source_urls = [
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 
-mpfr_version = '3.1.2'
+local_mpfr_version = '3.1.2'
 
 sources = [
     SOURCELOWER_TAR_BZ2,
     'gmp-6.0.0a.tar.bz2',
-    'mpfr-%s.tar.gz' % mpfr_version,
+    'mpfr-%s.tar.gz' % local_mpfr_version,
     'mpc-1.0.2.tar.gz',
 ]
 
-patches = [('mpfr-%s-allpatches-20140630.patch' % mpfr_version, '../mpfr-%s' % mpfr_version)]
+patches = [('mpfr-%s-allpatches-20140630.patch' % local_mpfr_version, '../mpfr-%s' % local_mpfr_version)]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+# commented out 'languages' setting since dummy GCC easyblock doesn't define this as a known easyconfig parameter
+# languages = ['c', 'c++', 'fortran', 'lto']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/test/framework/easyconfigs/test_ecs/g/GCC/GCC-4.9.3-2.25.eb
+++ b/test/framework/easyconfigs/test_ecs/g/GCC/GCC-4.9.3-2.25.eb
@@ -4,8 +4,8 @@ easyblock = 'Toolchain'
 name = 'GCC'
 version = '4.9.3'
 
-binutilsver = '2.25'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.25'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -16,11 +16,11 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (system-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
-altroot = 'GCCcore'
-altversion = 'GCCcore'
+#altroot = 'GCCcore'
+#altversion = 'GCCcore'
 
 # this bundle serves as a compiler-only toolchain, so it should be marked as compiler (important for HMNS)
 moduleclass = 'compiler'

--- a/test/framework/easyconfigs/test_ecs/g/GCC/GCC-4.9.3-2.26.eb
+++ b/test/framework/easyconfigs/test_ecs/g/GCC/GCC-4.9.3-2.26.eb
@@ -4,8 +4,8 @@ easyblock = 'Toolchain'
 name = 'GCC'
 version = '4.9.3'
 
-binutilsver = '2.26'
-versionsuffix = '-%s' % binutilsver
+local_binutilsver = '2.26'
+versionsuffix = '-%s' % local_binutilsver
 
 homepage = 'http://gcc.gnu.org/'
 description = """The GNU Compiler Collection includes front ends for C, C++, Objective-C, Fortran, Java, and Ada,
@@ -16,11 +16,11 @@ toolchain = SYSTEM
 dependencies = [
     ('GCCcore', version),
     # binutils built on top of GCCcore, which was built on top of (system-built) binutils
-    ('binutils', binutilsver, '', ('GCCcore', version)),
+    ('binutils', local_binutilsver, '', ('GCCcore', version)),
 ]
 
-altroot = 'GCCcore'
-altversion = 'GCCcore'
+#altroot = 'GCCcore'
+#altversion = 'GCCcore'
 
 # this bundle serves as a compiler-only toolchain, so it should be marked as compiler (important for HMNS)
 moduleclass = 'compiler'

--- a/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb
+++ b/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb
@@ -19,7 +19,8 @@ source_urls = [
 ]
 sources = [SOURCELOWER_TAR_GZ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+# commented out 'languages' setting since dummy GCC easyblock doesn't define this as a known easyconfig parameter
+# languages = ['c', 'c++', 'fortran', 'lto']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/test/framework/easyconfigs/test_ecs/g/GCC/GCC-7.3.0-2.30.eb
+++ b/test/framework/easyconfigs/test_ecs/g/GCC/GCC-7.3.0-2.30.eb
@@ -19,7 +19,8 @@ source_urls = [
 ]
 sources = [SOURCELOWER_TAR_GZ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+# commented out 'languages' setting since dummy GCC easyblock doesn't define this as a known easyconfig parameter
+# languages = ['c', 'c++', 'fortran', 'lto']
 
 # building GCC sometimes fails if make parallelism is too high, so let's limit it
 maxparallel = 4

--- a/test/framework/easyconfigs/test_ecs/g/GCCcore/GCCcore-4.9.3.eb
+++ b/test/framework/easyconfigs/test_ecs/g/GCCcore/GCCcore-4.9.3.eb
@@ -14,7 +14,7 @@ source_urls = [
     'http://ftpmirror.gnu.org/%(namelower)s/%(namelower)s-%(version)s',  # GCC auto-resolving HTTP mirror
 ]
 
-gcc_name = 'GCC'
+#gcc_name = 'GCC'
 
 sources = [
     SOURCELOWER_TAR_BZ2,

--- a/test/framework/easyconfigs/test_ecs/g/gcccuda/gcccuda-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gcccuda/gcccuda-2018a.eb
@@ -8,14 +8,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain, along w
 
 toolchain = SYSTEM
 
-comp_name = 'GCC'
-comp_ver = '6.4.0-2.28'
-comp = (comp_name, comp_ver)
+local_comp = ('GCC', '6.4.0-2.28')
 
 # compiler toolchain dependencies
 dependencies = [
-    comp,
-    ('CUDA', '9.1.85', '', comp),
+    local_comp,
+    ('CUDA', '9.1.85', '', local_comp),
 ]
 
 moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/g/gmvapich2/gmvapich2-15.11.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gmvapich2/gmvapich2-15.11.eb
@@ -9,14 +9,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain,
 
 toolchain = SYSTEM
 
-compname = 'GCC'
-compver = '4.9.3-2.25'
-comp = (compname, compver)
+local_comp = ('GCC', '4.9.3-2.25')
 
 # compiler toolchain dependencies
 dependencies = [
-    comp,
-    ('MVAPICH2', '2.2a', '', comp),
+    local_comp,
+    ('MVAPICH2', '2.2a', '', local_comp),
 ]
 
 moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/g/golf/golf-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/g/golf/golf-2018a.eb
@@ -9,18 +9,13 @@ OpenBLAS (BLAS and LAPACK support), and FFTW."""
 
 toolchain = SYSTEM
 
-comp_name = 'GCC'
-comp_version = '6.4.0-2.28'
-comp = (comp_name, comp_version)
-
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
+local_comp = ('GCC', '6.4.0-2.28')
 
 # compiler toolchain dependencies
 dependencies = [
-    comp,
-    (blaslib, blasver, '', comp),
-    ('FFTW', '3.3.7', '-serial', comp),
+    local_comp,
+    ('OpenBLAS', '0.2.20', '', local_comp),
+    ('FFTW', '3.3.7', '-serial', local_comp),
 ]
 
 moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/g/golfc/golfc-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/g/golfc/golfc-2018a.eb
@@ -9,21 +9,16 @@ description = """GCC based compiler toolchain __with CUDA support__, and includi
 
 toolchain = SYSTEM
 
-comp_name = 'GCC'
-comp_ver = '6.4.0-2.28'
-comp = (comp_name, comp_ver)
-
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
+local_comp = ('GCC', '6.4.0-2.28')
 
 # compiler toolchain dependencies
 # we need GCC as explicit dependency instead of golf toolchain
 # because of toolchain preperation functions
 dependencies = [
-    comp, # part of golf and gcccuda
-    ('CUDA', '9.1.85', '', comp),  # part of gcccuda
-    (blaslib, blasver, '', comp),
-    ('FFTW', '3.3.7', '-serial', comp),
+    local_comp, # part of golf and gcccuda
+    ('CUDA', '9.1.85', '', local_comp),  # part of gcccuda
+    ('OpenBLAS', '0.2.20', '', local_comp),
+    ('FFTW', '3.3.7', '-serial', local_comp),
 ]
 
 moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/g/gompi/gompi-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gompi/gompi-2018a.eb
@@ -9,17 +9,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain,
 
 toolchain = SYSTEM
 
-compname = 'GCC'
-compver = '6.4.0-2.28'
-comp = (compname, compver)
-
-mpilib = 'OpenMPI'
-mpiver = '2.1.2'
+local_comp = ('GCC', '6.4.0-2.28')
 
 # compiler toolchain dependencies
 dependencies = [
-    comp,
-    (mpilib, mpiver, '', comp),
+    local_comp,
+    ('OpenMPI', '2.1.2', '', local_comp),
 ]
 
 moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/g/gompi/gompi-2018b.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gompi/gompi-2018b.eb
@@ -9,17 +9,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain,
 
 toolchain = SYSTEM
 
-compname = 'GCC'
-compver = '7.3.0-2.30'
-comp = (compname, compver)
-
-mpilib = 'OpenMPI'
-mpiver = '3.1.1'
+local_comp = ('GCC', '7.3.0-2.30')
 
 # compiler toolchain dependencies
 dependencies = [
-    comp,
-    (mpilib, mpiver, '', comp),
+    local_comp,
+    ('OpenMPI', '3.1.1', '', local_comp),
 ]
 
 moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/g/gompic/gompic-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gompic/gompic-2018a.eb
@@ -9,14 +9,12 @@ description = """GNU Compiler Collection (GCC) based compiler toolchain along wi
 
 toolchain = SYSTEM
 
-comp_name = 'GCC'
-comp_ver = '6.4.0-2.28'
-comp = (comp_name, comp_ver)
+local_comp = ('GCC', '6.4.0-2.28')
 
 # compiler toolchain dependencies
 dependencies = [
-    comp,  # part of gcccuda
-    ('CUDA', '9.1.85', '', comp),  # part of gcccuda
+    local_comp,  # part of gcccuda
+    ('CUDA', '9.1.85', '', local_comp),  # part of gcccuda
     ('OpenMPI', '2.1.2', '', ('gcccuda', version)),
 ]
 

--- a/test/framework/easyconfigs/test_ecs/i/icc/icc-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/test/framework/easyconfigs/test_ecs/i/icc/icc-2016.1.150-GCC-4.9.3-2.25.eb
@@ -13,23 +13,21 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_cpp_update
 
 checksums = ['4b93b0ff549e6bd8d1a8b9a441b235a8']
 
-gccver = '4.9.3'
-binutilsver = '2.25'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '4.9.3'
+local_binutilsver = '2.25'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
-# full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
+# full list of local_components can be obtained from pset/mediaconfig.xml in unpacked sources
 # cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
-components = ['intel-comp', 'intel-ccomp', 'intel-icc', 'intel-openmp', 'intel-ipsc?_']
+# components = ['intel-comp', 'intel-ccomp', 'intel-icc', 'intel-openmp', 'intel-ipsc?_']
 
 dontcreateinstalldir = 'True'
 
-# license file
-import os
-license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+license_file = HOME + '/licenses/intel/license.lic'
 
 moduleclass = 'compiler'

--- a/test/framework/easyconfigs/test_ecs/i/iccifortcuda/iccifortcuda-2016.1.150.eb
+++ b/test/framework/easyconfigs/test_ecs/i/iccifortcuda/iccifortcuda-2016.1.150.eb
@@ -8,15 +8,13 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-comp_name = 'iccifort'
-comp_ver = '2016.1.150'
-gccsuff = '-GCC-4.9.3-2.25'
-cudacomp = (comp_name, '%s%s' % (comp_ver, gccsuff))
+local_comp_ver = '2016.1.150'
+local_gccsuff = '-GCC-4.9.3-2.25'
 
 dependencies = [
-    ('icc', comp_ver, gccsuff),
-    ('ifort', comp_ver, gccsuff),
-    ('CUDA', '5.5.22', '', cudacomp),
+    ('icc', local_comp_ver, local_gccsuff),
+    ('ifort', local_comp_ver, local_gccsuff),
+    ('CUDA', '5.5.22', '', ('iccifort', '%s%s' % (local_comp_ver, local_gccsuff))),
 ]
 
 moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/i/ifort/ifort-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/test/framework/easyconfigs/test_ecs/i/ifort/ifort-2016.1.150-GCC-4.9.3-2.25.eb
@@ -13,23 +13,21 @@ sources = ['parallel_studio_xe_%(version_major)s_composer_edition_for_fortran_up
 
 checksums = ['1e848c8283cf6a0210bce1d35ecd748b']
 
-gccver = '4.9.3'
-binutilsver = '2.25'
-versionsuffix = '-GCC-%s-%s' % (gccver, binutilsver)
+local_gccver = '4.9.3'
+local_binutilsver = '2.25'
+versionsuffix = '-GCC-%s-%s' % (local_gccver, local_binutilsver)
 
 dependencies = [
-    ('GCCcore', gccver),
-    ('binutils', binutilsver, '', ('GCCcore', gccver)),
+    ('GCCcore', local_gccver),
+    ('binutils', local_binutilsver, '', ('GCCcore', local_gccver)),
 ]
 
-# full list of components can be obtained from pset/mediaconfig.xml in unpacked sources
+# full list of local_components can be obtained from pset/mediaconfig.xml in unpacked sources
 # cfr. https://software.intel.com/en-us/articles/intel-composer-xe-2015-silent-installation-guide
-components = ['intel-comp', 'intel-fcomp', 'intel-ifort', 'intel-openmp', 'intel-ipsf?_']
+# components = ['intel-comp', 'intel-fcomp', 'intel-ifort', 'intel-openmp', 'intel-ipsf?_']
 
 dontcreateinstalldir = 'True'
 
-# license file
-import os
-license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+license_file = HOME + '/licenses/intel/license.lic'
 
 moduleclass = 'compiler'

--- a/test/framework/easyconfigs/test_ecs/i/ifort/ifort-2016.1.150.eb
+++ b/test/framework/easyconfigs/test_ecs/i/ifort/ifort-2016.1.150.eb
@@ -13,8 +13,6 @@ sources = ['l_fcompxe_%s.tgz' % version]
 
 dontcreateinstalldir = 'True'
 
-# license file
-import os
-license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+license_file = HOME + '/licenses/intel/license.lic'
 
 moduleclass = 'compiler'

--- a/test/framework/easyconfigs/test_ecs/i/iimpi/iimpi-2016.01.eb
+++ b/test/framework/easyconfigs/test_ecs/i/iimpi/iimpi-2016.01.eb
@@ -8,12 +8,12 @@ description = """Intel C/C++ and Fortran compilers, alongside Intel MPI."""
 
 toolchain = SYSTEM
 
-compver = '2016.1.150-GCC-4.9.3-2.25'
+local_compver = '2016.1.150-GCC-4.9.3-2.25'
 
 dependencies = [
-    ('icc', compver),
-    ('ifort', compver),
-    ('impi', '5.1.2.150', '', ('iccifort', compver)),
+    ('icc', local_compver),
+    ('ifort', local_compver),
+    ('impi', '5.1.2.150', '', ('iccifort', local_compver)),
 ]
 
 moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/i/imkl/imkl-11.3.1.150-iimpi-2016.01.eb
+++ b/test/framework/easyconfigs/test_ecs/i/imkl/imkl-11.3.1.150-iimpi-2016.01.eb
@@ -16,10 +16,6 @@ sources = ['l_mkl_%(version)s.tgz']
 
 dontcreateinstalldir = 'True'
 
-interfaces = True
-
-# license file
-import os
-license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+license_file = HOME + '/licenses/intel/license.lic'
 
 moduleclass = 'numlib'

--- a/test/framework/easyconfigs/test_ecs/i/impi/impi-5.1.2.150-iccifort-2016.1.150-GCC-4.9.3-2.25.eb
+++ b/test/framework/easyconfigs/test_ecs/i/impi/impi-5.1.2.150-iccifort-2016.1.150-GCC-4.9.3-2.25.eb
@@ -15,8 +15,6 @@ sources = ['l_mpi_p_%(version)s.tgz']
 
 dontcreateinstalldir = 'True'
 
-# license file
-import os
-license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+license_file = HOME + '/licenses/intel/license.lic'
 
 moduleclass = 'mpi'

--- a/test/framework/easyconfigs/test_ecs/i/impi/impi-5.1.2.150-iccifortcuda-2016.1.150.eb
+++ b/test/framework/easyconfigs/test_ecs/i/impi/impi-5.1.2.150-iccifortcuda-2016.1.150.eb
@@ -15,8 +15,6 @@ sources = ['l_mpi_p_%(version)s.tgz']
 
 dontcreateinstalldir = 'True'
 
-# license file
-import os
-license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+license_file = HOME + '/licenses/intel/license.lic'
 
 moduleclass = 'mpi'

--- a/test/framework/easyconfigs/test_ecs/i/impi/impi-5.1.2.150.eb
+++ b/test/framework/easyconfigs/test_ecs/i/impi/impi-5.1.2.150.eb
@@ -15,8 +15,6 @@ sources = ['l_mpi_p_%(version)s.tgz']
 
 dontcreateinstalldir = 'True'
 
-# license file
-import os
-license_file = os.path.join(os.getenv('HOME'), "licenses", "intel", "license.lic")
+license_file = HOME + '/licenses/intel/license.lic'
 
 moduleclass = 'mpi'

--- a/test/framework/easyconfigs/test_ecs/i/intel/intel-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/i/intel/intel-2018a.eb
@@ -8,10 +8,8 @@ description = """Intel Cluster Toolkit Compiler Edition provides Intel C/C++ and
 
 toolchain = SYSTEM
 
-compver = '2011.13.367'
-
 # fake intel toolchain easyconfig, no dependencies (good enough for testing)
-fake_dependencies = [
+local_fake_dependencies = [
     ('GCCcore', '6.4.0'),
     ('binutils', '2.28', '-GCCcore-6.4.0'),
     ('icc', '2018.1.163', '-GCCcore-6.4.0'),

--- a/test/framework/easyconfigs/test_ecs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-6.4.0-2.28.eb
+++ b/test/framework/easyconfigs/test_ecs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-6.4.0-2.28.eb
@@ -8,12 +8,12 @@ description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 B
 
 toolchain = {'name': 'GCC', 'version': '6.4.0-2.28'}
 
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
+local_large_src = 'large.tgz'
+local_timing_src = 'timing.tgz'
 sources = [
     'v%(version)s.tar.gz',
-    large_src,
-    timing_src,
+    local_large_src,
+    local_timing_src,
 ]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
@@ -24,15 +24,15 @@ source_urls = [
 
 patches = [
     'OpenBLAS-%(version)s_Makefile-LAPACK-sources.patch',
-    (large_src, '.'),
-    (timing_src, '.'),
+    (local_large_src, '.'),
+    (local_timing_src, '.'),
 ]
 
 skipsteps = ['configure']
 
-threading = 'USE_THREAD=1'
-buildopts = 'BINARY=64 ' + threading + ' CC="$CC" FC="$F77"'
-installopts = threading + " PREFIX=%(installdir)s"
+local_threading = 'USE_THREAD=1'
+buildopts = 'BINARY=64 ' + local_threading + ' CC="$CC" FC="$F77"'
+installopts = local_threading + " PREFIX=%(installdir)s"
 
 # extensive testing can be enabled by uncommenting the line below
 # runtest = 'PATH=.:$PATH lapack-timing'

--- a/test/framework/easyconfigs/test_ecs/o/OpenBLAS/OpenBLAS-0.2.8-GCC-4.8.2-LAPACK-3.4.2.eb
+++ b/test/framework/easyconfigs/test_ecs/o/OpenBLAS/OpenBLAS-0.2.8-GCC-4.8.2-LAPACK-3.4.2.eb
@@ -3,22 +3,22 @@ easyblock = 'ConfigureMake'
 name = 'OpenBLAS'
 version = '0.2.8'
 
-lapackver = '3.4.2'
-versionsuffix = '-LAPACK-%s' % lapackver
+local_lapackver = '3.4.2'
+versionsuffix = '-LAPACK-%s' % local_lapackver
 
 homepage = 'http://xianyi.github.com/OpenBLAS/'
 description = """OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version."""
 
 toolchain = {'name': 'GCC', 'version': '4.8.2'}
 
-lapack_src = 'lapack-%s.tgz' % lapackver
-large_src = 'large.tgz'
-timing_src = 'timing.tgz'
+local_lapack_src = 'lapack-%s.tgz' % local_lapackver
+local_large_src = 'large.tgz'
+local_timing_src = 'timing.tgz'
 sources = [
     'v%(version)s.tar.gz',
-    lapack_src,
-    large_src,
-    timing_src,
+    local_lapack_src,
+    local_large_src,
+    local_timing_src,
 ]
 source_urls = [
     # order matters, trying to download the LAPACK tarball from GitHub causes trouble
@@ -29,16 +29,16 @@ source_urls = [
 
 patches = [
     # 'OpenBLAS-%s_Makefile-LAPACK-sources.patch' % version,
-    (lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
-    (large_src, '.'),
-    (timing_src, '.'),
+    (local_lapack_src, '.'),  # copy LAPACK tarball to unpacked OpenBLAS dir
+    (local_large_src, '.'),
+    (local_timing_src, '.'),
 ]
 
 skipsteps = ['configure']
 
-threading = 'USE_THREAD=1'
-buildopts = 'BINARY=64 ' + threading + ' CC="$CC" FC="$F77"'
-installopts = threading + " PREFIX=%(installdir)s"
+local_threading = 'USE_THREAD=1'
+buildopts = 'BINARY=64 ' + local_threading + ' CC="$CC" FC="$F77"'
+installopts = local_threading + " PREFIX=%(installdir)s"
 
 # extensive testing can be enabled by uncommenting the line below
 #runtest = 'PATH=.:$PATH lapack-timing'

--- a/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-2.1.2-GCC-4.6.4.eb
+++ b/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-2.1.2-GCC-4.6.4.eb
@@ -26,11 +26,11 @@ else:
     osdependencies = ['libibverbs-devel']
 
 sanity_check_paths = {
-    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
-             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in ["mpi_cxx", "mpi_f77", "mpi_f90",
-                                                                    "mpi", "ompitrace", "open-pal",
-                                                                    "open-rte", "vt", "vt-hyb",
-                                                                    "vt-mpi", "vt-mpi-unify"]] +
+    'files': ["bin/%s" % f for f in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (l, SHLIB_EXT) for l in ["mpi_cxx", "mpi_f77", "mpi_f90",
+                                                        "mpi", "ompitrace", "open-pal",
+                                                        "open-rte", "vt", "vt-hyb",
+                                                        "vt-mpi", "vt-mpi-unify"]] +
              ["include/%s.h" % x for x in ["mpi-ext", "mpif-common", "mpif-config", "mpif",
                                            "mpif-mpi-io", "mpi", "mpi_portable_platform"]],
     'dirs': ["include/openmpi/ompi/mpi/cxx"],

--- a/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-2.1.2-GCC-6.4.0-2.28.eb
+++ b/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-2.1.2-GCC-6.4.0-2.28.eb
@@ -26,11 +26,11 @@ else:
     osdependencies = ['libibverbs-devel']
 
 sanity_check_paths = {
-    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
-             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in ["mpi_cxx", "mpi_f77", "mpi_f90",
-                                                                    "mpi", "ompitrace", "open-pal",
-                                                                    "open-rte", "vt", "vt-hyb",
-                                                                    "vt-mpi", "vt-mpi-unify"]] +
+    'files': ["bin/%s" % f for f in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (l, SHLIB_EXT) for l in ["mpi_cxx", "mpi_f77", "mpi_f90",
+                                                        "mpi", "ompitrace", "open-pal",
+                                                        "open-rte", "vt", "vt-hyb",
+                                                        "vt-mpi", "vt-mpi-unify"]] +
              ["include/%s.h" % x for x in ["mpi-ext", "mpif-common", "mpif-config", "mpif",
                                            "mpif-mpi-io", "mpi", "mpi_portable_platform"]],
     'dirs': ["include/openmpi/ompi/mpi/cxx"],

--- a/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-2.1.2-gcccuda-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-2.1.2-gcccuda-2018a.eb
@@ -26,10 +26,10 @@ configopts += '--with-cuda=$CUDA_HOME '             # CUDA-aware build; N.B. --d
 # needed for --with-verbs
 osdependencies = [('libibverbs-dev', 'libibverbs-devel')]
 
-libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
+local_libs = ["mpi_cxx", "mpi_mpifh", "mpi", "ompitrace", "open-pal", "open-rte", "vt", "vt-hyb", "vt-mpi", "vt-mpi-unify"]
 sanity_check_paths = {
-    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
-             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in libs] +
+    'files': ["bin/%s" % f for f in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (l, SHLIB_EXT) for l in local_libs] +
              ["include/%s.h" % x for x in ["mpi-ext", "mpif-config", "mpif", "mpi", "mpi_portable_platform"]],
     'dirs': ["include/openmpi/ompi/mpi/cxx"],
 }

--- a/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-3.1.1-GCC-7.3.0-2.30.eb
+++ b/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-3.1.1-GCC-7.3.0-2.30.eb
@@ -26,11 +26,11 @@ else:
     osdependencies = ['libibverbs-devel']
 
 sanity_check_paths = {
-    'files': ["bin/%s" % binfile for binfile in ["ompi_info", "opal_wrapper", "orterun"]] +
-             ["lib/lib%s.%s" % (libfile, SHLIB_EXT) for libfile in ["mpi_cxx", "mpi_f77", "mpi_f90",
-                                                                    "mpi", "ompitrace", "open-pal",
-                                                                    "open-rte", "vt", "vt-hyb",
-                                                                    "vt-mpi", "vt-mpi-unify"]] +
+    'files': ["bin/%s" % f for f in ["ompi_info", "opal_wrapper", "orterun"]] +
+             ["lib/lib%s.%s" % (l, SHLIB_EXT) for l in ["mpi_cxx", "mpi_f77", "mpi_f90",
+                                                        "mpi", "ompitrace", "open-pal",
+                                                        "open-rte", "vt", "vt-hyb",
+                                                        "vt-mpi", "vt-mpi-unify"]] +
              ["include/%s.h" % x for x in ["mpi-ext", "mpif-common", "mpif-config", "mpif",
                                            "mpif-mpi-io", "mpi", "mpi_portable_platform"]],
     'dirs': ["include/openmpi/ompi/mpi/cxx"],

--- a/test/framework/easyconfigs/test_ecs/p/Python/Python-2.7.10-intel-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/p/Python/Python-2.7.10-intel-2018a.eb
@@ -10,8 +10,8 @@ more effectively."""
 toolchain = {'name': 'intel', 'version': '2018a'}
 toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
 
-numpyversion = '1.9.2'
-scipyversion = '0.15.1'
+local_numpyver = '1.9.2'
+local_scipyver = '0.15.1'
 
 source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources = [SOURCE_TGZ]
@@ -44,14 +44,14 @@ exts_list = [
     ['nose', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/n/nose/'],
     }],
-    ['numpy', numpyversion, {
-        'source_urls': [['http://sourceforge.net/projects/numpy/files/NumPy/%s' % numpyversion, 'download']],
+    ['numpy', local_numpyver, {
+        'source_urls': [['http://sourceforge.net/projects/numpy/files/NumPy/%s' % local_numpyver, 'download']],
         'patches': [
-            'numpy-1.8.0-mkl.patch',  # % numpyversion,
+            'numpy-1.8.0-mkl.patch',  # % local_numpyver,
         ],
     }],
-    ['scipy', scipyversion, {
-        'source_urls': [['http://sourceforge.net/projects/scipy/files/scipy/%s' % scipyversion, 'download']],
+    ['scipy', local_scipyver, {
+        'source_urls': [['http://sourceforge.net/projects/scipy/files/scipy/%s' % local_scipyver, 'download']],
     }],
     ['blist', '1.3.6', {
         'source_urls': ['https://pypi.python.org/packages/source/b/blist/'],

--- a/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-GCC-6.4.0-2.28.eb
+++ b/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-GCC-6.4.0-2.28.eb
@@ -22,8 +22,8 @@ toolchain = {'name': 'GCC', 'version': '6.4.0-2.28'}
 
 # eg. http://www.sqlite.org/2014/sqlite-autoconf-3080600.tar.gz
 source_urls = ['http://www.sqlite.org/2015/']
-version_str = '%(version_major)s' + ''.join('%02d' % int(x) for x in version.split('.')[1:])
-sources = ['sqlite-autoconf-%s.tar.gz' % version_str]
+local_version_str = '%(version_major)s' + ''.join('%02d' % int(x) for x in version.split('.')[1:])
+sources = ['sqlite-autoconf-%s.tar.gz' % local_version_str]
 
 # commented out for testing to avoid having to add them all - dependencies are tested in other files
 dependencies = [

--- a/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-foss-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-foss-2018a.eb
@@ -22,8 +22,8 @@ toolchain = {'name': 'foss', 'version': '2018a'}
 
 # eg. http://www.sqlite.org/2014/sqlite-autoconf-3080600.tar.gz
 source_urls = ['http://www.sqlite.org/2015/']
-version_str = '%(version_major)s' + ''.join('%02d' % int(x) for x in version.split('.')[1:])
-sources = ['sqlite-autoconf-%s.tar.gz' % version_str]
+local_version_str = '%(version_major)s' + ''.join('%02d' % int(x) for x in version.split('.')[1:])
+sources = ['sqlite-autoconf-%s.tar.gz' % local_version_str]
 
 # commented out for testing to avoid having to add them all - dependencies are tested in other files
 dependencies = [

--- a/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-gompi-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-gompi-2018a.eb
@@ -22,8 +22,8 @@ toolchain = {'name': 'gompi', 'version': '2018a'}
 
 # eg. http://www.sqlite.org/2014/sqlite-autoconf-3080600.tar.gz
 source_urls = ['http://www.sqlite.org/2015/']
-version_str = '%(version_major)s' + ''.join('%02d' % int(x) for x in version.split('.')[1:])
-sources = ['sqlite-autoconf-%s.tar.gz' % version_str]
+local_version_str = '%(version_major)s' + ''.join('%02d' % int(x) for x in version.split('.')[1:])
+sources = ['sqlite-autoconf-%s.tar.gz' % local_version_str]
 
 # commented out for testing to avoid having to add them all - dependencies are tested in other files
 dependencies = [

--- a/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2018a-OpenBLAS-0.2.20.eb
+++ b/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2018a-OpenBLAS-0.2.20.eb
@@ -14,12 +14,12 @@ toolchainopts = {'pic': True}
 source_urls = [homepage]
 sources = [SOURCELOWER_TGZ]
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.20'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver, '')]
+dependencies = [(local_blaslib, local_blasver, '')]
 
 # parallel build tends to fail, so disabling it
 parallel = 1

--- a/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2018a-OpenBLAS-0.2.20.eb
+++ b/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2018a-OpenBLAS-0.2.20.eb
@@ -14,12 +14,12 @@ toolchainopts = {'pic': True}
 source_urls = [homepage]
 sources = ['%(namelower)s-%(version)s.tgz']
 
-blaslib = 'OpenBLAS'
-blasver = '0.2.20'
+local_blaslib = 'OpenBLAS'
+local_blasver = '0.2.20'
 
-versionsuffix = "-%s-%s" % (blaslib, blasver)
+versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 
-dependencies = [(blaslib, blasver)]
+dependencies = [(local_blaslib, local_blasver)]
 
 # parallel build tends to fail, so disabling it
 parallel = 1

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-multiple.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-multiple.eb
@@ -21,5 +21,5 @@ moduleclass = 'tools'
 versionsuffix = '-somesuffix'
 
 [versionprefixed]
-local_block = 'versionsuffixed'
+block = 'versionsuffixed'
 versionprefix = 'someprefix-'

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-multiple.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-multiple.eb
@@ -21,5 +21,5 @@ moduleclass = 'tools'
 versionsuffix = '-somesuffix'
 
 [versionprefixed]
-block = 'versionsuffixed'
+local_block = 'versionsuffixed'
 versionprefix = 'someprefix-'

--- a/test/framework/easyconfigs/v1.0/g/GCC/GCC-4.6.3.eb
+++ b/test/framework/easyconfigs/v1.0/g/GCC/GCC-4.6.3.eb
@@ -25,7 +25,7 @@ source_urls = [
     'http://www.multiprecision.org/mpc/download',  # MPC official
 ]
 
-languages = ['c', 'c++', 'fortran', 'lto']
+# languages = ['c', 'c++', 'fortran', 'lto']
 
 # compiler class
 moduleclass = 'compiler'

--- a/test/framework/easyconfigs/yeb/intel-2018a.yeb
+++ b/test/framework/easyconfigs/yeb/intel-2018a.yeb
@@ -14,11 +14,11 @@ description:
 toolchain: {name: system, version: system}
 
 # fake intel toolchain easyconfig, no dependencies (good enough for testing)
-fake_dependencies: [
-    [icc, *compver],
-    [ifort, *compver],
-    [impi, 2018.1.163],
-    [imkl, 2018.1.163]
+dependencies: [
+    # [icc, *compver],
+    # [ifort, *compver],
+    # [impi, 2018.1.163],
+    # [imkl, 2018.1.163]
 ]
 
 moduleclass: toolchain

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1866,7 +1866,7 @@ class FileToolsTest(EnhancedTestCase):
 
         self.assertEqual(stdout, '')
 
-        error_pattern = r"Detected import from 'vsc' namespace in .*/test/framework/filetools.py \(line [0-9]+\)"
+        error_pattern = r"Detected import from 'vsc' namespace in .*test/framework/filetools.py \(line [0-9]+\)"
         regex = re.compile(r"^\nERROR: %s" % error_pattern)
         self.assertTrue(regex.search(stderr), "Pattern '%s' found in: %s" % (regex.pattern, stderr))
 

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -131,6 +131,9 @@ class ToolchainTest(EnhancedTestCase):
 
     def test_is_system_toolchain(self):
         """Test is_system_toolchain method."""
+
+        init_config()
+
         for ver in ['system', '']:
             tc = self.get_toolchain('system', version=ver)
             self.assertTrue(tc.is_system_toolchain())
@@ -158,7 +161,7 @@ class ToolchainTest(EnhancedTestCase):
             stderr = self.get_stderr()
             self.mock_stderr(False)
             self.assertTrue(tc.is_system_toolchain())
-            self.assertTrue(dummy_depr_warning in stderr)
+            self.assertTrue(dummy_depr_warning in stderr, "Found '%s' in: %s" % (dummy_depr_warning, stderr))
 
     def test_get_variable_compilers(self):
         """Test get_variable function to obtain compiler variables."""

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -434,6 +434,7 @@ def init_config(args=None, build_options=None, with_include=True):
     default_build_options = {
         'extended_dry_run': False,
         'external_modules_metadata': ConfigObj(),
+        'strict_local_var_naming': True,
         'suffix_modules_path': GENERAL_CLASS,
         'valid_module_classes': module_classes(),
         'valid_stops': [x[0] for x in EasyBlock.get_steps()],


### PR DESCRIPTION
cfr. discussion in #2912

Marked `WIP` since it needs a bit more love before it can be considered complete, in particular:

* [x] ~~improve regular expression used to rename non-conforming local variables via `--fix-deprecated-easyconfigs`~~
* [x] disallow easyconfig parameters that have single-letter name or a name that starts with `local_*`
* [x] ~~make enhanced test for `--fix-deprecated-easyconfigs` pass~~
