### PR TITLE
add support for --new-branch-github, --new-pr-from-branch, --sync-branch-with-develop, --update-branch-github

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -410,7 +410,7 @@ class EasyConfig(object):
         if rawtxt is None:
             self.path = path
             self.rawtxt = read_file(path)
-            self.log.debug("Raw contents from supplied easyconfig file %s: %s" % (path, self.rawtxt))
+            self.log.debug("Raw contents from supplied easyconfig file %s: %s", path, self.rawtxt)
         else:
             self.rawtxt = rawtxt
             self.log.debug("Supplied raw easyconfig contents: %s" % self.rawtxt)
@@ -604,7 +604,7 @@ class EasyConfig(object):
                                  type(self.build_specs))
         self.log.debug("Obtained specs dict %s" % arg_specs)
 
-        self.log.info("Parsing easyconfig file %s with rawcontent: %s" % (self.path, self.rawtxt))
+        self.log.info("Parsing easyconfig file %s with rawcontent: %s", self.path, self.rawtxt)
         self.parser.set_specifications(arg_specs)
         local_vars = self.parser.get_config_dict()
         self.log.debug("Parsed easyconfig as a dictionary: %s" % local_vars)

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -57,7 +57,7 @@ from easybuild.tools.config import find_last_log, get_repository, get_repository
 from easybuild.tools.containers.common import containerize
 from easybuild.tools.docs import list_software
 from easybuild.tools.filetools import adjust_permissions, cleanup, write_file
-from easybuild.tools.github import check_github, close_pr, create_branch_github, find_easybuild_easyconfig
+from easybuild.tools.github import check_github, close_pr, new_branch_github, find_easybuild_easyconfig
 from easybuild.tools.github import install_github_token, list_prs, new_pr, new_pr_from_branch, merge_pr
 from easybuild.tools.github import sync_pr_with_develop, update_pr
 from easybuild.tools.hooks import START, END, load_hooks, run_hook
@@ -294,7 +294,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     categorized_paths = categorize_files_by_type(orig_paths)
 
     # command line options that do not require any easyconfigs to be specified
-    pr_options = options.create_branch_github or options.new_pr or options.new_pr_from_branch
+    pr_options = options.new_branch_github or options.new_pr or options.new_pr_from_branch
     pr_options = pr_options or options.preview_pr or options.sync_pr_with_develop or options.update_pr
     no_ec_opts = [options.aggregate_regtest, options.regtest, pr_options, search_query]
 
@@ -382,8 +382,8 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     if pr_options:
         if options.new_pr:
             new_pr(categorized_paths, ordered_ecs)
-        elif options.create_branch_github:
-            create_branch_github(categorized_paths, ordered_ecs)
+        elif options.new_branch_github:
+            new_branch_github(categorized_paths, ordered_ecs)
         elif options.new_pr_from_branch:
             new_pr_from_branch(options.new_pr_from_branch)
         elif options.preview_pr:

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -59,7 +59,7 @@ from easybuild.tools.docs import list_software
 from easybuild.tools.filetools import adjust_permissions, cleanup, write_file
 from easybuild.tools.github import check_github, close_pr, new_branch_github, find_easybuild_easyconfig
 from easybuild.tools.github import install_github_token, list_prs, new_pr, new_pr_from_branch, merge_pr
-from easybuild.tools.github import sync_pr_with_develop, update_pr
+from easybuild.tools.github import sync_pr_with_develop, update_branch, update_pr
 from easybuild.tools.hooks import START, END, load_hooks, run_hook
 from easybuild.tools.modules import modules_tool
 from easybuild.tools.options import set_up_configuration, use_color
@@ -294,8 +294,8 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     categorized_paths = categorize_files_by_type(orig_paths)
 
     # command line options that do not require any easyconfigs to be specified
-    pr_options = options.new_branch_github or options.new_pr or options.new_pr_from_branch
-    pr_options = pr_options or options.preview_pr or options.sync_pr_with_develop or options.update_pr
+    pr_options = options.new_branch_github or options.new_pr or options.new_pr_from_branch or options.preview_pr
+    pr_options = pr_options or options.sync_pr_with_develop or options.update_branch_github or options.update_pr
     no_ec_opts = [options.aggregate_regtest, options.regtest, pr_options, search_query]
 
     # determine paths to easyconfigs
@@ -390,8 +390,10 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
             print(review_pr(paths=determined_paths, colored=use_color(options.color)))
         elif options.sync_pr_with_develop:
             sync_pr_with_develop(options.sync_pr_with_develop)
+        elif options.update_branch_github:
+            update_branch(options.update_branch_github, categorized_paths, ordered_ecs)
         elif options.update_pr:
-            update_pr(options.update_pr, categorized_paths, ordered_ecs, commit_msg=options.pr_commit_msg)
+            update_pr(options.update_pr, categorized_paths, ordered_ecs)
         else:
             raise EasyBuildError("Unknown PR option!")
 

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -314,9 +314,9 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     elif any(no_ec_opts):
         paths = determined_paths
     else:
