### PR TITLE
avoid setting GC3Pie's max_in_flight to None if --job-max-jobs is not specified

### DIFF
--- a/easybuild/tools/job/gc3pie.py
+++ b/easybuild/tools/job/gc3pie.py
@@ -232,7 +232,7 @@ class GC3Pie(JobBackend):
         self._engine.retrieve_overwrites = True
 
         # some sites may not be happy with flooding the cluster with build jobs...
-        self._engine.max_in_flight = build_option('job_max_jobs')
+        self._engine.max_in_flight = build_option('job_max_jobs') or 0
 
         # Add your application to the engine. This will NOT submit
         # your application yet, but will make the engine *aware* of

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,13 +36,13 @@ autopep8; python_version >= '2.7'
 PyYAML<5.0; python_version < '2.7'
 PyYAML; python_version >= '2.7'
 
-# optional Python packages for EasyBuild (GC3Pie is not compatible with Python 3 yet)
-GC3Pie; python_version < '3.0'
+# optional Python packages for EasyBuild
 
-# optional Python packages for EasyBuild -- flake8 is a superset of pycodestyle
+# flake8 is a superset of pycodestyle
 pycodestyle; python_version < '2.7'
 flake8; python_version >= '2.7'
 
+GC3Pie
 python-graph-dot
 python-hglib
 requests


### PR DESCRIPTION
This fixes the following failing test when running the test suite with Python 3 and having GC3Pie 2.6.0 installed:

```
ERROR: test_build_easyconfigs_in_parallel_gc3pie (test.framework.parallelbuild.ParallelBuildTest)
Test build_easyconfigs_in_parallel(), using GC3Pie with local config as backend for --job.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/easybuild-framework/easybuild-framework/test/framework/parallelbuild.py", line 258, in test_build_easyconfigs_in_parallel_gc3pie
    build_easyconfigs_in_parallel(cmd, ordered_ecs, prepare_first=False)
  File "/home/runner/work/easybuild-framework/easybuild-framework/easybuild/tools/parallelbuild.py", line 114, in build_easyconfigs_in_parallel
    active_job_backend.complete()
  File "/home/runner/work/easybuild-framework/easybuild-framework/easybuild/tools/job/gc3pie.py", line 254, in complete
    self._engine.progress()
  File "/opt/hostedtoolcache/Python/3.5.7/x64/lib/python3.5/site-packages/gc3libs/core.py", line 1649, in progress
    if self.max_in_flight > 0:
TypeError: unorderable types: NoneType() > int()

```

The problem is that `build_option('job_max_jobs')` yields `None`, which works fine in Python 2 because `None > 0` is equivalent with `False` there, but with Python 3 you get a `TypeError`