### PR TITLE
skip validation when copying EasyConfig object for extension

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -530,12 +530,15 @@ class EasyConfig(object):
                 self.mandatory.append(key)
         self.log.debug("Updated list of mandatory easyconfig parameters: %s", self.mandatory)
 
-    def copy(self):
+    def copy(self, validate=None):
         """
         Return a copy of this EasyConfig instance.
         """
+        if validate is None:
+            validate = self.validation
+
         # create a new EasyConfig instance
-        ec = EasyConfig(self.path, validate=self.validation, hidden=self.hidden, rawtxt=self.rawtxt)
+        ec = EasyConfig(self.path, validate=validate, hidden=self.hidden, rawtxt=self.rawtxt)
         # take a copy of the actual config dictionary (which already contains the extra options)
         ec._config = copy.deepcopy(self._config)
         # since rawtxt is defined, self.path may not get inherited, make sure it does

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -57,7 +57,7 @@ class Extension(object):
         """
         self.master = mself
         self.log = self.master.log
-        self.cfg = self.master.cfg.copy()
+        self.cfg = self.master.cfg.copy(validate=False)
         self.ext = copy.deepcopy(ext)
         self.dry_run = self.master.dry_run
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -451,6 +451,12 @@ class EasyConfigTest(EnhancedTestCase):
         eb = EasyBlock(ec)
         eb.fetch_step()
 
+        # inject OS dependency that can not be fullfilled,
+        # to check whether OS deps are validated again for each extension (they shouldn't be);
+        # we need to tweak the contents of the easyconfig file via cfg.rawtxt, since that's what is used to re-parse
+        # the easyconfig file for the extension
+        eb.cfg.rawtxt += "\nosdependencies = ['this_os_dep_does_not_exist']"
+
         # run extensions step to install 'toy' extension
         eb.extensions_step()
 


### PR DESCRIPTION
Currently when an extension is initialized, the `EasyConfig` instance of the "parent" is copied into the extension (since stuff like `toolchain` etc. is also relevant for installing the extension).

By default, this results in re-validating the easyconfig file (which includes re-checking the OS dependencies), which is silly.
Even worse, it leads to problems like the ones reported in https://github.com/easybuilders/easybuild-easyconfigs/issues/8661 since commands like `rpm -q` may break when particular modules (like `XZ` are loaded).

cc @zao, @terjekv, @akesandgren