### PR TITLE
fix broken test_download_repo due to archiving of easyconfigs

### DIFF
--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -303,7 +303,7 @@ class GithubTest(EnhancedTestCase):
         self.assertTrue(os.path.exists(repodir))
         shafile = os.path.join(repodir, 'latest-sha')
         self.assertTrue(re.match('^[0-9a-f]{40}$', read_file(shafile)))
-        self.assertTrue(os.path.exists(os.path.join(repodir, 'easybuild', 'easyconfigs', 'f', 'foss', 'foss-2015a.eb')))
+        self.assertTrue(os.path.exists(os.path.join(repodir, 'easybuild', 'easyconfigs', 'f', 'foss', 'foss-2019b.eb')))
 
         # existing downloaded repo is not reperformed, except if SHA is different
         account, repo, branch = 'boegel', 'easybuild-easyblocks', 'develop'


### PR DESCRIPTION
I'm deliberately opening this to the `master` branch, since we don't want a big red cross in Travis for a silly issue like this...