### PR TITLE
fix use of obtain_file method for extensions

### DIFF
--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -88,6 +88,7 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             self.installdir = self.master.installdir
             self.modules_tool = self.master.modules_tool
             self.module_generator = self.master.module_generator
+            self.robot_path = self.master.robot_path
             self.is_extension = True
             self.unpack_options = None
         else:

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1242,6 +1242,24 @@ class EasyBlockTest(EnhancedTestCase):
 
         shutil.rmtree(tmpdir)
 
+    def test_obtain_file_extension(self):
+        """Test use of obtain_file method on an extension."""
+
+        testdir = os.path.abspath(os.path.dirname(__file__))
+        toy_ec_file = os.path.join(testdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0-gompi-2018a-test.eb')
+        toy_ec = process_easyconfig(toy_ec_file)[0]
+        toy_eb = EasyBlock(toy_ec['ec'])
+
+        toy_eb.fetch_step()
+
+        test_ext = toy_eb.exts[-1]
+        test_ext_src_fn = os.path.basename(test_ext['src'])
+
+        ext = ExtensionEasyBlock(toy_eb, test_ext)
+        ext_src_path = ext.obtain_file(test_ext_src_fn)
+        self.assertEqual(os.path.basename(ext_src_path), 'toy-0.0.tar.gz')
+        self.assertTrue(os.path.exists(ext_src_path))
+
     def test_check_readiness(self):
         """Test check_readiness method."""
         init_config(build_options={'validate': False, 'silent': True})

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -833,8 +833,8 @@ class FileToolsTest(EnhancedTestCase):
         ft.write_file(fp + '.1', 'evenmoarbar')
         ft.move_logs(fp, os.path.join(self.test_prefix, 'bar.log'))
 
-        logs = sorted([f for f in os.listdir(self.test_prefix) if 'log' in f])
-        self.assertEqual(len(logs), 7)
+        logs = sorted([f for f in os.listdir(self.test_prefix) if '.log' in f])
+        self.assertEqual(len(logs), 7, "Found exactly 7 log files: %d (%s)" % (len(logs), logs))
         self.assertEqual(len([x for x in logs if x.startswith('eb-test-')]), 1)
         self.assertEqual(len([x for x in logs if x.startswith('foo')]), 2)
         self.assertEqual(len([x for x in logs if x.startswith('bar')]), 4)


### PR DESCRIPTION
Without the change in `extensioneasyblock.py`, the added test fails with:

```
ERROR: test_obtain_file_extension (test.framework.easyblock.EasyBlockTest)
Test use of obtain_file method on an extension.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/framework/easyblock.py", line 1259, in test_obtain_file_extension
    print ext.obtain_file(test_ext_src_fn)
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyblock.py", line 635, in obtain_file
    if self.robot_path:
AttributeError: 'ExtensionEasyBlock' object has no attribute 'robot_path'
```

This fix is motivated by a need to use `obtain_file` in the `TensorFlow` easyblock, and by hitting that same error when installing a bundle that includes `TensorFlow` as extension...