-        print_error(("Please provide one or multiple easyconfig files, or use software build "
-                     "options to make EasyBuild search for easyconfigs"),
-                     log=_log, opt_parser=eb_go.parser, exit_on_error=not testing)
+        print_error("Please provide one or multiple easyconfig files, or use software build " +
+                    "options to make EasyBuild search for easyconfigs",
+                    log=_log, opt_parser=eb_go.parser, exit_on_error=not testing)
     _log.debug("Paths: %s", paths)
 
     # run regtest

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -57,7 +57,7 @@ from easybuild.tools.config import find_last_log, get_repository, get_repository
 from easybuild.tools.containers.common import containerize
 from easybuild.tools.docs import list_software
 from easybuild.tools.filetools import adjust_permissions, cleanup, write_file
-from easybuild.tools.github import check_github, close_pr, create_new_branch, find_easybuild_easyconfig
+from easybuild.tools.github import check_github, close_pr, create_branch_github, find_easybuild_easyconfig
 from easybuild.tools.github import install_github_token, list_prs, new_pr, new_pr_from_branch, merge_pr
 from easybuild.tools.github import sync_pr_with_develop, update_pr
 from easybuild.tools.hooks import START, END, load_hooks, run_hook
@@ -294,7 +294,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     categorized_paths = categorize_files_by_type(orig_paths)
 
     # command line options that do not require any easyconfigs to be specified
-    pr_options = options.create_pr_branch or options.new_pr or options.new_pr_from_branch
+    pr_options = options.create_branch_github or options.new_pr or options.new_pr_from_branch
     pr_options = pr_options or options.preview_pr or options.sync_pr_with_develop or options.update_pr
     no_ec_opts = [options.aggregate_regtest, options.regtest, pr_options, search_query]
 
@@ -382,8 +382,8 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     if pr_options:
         if options.new_pr:
             new_pr(categorized_paths, ordered_ecs)
-        elif options.create_pr_branch:
-            create_new_branch(categorized_paths, ordered_ecs)
+        elif options.create_branch_github:
+            create_branch_github(categorized_paths, ordered_ecs)
         elif options.new_pr_from_branch:
             new_pr_from_branch(options.new_pr_from_branch)
         elif options.preview_pr:

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -57,8 +57,9 @@ from easybuild.tools.config import find_last_log, get_repository, get_repository
 from easybuild.tools.containers.common import containerize
 from easybuild.tools.docs import list_software
 from easybuild.tools.filetools import adjust_permissions, cleanup, write_file
-from easybuild.tools.github import check_github, find_easybuild_easyconfig, install_github_token
-from easybuild.tools.github import close_pr, list_prs, new_pr, merge_pr, sync_pr_with_develop, update_pr
+from easybuild.tools.github import check_github, close_pr, create_new_branch, find_easybuild_easyconfig
+from easybuild.tools.github import install_github_token, list_prs, new_pr, new_pr_from_branch, merge_pr
+from easybuild.tools.github import sync_pr_with_develop, update_pr
 from easybuild.tools.hooks import START, END, load_hooks, run_hook
 from easybuild.tools.modules import modules_tool
 from easybuild.tools.options import set_up_configuration, use_color
@@ -293,7 +294,8 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     categorized_paths = categorize_files_by_type(orig_paths)
 
     # command line options that do not require any easyconfigs to be specified
-    pr_options = options.new_pr or options.preview_pr or options.sync_pr_with_develop or options.update_pr
+    pr_options = options.create_pr_branch or options.new_pr or options.new_pr_from_branch
+    pr_options = pr_options or options.preview_pr or options.sync_pr_with_develop or options.update_pr
     no_ec_opts = [options.aggregate_regtest, options.regtest, pr_options, search_query]
 
     # determine paths to easyconfigs
@@ -306,16 +308,15 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     if determined_paths:
         # transform paths into tuples, use 'False' to indicate the corresponding easyconfig files were not generated
         paths = [(p, False) for p in determined_paths]
+    elif 'name' in build_specs:
+        # try to obtain or generate an easyconfig file via build specifications if a software name is provided
+        paths = find_easyconfigs_by_specs(build_specs, robot_path, try_to_generate, testing=testing)
+    elif any(no_ec_opts):
+        paths = determined_paths
     else:
-        if 'name' in build_specs:
-            # try to obtain or generate an easyconfig file via build specifications if a software name is provided
-            paths = find_easyconfigs_by_specs(build_specs, robot_path, try_to_generate, testing=testing)
-        elif any(no_ec_opts):
-            paths = determined_paths
-        else:
-            print_error(("Please provide one or multiple easyconfig files, or use software build "
-                         "options to make EasyBuild search for easyconfigs"),
-                        log=_log, opt_parser=eb_go.parser, exit_on_error=not testing)
+        print_error(("Please provide one or multiple easyconfig files, or use software build "
+                     "options to make EasyBuild search for easyconfigs"),
+                     log=_log, opt_parser=eb_go.parser, exit_on_error=not testing)
     _log.debug("Paths: %s", paths)
 
     # run regtest
@@ -380,8 +381,11 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     # creating/updating PRs
     if pr_options:
         if options.new_pr:
