### PR TITLE
add support for --remove-ghost-install-dirs, and warn about (potential) ghost install dirs by default when --force/--rebuild is used

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1613,7 +1613,6 @@ class EasyBlock(object):
         self.cfg['parallel'] = det_parallelism(par=par, maxpar=self.cfg['maxparallel'])
         self.log.info("Setting parallelism: %s" % self.cfg['parallel'])
 
-
     def remove_module_file(self):
         """Remove module file (if it exists), and check for ghost installation directory (and deal with it)."""
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1664,6 +1664,20 @@ class EasyBlock(object):
         # remove existing module file under --force (but only if --skip is not used)
         elif build_option('force') or build_option('rebuild'):
             if os.path.exists(self.mod_filepath):
+
+                # if installation directory used by module file differs from the one used now,
+                # clean it up to avoid leaving behind a ghost installation
+                # (see also https://github.com/easybuilders/easybuild-framework/issues/3026)
+                old_installdir = self.module_generator.det_installdir(self.mod_filepath)
+                if old_installdir is None:
+                    warning_msg = "Failed to determine installation directory from module file %s" % self.mod_filepath
+                    warning_msg += ", can't clean up potential ghost installation for %s %s" % (self.name, self.version)
+                    print_warning(warning_msg)
+                elif os.path.exists(old_installdir) and not os.path.samefile(old_installdir, self.installdir):
+                    remove_dir(old_installdir)
+                    self.log.info("Ghost installation directory %s removed", old_installdir)
+                    print_msg("Ghost installation directory %s removed", old_installdir)
+
                 self.log.info("Removing existing module file %s", self.mod_filepath)
                 remove_file(self.mod_filepath)
 

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -227,6 +227,7 @@ BUILD_OPTIONS_CMDLINE = {
         'module_only',
         'package',
         'read_only_installdir',
+        'remove_ghost_install_dirs',
         'rebuild',
         'robot',
         'rpath',

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -334,6 +334,20 @@ class ModuleGenerator(object):
 
         return res
 
+    def det_installdir(self, modfile):
+        """
+        Determine installation directory used by given module file
+        """
+        res = None
+
+        modtxt = read_file(modfile)
+        root_regex = re.compile(self.INSTALLDIR_REGEX, re.M)
+        match = root_regex.search(modtxt)
+        if match:
+            res = match.group('installdir')
+
+        return res
+
     # From this point on just not implemented methods
 
     def check_group(self, group, error_msg=None):
@@ -621,6 +635,7 @@ class ModuleGeneratorTcl(ModuleGenerator):
     MODULE_SHEBANG = '#%Module'
     CHARS_TO_ESCAPE = ['$']
 
+    INSTALLDIR_REGEX = r"^set root\s+(?P<installdir>.*)"
     LOAD_REGEX = r"^\s*module\s+(?:load|depends-on)\s+(\S+)"
     LOAD_TEMPLATE = "module load %(mod_name)s"
     LOAD_TEMPLATE_DEPENDS_ON = "depends-on %(mod_name)s"
@@ -963,6 +978,7 @@ class ModuleGeneratorLua(ModuleGenerator):
     MODULE_SHEBANG = ''  # no 'shebang' in Lua module files
     CHARS_TO_ESCAPE = []
 
+    INSTALLDIR_REGEX = r'^local root\s+=\s+"(?P<installdir>.*)"'
     LOAD_REGEX = r'^\s*(?:load|depends_on)\("(\S+)"'
     LOAD_TEMPLATE = 'load("%(mod_name)s")'
     LOAD_TEMPLATE_DEPENDS_ON = 'depends_on("%(mod_name)s")'

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -405,6 +405,9 @@ class EasyBuildOptions(GeneralOption):
                         None, 'store_true', False, 'p'),
             'read-only-installdir': ("Set read-only permissions on installation directory after installation",
                                      None, 'store_true', False),
+            'remove-ghost-install-dirs': ("Remove ghost installation directories when --force or --rebuild is used, "
+                                          "rather than just warning about them",
+                                          None, 'store_true', False),
             'rpath': ("Enable use of RPATH for linking with libraries", None, 'store_true', False),
             'rpath-filter': ("List of regex patterns to use for filtering out RPATH paths", 'strlist', 'store', None),
             'set-default-module': ("Set the generated module as default", None, 'store_true', False),

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -1198,6 +1198,23 @@ class ModuleGeneratorTest(EnhancedTestCase):
         # only with depth=0, only direct dependencies are returned
         self.assertEqual(dependencies_for('foss/2018a', self.modtool, depth=0), expected[:-2])
 
