### PR TITLE
deprecate running EasyBuild with Python 2.6 via new check_python_version() function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
   include:
     # also test default configuration with Python 2.6
     - python: 2.6
-      env: LMOD_VERSION=7.8.22
+      env: LMOD_VERSION=7.8.22 TEST_EASYBUILD_SILENCE_DEPRECATION_WARNINGS=Python26
       dist: trusty
     # single configuration to test with Lmod 6 and Python 2.7
     - python: 2.7

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -93,7 +93,8 @@ from easybuild.tools.run import run_cmd
 from easybuild.tools.package.utilities import avail_package_naming_schemes
 from easybuild.tools.toolchain.compiler import DEFAULT_OPT_LEVEL, OPTARCH_MAP_CHAR, OPTARCH_SEP, Compiler
 from easybuild.tools.repository.repository import avail_repositories
-from easybuild.tools.systemtools import get_cpu_architecture, get_cpu_family, get_cpu_features, get_system_info
+from easybuild.tools.systemtools import check_python_version, get_cpu_architecture, get_cpu_family, get_cpu_features
+from easybuild.tools.systemtools import get_system_info
 from easybuild.tools.version import this_is_easybuild
 
 
@@ -1302,6 +1303,7 @@ def set_up_configuration(args=None, logfile=None, testing=False, silent=False):
     :param testing: enable testing mode
     :param silent: stay silent (no printing)
     """
+    check_python_version()
 
     # set up fake 'vsc' Python package, to catch easyblocks/scripts that still import from vsc.* namespace
     # this must be done early on, to catch imports from the vsc namespace in modules included via --include-*

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1304,7 +1304,6 @@ def set_up_configuration(args=None, logfile=None, testing=False, silent=False):
     :param testing: enable testing mode
     :param silent: stay silent (no printing)
     """
-    check_python_version()
 
     # set up fake 'vsc' Python package, to catch easyblocks/scripts that still import from vsc.* namespace
     # this must be done early on, to catch imports from the vsc namespace in modules included via --include-*
@@ -1370,6 +1369,8 @@ def set_up_configuration(args=None, logfile=None, testing=False, silent=False):
     # initialise the EasyBuild configuration & build options
     init(options, config_options_dict)
     init_build_options(build_options=build_options, cmdline_options=options)
+
+    check_python_version()
 
     # move directory containing fake vsc namespace into temporary directory used for this session
     # (to ensure it gets cleaned up properly)

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -802,3 +802,29 @@ def det_terminal_size():
             height, width = 25, 80
 
     return height, width
+
+
+def check_python_version():
+    """Check currently used Python version."""
+    python_maj_ver = sys.version_info[0]
+    python_min_ver = sys.version_info[1]
+    python_ver = '%d.%d' % (python_maj_ver, python_min_ver)
+    _log.info("Found Python version %s", python_ver)
+
+    if python_maj_ver == 2:
+        if python_min_ver < 6:
+            raise EasyBuildError("Python 2.6 or higher is required when using Python 2, found Python %s", python_ver)
+        elif python_min_ver == 6:
+            _log.deprecated("Running EasyBuild with Python 2.6 is deprecated", '5.0')
+        else:
+            _log.info("Running EasyBuild with Python 2 (version %s)", python_ver)
+
+    elif python_maj_ver == 3:
+        if python_min_ver < 5:
+            raise EasyBuildError("Python 3.5 or higher is required when using Python 3, found Python %s", python_ver)
+        else:
+            _log.info("Running EasyBuild with Python 3 (version %s)", python_ver)
+    else:
+        raise EasyBuildError("EasyBuild is not compatible (yet) with Python %s", python_ver)
+
+    return (python_maj_ver, python_min_ver)

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -43,6 +43,7 @@ from socket import gethostname
 
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import build_option
 from easybuild.tools.filetools import is_readable, read_file, which
 from easybuild.tools.run import run_cmd
 