-            new_pr(categorized_paths, ordered_ecs, title=options.pr_title, descr=options.pr_descr,
-                   commit_msg=options.pr_commit_msg)
+            new_pr(categorized_paths, ordered_ecs)
+        elif options.create_pr_branch:
+            create_new_branch(categorized_paths, ordered_ecs)
+        elif options.new_pr_from_branch:
+            new_pr_from_branch(options.new_pr_from_branch)
         elif options.preview_pr:
             print(review_pr(paths=determined_paths, colored=use_color(options.color)))
         elif options.sync_pr_with_develop:

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -191,9 +191,12 @@ BUILD_OPTIONS_CMDLINE = {
         'package_tool_options',
         'parallel',
         'pr_branch_name',
+        'pr_commit_msg',
+        'pr_descr',
         'pr_target_account',
         'pr_target_branch',
         'pr_target_repo',
+        'pr_title',
         'rpath_filter',
         'regtest_output_dir',
         'silence_deprecation_warnings',
@@ -439,7 +442,7 @@ def init_build_options(build_options=None, cmdline_options=None):
             cmdline_options.force = True
             retain_all_deps = True
 
-        if cmdline_options.new_pr or cmdline_options.update_pr:
+        if cmdline_options.new_pr or cmdline_options.create_pr_branch or cmdline_options.update_pr:
             _log.info("Retaining all dependencies of specified easyconfigs to create/update pull request")
             retain_all_deps = True
 
@@ -449,7 +452,8 @@ def init_build_options(build_options=None, cmdline_options=None):
                                       cmdline_options.dry_run_short, cmdline_options.dump_env_script,
                                       cmdline_options.extended_dry_run, cmdline_options.fix_deprecated_easyconfigs,
                                       cmdline_options.missing_modules, cmdline_options.new_pr,
-                                      cmdline_options.preview_pr, cmdline_options.update_pr]
+                                      cmdline_options.create_pr_branch, cmdline_options.preview_pr,
+                                      cmdline_options.update_pr]
         if any(auto_ignore_osdeps_options):
             _log.info("Auto-enabling ignoring of OS dependencies")
             cmdline_options.ignore_osdeps = True

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -442,7 +442,7 @@ def init_build_options(build_options=None, cmdline_options=None):
             cmdline_options.force = True
             retain_all_deps = True
 
-        if cmdline_options.new_pr or cmdline_options.create_branch_github or cmdline_options.update_pr:
+        if cmdline_options.new_branch_github or cmdline_options.new_pr or cmdline_options.update_pr:
             _log.info("Retaining all dependencies of specified easyconfigs to create/update pull request")
             retain_all_deps = True
 
@@ -451,8 +451,8 @@ def init_build_options(build_options=None, cmdline_options=None):
                                       cmdline_options.dep_graph, cmdline_options.dry_run,
                                       cmdline_options.dry_run_short, cmdline_options.dump_env_script,
                                       cmdline_options.extended_dry_run, cmdline_options.fix_deprecated_easyconfigs,
-                                      cmdline_options.missing_modules, cmdline_options.new_pr,
-                                      cmdline_options.create_branch_github, cmdline_options.preview_pr,
+                                      cmdline_options.missing_modules, cmdline_options.new_branch_github,
+                                      cmdline_options.new_pr, cmdline_options.preview_pr,
                                       cmdline_options.update_pr]
         if any(auto_ignore_osdeps_options):
             _log.info("Auto-enabling ignoring of OS dependencies")

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -442,8 +442,11 @@ def init_build_options(build_options=None, cmdline_options=None):
             cmdline_options.force = True
             retain_all_deps = True
 
-        if cmdline_options.new_branch_github or cmdline_options.new_pr or cmdline_options.update_pr:
-            _log.info("Retaining all dependencies of specified easyconfigs to create/update pull request")
+        new_update_opt = cmdline_options.new_branch_github or cmdline_options.new_pr
+        new_update_opt = new_update_opt or cmdline_options.update_branch_github or cmdline_options.update_pr
+
+        if new_update_opt:
+            _log.info("Retaining all dependencies of specified easyconfigs to create/update branch or pull request")
             retain_all_deps = True
 
         auto_ignore_osdeps_options = [cmdline_options.check_conflicts, cmdline_options.check_contrib,
@@ -453,7 +456,7 @@ def init_build_options(build_options=None, cmdline_options=None):
                                       cmdline_options.extended_dry_run, cmdline_options.fix_deprecated_easyconfigs,
                                       cmdline_options.missing_modules, cmdline_options.new_branch_github,
                                       cmdline_options.new_pr, cmdline_options.preview_pr,
-                                      cmdline_options.update_pr]
+                                      cmdline_options.update_branch_github, cmdline_options.update_pr]
         if any(auto_ignore_osdeps_options):
             _log.info("Auto-enabling ignoring of OS dependencies")
             cmdline_options.ignore_osdeps = True

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -442,7 +442,7 @@ def init_build_options(build_options=None, cmdline_options=None):
             cmdline_options.force = True
             retain_all_deps = True
 
-        if cmdline_options.new_pr or cmdline_options.create_pr_branch or cmdline_options.update_pr:
+        if cmdline_options.new_pr or cmdline_options.create_branch_github or cmdline_options.update_pr:
             _log.info("Retaining all dependencies of specified easyconfigs to create/update pull request")
             retain_all_deps = True
 
@@ -452,7 +452,7 @@ def init_build_options(build_options=None, cmdline_options=None):
                                       cmdline_options.dry_run_short, cmdline_options.dump_env_script,
                                       cmdline_options.extended_dry_run, cmdline_options.fix_deprecated_easyconfigs,
                                       cmdline_options.missing_modules, cmdline_options.new_pr,
