### PR TITLE
deprecate toolchains older than gompi/2016a and foss/2016a

### DIFF
--- a/easybuild/toolchains/foss.py
+++ b/easybuild/toolchains/foss.py
@@ -27,6 +27,7 @@ EasyBuild support for foss compiler toolchain (includes GCC, OpenMPI, OpenBLAS, 
 
 :author: Kenneth Hoste (Ghent University)
 """
+from distutils.version import LooseVersion
 
 from easybuild.toolchains.gompi import Gompi
 from easybuild.toolchains.golf import Golf
@@ -39,3 +40,16 @@ class Foss(Gompi, OpenBLAS, ScaLAPACK, Fftw):
     """Compiler toolchain with GCC, OpenMPI, OpenBLAS, ScaLAPACK and FFTW."""
     NAME = 'foss'
     SUBTOOLCHAIN = [Gompi.NAME, Golf.NAME]
+
+    def is_deprecated(self):
+        """Return whether or not this toolchain is deprecated."""
+        # foss toolchains older than foss/2016a are deprecated
+        # take into account that foss/2016.x is always < foss/2016a according to LooseVersion;
+        # foss/2016.01 & co are not deprecated yet...
+        foss_ver = LooseVersion(self.version)
+        if foss_ver < LooseVersion('2016a') and foss_ver < LooseVersion('2016.01'):
+            deprecated = True
+        else:
+            deprecated = False
+
+        return deprecated

--- a/easybuild/toolchains/gompi.py
+++ b/easybuild/toolchains/gompi.py
@@ -40,8 +40,14 @@ class Gompi(GccToolchain, OpenMPI):
 
     def is_deprecated(self):
         """Return whether or not this toolchain is deprecated."""
+        gompi_ver = LooseVersion(self.version)
         # deprecate oldest gompi toolchains (versions 1.x)
-        if LooseVersion(self.version) < LooseVersion('2000'):
+        if gompi_ver < LooseVersion('2000'):
+            deprecated = True
+        # gompi toolchains older than gompi/2016a are deprecated
+        # take into account that gompi/2016.x is always < gompi/2016a according to LooseVersion;
+        # gompi/2016.01 & co are not deprecated yet...
+        elif gompi_ver < LooseVersion('2016a') and gompi_ver < LooseVersion('2016.01'):
             deprecated = True
         else:
             deprecated = False

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1053,6 +1053,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 
+        # need to allow triggering deprecated behaviour because of old toolchain (< gompi/2016a)
+        self.allow_deprecated_behaviour()
+
         tmpdir = tempfile.mkdtemp()
         args = [
             # PR for foss/2015a, see https://github.com/easybuilders/easybuild-easyconfigs/pull/1239/files
@@ -1161,6 +1164,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 
+        # need to allow triggering deprecated behaviour because of old toolchain (< gompi/2016a)
+        self.allow_deprecated_behaviour()
+
         args = [
             # PR for foss/2015a, see https://github.com/easybuilders/easybuild-easyconfigs/pull/1239/files
             '--from-pr=1239',
@@ -1172,9 +1178,11 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         try:
             self.mock_stdout(True)
+            self.mock_stderr(True)
             self.eb_main(args, do_build=True, raise_error=True, testing=False)
             stdout = self.get_stdout()
             self.mock_stdout(False)
+            self.mock_stderr(False)
 
             msg_regexs = [
                 re.compile(r"^== Build succeeded for 1 out of 1", re.M),

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -692,6 +692,9 @@ class RobotTest(EnhancedTestCase):
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 
+        # need to allow triggering deprecated behaviour because of old toolchain (< gompi/2016a)
+        self.allow_deprecated_behaviour()
+
         test_ecs_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
 
         test_ec = 'toy-0.0-deps.eb'


### PR DESCRIPTION
see also https://github.com/easybuilders/easybuild-easyconfigs/pull/8585