+    def test_det_installdir(self):
+        """Test det_installdir method."""
+
+        # first create a module file we can test with
+        modtxt = self.modgen.MODULE_SHEBANG
+        if modtxt:
+            modtxt += '\n'
+
+        modtxt += self.modgen.get_description()
+
+        test_modfile = os.path.join(self.test_prefix, 'test' + self.modgen.MODULE_FILE_EXTENSION)
+        write_file(test_modfile, modtxt)
+
+        expected = self.modgen.app.installdir
+
+        self.assertEqual(self.modgen.det_installdir(test_modfile), expected)
+
 
 class TclModuleGeneratorTest(ModuleGeneratorTest):
     """Test for module_generator module for Tcl syntax."""

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2359,11 +2359,11 @@ class ToyBuildTest(EnhancedTestCase):
             toy_modfile += '.lua'
             dummy_toy_mod_txt = 'local root = "%s"\n' % toy_installdir
         else:
-            dummy_toy_mod_txt = '\n'.join(
+            dummy_toy_mod_txt = '\n'.join([
                 "#%Module",
                 "set root %s" % toy_installdir,
                 '',
-            )
+            ])
         write_file(toy_modfile, dummy_toy_mod_txt)
 
         stdout, stderr = self.run_test_toy_build_with_output()

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -180,6 +180,19 @@ class ToyBuildTest(EnhancedTestCase):
 
         return outtxt
 
+    def run_test_toy_build_with_output(self, *args, **kwargs):
+        """Run test_toy_build with specified arguments, catch stdout/stderr and return it."""
+
+        self.mock_stderr(True)
+        self.mock_stdout(True)
+        self.test_toy_build(*args, **kwargs)
+        stderr = self.get_stderr()
+        stdout = self.get_stdout()
+        self.mock_stderr(False)
+        self.mock_stdout(False)
+
+        return stdout, stderr
+
     def test_toy_broken(self):
         """Test deliberately broken toy build."""
         tmpdir = tempfile.mkdtemp()
@@ -2334,7 +2347,7 @@ class ToyBuildTest(EnhancedTestCase):
 
             self.test_toy_build(ec_file=test_ec)
 
-    def test_toy_remove_ghost_installdir(self):
+    def test_toy_ghost_installdir(self):
         """Test whether ghost installation directory is removed under --force."""
 
         toy_installdir = os.path.join(self.test_prefix, 'test123', 'toy', '0.0')
@@ -2344,24 +2357,33 @@ class ToyBuildTest(EnhancedTestCase):
         toy_modfile = os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0')
         if get_module_syntax() == 'Lua':
             toy_modfile += '.lua'
-            toy_mod_txt = 'local root = "%s"\n' % toy_installdir
+            dummy_toy_mod_txt = 'local root = "%s"\n' % toy_installdir
         else:
-            toy_mod_txt = '\n'.join(
+            dummy_toy_mod_txt = '\n'.join(
                 "#%Module",
                 "set root %s" % toy_installdir,
                 '',
             )
-        write_file(toy_modfile, toy_mod_txt)
+        write_file(toy_modfile, dummy_toy_mod_txt)
 
-        self.mock_stdout(True)
-        self.test_toy_build()
-        stdout = self.get_stdout()
-        self.mock_stdout(False)
+        stdout, stderr = self.run_test_toy_build_with_output()
 
-        self.assertFalse(os.path.exists(toy_installdir))
+        # by default, a warning is printed for ghost installation directories (but they're left untouched)
+        self.assertFalse(stdout)
+        regex = re.compile("WARNING: Likely ghost installation directory detected: %s" % toy_installdir)
+        self.assertTrue(regex.search(stderr), "Pattern '%s' found in: %s" % (regex.pattern, stderr))
+        self.assertTrue(os.path.exists(toy_installdir))
+
+        # cleanup of ghost installation directories can be enable via --remove-ghost-install-dirs
+        write_file(toy_modfile, dummy_toy_mod_txt)
+        stdout, stderr = self.run_test_toy_build_with_output(extra_args=['--remove-ghost-install-dirs'])
+
+        self.assertFalse(stderr)
 
         regex = re.compile("^== Ghost installation directory %s removed" % toy_installdir)
         self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
+
+        self.assertFalse(os.path.exists(toy_installdir))
 
 
 def suite():


### PR DESCRIPTION
fix for #3026 reported by @akesandgren