### PR TITLE
fix error reporting in adjust_permissions when using Python 3

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1164,8 +1164,8 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
 
     failed_paths = []
     fail_cnt = 0
+    err_msg = None
     for path in allpaths:
-
         try:
             # don't change permissions if path is a symlink, since we're not checking where the symlink points to
             # this is done because of security concerns (symlink may point out of installation directory)
@@ -1201,9 +1201,10 @@ def adjust_permissions(name, permissionBits, add=True, onlyfiles=False, onlydirs
                 fail_cnt += 1
             else:
                 failed_paths.append(path)
+                err_msg = err
 
     if failed_paths:
-        raise EasyBuildError("Failed to chmod/chown several paths: %s (last error: %s)", failed_paths, err)
+        raise EasyBuildError("Failed to chmod/chown several paths: %s (last error: %s)", failed_paths, err_msg)
 
     # we ignore some errors, but if there are to many, something is definitely wrong
     fail_ratio = fail_cnt / float(len(allpaths))

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1024,6 +1024,13 @@ class FileToolsTest(EnhancedTestCase):
             for bit in [stat.S_IXGRP, stat.S_IWOTH, stat.S_IXOTH]:
                 self.assertFalse(perms & bit)
 
+        # check error reporting when changing permissions fails
+        nosuchdir = os.path.join(self.test_prefix, 'nosuchdir')
+        err_msg = "Failed to chmod/chown several paths.*No such file or directory"
+        self.assertErrorRegex(EasyBuildError, err_msg, ft.adjust_permissions, nosuchdir, stat.S_IWOTH)
+        nosuchfile = os.path.join(self.test_prefix, 'nosuchfile')
+        self.assertErrorRegex(EasyBuildError, err_msg, ft.adjust_permissions, nosuchfile, stat.S_IWUSR, recursive=False)
+
         # restore original umask
         os.umask(orig_umask)
 


### PR DESCRIPTION
fix for:

```
ERROR: Traceback (most recent call last):
  File "/lib/python2.7/site-packages/easybuild_framework-4.0.0.dev0-py2.7.egg/easybuild/main.py", line 112, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/lib/python2.7/site-packages/easybuild_framework-4.0.0.dev0-py2.7.egg/easybuild/framework/easyblock.py", line 3078, in build_and_install_one
    adjust_permissions(new_log_dir, stat.S_IWUSR, add=True, recursive=False)
  File "/lib/python2.7/site-packages/easybuild_framework-4.0.0.dev0-py2.7.egg/easybuild/tools/filetools.py", line 1206, in adjust_permissions
    raise EasyBuildError("Failed to chmod/chown several paths: %s (last error: %s)", failed_paths, err)
UnboundLocalError: local variable 'err' referenced before assignment
```