### PR TITLE
Init git repo with git.repo.clone() instead of copy_dir()

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -556,6 +556,7 @@ def init_repo(path, repo_name, silent=False):
         raise EasyBuildError("Failed to init git repo at %s: %s", repo_path, err)
 
     _log.debug("temporary git working directory ready at %s", repo_path)
+
     return repo
 
 

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -534,24 +534,28 @@ def init_repo(path, repo_name, silent=False):
     """
     repo_path = os.path.join(path, repo_name)
 
-    # copy or init git working directory
+    if not os.path.exists(repo_path):
+        mkdir(repo_path, parents=True)
+
+    # clone repo in git_working_dirs_path to repo_path
     git_working_dirs_path = build_option('git_working_dirs_path')
     if git_working_dirs_path:
         workdir = os.path.join(git_working_dirs_path, repo_name)
         if os.path.exists(workdir):
-            print_msg("copying %s..." % workdir, silent=silent)
-            copy_dir(workdir, repo_path)
+            print_msg("cloning git repo from %s..." % workdir, silent=silent)
+            try:
+                workrepo = git.Repo(workdir)
+                workrepo.clone(repo_path)
+            except GitCommandError as err:
+                raise EasyBuildError("Failed to clone git repo at %s: %s", workdir, err)
 
-    if not os.path.exists(repo_path):
-        mkdir(repo_path, parents=True)
-
+    # initalize repo in repo_path
     try:
         repo = git.Repo.init(repo_path)
     except GitCommandError as err:
         raise EasyBuildError("Failed to init git repo at %s: %s", repo_path, err)
 
     _log.debug("temporary git working directory ready at %s", repo_path)
-
     return repo
 
 


### PR DESCRIPTION
Currently, `init_repo()` does a recursive copy of all files in the existing repo in `git_working_dirs_path` to the temporary git repo in `repo_path`. This can cause issues with `eb --new-pr` at later stages if (like me) you have some untracked and/or unstaged files in the repo. For instance, if the `.eb` file of the new easyconfig is untracked, it will be falsely detected as already existing in the branch.
This patch solves this issue by instead using `git.Repo.clone()` to clone the local repo in `git_working_dirs_path`. This ensures that only tracked files are transferred to the temporary repo.