### PR TITLE
enhance 'completed' message with how much time was needed the installation

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3145,7 +3145,7 @@ def build_and_install_one(ecdict, init_env):
         app.close_log()
         application_log = app.logfile
 
-    req_time = time2str((end_timestamp - start_timestamp).total_seconds())
+    req_time = time2str(end_timestamp - start_timestamp)
     print_msg("%s: Installation %s %s (took %s)" % (summary, ended, succ, req_time), log=_log, silent=silent)
 
     # check for errors

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -49,6 +49,7 @@ import stat
 import tempfile
 import time
 import traceback
+from datetime import datetime
 from distutils.version import LooseVersion
 from vsc.utils import fancylogger
 from vsc.utils.missing import get_class_for
@@ -93,7 +94,7 @@ from easybuild.tools.package.utilities import package
 from easybuild.tools.repository.repository import init_repository
 from easybuild.tools.toolchain import DUMMY_TOOLCHAIN_NAME
 from easybuild.tools.systemtools import det_parallelism, use_group
-from easybuild.tools.utilities import quote_str, remove_unwanted_chars, trace_msg
+from easybuild.tools.utilities import quote_str, remove_unwanted_chars, time2str, trace_msg
 from easybuild.tools.version import this_is_easybuild, VERBOSE_VERSION, VERSION
 
 
@@ -2984,6 +2985,8 @@ def build_and_install_one(ecdict, init_env):
     """
     silent = build_option('silent')
 
+    start_timestamp = datetime.now()
+
     spec = ecdict['spec']
     rawtxt = ecdict['ec'].rawtxt
     name = ecdict['ec']['name']
@@ -3122,6 +3125,8 @@ def build_and_install_one(ecdict, init_env):
             # take away user write permissions (again)
             adjust_permissions(new_log_dir, stat.S_IWUSR, add=False, recursive=False)
 
+    end_timestamp = datetime.now()
+
     if result:
         success = True
         summary = 'COMPLETED'
@@ -3140,7 +3145,8 @@ def build_and_install_one(ecdict, init_env):
         app.close_log()
         application_log = app.logfile
 
-    print_msg("%s: Installation %s %s" % (summary, ended, succ), log=_log, silent=silent)
+    req_time = time2str((end_timestamp - start_timestamp).total_seconds())
+    print_msg("%s: Installation %s %s (took %s)" % (summary, ended, succ, req_time), log=_log, silent=silent)
 
     # check for errors
     if filetools.errors_found_in_log > 0:

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -183,3 +183,22 @@ def trace_msg(message, silent=False):
     """Print trace message."""
     if build_option('trace'):
         print_msg('  >> ' + message, prefix=False)
+
+
+def time2str(time_secs):
+    """Return string representing provided amount of time (in seconds) in human-readable form."""
+    res = None
+    if time_secs < 60:
+        res = '%s sec' % time_secs
+    elif time_secs < 3600:
+        mins = int(time_secs / 60)
+        secs = int(time_secs - (mins * 60))
+        res = '%d min %d sec' % (mins, secs)
+    else:
+        hours = int(time_secs / 3600)
+        mins = int((time_secs - hours * 3600) / 60)
+        secs = int(time_secs - (hours * 3600) - (mins * 60))
+        hours_str = 'hours' if hours > 1 else 'hour'
+        res = '%d %s %d min %d sec' % (hours, hours_str, mins, secs)
+
+    return res

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -27,6 +27,7 @@ Module with various utility functions
 
 :author: Kenneth Hoste (Ghent University)
 """
+import datetime
 import glob
 import os
 import string
@@ -185,19 +186,25 @@ def trace_msg(message, silent=False):
         print_msg('  >> ' + message, prefix=False)
 
 
-def time2str(time_secs):
-    """Return string representing provided amount of time (in seconds) in human-readable form."""
+def time2str(delta):
+    """Return string representing provided datetime.timedelta value in human-readable form."""
     res = None
-    if time_secs < 60:
-        res = '%s sec' % time_secs
-    elif time_secs < 3600:
-        mins = int(time_secs / 60)
-        secs = int(time_secs - (mins * 60))
+
+    if not isinstance(delta, datetime.timedelta):
+        raise EasyBuildError("Incorrect value type provided to time2str, should be datetime.timedelta: %s", type(delta))
+
+    delta_secs = delta.days * 3600 * 24 + delta.seconds + delta.microseconds / 10**6
+
+    if delta_secs < 60:
+        res = '%s sec' % delta_secs
+    elif delta_secs < 3600:
+        mins = int(delta_secs / 60)
+        secs = int(delta_secs - (mins * 60))
         res = '%d min %d sec' % (mins, secs)
     else:
-        hours = int(time_secs / 3600)
-        mins = int((time_secs - hours * 3600) / 60)
-        secs = int(time_secs - (hours * 3600) - (mins * 60))
+        hours = int(delta_secs / 3600)
+        mins = int((delta_secs - hours * 3600) / 60)
+        secs = int(delta_secs - (hours * 3600) - (mins * 60))
         hours_str = 'hours' if hours > 1 else 'hour'
         res = '%d %s %d min %d sec' % (hours, hours_str, mins, secs)
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -33,6 +33,7 @@ import re
 import shutil
 import sys
 import tempfile
+from datetime import datetime
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
 
@@ -1725,24 +1726,30 @@ class EasyBlockTest(EnhancedTestCase):
     def test_time2str(self):
         """Test time2str function."""
 
+        start = datetime(2019, 7, 30, 5, 14, 23)
+
         test_cases = [
-            (14, "14 sec"),
-            (59, "59 sec"),
-            (60, "1 min 0 sec"),
-            (119, "1 min 59 sec"),
-            (1383, "23 min 3 sec"),
-            (3599, "59 min 59 sec"),
-            (3600, "1 hour 0 min 0 sec"),
-            (5691, "1 hour 34 min 51 sec"),
-            (7200, "2 hours 0 min 0 sec"),
-            (12096, "3 hours 21 min 36 sec"),
-            (40501, "11 hours 15 min 1 sec"),
-            (86400 - 1, "23 hours 59 min 59 sec"),
-            (86400, "24 hours 0 min 0 sec"),
-            (573921, "159 hours 25 min 21 sec"),
+            (start, "0 sec"),
+            (datetime(2019, 7, 30, 5, 14, 37), "14 sec"),
+            (datetime(2019, 7, 30, 5, 15, 22), "59 sec"),
+            (datetime(2019, 7, 30, 5, 15, 23), "1 min 0 sec"),
+            (datetime(2019, 7, 30, 5, 16, 22), "1 min 59 sec"),
+            (datetime(2019, 7, 30, 5, 37, 26), "23 min 3 sec"),
+            (datetime(2019, 7, 30, 6, 14, 22), "59 min 59 sec"),
+            (datetime(2019, 7, 30, 6, 14, 23), "1 hour 0 min 0 sec"),
+            (datetime(2019, 7, 30, 6, 49, 14), "1 hour 34 min 51 sec"),
+            (datetime(2019, 7, 30, 7, 14, 23), "2 hours 0 min 0 sec"),
+            (datetime(2019, 7, 30, 8, 35, 59), "3 hours 21 min 36 sec"),
+            (datetime(2019, 7, 30, 16, 29, 24), "11 hours 15 min 1 sec"),
+            (datetime(2019, 7, 31, 5, 14, 22), "23 hours 59 min 59 sec"),
+            (datetime(2019, 7, 31, 5, 14, 23), "24 hours 0 min 0 sec"),
+            (datetime(2019, 8, 5, 20, 39, 44), "159 hours 25 min 21 sec"),
         ]
-        for secs, expected in test_cases:
-            self.assertEqual(time2str(secs), expected)
+        for end, expected in test_cases:
+            self.assertEqual(time2str(end - start), expected)
+
+        error_pattern = "Incorrect value type provided to time2str, should be datetime.timedelta: <type 'int'>"
+        self.assertErrorRegex(EasyBuildError, error_pattern, time2str, 123)
 
 
 def suite():

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -47,6 +47,7 @@ from easybuild.tools.config import get_module_syntax
 from easybuild.tools.filetools import copy_dir, copy_file, mkdir, read_file, remove_file, write_file
 from easybuild.tools.module_generator import module_generator
 from easybuild.tools.modules import reset_module_caches
+from easybuild.tools.utilities import time2str
 from easybuild.tools.version import get_git_revision, this_is_easybuild
 
 
@@ -1720,6 +1721,28 @@ class EasyBlockTest(EnhancedTestCase):
         hpl = easyblocks['easybuild.easyblocks.hpl']
         self.assertEqual(hpl['class'], 'EB_HPL')
         self.assertTrue(hpl['loc'].endswith('sandbox/easybuild/easyblocks/h/hpl.py'))