-                                      cmdline_options.create_pr_branch, cmdline_options.preview_pr,
+                                      cmdline_options.create_branch_github, cmdline_options.preview_pr,
                                       cmdline_options.update_pr]
         if any(auto_ignore_osdeps_options):
             _log.info("Auto-enabling ignoring of OS dependencies")

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1272,7 +1272,7 @@ def merge_pr(pr):
 
 
 @only_if_module_is_available('git', pkgname='GitPython')
-def create_branch_github(paths, ecs, commit_msg=None):
+def new_branch_github(paths, ecs, commit_msg=None):
     """
     Create new branch on GitHub using specified filesystem
 
@@ -1519,7 +1519,7 @@ def new_pr(paths, ecs, title=None, descr=None, commit_msg=None):
         title = build_option('pr_title') or commit_msg
 
     # create new branch in GitHub
-    res = create_branch_github(paths, ecs, commit_msg=commit_msg)
+    res = new_branch_github(paths, ecs, commit_msg=commit_msg)
     file_info, deleted_paths, _, branch_name, diff_stat = res
 
     new_pr_from_branch(branch_name, title=title, descr=descr, pr_metadata=(file_info, deleted_paths, diff_stat))

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1272,7 +1272,7 @@ def merge_pr(pr):
 
 
 @only_if_module_is_available('git', pkgname='GitPython')
-def create_new_branch(paths, ecs, commit_msg=None):
+def create_branch_github(paths, ecs, commit_msg=None):
     """
     Create new branch on GitHub using specified filesystem
 
@@ -1482,7 +1482,7 @@ def new_pr(paths, ecs, title=None, descr=None, commit_msg=None):
         title = build_option('pr_title') or commit_msg
 
     # create new branch in GitHub
-    res = create_new_branch(paths, ecs, commit_msg=commit_msg)
+    res = create_branch_github(paths, ecs, commit_msg=commit_msg)
     file_info, deleted_paths, _, branch_name, diff_stat = res
 
     new_pr_from_branch(branch_name, title=title, descr=descr, pr_metadata=(file_info, deleted_paths, diff_stat))

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -2044,9 +2044,12 @@ def sync_branch_with_develop(branch_name):
     git_working_dir = tempfile.mkdtemp(prefix='git-working-dir')
     git_repo = init_repo(git_working_dir, target_repo)
 
-    setup_repo(git_repo, github_user, target_repo, branch_name)
+    # GitHub organisation or GitHub user where branch is located
+    github_account = build_option('github_org') or github_user
+
+    setup_repo(git_repo, github_account, target_repo, branch_name)
 
     sync_with_develop(git_repo, branch_name, target_account, target_repo)
 
     # push updated branch back to GitHub (unless we're doing a dry run)
