### PR TITLE
update GitPython to latest version that supports Python 2.6 to fix broken test_new_update_pr

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,8 @@ keyring==5.7.1; python_version < '2.7'
 keyring<=9.1; python_version >= '2.7'
 keyrings.alt; python_version >= '2.7'
 
-# GitPython 2.x may no longer be compatible with py2.6
-GitPython<2.0; python_version < '2.7'
+# GitPython 2.1.9 no longer supports Python 2.6
+GitPython==2.1.8; python_version < '2.7'
 GitPython; python_version >= '2.7'
 
 # pydot (dep for python-graph-dot) 1.2.0 and more recent doesn't work with Python 2.6


### PR DESCRIPTION
`test_new_update_pr` is currently broken with Python 2.6 after merging @lexming's PR #3062, see https://travis-ci.org/easybuilders/easybuild-framework/builds/605032445.
The GitHub tests are skipped for PRs to avoid leaking the GitHub token, so it went undetected in the PR tests.

The test fails because of a bug in GitPython, which was fixed in GitPython 2.1.8 (see https://github.com/gitpython-developers/GitPython/issues/687), which apparently is also the latest version supported Python 2.6, see https://github.com/gitpython-developers/GitPython/blob/master/doc/source/changes.rst#219---dropping-support-for-python-26