### PR TITLE
stop trying to use setuptools.setup in setup.py, always use distutils.core.setup instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,7 @@ before_install:
 install:
     # install environment modules or Lmod
     - export INSTALL_DEP=$TRAVIS_BUILD_DIR/easybuild/scripts/install_eb_dep.sh
+    - cd $HOME  # avoid downloading into easybuild-framework dir
     - if [ ! -z $ENV_MOD_VERSION ]; then source $INSTALL_DEP modules-${ENV_MOD_VERSION} $HOME; fi
     - if [ ! -z $LMOD_VERSION ]; then source $INSTALL_DEP lua-5.1.4.8 $HOME; fi
     - if [ ! -z $LMOD_VERSION ]; then source $INSTALL_DEP Lmod-${LMOD_VERSION} $HOME; fi

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -72,7 +72,7 @@ from easybuild.tools.docs import avail_cfgfile_constants, avail_easyconfig_const
 from easybuild.tools.docs import avail_toolchain_opts, avail_easyconfig_params, avail_easyconfig_templates
 from easybuild.tools.docs import list_easyblocks, list_toolchains
 from easybuild.tools.environment import restore_env, unset_env_vars
-from easybuild.tools.filetools import CHECKSUM_TYPE_SHA256, CHECKSUM_TYPES, install_fake_vsc
+from easybuild.tools.filetools import CHECKSUM_TYPE_SHA256, CHECKSUM_TYPES, install_fake_vsc, which
 from easybuild.tools.github import GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO
 from easybuild.tools.github import GITHUB_PR_DIRECTION_DESC, GITHUB_PR_ORDER_CREATED, GITHUB_PR_STATE_OPEN
 from easybuild.tools.github import GITHUB_PR_STATES, GITHUB_PR_ORDERS, GITHUB_PR_DIRECTIONS
@@ -1422,9 +1422,18 @@ def parse_external_modules_metadata(cfgs):
 
     # use external modules metadata configuration files that are available by default, unless others are specified
     if not cfgs:
-        # we expect to find *external_modules_metadata.cfg files in etc/
-        topdir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-        cfgs = glob.glob(os.path.join(topdir, 'etc', '*external_modules_metadata.cfg'))
+        cfgs = []
+
+        # we expect to find *external_modules_metadata.cfg files in etc/ on same level as easybuild/framework
+        topdirs = [os.path.dirname(os.path.dirname(os.path.dirname(__file__)))]
+
+        # etc/ could also be located next to bin/
+        eb_cmd = which('eb')
+        if eb_cmd:
+            topdirs.append(os.path.dirname(os.path.dirname(eb_cmd)))
+
+        for topdir in topdirs:
+            cfgs.extend(glob.glob(os.path.join(topdir, 'etc', '*external_modules_metadata.cfg')))
 
         if cfgs:
             _log.info("Using default external modules metadata cfg files: %s", cfgs)

--- a/setup.py
+++ b/setup.py
@@ -115,13 +115,4 @@ implement support for installing particular (groups of) software packages.""",
         "Topic :: Software Development :: Build Tools",
     ],
     platforms="Linux",
-    test_suite="test.framework.suite",
-    zip_safe=False,
-    extras_require={
-        'yeb': ["PyYAML >= 3.11"],
-        'coloredlogs': [
-            'coloredlogs',
-            'humanfriendly',  # determine whether terminal supports ANSI color
-        ],
-    },
 )

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,8 @@ def read(fname):
 # log levels: 0 = WARN (default), 1 = INFO, 2 = DEBUG
 log.set_verbosity(1)
 
+log.info("Installing version %s (API version %s)" % (VERSION, API_VERSION))
+
 
 def find_rel_test():
     """Return list of files recursively from basedir (aka find -type f)"""

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ or
 import glob
 import os
 from distutils import log
+from distutils.core import setup
 
 from easybuild.tools.version import VERSION
 
@@ -46,15 +47,6 @@ def read(fname):
 
 # log levels: 0 = WARN (default), 1 = INFO, 2 = DEBUG
 log.set_verbosity(1)
-
-try:
-    from setuptools import setup
-    log.info("Installing with setuptools.setup...")
-except ImportError as err:
-    log.info("Failed to import setuptools.setup, so falling back to distutils.setup")
-    from distutils.core import setup
-
-log.info("Installing version %s (API version %s)" % (VERSION, API_VERSION))
 
 
 def find_rel_test():


### PR DESCRIPTION
Using `setuptools` in `setup.py` has done more harm than good. It's frequently a cause of problems because of old/ancient versions being available in the OS, broken versions floating around everywhere, etc.
One recent example is https://lists.ugent.be/wws/arc/easybuild/2019-08/msg00057.html

In addition, it yields little to no benefit over just installing with the `setup` function from `distutils.core` instead.

So, let's abolish the `setuptools` requirement fully, following no longer requiring it as a runtime dependency (cfr. #2836).

(fixes #2941)