### PR TITLE
add support for specifying tuple of alternative checksums

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -748,18 +748,19 @@ def verify_checksum(path, checksums):
     :param file: path of file to verify checksum of
     :param checksum: checksum value (and type, optionally, default is MD5), e.g., 'af314', ('sha', '5ec1b')
     """
+
+    filename = os.path.basename(path)
+
     # if no checksum is provided, pretend checksum to be valid, unless presence of checksums to verify is enforced
     if checksums is None:
         if build_option('enforce_checksums'):
-            raise EasyBuildError("Missing checksum for %s", os.path.basename(path))
+            raise EasyBuildError("Missing checksum for %s", filename)
         else:
             return True
 
     # make sure we have a list of checksums
     if not isinstance(checksums, list):
         checksums = [checksums]
-
-    filename = os.path.basename(path)
 
     for checksum in checksums:
         if isinstance(checksum, dict):

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -769,8 +769,21 @@ def verify_checksum(path, checksums):
             else:
                 raise EasyBuildError("Length of checksum '%s' (%d) does not match with either MD5 (32) or SHA256 (64)",
                                      checksum, len(checksum))
-        elif isinstance(checksum, tuple) and len(checksum) == 2:
-            typ, checksum = checksum
+
+        elif isinstance(checksum, tuple):
+            # if checksum is specified as a tuple, it could either be specifying:
+            # * the type of checksum + the checksum value
+            # * a set of alternative valid checksums to consider => recursive call
+            if len(checksum) == 2 and checksum[0] in CHECKSUM_FUNCTIONS:
+                typ, checksum = checksum
+            else:
+                _log.info("Found %d alternative checksums for %s, considering them one-by-one...", len(checksum), path)
+                for cand_checksum in checksum:
+                    if verify_checksum(path, cand_checksum):
+                        _log.info("Found matching checksum for %s: %s", path, cand_checksum)
+                        return True
+                    else:
+                        _log.info("Ignoring non-matching checksum for %s (%s)...", path, cand_checksum)
         else:
             raise EasyBuildError("Invalid checksum spec '%s', should be a string (MD5) or 2-tuple (type, value).",
                                  checksum)

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -236,9 +236,10 @@ class FileToolsTest(EnhancedTestCase):
 
     def test_checksums(self):
         """Test checksum functionality."""
-        fh, fp = tempfile.mkstemp()
-        os.close(fh)
+
+        fp = os.path.join(self.test_prefix, 'test.txt')
         ft.write_file(fp, "easybuild\n")
+
         known_checksums = {
             'adler32': '0x379257805',
             'crc32': '0x1457143216',
@@ -261,10 +262,11 @@ class FileToolsTest(EnhancedTestCase):
         self.assertTrue(ft.verify_checksum(fp, known_checksums['md5']))
         self.assertTrue(ft.verify_checksum(fp, known_checksums['sha256']))
 
-        # checksum of length 32 is assumed to be MD5, length 64 to be SHA256, other lengths not allowed
         # providing non-matching MD5 and SHA256 checksums results in failed verification
         self.assertFalse(ft.verify_checksum(fp, '1c49562c4b404f3120a3fa0926c8d09c'))
         self.assertFalse(ft.verify_checksum(fp, '7167b64b1ca062b9674ffef46f9325db7167b64b1ca062b9674ffef46f9325db'))
+
+        # checksum of length 32 is assumed to be MD5, length 64 to be SHA256, other lengths not allowed
         # checksum of length other than 32/64 yields an error
         error_pattern = "Length of checksum '.*' \(\d+\) does not match with either MD5 \(32\) or SHA256 \(64\)"
         for checksum in ['tooshort', 'inbetween32and64charactersisnotgoodeither', known_checksums['sha256'] + 'foo']:
@@ -280,6 +282,23 @@ class FileToolsTest(EnhancedTestCase):
         self.assertFalse(ft.verify_checksum(fp, broken_checksums['md5']))
         self.assertFalse(ft.verify_checksum(fp, broken_checksums['sha256']))
 
+        # test specify alternative checksums
+        alt_checksums = ('7167b64b1ca062b9674ffef46f9325db7167b64b1ca062b9674ffef46f9325db', known_checksums['sha256'])
+        self.assertTrue(ft.verify_checksum(fp, alt_checksums))
+
+        alt_checksums = ('fecf50db81148786647312bbd3b5c740', '2c829facaba19c0fcd81f9ce96bef712',
+                         '840078aeb4b5d69506e7c8edae1e1b89', known_checksums['md5'])
+        self.assertTrue(ft.verify_checksum(fp, alt_checksums))
+
+        alt_checksums = ('840078aeb4b5d69506e7c8edae1e1b89', known_checksums['md5'], '2c829facaba19c0fcd81f9ce96bef712')
+        self.assertTrue(ft.verify_checksum(fp, alt_checksums))
+
+        alt_checksums = (known_checksums['md5'], '840078aeb4b5d69506e7c8edae1e1b89', '2c829facaba19c0fcd81f9ce96bef712')
+        self.assertTrue(ft.verify_checksum(fp, alt_checksums))
+
+        alt_checksums = (known_checksums['sha256'],)
+        self.assertTrue(ft.verify_checksum(fp, alt_checksums))
+
         # check whether missing checksums are enforced
         build_options = {
             'enforce_checksums': True,
@@ -289,9 +308,6 @@ class FileToolsTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, "Missing checksum for", ft.verify_checksum, fp, None)
         self.assertTrue(ft.verify_checksum(fp, known_checksums['md5']))
         self.assertTrue(ft.verify_checksum(fp, known_checksums['sha256']))
-
-        # cleanup
-        os.remove(fp)
 
     def test_common_path_prefix(self):
         """Test get common path prefix for a list of paths."""

--- a/test/framework/type_checking.py
+++ b/test/framework/type_checking.py
@@ -186,9 +186,14 @@ class TypeCheckingTest(EnhancedTestCase):
             [sha256_checksum1],
             # one checksum, for 3 files
             [sha256_checksum1, sha256_checksum2, sha256_checksum3],
-            # one checksum of specific type
+            # one checksum of specific type (as 2-tuple)
             [('md5', md5_checksum)],
             [('sha256', sha256_checksum1)],
+            # alternative checksums for a single file (n-tuple)
+            [(sha256_checksum1, sha256_checksum2)],
+            [(sha256_checksum1, sha256_checksum2, sha256_checksum3)],
+            [(sha256_checksum1, sha256_checksum2, sha256_checksum3, md5_checksum)],
+            [(md5_checksum,)],
             # multiple checksums of specific type, one for each file
             [('md5', md5_checksum), ('sha256', sha256_checksum1)],
             # checksum as dict (file to checksum mapping)
@@ -204,9 +209,16 @@ class TypeCheckingTest(EnhancedTestCase):
             ],
             # each item can be a list of checksums for a single file, which can be of different types...
             [
-                [sha256_checksum1, sha256_checksum2, sha256_checksum3],
-                [sha256_checksum1, ('md5', md5_checksum), {'foo.txt': sha256_checksum2}],
-                [sha256_checksum1],
+                # two checksums for a single file, *both* should match
+                [sha256_checksum1, md5_checksum],
+                # three checksums for a single file, *all* should match
+                [sha256_checksum1, ('md5', md5_checksum), {'foo.txt': sha256_checksum1}],
+                # single checksum for a single file
+                sha256_checksum1,
+                # filename-to-checksum mapping
+                {'foo.txt': sha256_checksum1, 'bar.txt': sha256_checksum2},
+                # 3 alternative checksums for a single file, one match is sufficient
+                (sha256_checksum1, sha256_checksum2, sha256_checksum3),
             ]
         ]
         for inp in inputs:


### PR DESCRIPTION
marked as `WIP` since I still need to look into:

* ~~make `--inject-checksums` aware of this?~~ (no need to, cfr. https://github.com/easybuilders/easybuild-framework/pull/2946#issuecomment-520552849)
* [x] ~~enhance type checking for easyconfig parameters?~~ (done)