-    return push_branch_to_github(git_repo, github_user, target_repo, branch_name)
+    return push_branch_to_github(git_repo, github_account, target_repo, branch_name)

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -695,6 +695,9 @@ def _easyconfigs_pr_common(paths, ecs, start_branch=None, pr_branch=None, start_
     if pr_target_repo != GITHUB_EASYCONFIGS_REPO:
         raise EasyBuildError("Don't know how to create/update a pull request to the %s repository", pr_target_repo)
 
+    if start_account is None:
+        start_account = GITHUB_EB_MAIN
+
     if start_branch is None:
         # if start branch is not specified, we're opening a new PR
         # account to use is determined by active EasyBuild configuration (--github-org or --github-user)
@@ -1268,13 +1271,12 @@ def merge_pr(pr):
 
 
 @only_if_module_is_available('git', pkgname='GitPython')
-def create_new_branch(paths, ecs, target_account=None, commit_msg=None):
+def create_new_branch(paths, ecs, commit_msg=None):
     """
     Create new branch on GitHub using specified filesystem
 
     :param paths: paths to categorized lists of files (easyconfigs, files to delete, patches)
     :param ecs: list of parsed easyconfigs, incl. for dependencies (if robot is enabled)
-    :param target_account: GitHub account to push branch to (--github-org or --github-user is used if None)
     :param commit_msg: commit message to use
     """
 
@@ -1282,11 +1284,8 @@ def create_new_branch(paths, ecs, target_account=None, commit_msg=None):
     if commit_msg is None:
         commit_msg = build_option('pr_commit_msg')
 
-    if target_account is None:
-        target_account = build_option('github_org') or build_option('github_user')
-
     # create branch, commit files to it & push to GitHub
-    res = _easyconfigs_pr_common(paths, ecs, pr_branch=branch_name, start_account=target_account, commit_msg=commit_msg)
+    res = _easyconfigs_pr_common(paths, ecs, pr_branch=branch_name, commit_msg=commit_msg)
 
     return res
 

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1355,26 +1355,14 @@ def new_pr_from_branch(branch_name, title=None, descr=None, pr_metadata=None):
             to_branch = '%s/%s' % (pr_target_account, pr_target_branch)
             msg = ["found %d changed file(s) in '%s' relative to '%s':" % (len(changed_files), from_branch, to_branch)]
             if ec_paths:
-                cnt = len(ec_paths)
-                msg.append("* %d new/changed easyconfig file(s):" % cnt)
-                if cnt > 10:
-                    msg.extend(["  " + x for x in ec_paths[:10]] + ["  ..."])
-                else:
-                    msg.extend(["  " + x for x in ec_paths])
+                msg.append("* %d new/changed easyconfig file(s):" % len(ec_paths))
+                msg.extend(["  " + x for x in ec_paths])
             if patch_paths:
-                cnt = len(patch_paths)
-                msg.append("* %d patch(es):" % cnt)
-                if cnt > 10:
-                    msg.extend(["  " + x for x in patch_paths[:10]] + ["  ..."])
-                else:
-                    msg.extend(["  " + x for x in patch_paths])
+                msg.append("* %d patch(es):" % len(patch_paths))
+                msg.extend(["  " + x for x in patch_paths])
             if deleted_paths:
-                cnt = len(deleted_paths)
-                msg.append("* %d deleted file(s)" % cnt)
-                if cnt > 10:
-                    msg.append(["  " + x for x in deleted_paths[:10]] + ["  ..."])
-                else:
-                    msg.append(["  " + x for x in deleted_paths])
+                msg.append("* %d deleted file(s)" % len(deleted_paths))
+                msg.append(["  " + x for x in deleted_paths])
 
             print_msg('\n'.join(msg), log=_log)
         else:

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1332,7 +1332,7 @@ def new_pr_from_branch(branch_name, title=None, descr=None, pr_metadata=None):
         remote = create_remote(git_repo, pr_target_account, pr_target_repo, https=True)
         git_repo.git.fetch(remote.name)
         if pr_target_branch in [b.name for b in git_repo.branches]:
-            git_repo.delete_head(pr_target_branch)
+            git_repo.delete_head(pr_target_branch, force=True)
         git_repo.git.checkout('remotes/%s/%s' % (remote.name, pr_target_branch), track=True, force=True)
 
         print_msg("determining metadata for pull request based on changed files...", log=_log)
@@ -1379,7 +1379,7 @@ def new_pr_from_branch(branch_name, title=None, descr=None, pr_metadata=None):
         remote = create_remote(git_repo, github_account, pr_target_repo, https=True)
         git_repo.git.fetch(remote.name)
         if branch_name in [b.name for b in git_repo.branches]:
-            git_repo.delete_head(branch_name)
+            git_repo.delete_head(branch_name, force=True)
         git_repo.git.checkout('remotes/%s/%s' % (remote.name, branch_name), track=True, force=True)
 
         # path to easyconfig files is expected to be absolute in det_file_info

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1327,7 +1327,7 @@ def new_pr_from_branch(branch_name, title=None, descr=None, pr_metadata=None):
         sync_with_develop(git_repo, branch_name, pr_target_account, pr_target_repo)
 
         # checkout target branch, to obtain diff with PR branch
-        # make sure right branch is being used by checkout it out via remotes/*
+        # make sure right branch is being used by checking it out via remotes/*
         print_msg("checking out target branch '%s/%s'..." % (pr_target_account, pr_target_branch), log=_log)
         remote = create_remote(git_repo, pr_target_account, pr_target_repo, https=True)
         git_repo.git.fetch(remote.name)

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1959,6 +1959,13 @@ def sync_with_develop(git_repo, branch_name, github_account, github_repo):
     pull_out = git_repo.git.pull(remote.name, GITHUB_DEVELOP_BRANCH)
     _log.debug("Output of 'git pull %s %s': %s", remote.name, GITHUB_DEVELOP_BRANCH, pull_out)
 
+    # fetch to make sure we can check out the 'develop' branch
+    fetch_out = git_repo.git.fetch(remote.name)
+    _log.debug("Output of 'git fetch %s': %s", remote.name, fetch_out)
+
+    _log.debug("Output of 'git branch -a': %s", git_repo.git.branch(a=True))
+    _log.debug("Output of 'git remote -v': %s", git_repo.git.remote(v=True))
+
     # create 'develop' branch (with force if one already exists),
     git_repo.create_head(GITHUB_DEVELOP_BRANCH, remote.refs.develop, force=True).checkout()
 

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1333,7 +1333,11 @@ def new_pr_from_branch(branch_name, title=None, descr=None, pr_metadata=None):
         git_repo.git.fetch(remote.name)
         if pr_target_branch in [b.name for b in git_repo.branches]:
             git_repo.delete_head(pr_target_branch, force=True)
-        git_repo.git.checkout('remotes/%s/%s' % (remote.name, pr_target_branch), track=True, force=True)
+
+        full_target_branch_ref = 'remotes/%s/%s' % (remote.name, pr_target_branch)
+        git_repo.git.checkout(full_target_branch_ref, track=True, force=True)
+
+        diff_stat = git_repo.git.diff(full_target_branch_ref, branch_name, stat=True)
 
         print_msg("determining metadata for pull request based on changed files...", log=_log)
 
@@ -1386,8 +1390,6 @@ def new_pr_from_branch(branch_name, title=None, descr=None, pr_metadata=None):
         ec_paths = [os.path.join(git_working_dir, pr_target_repo, x) for x in ec_paths]
 
         file_info = det_file_info(ec_paths, target_dir)
-
-        diff_stat = git_repo.git.diff(pr_target_branch, branch_name, stat=True)
 
     # label easyconfigs for new software and/or new easyconfigs for existing software
     labels = []

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -591,7 +591,7 @@ class EasyBuildOptions(GeneralOption):
             'close-pr-msg': ("Custom close message for pull request closed with --close-pr; ", str, 'store', None),
             'close-pr-reasons': ("Close reason for pull request closed with --close-pr; "
                                  "supported values: %s" % ", ".join(VALID_CLOSE_PR_REASONS), str, 'store', None),
-            'create-pr-branch': ("Create a new branch in GitHub in preparation for a PR", None, 'store_true', False),
+            'create-branch-github': ("Create new branch in GitHub in preparation for a PR", None, 'store_true', False),
             'list-prs': ("List pull requests", str, 'store_or_None',
                          ",".join([DEFAULT_LIST_PR_STATE, DEFAULT_LIST_PR_ORDER, DEFAULT_LIST_PR_DIREC]),
                          {'metavar': 'STATE,ORDER,DIRECTION'}),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -612,6 +612,7 @@ class EasyBuildOptions(GeneralOption):
             'review-pr': ("Review specified pull request", int, 'store', None, {'metavar': 'PR#'}),
             'test-report-env-filter': ("Regex used to filter out variables in environment dump of test report",
                                        None, 'regex', None),
+            'update-branch-github': ("Update specified branch in GitHub", str, 'store', None),
             'update-pr': ("Update an existing pull request", int, 'store', None, {'metavar': 'PR#'}),
             'upload-test-report': ("Upload full test report as a gist on GitHub", None, 'store_true', False, 'u'),
         })
