### PR TITLE
support use of glob patterns for paths to files with external modules metadata

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -449,8 +449,8 @@ class EasyBuildOptions(GeneralOption):
             'buildpath': ("Temporary build path", None, 'store', mk_full_default_path('buildpath')),
             'containerpath': ("Location where container recipe & image will be stored", None, 'store',
                               mk_full_default_path('containerpath')),
-            'external-modules-metadata': ("List of files specifying metadata for external modules (INI format)",
-                                          'strlist', 'store', None),
+            'external-modules-metadata': ("List of (glob patterns for) paths to files specifying metadata "
+                                          "for external modules (INI format)", 'strlist', 'store', None),
             'hooks': ("Location of Python module with hook implementations", 'str', 'store', None),
             'ignore-dirs': ("Directory names to ignore when searching for files/dirs",
                             'strlist', 'store', ['.git', '.svn']),


### PR DESCRIPTION
This is useful to better integrate with the pre-packaged software provided by OpenHPC.

@koomie @adrianreber have plans to include metadata files in the software RPMs, so EasyBuild can pick up on them.

For this to work, EasyBuild needs to support a file *pattern* to be passed to `$EASYBUILD_EXTERNAL_MODULES_METADATA` (rather than a list of absolute paths to files, which would have to be continuously updated).