### PR TITLE
make check for deprecated foss versions compatible with Python 3

### DIFF
--- a/easybuild/toolchains/foss.py
+++ b/easybuild/toolchains/foss.py
@@ -43,11 +43,16 @@ class Foss(Gompi, OpenBLAS, ScaLAPACK, Fftw):
 
     def is_deprecated(self):
         """Return whether or not this toolchain is deprecated."""
+        # need to transform a version like '2016a' with something that is safe to compare with '2000'
+        # comparing subversions that include letters causes TypeErrors in Python 3
+        # 'a' is assumed to be equivalent with '.01' (January), and 'b' with '.07' (June) (good enough for this purpose)
+        version = self.version.replace('a', '.01').replace('b', '.07')
+
         # foss toolchains older than foss/2016a are deprecated
         # take into account that foss/2016.x is always < foss/2016a according to LooseVersion;
         # foss/2016.01 & co are not deprecated yet...
-        foss_ver = LooseVersion(self.version)
-        if foss_ver < LooseVersion('2016a') and foss_ver < LooseVersion('2016.01'):
+        foss_ver = LooseVersion(version)
+        if foss_ver < LooseVersion('2016.01'):
             deprecated = True
         else:
             deprecated = False


### PR DESCRIPTION
required to fix currently broken easyconfig tests in `develop`, for example:

```
ERROR: test__parse_easyconfig_Tk-8.6.5-foss-2016.04.eb (test.easyconfigs.easyconfigs.EasyConfigTest)

Test for parsing of easyconfig Tk-8.6.5-foss-2016.04.eb

----------------------------------------------------------------------

Traceback (most recent call last):
  File "<string>", line 1, in innertest
  File "/home/travis/build/easybuilders/easybuild-easyconfigs/test/easyconfigs/easyconfigs.py", line 523, in template_easyconfig_test
    ecs = process_easyconfig(spec)
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/easybuild_framework-4.0.0.dev0-py3.6.egg/easybuild/framework/easyconfig/easyconfig.py", line 1762, in process_easyconfig
    ec = EasyConfig(spec, build_specs=build_specs, validate=validate, hidden=hidden)
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/easybuild_framework-4.0.0.dev0-py3.6.egg/easybuild/framework/easyconfig/easyconfig.py", line 471, in __init__
    self.check_deprecated(self.path)
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/easybuild_framework-4.0.0.dev0-py3.6.egg/easybuild/framework/easyconfig/easyconfig.py", line 704, in check_deprecated
    if self.toolchain.is_deprecated():
  File "/home/travis/virtualenv/python3.6.7/lib/python3.6/site-packages/easybuild_framework-4.0.0.dev0-py3.6.egg/easybuild/toolchains/foss.py", line 50, in is_deprecated
    if foss_ver < LooseVersion('2016a') and foss_ver < LooseVersion('2016.01'):
  File "/opt/python/3.6.7/lib/python3.6/distutils/version.py", line 52, in __lt__
    c = self._cmp(other)
  File "/opt/python/3.6.7/lib/python3.6/distutils/version.py", line 337, in _cmp
    if self.version < other.version:
TypeError: '<' not supported between instances of 'int' and 'str'
```