@@ -1358,6 +1359,8 @@ def set_up_configuration(args=None, logfile=None, testing=False, silent=False):
     if not robot_path:
         print_warning("Robot search path is empty!")
 
+    new_update_opt = options.new_pr or options.new_pr_from_branch or options.update_branch_github or options.update_pr
+
     # configure & initialize build options
     config_options_dict = eb_go.get_options_by_section('config')
     build_options = {
@@ -1366,7 +1369,7 @@ def set_up_configuration(args=None, logfile=None, testing=False, silent=False):
         'external_modules_metadata': parse_external_modules_metadata(options.external_modules_metadata),
         'pr_path': pr_path,
         'robot_path': robot_path,
-        'silent': testing or options.new_pr or options.update_pr,
+        'silent': testing or new_update_opt,
         'try_to_generate': try_to_generate,
         'valid_stops': [x[0] for x in EasyBlock.get_steps()],
     }

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -591,11 +591,11 @@ class EasyBuildOptions(GeneralOption):
             'close-pr-msg': ("Custom close message for pull request closed with --close-pr; ", str, 'store', None),
             'close-pr-reasons': ("Close reason for pull request closed with --close-pr; "
                                  "supported values: %s" % ", ".join(VALID_CLOSE_PR_REASONS), str, 'store', None),
-            'create-branch-github': ("Create new branch in GitHub in preparation for a PR", None, 'store_true', False),
             'list-prs': ("List pull requests", str, 'store_or_None',
                          ",".join([DEFAULT_LIST_PR_STATE, DEFAULT_LIST_PR_ORDER, DEFAULT_LIST_PR_DIREC]),
                          {'metavar': 'STATE,ORDER,DIRECTION'}),
             'merge-pr': ("Merge pull request", int, 'store', None, {'metavar': 'PR#'}),
+            'new-branch-github': ("Create new branch in GitHub in preparation for a PR", None, 'store_true', False),
             'new-pr': ("Open a new pull request", None, 'store_true', False),
             'new-pr-from-branch': ("Open a new pull request from branch in GitHub", str, 'store', None),
             'pr-branch-name': ("Branch name to use for new PRs; '<timestamp>_new_pr_<name><version>' if unspecified",

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -591,11 +591,13 @@ class EasyBuildOptions(GeneralOption):
             'close-pr-msg': ("Custom close message for pull request closed with --close-pr; ", str, 'store', None),
             'close-pr-reasons': ("Close reason for pull request closed with --close-pr; "
                                  "supported values: %s" % ", ".join(VALID_CLOSE_PR_REASONS), str, 'store', None),
+            'create-pr-branch': ("Create a new branch in GitHub in preparation for a PR", None, 'store_true', False),
             'list-prs': ("List pull requests", str, 'store_or_None',
                          ",".join([DEFAULT_LIST_PR_STATE, DEFAULT_LIST_PR_ORDER, DEFAULT_LIST_PR_DIREC]),
                          {'metavar': 'STATE,ORDER,DIRECTION'}),
             'merge-pr': ("Merge pull request", int, 'store', None, {'metavar': 'PR#'}),
             'new-pr': ("Open a new pull request", None, 'store_true', False),
+            'new-pr-from-branch': ("Open a new pull request from branch in GitHub", str, 'store', None),
             'pr-branch-name': ("Branch name to use for new PRs; '<timestamp>_new_pr_<name><version>' if unspecified",
                                str, 'store', None),
             'pr-commit-msg': ("Commit message for new/updated pull request created with --new-pr", str, 'store', None),

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3168,18 +3168,20 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--sync-branch-with-develop=%s' % test_branch,
             '--dry-run',
         ]
