### PR TITLE
print warning when 'eb' command is not found in $PATH and for empty robot search path

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -50,7 +50,7 @@ from easybuild.framework.easyconfig.easyconfig import EASYCONFIGS_ARCHIVE_DIR, A
 from easybuild.framework.easyconfig.easyconfig import create_paths, get_easyblock_class, process_easyconfig
 from easybuild.framework.easyconfig.format.yeb import quote_yaml_special_chars
 from easybuild.framework.easyconfig.style import cmdline_easyconfigs_style_check
-from easybuild.tools.build_log import EasyBuildError, print_msg
+from easybuild.tools.build_log import EasyBuildError, print_msg, print_warning
 from easybuild.tools.config import build_option
 from easybuild.tools.environment import restore_env
 from easybuild.tools.filetools import find_easyconfigs, is_patch_file, read_file, resolve_path, which, write_file
@@ -257,7 +257,9 @@ def get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None):
     # figure out installation prefix, e.g. distutils install path for easyconfigs
     eb_path = which('eb')
     if eb_path is None:
-        _log.warning("'eb' not found in $PATH, failed to determine installation prefix")
+        warning_msg = "'eb' not found in $PATH, failed to determine installation prefix!"
+        _log.warning(warning_msg)
+        print_warning(warning_msg)
     else:
         # real location to 'eb' should be <install_prefix>/bin/eb
         eb_path = resolve_path(eb_path)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1308,6 +1308,9 @@ def set_up_configuration(args=None, logfile=None, testing=False, silent=False):
     robot_path = det_robot_path(options.robot_paths, tweaked_ecs_paths, pr_path, auto_robot=auto_robot)
     log.debug("Full robot path: %s" % robot_path)
 
+    if not robot_path:
+        print_warning("Robot search path is empty!")
+
     # configure & initialize build options
     config_options_dict = eb_go.get_options_by_section('config')
     build_options = {


### PR DESCRIPTION
Using EasyBuild with an empty robot search path is likely to end in tears, so we should print a warning for it.

The location of the `eb` command is used as a fallback to determine the default robot search path, and having a setup where EasyBuild works (when run with `python -m easybuild.main`) without having the `eb` command available is weird, so deserves a warning as well.