### PR TITLE
be more forgiving in check_easy_install_cmd function of bootstrap script w.r.t. harmless warnings in output of 'easy_install --version'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20190523.01 f419ce397246b722d8fa4862d56275badfc9062e965a6e45be9c1282c552352d"
+    - EB_BOOTSTRAP_EXPECTED="20190806.01 6cb174564895769a1bdb008ea96f7df65b91df3132e0c2b9969b4a19e173465c"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -54,7 +54,7 @@ from distutils.version import LooseVersion
 from hashlib import md5
 
 
-EB_BOOTSTRAP_VERSION = '20190523.01'
+EB_BOOTSTRAP_VERSION = '20190806.01'
 
 # argparse preferrred, optparse deprecated >=2.7
 HAVE_ARGPARSE = False
@@ -385,7 +385,7 @@ def check_easy_install_cmd():
     import setuptools
     debug("Location of active setuptools installation: %s" % setuptools.__file__)
 
-    easy_install_regex = re.compile('^(setuptools|distribute) %s' % setuptools.__version__)
+    easy_install_regex = re.compile('^(setuptools|distribute) %s' % setuptools.__version__, re.M)
     debug("Pattern for 'easy_install --version': %s" % easy_install_regex.pattern)
 
     pythonpath = os.getenv('PYTHONPATH', '')
@@ -393,7 +393,7 @@ def check_easy_install_cmd():
     os.system("%s > %s 2>&1" % (cmd, outfile))
     outtxt = open(outfile).read().strip()
     debug("Output of '%s':\n%s" % (cmd, outtxt))
-    res = bool(easy_install_regex.match(outtxt))
+    res = bool(easy_install_regex.search(outtxt))
     debug("Result: %s" % res)
     if res:
         debug("Found right 'easy_install' command")


### PR DESCRIPTION
This helps to debug a failing bootstrap in case harmless locale warnings are included in the output of `easy_install --version`...