### PR TITLE
fix broken test_show_system_info on macOS due to 'Python' binary

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -4320,7 +4320,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             "^  -> features: ",
             "^\* software:$",
             "^  -> glibc version: ",
-            "^  -> Python binary: .*/python[0-9]?",
+            "^  -> Python binary: .*/[pP]ython[0-9]?",
             "^  -> Python version: [0-9.]+",
         ]
         for pattern in patterns:


### PR DESCRIPTION
For some mysterious reason, `sys.executable` on macOS points to a `Python` binary, rather than `python` as expected by the current `test_show_system_info`:

```
$ python -c 'import sys; print sys.executable'
/System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python
```

So, trivial fix to make sure the test keeps passing on `macOS`...