### PR TITLE
also check labels in check_pr_eligible_to_merge (WIP)

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -985,6 +985,14 @@ def check_pr_eligible_to_merge(pr_data):
     else:
         res = not_eligible(msg_tmpl % 'no milestone found')
 
+    # check whether at least one label is set
+    msg_tmpl = "* labels are set: %s"
+    if pr_data['labels']:
+        pr_labels = [label['name'] for label in pr_data['labels']]
+        print_msg(msg_tmpl % "OK (%s)" % ', '.join(pr_labels), prefix=False)
+    else:
+        res = not_eligible(msg_tmpl % 'no labels found')
+
     return res
 
 


### PR DESCRIPTION
(this currently breaks `test_merge_pr`, I'll work on that after feedback)

currently this only detects PRs with no labels

using https://developer.github.com/v3/pulls/#list-pull-requests-files it could also check if the PR modifies any existing files, and in that case check if any of `bug fix`, `enhancement` or `change` labels is set (?)

it would be good to also check if `new` and `update` labels are missing, since `--new-pr` only sets them automatically when it is executed by a maintainer, but the way it's done there is not applicable within `--merge-pr`, I'll need to come back to that later