### PR TITLE
run contrib style checks when using new/update/preview_pr (WIP)

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -331,8 +331,10 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     easyconfigs, generated_ecs = parse_easyconfigs(paths, validate=not options.inject_checksums)
 
     # handle --check-contrib & --check-style options
-    if run_contrib_style_checks([ec['ec'] for ec in easyconfigs], options.check_contrib, options.check_style):
-        clean_exit(logfile, eb_tmpdir, testing)
+    if run_contrib_style_checks([ec['ec'] for ec in easyconfigs], options.check_contrib or new_update_preview_pr,
+                                options.check_style):
+        if not new_update_preview_pr:
+            clean_exit(logfile, eb_tmpdir, testing)
 
     # verify easyconfig filenames, if desired
     if options.verify_easyconfig_filenames:


### PR DESCRIPTION
is there a reason not to do this? Anything that doesn't pass these checks at this point will make the tests fail later...

I suppose one could allow overriding with `-f`, if there is some corner case where one would have a reason to submit/update a PR that doesn't pass the tests (yet)
