### PR TITLE
disable templates when defining easyconfig parameters in EasyConfig.set_keys()

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -571,13 +571,20 @@ class EasyConfig(object):
 
         :param params: a dict value with names/values of easyconfig parameters to set
         """
-        for key in params:
+        # disable templating when setting easyconfig parameters
+        # required to avoid problems with values that need more parsing to be done (e.g. dependencies)
+        prev_enable_templating = self.enable_templating
+        self.enable_templating = False
+
+        for key in sorted(params.keys()):
             # validations are skipped, just set in the config
             if key in self._config.keys():
                 self[key] = params[key]
                 self.log.info("setting easyconfig parameter %s: value %s (type: %s)", key, self[key], type(self[key]))
             else:
                 raise EasyBuildError("Unknown easyconfig parameter: %s (value '%s')", key, params[key])
+
+        self.enable_templating = prev_enable_templating
 
     def parse(self):
         """


### PR DESCRIPTION
This patch fixes an elusive problem that only (sometimes) manifests with Python 3.5, as follows:

```
======================================================================
FAIL: test_toy_build_formatv2 (test.framework.toy_build.ToyBuildTest)
Perform a toy build (format v2).
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/easybuild-framework/easybuild-framework/test/framework/toy_build.py", line 324, in test_toy_build_formatv2
    self.check_toy(self.test_installpath, outtxt)
  File "/home/easybuild-framework/easybuild-framework/test/framework/toy_build.py", line 86, in check_toy
    self.assertTrue(success.search(outtxt), "COMPLETED message found in '%s" % outtxt)
AssertionError: None is not true : COMPLETED message found in '== 2019-09-23 08:14:07,988 generaloption.py:1505 DEBUG generate_cmd_line no ignore
...
== 2019-09-23 08:14:08,260 build_log.py:164 ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:124 in __init__): Unexpected type for dependency: == 6.4.0-2.28 (at easybuild/framework/easyconfig/templates.py:227 in template_constant_dict)
== 2019-09-23 08:14:08,261 build_log.py:164 ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:124 in __init__): Failed to process easyconfig /home/easybuild-framework/test/framework/easyconfigs/v2.0/toy.eb: Unexpected type for dependency: == 6.4.0-2.28 (at easybuild/framework/easyconfig/easyconfig.py:1771 in process_easyconfig)
```

It occasionally made the `test_toy_build_formatv2` test fail, but only when using Python 3.5, and only when the `dependencies` easyconfig parameter was being set first.

Ensuring a fixed order in which keys are processed in `set_keys()` also helps to make things more consistent...