-        txt, _ = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False)
+        stdout, stderr = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False)
+
+        self.assertFalse(stderr)
 
         github_path = r"boegel/easybuild-easyconfigs\.git"
         pattern = '\n'.join([
             r"== temporary log file in case of crash .*",
             r"== fetching branch '%s' from https://github\.com/%s\.\.\." % (test_branch, github_path),
             r"== pulling latest version of 'develop' branch from easybuilders/easybuild-easyconfigs\.\.\.",
-            r"== merging 'develop' branch into PR branch 'develop'\.\.\.",
-            r"== pushing branch 'develop' to remote '.*' \(git@github\.com:%s\) \[DRY RUN\]" % github_path,
+            r"== merging 'develop' branch into PR branch '%s'\.\.\." % test_branch,
+            r"== pushing branch '%s' to remote '.*' \(git@github\.com:%s\) \[DRY RUN\]" % (test_branch, github_path),
         ])
         regex = re.compile(pattern)
-        self.assertTrue(regex.match(txt), "Pattern '%s' doesn't match: %s" % (regex.pattern, txt))
+        self.assertTrue(regex.match(stdout), "Pattern '%s' doesn't match: %s" % (regex.pattern, stdout))
 
     def test_new_pr_python(self):
         """Check generated PR title for --new-pr on easyconfig that includes Python dependency."""

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2820,6 +2820,32 @@ class CommandLineOptionsTest(EnhancedTestCase):
             stderr_txt = stderr_txt.strip()
         return stdout_txt, stderr_txt
 
+    def test_create_branch_github(self):
+        """Test for --create-branch-github."""
+        if self.github_token is None:
+            print("Skipping test_create_branch_github, no GitHub token available?")
+            return
+
+        topdir = os.path.dirname(os.path.abspath(__file__))
+        test_ecs = os.path.join(topdir, 'easyconfigs', 'test_ecs')
+        toy_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
+
+        args = [
+            '--create-branch-github',
+            '--github-user=%s' % GITHUB_TEST_ACCOUNT,
+            toy_ec,
+            '-D',
+        ]
+        txt, _ = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False)
+
+        remote = 'git@github.com:%s/easybuild-easyconfigs.git' % GITHUB_TEST_ACCOUNT
+        regexs = [
+            r"^== fetching branch 'develop' from https://github.com/easybuilders/easybuild-easyconfigs.git\.\.\.",
+            r"^== copying easyconfigs to .*/easybuild-easyconfigs\.\.\.",
+            r"^== pushing branch '.*' to remote '.*' \(%s\) \[DRY RUN\]" % remote,
+        ]
+        self._assert_regexs(regexs, txt)
+
     def test_new_update_pr(self):
         """Test use of --new-pr (dry run only)."""
         if self.github_token is None:

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2846,6 +2846,44 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         self._assert_regexs(regexs, txt)
 
+    def test_new_pr_from_branch(self):
+        """Test --new-pr-from-branch."""
+        if self.github_token is None:
+            print("Skipping test_new_pr_from_branch, no GitHub token available?")
+            return
+
+        # see https://github.com/boegel/easybuild-easyconfigs/tree/test_new_pr_from_branch_DO_NOT_REMOVE
+        # branch created specifically for this test,
+        # only adds toy-0.0.eb test easyconfig compared to central develop branch
+        test_branch = 'test_new_pr_from_branch_DO_NOT_REMOVE'
+
+        args = [
+            '--new-pr-from-branch=%s' % test_branch,
+            '--github-user=%s' % GITHUB_TEST_ACCOUNT,  # used to get GitHub token
+            '--github-org=boegel',  # used to determine account to grab branch from
+            '-D',
+        ]
+        txt, _ = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False)
+
+        regexs = [
+            r"^== fetching branch '%s' from https://github.com/boegel/easybuild-easyconfigs.git\.\.\." % test_branch,
+            r"^== syncing 'test_new_pr_from_branch_DO_NOT_REMOVE' with current 'easybuilders/develop' branch\.\.\.",
+            r"^== pulling latest version of 'develop' branch from easybuilders/easybuild-easyconfigs\.\.\.",
+            r"^== merging 'develop' branch into PR branch 'test_new_pr_from_branch_DO_NOT_REMOVE'\.\.\.",
+            r"^== checking out target branch 'easybuilders/develop'\.\.\.",
+            r"^== determining metadata for pull request based on changed files\.\.\.",
+            r"^== found 1 changed file\(s\) in 'boegel/test_new_pr_from_branch_DO_NOT_REMOVE' " +
+            "relative to 'easybuilders/develop':$",
+            r"^\* 1 new/changed easyconfig file\(s\):\n  easybuild/easyconfigs/t/toy/toy-0\.0\.eb",
+            r"^== checking out PR branch 'boegel/test_new_pr_from_branch_DO_NOT_REMOVE'\.\.\.$",
+            r"\* target: easybuilders/easybuild-easyconfigs:develop$",
+            r"^\* from: boegel/easybuild-easyconfigs:test_new_pr_from_branch_DO_NOT_REMOVE$",
+            r'^\* title: "\{tools\}\[system/system\] toy v0\.0"$',
+            r"^ 1 file changed, 32 insertions\(\+\)$",
+            r"^\* overview of changes:\n  easybuild/easyconfigs/t/toy/toy-0\.0\.eb | 32",
+        ]
+        self._assert_regexs(regexs, txt)
+
     def test_new_update_pr(self):
         """Test use of --new-pr (dry run only)."""
         if self.github_token is None:

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3053,7 +3053,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             r"== temporary log file in case of crash .*",
             r"== Determined branch name corresponding to easybuilders/easybuild-easyconfigs PR #9150: develop",
             r"== fetching branch 'develop' from https://github\.com/%s\.\.\." % github_path,