@@ -840,11 +841,17 @@ def check_python_version():
     python_ver = '%d.%d' % (python_maj_ver, python_min_ver)
     _log.info("Found Python version %s", python_ver)
 
+    silence_deprecation_warnings = build_option('silence_deprecation_warnings') or []
+
     if python_maj_ver == 2:
         if python_min_ver < 6:
             raise EasyBuildError("Python 2.6 or higher is required when using Python 2, found Python %s", python_ver)
         elif python_min_ver == 6:
-            _log.deprecated("Running EasyBuild with Python 2.6 is deprecated", '5.0')
+            depr_msg = "Running EasyBuild with Python 2.6 is deprecated"
+            if 'Python26' in silence_deprecation_warnings:
+                _log.warning(depr_msg)
+            else:
+                _log.deprecated(depr_msg, '5.0')
         else:
             _log.info("Running EasyBuild with Python 2 (version %s)", python_ver)
 

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -35,6 +35,7 @@ from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
 
 import easybuild.tools.systemtools as st
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import read_file
 from easybuild.tools.py2vs3 import string_type
 from easybuild.tools.run import run_cmd
@@ -42,10 +43,11 @@ from easybuild.tools.systemtools import CPU_ARCHITECTURES, AARCH32, AARCH64, POW
 from easybuild.tools.systemtools import CPU_FAMILIES, POWER_LE, DARWIN, LINUX, UNKNOWN
 from easybuild.tools.systemtools import CPU_VENDORS, AMD, APM, ARM, CAVIUM, IBM, INTEL
 from easybuild.tools.systemtools import MAX_FREQ_FP, PROC_CPUINFO_FP, PROC_MEMINFO_FP
+from easybuild.tools.systemtools import check_python_version
 from easybuild.tools.systemtools import det_parallelism, get_avail_core_count, get_cpu_architecture, get_cpu_family
 from easybuild.tools.systemtools import get_cpu_features, get_cpu_model, get_cpu_speed, get_cpu_vendor
-from easybuild.tools.systemtools import get_glibc_version, get_os_type, get_os_name, get_os_version, get_platform_name
-from easybuild.tools.systemtools import get_shared_lib_ext, get_system_info, get_total_memory, get_gcc_version
+from easybuild.tools.systemtools import get_gcc_version, get_glibc_version, get_os_type, get_os_name, get_os_version
+from easybuild.tools.systemtools import get_platform_name, get_shared_lib_ext, get_system_info, get_total_memory
 
 
 PROC_CPUINFO_TXT = None
@@ -335,6 +337,7 @@ class SystemToolsTest(EnhancedTestCase):
         self.orig_run_cmd = st.run_cmd
         self.orig_platform_uname = st.platform.uname
         self.orig_get_tool_version = st.get_tool_version
+        self.orig_sys_version_info = st.sys.version_info
 
     def tearDown(self):
         """Cleanup after systemtools test."""
@@ -345,6 +348,7 @@ class SystemToolsTest(EnhancedTestCase):
         st.run_cmd = self.orig_run_cmd
         st.platform.uname = self.orig_platform_uname
         st.get_tool_version = self.orig_get_tool_version
+        st.sys.version_info = self.orig_sys_version_info
         super(SystemToolsTest, self).tearDown()
 
     def test_avail_core_count_native(self):
@@ -766,6 +770,70 @@ class SystemToolsTest(EnhancedTestCase):
         (height, width) = st.det_terminal_size()
         self.assertTrue(isinstance(height, int) and height >= 0)
         self.assertTrue(isinstance(width, int) and width >= 0)
