### PR TITLE
imply --disable-pre-create-installdir with --inject-checksums

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -989,6 +989,10 @@ class EasyBuildOptions(GeneralOption):
             self.options.ignore_osdeps = True
             self.options.modules_tool = None
 
+        # imply --disable-pre-create-installdir with --inject-checksums
+        if self.options.inject_checksums:
+            self.options.pre_create_installdir = False
+
     def _postprocess_list_avail(self):
         """Create all the additional info that can be requested (exit at the end)"""
         msg = ''

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3900,6 +3900,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.mock_stdout(False)
         self.mock_stderr(False)
 
+        # make sure software install directory is *not* created (see bug issue #3064)
+        self.assertFalse(os.path.exists(os.path.join(self.test_installpath, 'software', 'toy')))
+
         # SHA256 is default type of checksums used
         self.assertTrue("injecting sha256 checksums in" in stdout)
         self.assertEqual(stderr, '')


### PR DESCRIPTION
fixes #3064 