### PR TITLE
fix for unsetting ...-%(pyver)s in job context

### DIFF
--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -135,7 +135,7 @@ def submit_jobs(ordered_ecs, cmd_line_opts, testing=False, prepare_first=True):
     # compose string with command line options, properly quoted and with '%' characters escaped
     opts_str = ' '.join(opts).replace('%', '%%')
 
-    command = "unset TMPDIR && cd %s && eb %%(spec)s %s %%(add_opts)s --testoutput=%%(output_dir)s" % (curdir, opts_str)
+    command = "unset TMPDIR && cd %s && eb %%(spec)s %s %%(add_opts)s --testoutput='%%(output_dir)s'" % (curdir, opts_str)
     _log.info("Command template for jobs: %s" % command)
     if testing:
         _log.debug("Skipping actual submission of jobs since testing mode is enabled")


### PR DESCRIPTION
Hi,

When running eb on configs referring to specific python versions, with v4.0.1 in a multideps context the log contains something like:

/var/tmp/slurmd_spool/job13282805/slurm_script: line 4: syntax error near unexpected token `('
/var/tmp/slurmd_spool/job13282805/slurm_script: line 4: `unset TMPDIR && 
...
foss-2019a-Python-%(pyver)s'

For this I single quoted the --testoutput parameter in line 138 of tools/parallelbuild.py .

This is not the canonical way, of course. shlex.quote would be the preferred approach in python3, but is not feasible for python2, right?

Perhaps there are side-effects of better approaches / places for this fix. Just let me know.

Best regards,
Christian