### PR TITLE
move prepare_step before extract_step

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2887,9 +2887,9 @@ class EasyBlock(object):
         steps_part1 = [
             (FETCH_STEP, 'fetching files', [lambda x: x.fetch_step], False),
             ready_step_spec(True),
+            prepare_step_spec,
             source_step_spec(True),
             patch_step_spec,
-            prepare_step_spec,
             configure_step_spec,
             build_step_spec,
             test_step_spec,
@@ -2901,9 +2901,9 @@ class EasyBlock(object):
         # not all parts of all steps need to be rerun (see e.g., ready, prepare)
         steps_part2 = [
             ready_step_spec(False),
+            prepare_step_spec,
             source_step_spec(False),
             patch_step_spec,
-            prepare_step_spec,
             configure_step_spec,
             build_step_spec,
             test_step_spec,

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1859,6 +1859,9 @@ class EasyBlock(object):
             else:
                 raise EasyBuildError("Unpacking source %s failed", src['name'])
 
+        # guess directory to start configure/build/install process in, and move there
+        self.guess_start_dir()
+
     def patch_step(self, beginpath=None):
         """
         Apply the patches
@@ -1963,10 +1966,6 @@ class EasyBlock(object):
         if extra_modules:
             self.log.info("Loading extra modules: %s", extra_modules)
             self.modules_tool.load(extra_modules)
-
-        # guess directory to start configure/build/install process in, and move there
-        if start_dir:
-            self.guess_start_dir()
 
     def configure_step(self):
         """Configure build  (abstract method)."""

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -549,7 +549,7 @@ def dump_env_script(easyconfigs):
 
         # prepare build environment (in dry run mode)
         app.check_readiness_step()
-        app.prepare_step(start_dir=False)
+        app.prepare_step()
 
         # compose script
         ecfile = os.path.basename(ec.path)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -185,7 +185,7 @@ class EasyBlockTest(EnhancedTestCase):
 
         self.mock_stderr(True)
         self.mock_stdout(True)
-        eb.prepare_step(start_dir=False)
+        eb.prepare_step()
         stderr = self.get_stderr()
         stdout = self.get_stdout()
         self.mock_stderr(False)


### PR DESCRIPTION
cfr. #1376

I don't actually intend to get this merged, I just want to get this on record...

I started looking into this, and it quickly became clear that @wpoely86's view was right: moving up the `prepare_step` such that dependencies required for unpacking sources is quite intrusive to do.

The `guess_start_dir()` call had to be moved from `prepare_step` to the end of `extract_step`, since it obviously requires that the sources are unpacked. That's a fairly minor issue, more like a logical consequence (you could even argue that `guess_start_dir()` is out of place in `prepare_step`, I guess).

As anticipated in #1376, this impacts easyblocks where the `prepare_step` is customized and it is assumed that the sources are already unpacked when it is being called. At first sight, this affects at least two software-specific easyblocks in the central repository: `DL_POLY_Classic` and `OpenCV`.
Although it's fairly easy to fix them to take into account that `prepare_step` is run before `extract_step`, it highlights the impact that the change has (we should take into account that there are other (customized) easyblocks outside of the central repository that may be affected).

This change also breaks a test (`test_guess_start_dir`), which may be easy to fix (it looks like a problem with assumptions made by the test itself, rather than an actual problem being caught), but it's still a sign of trouble...



