### PR TITLE
add support for --sync-pr-with-develop

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1846,9 +1846,8 @@ def sync_pr_with_develop(pr_id):
     # initialize repository
     git_working_dir = tempfile.mkdtemp(prefix='git-working-dir')
     git_repo = init_repo(git_working_dir, target_repo)
-    repo_path = os.path.join(git_working_dir, target_repo)
 
-    pr_remote_name = setup_repo(git_repo, pr_account, target_repo, pr_branch)
+    setup_repo(git_repo, pr_account, target_repo, pr_branch)
 
     # pull in latest version of 'develop' branch from central repository
     msg = "pulling latest version of '%s' branch from %s/%s..." % (target_account, target_repo, GITHUB_DEVELOP_BRANCH)

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -814,10 +814,21 @@ def _easyconfigs_pr_common(paths, ecs, start_branch=None, pr_branch=None, start_
     return file_info, deleted_paths, git_repo, pr_branch, diff_stat
 
 
-def create_remote(git_repo, account, repo):
-    """Create remote in specified git working directory for specified account & repository."""
+def create_remote(git_repo, account, repo, https=False):
+    """
+    Create remote in specified git working directory for specified account & repository.
 
-    github_url = 'git@github.com:%s/%s.git' % (account, repo)
+    :param git_repo: git.Repo instance to use (after init_repo & setup_repo)
+    :param account: GitHub account name
+    :param repo: repository name
+    :param https: use https:// URL rather than git@
+    """
+
+    if https:
+        github_url = 'https://github.com/%s/%s.git' % (account, repo)
+    else:
+        github_url = 'git@github.com:%s/%s.git' % (account, repo)
+
     salt = ''.join(random.choice(ascii_letters) for _ in range(5))
     remote_name = 'github_%s_%s' % (account, salt)
 
@@ -830,7 +841,14 @@ def create_remote(git_repo, account, repo):
 
 
 def push_branch_to_github(git_repo, target_account, target_repo, branch):
-    """Push specified branch to GitHub from specified git repository."""
+    """
+    Push specified branch to GitHub from specified git repository.
+
+    :param git_repo: git.Repo instance to use (after init_repo & setup_repo)
+    :param target_account: GitHub account name
+    :param target_repo: repository name
+    :param branch: name of branch to push
+    """
 
     # push to GitHub
     remote = create_remote(git_repo, target_account, target_repo)
@@ -1815,7 +1833,7 @@ def fetch_pr_data(pr, pr_target_account, pr_target_repo, github_user, full=False
 
 
 def sync_pr_with_develop(pr_id):
-    """Sync pull request with current develop branch."""
+    """Sync pull request with specified ID with current develop branch."""
     github_user = build_option('github_user')
     if github_user is None:
         raise EasyBuildError("GitHub user must be specified to use --sync-pr-with-develop")
@@ -1835,7 +1853,7 @@ def sync_pr_with_develop(pr_id):
     # pull in latest version of 'develop' branch from central repository
     msg = "pulling latest version of '%s' branch from %s/%s..." % (target_account, target_repo, GITHUB_DEVELOP_BRANCH)
     print_msg(msg, log=_log)
-    easybuilders_remote = create_remote(git_repo, target_account, target_repo)
+    easybuilders_remote = create_remote(git_repo, target_account, target_repo, https=True)
     pull_out = git_repo.git.pull(easybuilders_remote.name, GITHUB_DEVELOP_BRANCH)
     _log.debug("Output of 'git pull %s %s': %s", easybuilders_remote.name, GITHUB_DEVELOP_BRANCH, pull_out)
 

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1359,19 +1359,39 @@ def new_pr(paths, ecs, title=None, descr=None, commit_msg=None):
                 _log.info("Failed to add labels to PR# %s: %s." % (pr, err))
 
 
+def det_account_branch_for_pr(pr_id, github_user=None):
+    """Determine account & branch corresponding to pull request with specified id."""
+
+    if github_user is None:
+        github_user = build_option('github_user')
+
+    if github_user is None:
+        raise EasyBuildError("GitHub username (--github-user) must be specified!")
+
+    pr_target_account = build_option('pr_target_account')
+    pr_target_repo = build_option('pr_target_repo')
+
+    pr_data, _ = fetch_pr_data(pr_id, pr_target_account, pr_target_repo, github_user)
+
+    # branch that corresponds with PR is supplied in form <account>:<branch_label>
+    account = pr_data['head']['label'].split(':')[0]
+    branch = ':'.join(pr_data['head']['label'].split(':')[1:])
+    github_target = '%s/%s' % (pr_target_account, pr_target_repo)
+    print_msg("Determined branch name corresponding to %s PR #%s: %s" % (github_target, pr_id, branch), log=_log)
+
+    return account, branch
+
+
 @only_if_module_is_available('git', pkgname='GitPython')
-def update_pr(pr, paths, ecs, commit_msg=None):
+def update_pr(pr_id, paths, ecs, commit_msg=None):
     """
     Update specified pull request using specified files
 
-    :param pr: ID of pull request to update
+    :param pr_id: ID of pull request to update
     :param paths: paths to categorized lists of files (easyconfigs, files to delete, patches)
     :param ecs: list of parsed easyconfigs, incl. for dependencies (if robot is enabled)
     :param commit_msg: commit message to use
     """
-    github_user = build_option('github_user')
-    if github_user is None:
-        raise EasyBuildError("GitHub user must be specified to use --update-pr")
 
     if commit_msg is None:
         raise EasyBuildError("A meaningful commit message must be specified via --pr-commit-msg when using --update-pr")
@@ -1379,13 +1399,7 @@ def update_pr(pr, paths, ecs, commit_msg=None):
     pr_target_account = build_option('pr_target_account')
     pr_target_repo = build_option('pr_target_repo')
 
-    pr_data, _ = fetch_pr_data(pr, pr_target_account, pr_target_repo, github_user)
-
-    # branch that corresponds with PR is supplied in form <account>:<branch_label>
-    account = pr_data['head']['label'].split(':')[0]
-    branch = ':'.join(pr_data['head']['label'].split(':')[1:])
-    github_target = '%s/%s' % (pr_target_account, pr_target_repo)
-    print_msg("Determined branch name corresponding to %s PR #%s: %s" % (github_target, pr, branch), log=_log)
+    account, branch = det_account_branch_for_pr(pr_id)
 
     _, _, _, _, diff_stat = _easyconfigs_pr_common(paths, ecs, start_branch=branch, pr_branch=branch,
                                                    start_account=account, commit_msg=commit_msg)
@@ -1393,7 +1407,7 @@ def update_pr(pr, paths, ecs, commit_msg=None):
     print_msg("Overview of changes:\n%s\n" % diff_stat, log=_log, prefix=False)
 
     full_repo = '%s/%s' % (pr_target_account, pr_target_repo)
-    msg = "Updated %s PR #%s by pushing to branch %s/%s" % (full_repo, pr, account, branch)
+    msg = "Updated %s PR #%s by pushing to branch %s/%s" % (full_repo, pr_id, account, branch)
     if build_option('dry_run') or build_option('extended_dry_run'):
         msg += " [DRY RUN]"
     print_msg(msg, log=_log, prefix=False)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -605,6 +605,8 @@ class EasyBuildOptions(GeneralOption):
             'pr-target-repo': ("Target repository for new/updating PRs", str, 'store', GITHUB_EASYCONFIGS_REPO),
             'pr-title': ("Title for new pull request created with --new-pr", str, 'store', None),
             'preview-pr': ("Preview a new pull request", None, 'store_true', False),
+            'sync-pr-with-develop': ("Sync pull request with current 'develop' branch",
+                                     int, 'store', None, {'metavar': 'PR#'}),
             'review-pr': ("Review specified pull request", int, 'store', None, {'metavar': 'PR#'}),
             'test-report-env-filter': ("Regex used to filter out variables in environment dump of test report",
                                        None, 'regex', None),

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -663,6 +663,35 @@ class GithubTest(EnhancedTestCase):
         self.assertEqual(account, 'migueldiascosta')
         self.assertEqual(branch, 'fix_inject_checksums')
 
+    def test_push_branch_to_github(self):
+        """Test push_branch_to_github."""
+
+        build_options = {'dry_run': True}
+        init_config(build_options=build_options)
+
+        git_repo = gh.init_repo(self.test_prefix, GITHUB_REPO)
+        branch = 'test123'
+
+        self.mock_stderr(True)
+        self.mock_stdout(True)
+        gh.setup_repo(git_repo, GITHUB_USER, GITHUB_REPO, 'master')
+        git_repo.create_head(branch, force=True)
+        gh.push_branch_to_github(git_repo, GITHUB_USER, GITHUB_REPO, branch)
+        stderr = self.get_stderr()
+        stdout = self.get_stdout()
+        self.mock_stderr(True)
+        self.mock_stdout(True)
+
+        self.assertEqual(stderr, '')
+
+        github_path = '%s/%s.git' % (GITHUB_USER, GITHUB_REPO)
+        pattern = r'^' + '\n'.join([
+            r"== fetching branch 'master' from https://github.com/%s\.\.\." % github_path,
+            r"== pushing branch 'test123' to remote 'github_.*' \(git@github.com:%s\) \[DRY RUN\]" % github_path,
+        ]) + r'$'
+        regex = re.compile(pattern)
+        self.assertTrue(regex.match(stdout.strip()), "Pattern '%s' doesn't match: %s" % (regex.pattern, stdout))
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -636,6 +636,33 @@ class GithubTest(EnhancedTestCase):
         gist_id = gist_url.split('/')[-1]
         gh.delete_gist(gist_id, github_user=GITHUB_TEST_ACCOUNT, github_token=self.github_token)
 
+    def test_det_account_branch_for_pr(self):
+        """Test det_account_branch_for_pr."""
+
+        init_config(build_options={
+            'pr_target_account': 'easybuilders',
+            'pr_target_repo': 'easybuild-easyconfigs',
+        })
+
+        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/9149
+        self.mock_stdout(True)
+        account, branch = gh.det_account_branch_for_pr(9149, github_user=GITHUB_TEST_ACCOUNT)
+        self.mock_stdout(False)
+        self.assertEqual(account, 'boegel')
+        self.assertEqual(branch, '20191017070734_new_pr_EasyBuild401')
+
+        init_config(build_options={
+            'pr_target_account': 'easybuilders',
+            'pr_target_repo': 'easybuild-framework',
+        })
+
+        # see https://github.com/easybuilders/easybuild-framework/pull/3069
+        self.mock_stdout(True)
+        account, branch = gh.det_account_branch_for_pr(3069, github_user=GITHUB_TEST_ACCOUNT)
+        self.mock_stdout(False)
+        self.assertEqual(account, 'migueldiascosta')
+        self.assertEqual(branch, 'fix_inject_checksums')
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -638,6 +638,9 @@ class GithubTest(EnhancedTestCase):
 
     def test_det_account_branch_for_pr(self):
         """Test det_account_branch_for_pr."""
+        if self.skip_github_tests:
+            print("Skipping test_det_account_branch_for_pr, no GitHub token available?")
+            return
 
         init_config(build_options={
             'pr_target_account': 'easybuilders',


### PR DESCRIPTION
With `--sync-pr-with-develop`, you can sync the branch (on GitHub) that corresponds to a specific pull request with the latest version of the `develop` branch from the central repository.

Examples:

* syncing https://github.com/easybuilders/easybuild-easyconfigs/pull/7277 with `develop` branch from central repository (https://github.com/easybuilders/easybuild-easyconfigs):
  ```
  $ eb --sync-pr-with-develop 7277
  == temporary log file in case of crash /tmp/eb-Uul_00/easybuild-kwe1IC.log
  == Determined branch name corresponding to easybuilders/easybuild-easyconfigs PR #7277: 20181210212203_new_pr_ack224
  == cloning git repo from /user/example/easybuild-easyconfigs...
  == fetching branch '20181210212203_new_pr_ack224' from https://github.com/boegel/easybuild-easyconfigs.git...
  == pulling latest version of 'easybuilders' branch from easybuild-easyconfigs/develop...
  == merging 'develop' branch into PR branch '20181210212203_new_pr_ack224'...
  == pushing branch '20181210212203_new_pr_ack224' to remote 'github_boegel_IhzHm' (git@github.com:boegel/easybuild-easyconfigs.git)
  == Temporary log file(s) /tmp/eb-Uul_00/easybuild-kwe1IC.log* have been removed.
  == Temporary directory /tmp/eb-Uul_00 has been removed.
  ```
  resulting commit: https://github.com/easybuilders/easybuild-easyconfigs/pull/7277/commits/c0866277e1e6f2b705c7743f0099eff4b33496fc

* dry run of syncing #3028 with `develop` branch from central repository (https://github.com/easybuilders/easybuild-framework):
  ```
  $ eb --sync-pr 3028 --pr-target-repo easybuild-framework --dry-run
  == temporary log file in case of crash /tmp/eb-NLTcIF/easybuild-zDtzwv.log
  == Determined branch name corresponding to easybuilders/easybuild-framework PR #3028: bootstrap_py3
  == cloning git repo from /home/example/easybuild-framework...
  == fetching branch 'bootstrap_py3' from https://github.com/boegel/easybuild-framework.git...
  == pulling latest version of 'easybuilders' branch from easybuild-framework/develop...
  == merging 'develop' branch into PR branch 'bootstrap_py3'...
  == pushing branch 'bootstrap_py3' to remote 'github_boegel_SRxxW' (git@github.com:boegel/easybuild-framework.git) [DRY RUN]
  == Temporary log file(s) /tmp/eb-NLTcIF/easybuild-zDtzwv.log* have been removed.
  == Temporary directory /tmp/eb-NLTcIF has been removed.
  ```
  (same result with `-D` or `-x` instead of `--dry-run`)

Just using `--sync-pr` works too, since there's only one option that starts with `--sync-pr`...