### PR TITLE
fixes required to avoid breaking Cray support

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1896,11 +1896,12 @@ class EasyBlock(object):
             if not apply_patch(patch['path'], src, copy=copy_patch, level=level):
                 raise EasyBuildError("Applying patch %s failed", patch['name'])
 
-    def prepare_step(self, start_dir=True):
+    def prepare_step(self, start_dir=True, load_tc_deps_modules=True):
         """
         Pre-configure step. Set's up the builddir just before starting configure
 
         :param start_dir: guess start directory based on unpacked sources
+        :param load_tc_deps_modules: load modules for toolchain and dependencies in build environment
         """
         if self.dry_run:
             self.dry_run_msg("Defining build environment, based on toolchain (options) and specified dependencies...\n")
@@ -1941,7 +1942,8 @@ class EasyBlock(object):
 
         # prepare toolchain: load toolchain module and dependencies, set up build environment
         self.toolchain.prepare(self.cfg['onlytcmod'], deps=self.cfg.dependencies(), silent=self.silent,
-                               rpath_filter_dirs=self.rpath_filter_dirs, rpath_include_dirs=self.rpath_include_dirs)
+                               loadmod=load_tc_deps_modules, rpath_filter_dirs=self.rpath_filter_dirs,
+                               rpath_include_dirs=self.rpath_include_dirs)
 
         # keep track of environment variables that were tweaked and need to be restored after environment got reset
         # $TMPDIR may be tweaked for OpenMPI 2.x, which doesn't like long $TMPDIR paths...


### PR DESCRIPTION
Two issues popped up when testing current `develop` on CSCS' Piz Daint:

* The `CrayToolchain` easyblock needs a tweak to avoid loading the modules for the dependencies specified in easyconfig file to install a new toolchain (for example `CrayGNU` or `CrayIntel`)

  This is required because of the change in semantics of the `dummy` toolchain (which is now an alias for the new `system` toolchain), where using a `dummy` version no longer implies not loading the modules for the toolchain and dependencies in the build environment (see also #2877).

  Doing so is a) not needed at all to install a `Cray*` toolchain, b) requires more than a simple `module load`, since it's likely that modules that loaded in the default environment on a Cray system will trigger a conflict, for example:

  ```
  Module 'PrgEnv-gnu/6.0.4' conflicts with the currently loaded module(s) 'PrgEnv-cray/6.0.4'")
  ```

  The `prepare_step` has been updated in 42a166b to allow *not* loading the modules for the toolchain & dependencies (the default is of course unchanged), which can be leveraged easily in the `CrayToolchain` easyblock.

* The output of `modulecmd python load` sometimes includes a faulty `source` command using some versions of Cray's environment modules 3.2.10.x (certainly with `modules/3.2.10.6`).

  The `run_module` method of `EnvironmentModulesC` class has been customized to strip out these faulty `source` commands, which fixes problems like:

  ```
  Changing environment as dictated by module failed: invalid syntax (<string>, line 1) (stdout: source /opt/cray/pe/modules/3.2.10.6/init/bash
  source /opt/cray/pe/modules/3.2.10.6/init/bash
  ```

cc @gppezzi @victorusu