-            r"== pulling latest version of 'easybuilders' branch from easybuild-easyconfigs/develop\.\.\.",
+            r"== pulling latest version of 'develop' branch from easybuilders/easybuild-easyconfigs\.\.\.",
             r"== merging 'develop' branch into PR branch 'develop'\.\.\.",
             r"== pushing branch 'develop' to remote '.*' \(git@github\.com:%s\) \[DRY RUN\]" % github_path,
         ])

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2884,6 +2884,35 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         self._assert_regexs(regexs, txt)
 
+    def test_update_branch_github(self):
+        """Test --update-branch-github."""
+        if self.github_token is None:
+            print("Skipping test_update_branch_github, no GitHub token available?")
+            return
+
+        topdir = os.path.dirname(os.path.abspath(__file__))
+        test_ecs = os.path.join(topdir, 'easyconfigs', 'test_ecs')
+        toy_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
+
+        args = [
+            '--update-branch-github=develop',
+            '--github-user=boegel',  # used to determine account to grab branch from (no GitHub token needed)
+            toy_ec,
+            '--pr-commit-msg="this is just a test"',
+            '-D',
+        ]
+        txt, _ = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False)
+
+        full_repo = 'boegel/easybuild-easyconfigs'
+        regexs = [
+            r"^== fetching branch 'develop' from https://github.com/%s.git\.\.\." % full_repo,
+            r"^== copying easyconfigs to .*/git-working-dir.*/easybuild-easyconfigs...",
+            r"^== pushing branch 'develop' to remote '.*' \(git@github.com:%s.git\) \[DRY RUN\]" % full_repo,
+            r"^Overview of changes:\n.*/easyconfigs/t/toy/toy-0.0.eb \| 32",
+            r"== pushed updated branch 'develop' to boegel/easybuild-easyconfigs \[DRY RUN\]",
+        ]
+        self._assert_regexs(regexs, txt)
+
     def test_new_update_pr(self):
         """Test use of --new-pr (dry run only)."""
         if self.github_token is None:
@@ -3067,9 +3096,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
             r"^== fetching branch 'develop' from https://github.com/easybuilders/easybuild-easyconfigs.git...",
             r".*/toy-0.0-gompi-2018a-test.eb\s*\|",
             r"^\s*1 file(s?) changed",
-            "^== pushing branch 'develop' to remote '.*' \(git@github.com:easybuilders/easybuild-easyconfigs.git\)",
-            r"^Updated easybuilders/easybuild-easyconfigs PR #2237 "
-            "by pushing to branch easybuilders/develop \[DRY RUN\]",
+            r"^== pushing branch 'develop' to remote '.*' \(git@github.com:easybuilders/easybuild-easyconfigs.git\)",
+            r"^== pushed updated branch 'develop' to easybuilders/easybuild-easyconfigs \[DRY RUN\]",
+            r"^== updated https://github.com/easybuilders/easybuild-easyconfigs/pull/2237 \[DRY RUN\]",
         ]
         self._assert_regexs(regexs, txt)
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2820,8 +2820,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             stderr_txt = stderr_txt.strip()
         return stdout_txt, stderr_txt
 
-    def test_create_branch_github(self):
-        """Test for --create-branch-github."""
+    def test_new_branch_github(self):
+        """Test for --new-branch-github."""
         if self.github_token is None:
             print("Skipping test_create_branch_github, no GitHub token available?")
             return
@@ -2831,7 +2831,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         toy_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
 
         args = [
-            '--create-branch-github',
+            '--new-branch-github',
             '--github-user=%s' % GITHUB_TEST_ACCOUNT,
             toy_ec,
             '-D',


### PR DESCRIPTION
This PR re-organizes the code in `github.py` quite a bit, to allow adding support for `--new-branch-github` and `--new-pr-from-branch`:

* `new_pr` was broken up into `new_branch_github` and `new_pr_from_branch`
* `sync_with_develop` function is fleshed out from `sync_pr_with_develop`, and used in `new_pr_from_branch` to figure out the list of changed files in the branch relative to current `develop`
* title, descr & commit msg are now passed to `new_pr` via `build_option` (mainly for consistency reasons)

The idea is to allow contributors to first push a new branch to GitHub without creating the corresponding PR to `develop` (using `eb --new-branch-github ...`), to check if the tests that are run in GitHub CI pass, and only actually open the PR when the tests pass (using `eb --new-pr-from-branch`).

edit: More changes, with the help of @migueldiascosta:

* added support for `--update-branch-github` (by fleshing out `update_branch` from `update_pr`)
* added support for `--sync-branch-with-develop` (by fleshing out `sync_branch_with_develop` from `sync_pr_with_develop`)