### PR TITLE
fixes for --read-only-installdir: avoid crash with ModuleRC easyblock + also make log file in installdir read-only

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3075,7 +3075,12 @@ def build_and_install_one(ecdict, init_env):
             new_log_dir = os.path.join(app.installdir, config.log_path(ec=app.cfg))
             if build_option('read_only_installdir'):
                 # temporarily re-enable write permissions for copying log/easyconfig to install dir
-                adjust_permissions(new_log_dir, stat.S_IWUSR, add=True, recursive=False)
+                if os.path.exists(new_log_dir):
+                    adjust_permissions(new_log_dir, stat.S_IWUSR, add=True, recursive=False)
+                else:
+                    adjust_permissions(app.installdir, stat.S_IWUSR, add=True, recursive=False)
+                    mkdir(new_log_dir, parents=True)
+                    adjust_permissions(app.installdir, stat.S_IWUSR, add=False, recursive=False)
 
             # collect build stats
             _log.info("Collecting build stats...")
@@ -3125,7 +3130,7 @@ def build_and_install_one(ecdict, init_env):
 
         if build_option('read_only_installdir'):
             # take away user write permissions (again)
-            adjust_permissions(new_log_dir, stat.S_IWUSR, add=False, recursive=False)
+            adjust_permissions(new_log_dir, stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH, add=False, recursive=True)
 
     end_timestamp = datetime.now()
 

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -32,6 +32,7 @@ import os
 import platform
 import shutil
 
+from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.environment import setvar
@@ -42,6 +43,16 @@ from easybuild.tools.run import run_cmd
 
 class EB_toy(ExtensionEasyBlock):
     """Support for building/installing toy."""
+
+    @staticmethod
+    def extra_options(extra_vars=None):
+        """Custom easyconfig parameters for toytoy."""
+        if extra_vars is None:
+            extra_vars = {}
+
+        extra_vars['make_module'] = [True, "Skip generating (final) module file", CUSTOM]
+
+        return ExtensionEasyBlock.extra_options(extra_vars)
 
     def __init__(self, *args, **kwargs):
         """Constructor"""
@@ -115,6 +126,15 @@ class EB_toy(ExtensionEasyBlock):
         self.configure_step()
         self.build_step()
         self.install_step()
+
+    def make_module_step(self, fake=False):
+        """Generate module file."""
+        if self.cfg.get('make_module', True) or fake:
+            modpath = super(EB_toy, self).make_module_step(fake=fake)
+        else:
+            modpath = self.module_generator.get_modules_path(fake=fake)
+
+        return modpath
 
     def make_module_extra(self):
         """Extra stuff for toy module"""


### PR DESCRIPTION
This fixes two issues I encountered when EasyBuild was configured with `--read-only-installdir`:

* a `No such file or directory` crash when wrapping up the installation of the `Java/1.8` wrapper using the `ModuleRC` easyblock, when EasyBuild was trying to re-enable write permissions on the `easybuild/` subdirectory of the install directory (which didn't exist yet because `ModuleRC` doesn't create a "devel" module in that directory)

* the write permissions on the `easybuild/` subdirectory were only removed for the directory itself, not it's contents, so the log file & other stuff that get dropped in there after completing the installation still had write permissions enabled

Both issues were reproduced via the tests and fixed.