### PR TITLE
escape '+' in search queries + handle invalid search queries better

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -619,8 +619,15 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filen
         raise EasyBuildError("search_file: ignore_dirs (%s) should be of type list, not %s",
                              ignore_dirs, type(ignore_dirs))
 
+    # escape some special characters in query that may also occur in actual software names: +
+    # do not use re.escape, since that breaks queries with genuine regex characters like ^ or .*
+    query = re.sub('([+])', r'\\\1', query)
+
     # compile regex, case-insensitive
-    query = re.compile(query, re.I)
+    try:
+        query = re.compile(query, re.I)
+    except re.error as err:
+        raise EasyBuildError("Invalid search query: %s", err)
 
     var_defs = []
     hits = []

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1615,7 +1615,16 @@ class FileToolsTest(EnhancedTestCase):
         for pattern in ['netCDF-C++', 'foo.*bar', 'foo|bar']:
             var_defs, hits = ft.search_file([test_ecs], pattern, terse=True, filename_only=True)
             self.assertEqual(var_defs, [])
+            # no hits for any of these in test easyconfigs
             self.assertEqual(hits, [])
+
+        # create hit for netCDF-C++ search
+        test_ec = os.path.join(self.test_prefix, 'netCDF-C++-4.2-foss-2019a.eb')
+        ft.write_file(test_ec, '')
+        for pattern in ['netCDF-C++', 'CDF', 'C++', '^netCDF']:
+            var_defs, hits = ft.search_file([self.test_prefix], pattern, terse=True, filename_only=True)
+            self.assertEqual(var_defs, [])
+            self.assertEqual(hits, ['netCDF-C++-4.2-foss-2019a.eb'])
 
         # check how simply invalid queries are handled
         for pattern in ['*foo', '(foo', ')foo', 'foo)', 'foo(']:

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1610,6 +1610,17 @@ class FileToolsTest(EnhancedTestCase):
                                 'hwloc-1.11.8-GCC-7.3.0-2.30.eb', 'hwloc-1.6.2-GCC-4.9.3-2.26.eb',
                                 'hwloc-1.8-gcccuda-2018a.eb'])
 
+        # patterns that include special characters + (or ++) shouldn't cause trouble
+        # cfr. https://github.com/easybuilders/easybuild-framework/issues/2966
+        for pattern in ['netCDF-C++', 'foo.*bar', 'foo|bar']:
+            var_defs, hits = ft.search_file([test_ecs], pattern, terse=True, filename_only=True)
+            self.assertEqual(var_defs, [])
+            self.assertEqual(hits, [])
+
+        # check how simply invalid queries are handled
+        for pattern in ['*foo', '(foo', ')foo', 'foo)', 'foo(']:
+            self.assertErrorRegex(EasyBuildError, "Invalid search query", ft.search_file, [test_ecs], pattern)
+
     def test_find_eb_script(self):
         """Test find_eb_script function."""
         self.assertTrue(os.path.exists(ft.find_eb_script('rpath_args.py')))


### PR DESCRIPTION
fix for #2966 reported by @akesandgren 