### PR TITLE
fix running framework suite from easybuild-framework directory

### DIFF
--- a/easybuild/framework/__init__.py
+++ b/easybuild/framework/__init__.py
@@ -32,3 +32,5 @@ which is a collection of additional modules/classes to be used for software comp
 :author: Pieter De Baets (Ghent University)
 :author: Jens Timmerman (Ghent University)
 """
+import os
+__path__ = __import__('pkgutil').extend_path([os.path.abspath(p) for p in __path__], __name__)

--- a/easybuild/toolchains/__init__.py
+++ b/easybuild/toolchains/__init__.py
@@ -28,4 +28,5 @@ Declaration of toolchains namespace.
 :author: Stijn De Weirdt (Ghent University)
 :author: Kenneth Hoste (Ghent University)
 """
-__path__ = __import__('pkgutil').extend_path(__path__, __name__)
+import os
+__path__ = __import__('pkgutil').extend_path([os.path.abspath(p) for p in __path__], __name__)

--- a/easybuild/tools/toolchain/__init__.py
+++ b/easybuild/tools/toolchain/__init__.py
@@ -1,0 +1,32 @@
+##
+# Copyright 2012-2019 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+Declaration of tools.toolchain namespace.
+
+:author: Stijn De Weirdt (Ghent University)
+:author: Kenneth Hoste (Ghent University)
+"""
+import os
+__path__ = __import__('pkgutil').extend_path([os.path.abspath(p) for p in __path__], __name__)


### PR DESCRIPTION
fixes problems like shown below when the tests are run directly from the `easybuild-framework` directory...

```
======================================================================
ERROR: test_det_easyconfig_paths_from_pr (__main__.RobotTest)
Test det_easyconfig_paths function, with --from-pr enabled as well.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Volumes/work/easybuild-framework/test/framework/robot.py", line 729, in test_det_easyconfig_paths_from_pr
    outtxt = self.eb_main(args, logfile=dummylogfn, raise_error=True)
  File "test/framework/utilities.py", line 297, in eb_main
    raise myerr
EasyBuildError: 'Failed to process easyconfig /Volumes/work/easybuild-framework/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0.eb: Failed to import EB_toy easyblock: No module named extensioneasyblock'

```