### PR TITLE
correctly specify that ActiveMNS & co are singleton classes

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -67,7 +67,7 @@ from easybuild.tools.module_naming_scheme.mns import DEVEL_MODULE_SUFFIX
 from easybuild.tools.module_naming_scheme.utilities import avail_module_naming_schemes, det_full_ec_version
 from easybuild.tools.module_naming_scheme.utilities import det_hidden_modname, is_valid_module_name
 from easybuild.tools.modules import modules_tool
-from easybuild.tools.py2vs3 import OrderedDict, string_type
+from easybuild.tools.py2vs3 import OrderedDict, create_base_metaclass, string_type
 from easybuild.tools.systemtools import check_os_dependency
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME, is_system_toolchain
 from easybuild.tools.toolchain.toolchain import TOOLCHAIN_CAPABILITIES, TOOLCHAIN_CAPABILITY_CUDA
@@ -2212,10 +2212,12 @@ def fix_deprecated_easyconfigs(paths):
     print_msg("\nAll done! Fixed %d easyconfigs (out of %d found).\n", fixed_cnt, cnt, prefix=False)
 
 
-class ActiveMNS(object):
-    """Wrapper class for active module naming scheme."""
+# singleton metaclass: only one instance is created
+BaseActiveMNS = create_base_metaclass('BaseActiveMNS', Singleton, object)
 
-    __metaclass__ = Singleton
+
+class ActiveMNS(BaseActiveMNS):
+    """Wrapper class for active module naming scheme."""
 
     def __init__(self, *args, **kwargs):
         """Initialize logger."""

--- a/easybuild/tools/module_naming_scheme/mns.py
+++ b/easybuild/tools/module_naming_scheme/mns.py
@@ -33,16 +33,18 @@ import re
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import Singleton
+from easybuild.tools.py2vs3 import create_base_metaclass
 
 
 DEVEL_MODULE_SUFFIX = '-easybuild-devel'
 
 
-class ModuleNamingScheme(object):
-    """Abstract class for a module naming scheme implementation."""
+# singleton metaclass: only one instance is created
+BaseModuleNamingScheme = create_base_metaclass('BaseModuleNamingScheme', Singleton, object)
 
-    # singleton metaclass: only one instance is created
-    __metaclass__ = Singleton
+
+class ModuleNamingScheme(BaseModuleNamingScheme):
+    """Abstract class for a module naming scheme implementation."""
 
     REQUIRED_KEYS = None
 

--- a/easybuild/tools/package/utilities.py
+++ b/easybuild/tools/package/utilities.py
@@ -42,6 +42,7 @@ from easybuild.tools.config import build_option, get_package_naming_scheme, log_
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import change_dir, which
 from easybuild.tools.package.package_naming_scheme.pns import PackageNamingScheme
+from easybuild.tools.py2vs3 import create_base_metaclass
 from easybuild.tools.run import run_cmd
 from easybuild.tools.utilities import get_subclasses, import_available_modules
 
@@ -170,11 +171,14 @@ def check_pkg_support():
         raise EasyBuildError("Selected packaging tool '%s' not found", pkgtool)
 
 
-class ActivePNS(object):
+# singleton metaclass: only one instance is created
+BaseActivePNS = create_base_metaclass('BaseActivePNS', Singleton, object)
+
+
+class ActivePNS(BaseActivePNS):
     """
     The wrapper class for Package Naming Schemes.
     """
-    __metaclass__ = Singleton
 
     def __init__(self):
         """Initialize logger and find available PNSes to load"""

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1972,6 +1972,13 @@ class EasyConfigTest(EnhancedTestCase):
         except ImportError:
             print("Skipping test_dep_graph, since pygraph is not available")
 
+    def test_ActiveMNS_singleton(self):
+        """Make sure ActiveMNS is a singleton class."""
+
+        mns1 = ActiveMNS()
+        mns2 = ActiveMNS()
+        self.assertEqual(id(mns1), id(mns2))
+
     def test_ActiveMNS_det_full_module_name(self):
         """Test det_full_module_name method of ActiveMNS."""
         build_options = {


### PR DESCRIPTION
This was overlooked when porting to Python 3.

While the `__metaclass__ = Singleton` that specifies a singleton class in Python 2 does no harm when using Python 3, it's blatantly ignored when using Python 3, so `ActiveMNS` isn't a singleton class at all then...

This is important w.r.t. the time required for running the easyconfig test suite, to avoid that 475k (identical) `ActiveMNS` instances are created...