### PR TITLE
define $EB_SCRIPT_PATH in 'eb' wrapper script, and consider it before location of 'eb' determined via $PATH in get_paths_for function

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -287,8 +287,7 @@ def get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None):
             if eb_path != resolved_eb_path:
                 install_prefix = os.path.dirname(os.path.dirname(resolved_eb_path))
                 path_list.append(install_prefix)
-                _log.info("Also considering installation prefix %s (via resolved path to 'eb' script)...",
-                           install_prefix)
+                _log.info("Also considering installation prefix %s (via resolved path to 'eb')...", install_prefix)
 
     # look for desired subdirs
     for path in path_list:

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -255,17 +255,31 @@ def get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None):
     path_list.extend(sys.path)
 
     # figure out installation prefix, e.g. distutils install path for easyconfigs
-    eb_path = which('eb')
+
+    # prefer using path specified in $EB_SCRIPT_PATH (if defined), which is set by 'eb' wrapper script
+    eb_path = os.getenv('EB_SCRIPT_PATH')
+    if eb_path is None:
+        # try to determine location of 'eb' script via $PATH, as fallback mechanism
+        eb_path = which('eb')
+
     if eb_path is None:
         warning_msg = "'eb' not found in $PATH, failed to determine installation prefix!"
         _log.warning(warning_msg)
         print_warning(warning_msg)
     else:
-        # real location to 'eb' should be <install_prefix>/bin/eb
-        eb_path = resolve_path(eb_path)
+        # eb_path is location to 'eb' wrapper script, e.g. <install_prefix>/bin/eb
+        # so installation prefix is usually two levels up
         install_prefix = os.path.dirname(os.path.dirname(eb_path))
         path_list.append(install_prefix)
         _log.debug("Also considering installation prefix %s..." % install_prefix)
+
+        # also consider fully resolved location to 'eb' wrapper
+        # see https://github.com/easybuilders/easybuild-framework/pull/2248
+        resolved_eb_path = resolve_path(eb_path)
+        if eb_path != resolved_eb_path:
+            install_prefix = os.path.dirname(os.path.dirname(resolved_eb_path))
+            path_list.append(install_prefix)
+            _log.debug("Also considering installation prefix %s (via resolved path to 'eb' script)..." % install_prefix)
 
     # look for desired subdirs
     for path in path_list:

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -261,6 +261,9 @@ def get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None):
     if eb_path is None:
         # try to determine location of 'eb' script via $PATH, as fallback mechanism
         eb_path = which('eb')
+        _log.info("Location to 'eb' script (found via $PATH): %s", eb_path)
+    else:
+        _log.info("Found location to 'eb' script via $EB_SCRIPT_PATH: %s", eb_path)
 
     if eb_path is None:
         warning_msg = "'eb' not found in $PATH, failed to determine installation prefix!"
@@ -270,16 +273,22 @@ def get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None):
         # eb_path is location to 'eb' wrapper script, e.g. <install_prefix>/bin/eb
         # so installation prefix is usually two levels up
         install_prefix = os.path.dirname(os.path.dirname(eb_path))
-        path_list.append(install_prefix)
-        _log.debug("Also considering installation prefix %s..." % install_prefix)
 
-        # also consider fully resolved location to 'eb' wrapper
-        # see https://github.com/easybuilders/easybuild-framework/pull/2248
-        resolved_eb_path = resolve_path(eb_path)
-        if eb_path != resolved_eb_path:
-            install_prefix = os.path.dirname(os.path.dirname(resolved_eb_path))
+        # only consider resolved path to 'eb' script if desired subdir is not found relative to 'eb' script location
+        if os.path.exists(os.path.join(install_prefix, 'easybuild', subdir)):
             path_list.append(install_prefix)
-            _log.debug("Also considering installation prefix %s (via resolved path to 'eb' script)..." % install_prefix)
+            _log.info("Also considering installation prefix %s (determined via path to 'eb' script)...", install_prefix)
+        else:
+            _log.info("Not considering %s (no easybuild/%s subdir found)", install_prefix, subdir)
+
+            # also consider fully resolved location to 'eb' wrapper
+            # see https://github.com/easybuilders/easybuild-framework/pull/2248
+            resolved_eb_path = resolve_path(eb_path)
+            if eb_path != resolved_eb_path:
+                install_prefix = os.path.dirname(os.path.dirname(resolved_eb_path))
+                path_list.append(install_prefix)
+                _log.info("Also considering installation prefix %s (via resolved path to 'eb' script)...",
+                           install_prefix)
 
     # look for desired subdirs
     for path in path_list:

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -703,7 +703,7 @@ def find_eb_script(script_name):
         prev_script_loc = script_loc
 
         # fallback mechanism: check in location relative to location of 'eb'
-        eb_path = which('eb')
+        eb_path = os.getenv('EB_SCRIPT_PATH') or which('eb')
         if eb_path is None:
             _log.warning("'eb' not found in $PATH, failed to determine installation prefix")
         else:

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1476,7 +1476,7 @@ def parse_external_modules_metadata(cfgs):
         topdirs = [os.path.dirname(os.path.dirname(os.path.dirname(__file__)))]
 
         # etc/ could also be located next to bin/
-        eb_cmd = which('eb')
+        eb_cmd = os.getenv('EB_SCRIPT_PATH') or which('eb')
         if eb_cmd:
             topdirs.append(os.path.dirname(os.path.dirname(eb_cmd)))
 

--- a/eb
+++ b/eb
@@ -90,5 +90,7 @@ then
     export FANCYLOGGER_IGNORE_MPI4PY=1
 fi
 
+export EB_SCRIPT_PATH=$0
+
 verbose "$PYTHON -m easybuild.main `echo \"$@\"`"
 $PYTHON -m easybuild.main "$@"

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -63,8 +63,8 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import module_classes
 from easybuild.tools.configobj import ConfigObj
 from easybuild.tools.docs import avail_easyconfig_constants, avail_easyconfig_templates
-from easybuild.tools.filetools import adjust_permissions, change_dir, copy_file, mkdir, move_file
-from easybuild.tools.filetools import read_file, remove_file, symlink, write_file
+from easybuild.tools.filetools import adjust_permissions, change_dir, copy_file, mkdir, read_file, remove_file
+from easybuild.tools.filetools import symlink, write_file
 from easybuild.tools.module_naming_scheme.toolchain import det_toolchain_compilers, det_toolchain_mpi
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.options import parse_external_modules_metadata

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -2633,10 +2633,7 @@ class EasyConfigTest(EnhancedTestCase):
         os.environ['EB_SCRIPT_PATH'] = eb_symlink
 
         res = get_paths_for(subdir='easyconfigs', robot_path=None)
-        # not an exact match (since it's a symlinked path in a deeper subdir),
-        # but fully resolved path to correct directory
         self.assertTrue(os.path.exists(res[0]))
-        self.assertFalse(res[0] == os.path.join(someprefix, 'easybuild', 'easyconfigs'))
         self.assertTrue(os.path.samefile(res[0], os.path.join(someprefix, 'easybuild', 'easyconfigs')))
 
     def test_is_generic_easyblock(self):


### PR DESCRIPTION
fix for #3045 (cc @akesandgren)