### PR TITLE
Add support for iccifort compiler-only toolchain without icc/ifort deps.

### DIFF
--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -34,6 +34,7 @@ from distutils.version import LooseVersion
 import easybuild.tools.systemtools as systemtools
 from easybuild.framework.easyconfig.easyconfig import process_easyconfig, robot_find_easyconfig
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import build_option
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.toolchain.compiler import Compiler
 
@@ -110,7 +111,10 @@ class IntelIccIfort(Compiler):
         # if so, change self.COMPILER_MODULE_NAME to only 'iccifort', as standalone compiler-only toolchain
         tc_dict = self.as_dict()
         # grab version from parsed easyconfig file for toolchain
-        eb_file = robot_find_easyconfig(tc_dict['name'], det_full_ec_version(tc_dict))
+        if build_option('robot_path', default=None):
+            eb_file = robot_find_easyconfig(tc_dict['name'], det_full_ec_version(tc_dict))
+        else:
+            eb_file = None
         if eb_file is not None:
             # eb_file is often None in tests
             tc_ec = process_easyconfig(eb_file, parse_only=True)

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -111,13 +111,15 @@ class IntelIccIfort(Compiler):
         tc_dict = self.as_dict()
         # grab version from parsed easyconfig file for toolchain
         eb_file = robot_find_easyconfig(tc_dict['name'], det_full_ec_version(tc_dict))
-        tc_ec = process_easyconfig(eb_file, parse_only=True)
-        if len(tc_ec) > 1:
-            self.log.warning("More than one toolchain specification found for %s, only retaining first" % tc_dict)
-            self.log.debug("Full list of toolchain specifications: %s" % tc_ec)
-        if tc_ec[0]['ec']['moduleclass'] == 'compiler':
-            self.COMPILER_MODULE_NAME = ['iccifort']
-            self.log.info("Intel COMPILER_MODULE_NAME set to: %s" % self.COMPILER_MODULE_NAME)
+        if eb_file is not None:
+            # eb_file is often None in tests
+            tc_ec = process_easyconfig(eb_file, parse_only=True)
+            if len(tc_ec) > 1:
+                self.log.warning("More than one toolchain specification found for %s, only retaining first" % tc_dict)
+                self.log.debug("Full list of toolchain specifications: %s" % tc_ec)
+            if tc_ec[0]['ec']['moduleclass'] == 'compiler':
+                self.COMPILER_MODULE_NAME = ['iccifort']
+                self.log.info("Intel COMPILER_MODULE_NAME set to: %s" % self.COMPILER_MODULE_NAME)
 
     def _set_compiler_vars(self):
         """Intel compilers-specific adjustments after setting compiler variables."""

--- a/easybuild/tools/module_naming_scheme/hierarchical_mns.py
+++ b/easybuild/tools/module_naming_scheme/hierarchical_mns.py
@@ -51,12 +51,14 @@ GCCCORE = GCCcore.NAME
 COMP_NAME_VERSION_TEMPLATES = {
     # required for use of iccifort toolchain
     'icc,ifort': ('intel', '%(icc)s'),
+    'iccifort': ('intel', '%(iccifort)s'),
     # required for use of ClangGCC toolchain
     'Clang,GCC': ('Clang-GCC', '%(Clang)s-%(GCC)s'),
     # required for use of gcccuda toolchain, and for CUDA installed with GCC toolchain
     'CUDA,GCC': ('GCC-CUDA', '%(GCC)s-%(CUDA)s'),
     # required for use of iccifortcuda toolchain
     'CUDA,icc,ifort': ('intel-CUDA', '%(icc)s-%(CUDA)s'),
+    'CUDA,iccifort': ('intel-CUDA', '%(iccifort)s-%(CUDA)s'),
     # required for CUDA installed with iccifort toolchain
     # need to use 'intel' here because 'iccifort' toolchain maps to 'intel' (see above)
     'CUDA,intel': ('intel-CUDA', '%(intel)s-%(CUDA)s'),

--- a/test/framework/easyconfigs/test_ecs/i/iccifort/iccifort-2019.4.227-GCC-8.3.0.eb
+++ b/test/framework/easyconfigs/test_ecs/i/iccifort/iccifort-2019.4.227-GCC-8.3.0.eb
@@ -1,0 +1,14 @@
+# This is an easyconfig file for EasyBuild, see https://easybuilders.github.io/easybuild
+easyblock = "Toolchain"
+
+name = 'iccifort'
+version = '2019.4.227'
+versionsuffix = '-GCC-8.3.0'
+
+homepage = 'http://software.intel.com/en-us/intel-cluster-toolkit-compiler/'
+description = """Intel Cluster Toolkit Compiler Edition provides Intel C,C++ and fortran compilers,
+Intel MPI and Intel MKL"""
+
+toolchain = SYSTEM
+
+moduleclass = 'compiler'

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1223,6 +1223,24 @@ class ToolchainTest(EnhancedTestCase):
         liblapack += "-Wl,--end-group -Wl,-Bdynamic -ldl"
         self.assertEqual(os.environ.get('LIBLAPACK', '(not set)'), liblapack)
 
+    def test_iccifort_standalone(self):
+        """Test if toolchain with iccifort but no icc and ifort is accepted."""
+        version = "2019.4.227-GCC-8.3.0"
+        iccifort_mod_txt = '\n'.join([
+            '#%Module',
+            "setenv EBROOTICCIFORT %s" % self.test_prefix,
+            "setenv EBVERSIONICCIFORT %s" % version,
+        ])
+        write_file(os.path.join(self.test_prefix, 'iccifort', version), iccifort_mod_txt)
+        self.modtool.prepend_module_path(self.test_prefix)
+
+        test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+        init_config(build_options={'robot_path': [test_ecs_dir]})
+        tc = self.get_toolchain('iccifort', version=version)
+        tc.prepare()
+        self.assertEqual(tc.get_variable('CC'), 'icc')
+        self.assertEqual(tc.get_variable('FC'), 'ifort')
+
     def test_compiler_cache(self):
         """Test ccache"""
         topdir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Relates to easybuilders/easybuild-easyconfigs#8879 and easybuilders/easybuild-easyblocks#1799.

The toolchain components need to be adjusted dynamically depending on 'moduleclass' (which is also used by HMNS to determine if this is a compiler-toolchain that needs MODULEPATH extensions.