### PR TITLE
trim set of test configurations in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,8 @@ python: 2.7
 dist: xenial
 env:
   matrix:
-    # purposely specifying slowest builds first, to gain time overall
     - LMOD_VERSION=7.8.22
     - LMOD_VERSION=7.8.22 TEST_EASYBUILD_MODULE_SYNTAX=Tcl
-    - LMOD_VERSION=8.2.3
-    - LMOD_VERSION=8.2.3 TEST_EASYBUILD_MODULE_SYNTAX=Tcl
     - ENV_MOD_VERSION=3.2.10 TEST_EASYBUILD_MODULES_TOOL=EnvironmentModulesC TEST_EASYBUILD_MODULE_SYNTAX=Tcl
     - ENV_MOD_TCL_VERSION=1.147 TEST_EASYBUILD_MODULES_TOOL=EnvironmentModulesTcl TEST_EASYBUILD_MODULE_SYNTAX=Tcl
     - ENV_MOD_VERSION=4.1.4 TEST_EASYBUILD_MODULE_SYNTAX=Tcl TEST_EASYBUILD_MODULES_TOOL=EnvironmentModules  # Tmod 4.1.4 is used in RHEL8
@@ -26,26 +23,6 @@ matrix:
       env: LMOD_VERSION=6.5.1 TEST_EASYBUILD_SILENCE_DEPRECATION_WARNINGS=Lmod6
     # also test with Python 3.6
     - python: 3.6
-      env: LMOD_VERSION=7.8.22
-    - python: 3.6
-      env: LMOD_VERSION=7.8.22 TEST_EASYBUILD_MODULE_SYNTAX=Tcl
-    - python: 3.6
-      env: LMOD_VERSION=8.2.3
-    - python: 3.6
-      env: LMOD_VERSION=8.2.3 TEST_EASYBUILD_MODULE_SYNTAX=Tcl
-    - python: 3.6
-      env: ENV_MOD_VERSION=3.2.10 TEST_EASYBUILD_MODULES_TOOL=EnvironmentModulesC TEST_EASYBUILD_MODULE_SYNTAX=Tcl
-    - python: 3.6
-      env: ENV_MOD_TCL_VERSION=1.147 TEST_EASYBUILD_MODULES_TOOL=EnvironmentModulesTcl TEST_EASYBUILD_MODULE_SYNTAX=Tcl
-    - python: 3.6
-      env: ENV_MOD_VERSION=4.1.4 TEST_EASYBUILD_MODULE_SYNTAX=Tcl TEST_EASYBUILD_MODULES_TOOL=EnvironmentModules  # Tmod 4.1.4 is used in RHEL8
-    # also test most common configuration with Python 3.5 and 3.7
-    - python: 3.5
-      env: LMOD_VERSION=7.8.22
-    - python: 3.7
-      env: LMOD_VERSION=7.8.22
-    - python: 3.8
-      dist: xenial
       env: LMOD_VERSION=7.8.22
 addons:
   apt:


### PR DESCRIPTION
removed:

* testing with Lmod 8 (still covered in GitHub CI)
* testing with Python 3.x (except for Lmod 7.x + Lua module syntax)

All these are still covered in GitHub CI, where test budget is less limited.