+
+    def test_time2str(self):
+        """Test time2str function."""
+
+        test_cases = [
+            (14, "14 sec"),
+            (59, "59 sec"),
+            (60, "1 min 0 sec"),
+            (119, "1 min 59 sec"),
+            (1383, "23 min 3 sec"),
+            (3599, "59 min 59 sec"),
+            (3600, "1 hour 0 min 0 sec"),
+            (5691, "1 hour 34 min 51 sec"),
+            (7200, "2 hours 0 min 0 sec"),
+            (12096, "3 hours 21 min 36 sec"),
+            (40501, "11 hours 15 min 1 sec"),
+            (86400 - 1, "23 hours 59 min 59 sec"),
+            (86400, "24 hours 0 min 0 sec"),
+            (573921, "159 hours 25 min 21 sec"),
+        ]
+        for secs, expected in test_cases:
+            self.assertEqual(time2str(secs), expected)
 
 
 def suite():

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1189,7 +1189,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                 re.compile(r"^\*\*\* DRY RUN using 'ConfigureMake' easyblock", re.M),
                 re.compile(r"^== building and installing FFTW/3.3.4-gompi-2015a\.\.\.", re.M),
                 re.compile(r"^building... \[DRY RUN\]", re.M),
-                re.compile(r"^== COMPLETED: Installation ended successfully", re.M),
+                re.compile(r"^== COMPLETED: Installation ended successfully \(took .* sec\)", re.M),
             ]
 
             for msg_regex in msg_regexs:
@@ -2627,7 +2627,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         msg_regexs = [
             re.compile(r"the actual build \& install procedure that will be performed may diverge", re.M),
             re.compile(r"^\*\*\* DRY RUN using 'EB_toy' easyblock", re.M),
-            re.compile(r"^== COMPLETED: Installation ended successfully", re.M),
+            re.compile(r"^== COMPLETED: Installation ended successfully \(took .* sec\)", re.M),
             re.compile(r"^\(no ignored errors during dry run\)", re.M),
         ]
         ignoring_error_regex = re.compile(r"WARNING: ignoring error", re.M)
@@ -3363,7 +3363,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args = ['toy-0.0.eb', '--force', '--stop=configure']
         txt, _ = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False, strip=True)
 
-        regex = re.compile("COMPLETED: Installation STOPPED successfully", re.M)
+        regex = re.compile("COMPLETED: Installation STOPPED successfully \(took .* sec\)", re.M)
         self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
 
     def test_fetch(self):
@@ -3381,7 +3381,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         patterns = [
             "^== fetching files\.\.\.$",
-            "^== COMPLETED: Installation STOPPED successfully$",
+            "^== COMPLETED: Installation STOPPED successfully \(took .* sec\)$",
         ]
         for pattern in patterns:
             regex = re.compile(pattern, re.M)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3363,7 +3363,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args = ['toy-0.0.eb', '--force', '--stop=configure']
         txt, _ = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False, strip=True)
 
-        regex = re.compile("COMPLETED: Installation STOPPED successfully \(took .* sec\)", re.M)
+        regex = re.compile(r"COMPLETED: Installation STOPPED successfully \(took .* sec\)", re.M)
         self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
 
     def test_fetch(self):
@@ -3380,8 +3380,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
         stdout, stderr = self._run_mock_eb(args, raise_error=True, strip=True, testing=False)
 
         patterns = [
-            "^== fetching files\.\.\.$",
-            "^== COMPLETED: Installation STOPPED successfully \(took .* sec\)$",
+            r"^== fetching files\.\.\.$",
+            r"^== COMPLETED: Installation STOPPED successfully \(took .* sec\)$",
         ]
         for pattern in patterns:
             regex = re.compile(pattern, re.M)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -82,7 +82,6 @@ class ToyBuildTest(EnhancedTestCase):
 
         # check for success
         success = re.compile(r"COMPLETED: Installation ended successfully \(took .* sec\)")
-        print success.pattern, outtxt
         self.assertTrue(success.search(outtxt), "COMPLETED message found in '%s" % outtxt)
 
         # if the module exists, it should be fine

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -81,7 +81,8 @@ class ToyBuildTest(EnhancedTestCase):
         full_version = ''.join([versionprefix, version, versionsuffix])
 
         # check for success
-        success = re.compile("COMPLETED: Installation ended successfully")
+        success = re.compile(r"COMPLETED: Installation ended successfully \(took .* sec\)")
+        print success.pattern, outtxt
         self.assertTrue(success.search(outtxt), "COMPLETED message found in '%s" % outtxt)
 
         # if the module exists, it should be fine


### PR DESCRIPTION
Before:

```
== COMPLETED: Installation ended successfully
```

now:

```
== COMPLETED: Installation ended successfully (took 5 sec)
```

For long-running builds the time will be shown in minutes/seconds or hours/minutes/seconds (not days), see example outputs in tests.