### PR TITLE
support using 'system' as alias for 'dummy' toolchain

### DIFF
--- a/easybuild/framework/easyconfig/constants.py
+++ b/easybuild/framework/easyconfig/constants.py
@@ -34,7 +34,7 @@ import os
 import platform
 from vsc.utils import fancylogger
 
-from easybuild.tools.systemtools import get_shared_lib_ext, get_os_name, get_os_type, get_os_version
+from easybuild.tools.systemtools import get_os_name, get_os_type, get_os_version
 
 
 _log = fancylogger.getLogger('easyconfig.constants', fname=False)
@@ -50,4 +50,5 @@ EASYCONFIG_CONSTANTS = {
     'OS_NAME': (get_os_name(), "System name (e.g. 'fedora' or 'RHEL')"),
     'OS_VERSION': (get_os_version(), "System version"),
     'SYS_PYTHON_VERSION': (platform.python_version(), "System Python version (platform.python_version())"),
+    'SYSTEM': ({'name': 'system', 'version': 'system'}, "System toolchain"),
 }

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -518,6 +518,19 @@ class EasyConfig(object):
             raise EasyBuildError("You may have some typos in your easyconfig file: %s",
                                  ', '.join(["%s -> %s" % typo for typo in typos]))
 
+        # handle 'system' alias for 'dummy' toolchain;
+        # this is done to help deal with the deprecation of the 'dummy' toolchain in EasyBuild 4.x,
+        # since it allows EasyBuild 3.x to process easyconfigs meant for EasyBuild 4.x
+        # (which is important for features like "eb --install-latest-eb-release")
+        # without having to make the extensive changes made when effectively replacing the 'dummy' toolchain
+        # with an actual 'system' toolchain (see https://github.com/easybuilders/easybuild-framework/pull/2877);
+        if local_vars['toolchain']['name'] == 'system':
+            local_vars['toolchain']['name'] = DUMMY_TOOLCHAIN_NAME
+            self.log.info("Found 'system' toolchain name, replaced with 'dummy'")
+            if local_vars['toolchain']['version'] == 'system':
+                local_vars['toolchain']['version'] = DUMMY_TOOLCHAIN_VERSION
+                self.log.info("Found 'system' toolchain version, replaced with 'dummy'")
+
         # we need toolchain to be set when we call _parse_dependency
         for key in ['toolchain'] + local_vars.keys():
             # validations are skipped, just set in the config

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -174,6 +174,11 @@ class EasyConfigParserTest(EnhancedTestCase):
     def test_easyconfig_constants(self):
         """Test available easyconfig constants."""
         constants = build_easyconfig_constants_dict()
+
+        # SYSTEM constant is a dict value, so takes special care
+        system_constant = constants.pop('SYSTEM')
+        self.assertEqual(system_constant, {'name': 'system', 'version': 'system'})
+
         # make sure both keys and values are only strings
         for constant_name in constants:
             self.assertTrue(isinstance(constant_name, basestring), "Constant name %s is a string" % constant_name)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2265,6 +2265,27 @@ class ToyBuildTest(EnhancedTestCase):
             self.assertTrue(perl_shebang_regex.match(perlbin_txt),
                             "Pattern '%s' found in %s: %s" % (perl_shebang_regex.pattern, perlbin_path, perlbin_txt))
 
+    def test_toy_system_toolchain_alias(self):
+        """Test use of 'system' toolchain alias."""
+        toy_ec = os.path.join(os.path.dirname(__file__), 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
+        toy_ec_txt = read_file(toy_ec)
+
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        tc_regex = re.compile('^toolchain = .*', re.M)
+
+        test_tcs = [
+            "toolchain = {'name': 'system', 'version': 'system'}",
+            "toolchain = {'name': 'system', 'version': ''}",
+            "toolchain = SYSTEM",
+        ]
+
+        for tc in test_tcs:
+            test_ec_txt = tc_regex.sub(tc, toy_ec_txt)
+            write_file(test_ec, test_ec_txt)
+
+            self.test_toy_build(ec_file=test_ec)
+
+
 def suite():
     """ return all the tests in this file """
     return TestLoaderFiltered().loadTestsFromTestCase(ToyBuildTest, sys.argv[1:])


### PR DESCRIPTION
This enables using `'system'` toolchain in easyconfigs, either directly:

```python
toolchain = {'name': 'system', 'version': 'system'}
```

or via the `SYSTEM` constant:

```python
toolchain = SYSTEM
```

This is done in preparation for EasyBuild 4.x, where the `dummy` toolchain is deprecated and replaced by the new `system` toolchain with slightly different behavior w.r.t. toolchain version and loading of dependencies in the build environment (see #2877).

The alias approach used here allows us to avoid the extensive work done in #2877 to properly handle allowing both using `system` and `dummy` as toolchain name.