+
+    def test_check_python_version(self):
+        """Test check_python_version function."""
+
+        def mock_python_ver(py_maj_ver, py_min_ver):
+            """Helper function to mock a particular Python version."""
+            st.sys.version_info = (py_maj_ver, py_min_ver) + sys.version_info[2:]
+
+        # mock running with different Python versions
+        mock_python_ver(1, 4)
+        error_pattern = r"EasyBuild is not compatible \(yet\) with Python 1.4"
+        self.assertErrorRegex(EasyBuildError, error_pattern, check_python_version)
+
+        mock_python_ver(4, 0)
+        error_pattern = r"EasyBuild is not compatible \(yet\) with Python 4.0"
+        self.assertErrorRegex(EasyBuildError, error_pattern, check_python_version)
+
+        mock_python_ver(2, 5)
+        error_pattern = r"Python 2.6 or higher is required when using Python 2, found Python 2.5"
+        self.assertErrorRegex(EasyBuildError, error_pattern, check_python_version)
+
+        # no problems when running with a supported Python version
+        for pyver in [(2, 7), (3, 5), (3, 6), (3, 7)]:
+            mock_python_ver(*pyver)
+            self.assertEqual(check_python_version(), pyver)
+
+        mock_python_ver(2, 6)
+        # deprecation warning triggers an error in test environment
+        error_pattern = r"Running EasyBuild with Python 2.6 is deprecated"
+        self.assertErrorRegex(EasyBuildError, error_pattern, check_python_version)
+
+        # we may trigger a deprecation warning below (when testing with Python 2.6)
+        py26_depr_warning = "\nWARNING: Deprecated functionality, will no longer work in v5.0: "
+        py26_depr_warning += "Running EasyBuild with Python 2.6 is deprecated"
+
+        self.allow_deprecated_behaviour()
+
+        # first test with mocked Python 2.6
+        self.mock_stderr(True)
+        check_python_version()
+        stderr = self.get_stderr()
+        self.mock_stderr(False)
+
+        # we should always get a deprecation warning here
+        self.assertTrue(stderr.startswith(py26_depr_warning))
+
+        # restore Python version info to check with Python version used to run tests
+        st.sys.version_info = self.orig_sys_version_info
+
+        # shouldn't raise any errors, since Python version used to run tests should be supported;
+        self.mock_stderr(True)
+        (py_maj_ver, py_min_ver) = check_python_version()
+        stderr = self.get_stderr()
+        self.mock_stderr(False)
+
+        self.assertTrue(py_maj_ver in [2, 3])
+        if py_maj_ver == 2:
+            self.assertTrue(py_min_ver in [6, 7])
+        else:
+            self.assertTrue(py_min_ver >= 5)
+
+        # only deprecation warning when actually testing with Python 2.6
+        if sys.version_info[:2] == (2, 6):
+            self.assertTrue(stderr.startswith(py26_depr_warning))
 
 
 def suite():

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -31,7 +31,7 @@ Unit tests for systemtools.py
 import re
 import sys
 
-from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
+from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
 
 import easybuild.tools.systemtools as st
@@ -773,6 +773,8 @@ class SystemToolsTest(EnhancedTestCase):
 
     def test_check_python_version(self):
         """Test check_python_version function."""
+
+        init_config(build_options={'silence_deprecation_warnings': []})
 
         def mock_python_ver(py_maj_ver, py_min_ver):
             """Helper function to mock a particular Python version."""


### PR DESCRIPTION
With this change included, a deprecation warning will be printed when EasyBuild is run on top of Python 2.6:

```
$ python -V
2.6.9
$ eb example.eb

WARNING: Deprecated functionality, will no longer work in v5.0:
Running EasyBuild with Python 2.6 is deprecated;
see http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html for more information

...
```

Currently the main motivation here is to (slightly) trim down on test configurations in Travis CI, but longer term some code cleanup can be done when we've dropped support for Python 2.6.

In addition to deprecating support for Python 2.6, we also check whether the Python version being used is actually supported via the added `check_python_version` function.
Up until now, we were only checking the Python version in the `eb` wrapper, so no Python version check was done at all when EasyBuild is being used as a library...