### PR TITLE
fix verbose output for 'eb' command, need to use "$@" to ensure arguments are shown correctly

### DIFF
--- a/eb
+++ b/eb
@@ -90,5 +90,5 @@ then
     export FANCYLOGGER_IGNORE_MPI4PY=1
 fi
 
-verbose "$PYTHON -m easybuild.main $@"
+verbose "$PYTHON -m easybuild.main `echo \"$@\"`"
 $PYTHON -m easybuild.main "$@"


### PR DESCRIPTION
Without this fix, extra arguments are not included in the debug output when `$EB_VERBOSE` is defined:

```
$ EB_VERBOSE=1 eb bzip2-1.0.6.eb --force
...
>> Selected Python command: python (/usr/bin/python)
>> python -m easybuild.main bzip2-1.0.6.eb
...
```

With this change, that's fixed:

```
$ EB_VERBOSE=1 eb bzip2-1.0.6.eb --force
...
>> Selected Python command: python (/usr/bin/python)
>> python -m easybuild.main bzip2-1.0.6.eb --force
...
```