### PR TITLE
fix traceback with --inject-checksums for extensions that set a boolean easyconfig parameter

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3485,7 +3485,7 @@ def inject_checksums(ecs, checksum_type):
                             strval = quote_str(val, prefer_single_quotes=True)
                             line = "%s'%s': %s," % (INDENT_4SPACES * 2, key, strval)
                             # fix long lines for list-type values (e.g. patches)
-                            if len(val) > 1 and isinstance(val, list):
+                            if isinstance(val, list) and len(val) > 1:
                                 exts_list_lines.append("%s'%s': [" % (INDENT_4SPACES * 2, key))
                                 exts_list_lines.extend(make_list_lines(val, indent_level=3))
                                 exts_list_lines.append(INDENT_4SPACES * 2 + '],',)

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-2018a-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-2018a-test.eb
@@ -39,6 +39,9 @@ exts_list = [
         ],
         'toy_ext_param': "mv anotherbar bar_bis",
         'unknowneasyconfigparameterthatshouldbeignored': 'foo',
+        # set boolean value (different from default value) to trigger (now fixed) bug with --inject-checksums
+        # cfr. https://github.com/easybuilders/easybuild-framework/pull/3034
+        'keepsymlinks': True,
     }),
     ('barbar', '0.0'),
     (name, version, {

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3979,6 +3979,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             'patches': [bar_patch, bar_patch_bis],
             'toy_ext_param': "mv anotherbar bar_bis",
             'unknowneasyconfigparameterthatshouldbeignored': 'foo',
+            'keepsymlinks': True,
         }))
         self.assertEqual(ec['exts_list'][2], ('barbar', '0.0', {
             'checksums': ['a33100d1837d6d54edff7d19f195056c4bd9a4c8d399e72feaf90f0216c4c91c'],


### PR DESCRIPTION
fix for EB crashing during checksum generation in some cases.
this can happen when the value of a dictionary item is not iterable, for example: `'modulename': False`
error:
```
  File "/work/smoors/hpc/easybuild-dev/easybuild-framework/easybuild/framework/easyblock.py", line 3488, in inject_checksums
    if len(val) > 1 and isinstance(val, list):
TypeError: object of type 'bool' has no len()

```