### PR TITLE
take into account that external modules may not be visible directly (due to module hierarchy)

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -125,10 +125,10 @@ def find_resolved_modules(easyconfigs, avail_modules, modtool, retain_all_deps=F
         for dep in easyconfig['dependencies']:
             dep_mod_name = dep.get('full_mod_name', ActiveMNS().det_full_module_name(dep))
 
-            # treat external modules as resolved when retain_all_deps is enabled (e.g., under --dry-run),
+            # always treat external modules as resolved,
             # since no corresponding easyconfig can be found for them
-            if retain_all_deps and dep.get('external_module', False):
-                _log.debug("Treating dependency marked as external dependency as resolved: %s", dep_mod_name)
+            if dep.get('external_module', False):
+                _log.debug("Treating dependency marked as external module as resolved: %s", dep_mod_name)
 
             elif retain_all_deps and dep_mod_name not in avail_modules:
                 # if all dependencies should be retained, include dep unless it has been already

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -451,6 +451,16 @@ class Toolchain(object):
             if dep_exists:
                 deps.append(dep)
                 self.log.devel("_check_dependencies: added toolchain dependency %s", str(dep))
+            elif dep['external_module']:
+                # external modules may be organised hierarchically,
+                # so not all modules may be directly available for loading;
+                # we assume here that the required modules are either provided by the toolchain,
+                # or are listed earlier as dependency
+                # examples from OpenHPC:
+                # - openmpi3 module provided by OpenHPC requires that gnu7, gnu8 or intel module is loaded first
+                # - fftw module provided by OpenHPC requires that compiler + MPI module are loaded first
+                self.log.info("Assuming non-visible external module %s is available", dep['full_mod_name'])
+                deps.append(dep)
             else:
                 missing_dep_mods.append(dep_mod_name)
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3571,6 +3571,24 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertEqual(metadata['two/2.1'], {'name': ['two'], 'version': ['2.1']})
         self.assertEqual(metadata['three/3.0'], {'name': ['three'], 'version': ['3.0']})
 
+        # check whether entries with unknown keys result in an error
+        cfg1 = os.path.join(self.test_prefix, 'broken_cfg1.cfg')
+        write_file(cfg1, "[one/1.0]\nname = one\nversion = 1.0\nfoo = bar")
+        cfg2 = os.path.join(self.test_prefix, 'cfg2.cfg')
+        write_file(cfg2, "[two/2.0]\nname = two\nversion = 2.0")
+        cfg3 = os.path.join(self.test_prefix, 'broken_cfg3.cfg')
+        write_file(cfg3, "[three/3.0]\nnaem = three\nzzz=zzz\nvresion = 3.0\naaa = aaa")
+        cfg4 = os.path.join(self.test_prefix, 'broken_cfg4.cfg')
+        write_file(cfg4, "[four/4]\nprfeix = /software/four/4")
+        broken_cfgs = [cfg1, cfg2, cfg3, cfg4]
+        error_pattern = '\n'.join([
+            r"Found metadata entries with unknown keys:",
+            r"\* four/4: prfeix",
+            r"\* one/1.0: foo",
+            r"\* three/3.0: aaa, naem, vresion, zzz",
+        ])
+        self.assertErrorRegex(EasyBuildError, error_pattern, parse_external_modules_metadata, broken_cfgs)
+
     def test_zip_logs(self):
         """Test use of --zip-logs"""
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1325,7 +1325,11 @@ class ToyBuildTest(EnhancedTestCase):
         extraectxt += "\nversionsuffix = '-external-deps-broken1'"
         write_file(toy_ec, ectxt + extraectxt)
 
-        err_msg = r"Module command \\'module load nosuchbuilddep/0.0.0\\' failed"
+        if isinstance(self.modtool, Lmod):
+            err_msg = r"Module command \\'module load nosuchbuilddep/0.0.0\\' failed"
+        else:
+            err_msg = r"Unable to locate a modulefile for 'nosuchbuilddep/0.0.0'"
+
         self.assertErrorRegex(EasyBuildError, err_msg, self.test_toy_build, ec_file=toy_ec,
                               raise_error=True, verbose=False)
 
@@ -1333,7 +1337,11 @@ class ToyBuildTest(EnhancedTestCase):
         extraectxt += "\nversionsuffix = '-external-deps-broken2'"
         write_file(toy_ec, ectxt + extraectxt)
 
-        err_msg = r"Module command \\'module load nosuchmodule/1.2.3\\' failed"
+        if isinstance(self.modtool, Lmod):
+            err_msg = r"Module command \\'module load nosuchmodule/1.2.3\\' failed"
+        else:
+            err_msg = r"Unable to locate a modulefile for 'nosuchmodule/1.2.3'"
+
         self.assertErrorRegex(EasyBuildError, err_msg, self.test_toy_build, ec_file=toy_ec,
                               raise_error=True, verbose=False)
 


### PR DESCRIPTION
Modules provided through OpenHPC packages are organized hierarchically, where for example a `gnu*` module must be loaded before an `openmpi*` or `openblas` module becomes available for loading, an `openmpi*` must be loaded before `fftw` can be loaded, etc.

These minor enhancements that basically loosen up the restrictions for using external modules (see https://easybuild.readthedocs.io/en/latest/Using_external_modules.html) a bit are sufficient to let EasyBuild also leverage external modules that are organized hierarchically.

The assumption here is that the dependencies (or toolchain components) are ordered correctly, i.e.  that if module Y requires module X to be loaded first, X is listed before Y.

Although the checks here are loosened up a bit, incorrectly ordering things will still result in an installation failure, since the sanity check which tries to load the resulting module will fail in that case.

I've also extended `parse_external_modules_metadata` a bit so no unknown keys are listed in the metadata for external modules (to avoid silly mistakes like typos going undetected).

cc @koomie @adrianreber