### PR TITLE
change order of 'python*' commands considered by 'eb' command: python, python3, python2

### DIFF
--- a/eb
+++ b/eb
@@ -43,7 +43,7 @@ function verbose() {
 }
 
 PYTHON=
-for python_cmd in ${EB_PYTHON} 'python2' 'python3' 'python'; do
+for python_cmd in ${EB_PYTHON} 'python' 'python3' 'python2'; do
 
     verbose "Considering '$python_cmd'..."
 


### PR DESCRIPTION
* `python` is considered first since that's assumed to be the preferred Python version
* `python3` is considered before `python2` since Python 2 is EOL on Dec 31st 2019