### PR TITLE
install fake 'vsc' namespace *before* parsing EasyBuild configuration 

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1894,7 +1894,7 @@ def install_fake_vsc():
     """
     # note: install_fake_vsc is called before parsing configuration, so avoid using functions that use build_option,
     # like mkdir, write_file, ...
-    fake_vsc_path = os.path.join(tempfile.gettempdir(), 'fake_vsc')
+    fake_vsc_path = os.path.join(tempfile.mkdtemp(prefix='fake_vsc_'))
 
     fake_vsc_init = '\n'.join([
         'import sys',
@@ -1922,3 +1922,5 @@ def install_fake_vsc():
         fp.write(fake_vsc_init)
 
     sys.path.insert(0, fake_vsc_path)
+
+    return fake_vsc_path

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1892,8 +1892,9 @@ def install_fake_vsc():
     (vsc-base & vsc-install were ingested into the EasyBuild framework for EasyBuild 4.0,
      see https://github.com/easybuilders/easybuild-framework/pull/2708)
     """
+    # note: install_fake_vsc is called before parsing configuration, so avoid using functions that use build_option,
+    # like mkdir, write_file, ...
     fake_vsc_path = os.path.join(tempfile.gettempdir(), 'fake_vsc')
-    mkdir(os.path.join(fake_vsc_path, 'vsc'), parents=True)
 
     fake_vsc_init = '\n'.join([
         'import sys',
@@ -1913,6 +1914,11 @@ def install_fake_vsc():
         'sys.stderr.write("The functionality you need may be available in the \'easybuild.base.*\' namespace.\\n")',
         'sys.exit(1)',
     ])
-    write_file(os.path.join(fake_vsc_path, 'vsc', '__init__.py'), fake_vsc_init)
+
+    fake_vsc_init_path = os.path.join(fake_vsc_path, 'vsc', '__init__.py')
+    if not os.path.exists(os.path.dirname(fake_vsc_init_path)):
+        os.makedirs(os.path.dirname(fake_vsc_init_path))
+    with open(fake_vsc_init_path, 'w') as fp:
+        fp.write(fake_vsc_init)
 
     sys.path.insert(0, fake_vsc_path)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1259,6 +1259,9 @@ def set_up_configuration(args=None, logfile=None, testing=False, silent=False):
     :param silent: stay silent (no printing)
     """
 
+    # set up fake 'vsc' Python package, to catch easyblocks/scripts that still import from vsc.* namespace
+    install_fake_vsc()
+
     # parse EasyBuild configuration settings
     eb_go = parse_options(args=args)
     options = eb_go.options
@@ -1316,9 +1319,6 @@ def set_up_configuration(args=None, logfile=None, testing=False, silent=False):
     # initialise the EasyBuild configuration & build options
     init(options, config_options_dict)
     init_build_options(build_options=build_options, cmdline_options=options)
-
-    # set up fake 'vsc' Python package, to catch easyblocks/scripts that still import from vsc.* namespace
-    install_fake_vsc()
 
     return eb_go, (build_specs, log, logfile, robot_path, search_query, tmpdir, try_to_generate, tweaked_ecs_paths)
 


### PR DESCRIPTION
fix for #2991 reported by @vanzod 