### PR TITLE
add back --add-dummy-to-minimal-toolchains as deprecated option

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -228,7 +228,13 @@ def det_subtoolchain_version(current_tc, subtoolchain_name, optional_toolchains,
 
     # system toolchain: bottom of the hierarchy
     if is_system_toolchain(subtoolchain_name):
-        if build_option('add_system_to_minimal_toolchains') and not incl_capabilities:
+        add_system_to_minimal_toolchains = build_option('add_system_to_minimal_toolchains')
+        if not add_system_to_minimal_toolchains and build_option('add_dummy_to_minimal_toolchains'):
+            depr_msg = "Use --add-system-to-minimal-toolchains instead of --add-dummy-to-minimal-toolchains"
+            _log.deprecated(depr_msg, '5.0')
+            add_system_to_minimal_toolchains = True
+
+        if add_system_to_minimal_toolchains and not incl_capabilities:
             subtoolchain_version = ''
     elif len(uniq_subtc_versions) == 1:
         subtoolchain_version = list(uniq_subtc_versions)[0]

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -205,6 +205,7 @@ BUILD_OPTIONS_CMDLINE = {
         'zip_logs',
     ],
     False: [
+        'add_dummy_to_minimal_toolchains',
         'add_system_to_minimal_toolchains',
         'allow_modules_tool_mismatch',
         'consider_archived_easyconfigs',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -317,6 +317,9 @@ class EasyBuildOptions(GeneralOption):
         descr = ("Override options", "Override default EasyBuild behavior.")
 
         opts = OrderedDict({
+            'add-dummy-to-minimal-toolchains': ("Include dummy toolchain in minimal toolchain searches "
+                                                "[DEPRECATED, use --add-system-to-minimal-toolchains instead!)",
+                                                None, 'store_true', False),
             'add-system-to-minimal-toolchains': ("Include system toolchain in minimal toolchain searches",
                                                  None, 'store_true', False),
             'allow-loaded-modules': ("List of software names for which to allow loaded modules in initial environment",

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -2462,7 +2462,21 @@ class EasyConfigTest(EnhancedTestCase):
                     for subtoolchain_name in subtoolchains[current_tc['name']]]
         self.assertEqual(versions, [None, ''])
 
+        # --add-dummy-to-minimal-toolchains is still supported, but deprecated
+        self.allow_deprecated_behaviour()
+        init_config(build_options={'add_system_to_minimal_toolchains': False, 'add_dummy_to_minimal_toolchains': True})
+        self.mock_stderr(True)
+        versions = [det_subtoolchain_version(current_tc, subtoolchain_name, optional_toolchains, cands)
+                    for subtoolchain_name in subtoolchains[current_tc['name']]]
+        stderr = self.get_stderr()
+        self.mock_stderr(False)
+        self.assertEqual(versions, [None, ''])
+        depr_msg = "WARNING: Deprecated functionality, will no longer work in v5.0: "
+        depr_msg += "Use --add-system-to-minimal-toolchains instead of --add-dummy-to-minimal-toolchains"
+        self.assertTrue(depr_msg in stderr)
+
         # and GCCcore if existing too
+        init_config(build_options={'add_system_to_minimal_toolchains': True})
         current_tc = {'name': 'GCC', 'version': '4.9.3-2.25'}
         cands = [{'name': 'GCCcore', 'version': '4.9.3'}]
         versions = [det_subtoolchain_version(current_tc, subtoolchain_name, optional_toolchains, cands)


### PR DESCRIPTION
Since `dummy` was only deprecated in #2877, `--add-dummy-to-minimal-toolchains` shouldn't have been removed, only deprecated...