### PR TITLE
make including 'extensions' statement in generated Lua module files opt-in for now

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -228,6 +228,7 @@ BUILD_OPTIONS_CMDLINE = {
         'lib64_fallback_sanity_check',
         'logtostdout',
         'minimal_toolchains',
+        'module_extensions',
         'module_only',
         'package',
         'read_only_installdir',

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -1159,13 +1159,14 @@ class ModuleGeneratorLua(ModuleGenerator):
         for line in self._generate_whatis_lines():
             whatis_lines.append("whatis(%s%s%s)" % (self.START_STR, self.check_str(line), self.END_STR))
 
-        extensions_list = self._generate_extensions_list()
+        if build_option('module_extensions'):
+            extensions_list = self._generate_extensions_list()
 
-        if extensions_list:
-            extensions_stmt = 'extensions(%s)' % ', '.join(['"%s"' % x for x in extensions_list])
-            # put this behind a Lmod version check as 'extensions' is only supported since Lmod 8.2.0,
-            # see https://lmod.readthedocs.io/en/latest/330_extensions.html#module-extensions
-            lines.extend(['', self.conditional_statement(self.check_version("8", "2"), extensions_stmt)])
+            if extensions_list:
+                extensions_stmt = 'extensions(%s)' % ', '.join(['"%s"' % x for x in extensions_list])
+                # put this behind a Lmod version check as 'extensions' is only supported since Lmod 8.2.0,
+                # see https://lmod.readthedocs.io/en/latest/330_extensions.html#module-extensions
+                lines.extend(['', self.conditional_statement(self.check_version("8", "2"), extensions_stmt)])
 
         txt += '\n'.join([''] + lines + ['']) % {
             'name': self.app.name,

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -475,6 +475,8 @@ class EasyBuildOptions(GeneralOption):
             'module-depends-on': ("Use depends_on (Lmod 7.6.1+) for dependencies in all generated modules "
                                   "(implies recursive unloading of modules).",
                                   None, 'store_true', False),
+            'module-extensions': ("Include 'extensions' statement in generated module file (Lua syntax only)",
+                                  None, 'store_true', False),
             'module-naming-scheme': ("Module naming scheme to use", None, 'store', DEFAULT_MNS),
             'module-syntax': ("Syntax to be used for module files", 'choice', 'store', DEFAULT_MODULE_SYNTAX,
                               sorted(avail_module_generators().keys())),

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -701,6 +701,9 @@ class ModuleGeneratorTest(EnhancedTestCase):
         if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
             return
 
+        # currently requires opt-in via --module-extensions
+        init_config(build_options={'module_extensions': True})
+
         test_dir = os.path.abspath(os.path.dirname(__file__))
         os.environ['MODULEPATH'] = os.path.join(test_dir, 'modules')
         test_ec = os.path.join(test_dir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0-gompi-2018a-test.eb')


### PR DESCRIPTION
Lmod apparently chokes on a module file is the list of extensions is too long (which is the case for `Perl`) after including an `extensions` statement (see @wpoely86's PR #3085):
```
== 2019-11-30 08:50:24,617 build_log.py:164 ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:124 in __init__): Module command 'module load Perl/5.30.0-GCCcore-8.3.0' failed with exit code 1; stderr: Lmod has detected the following error: Unable to load module because of error when evaluating modulefile:
     /tmp/eb-idlfoc6k/tmp2s1c6_jv/all/Perl/5.30.0-GCCcore-8.3.0.lua: [string "help([==[..."]:118: function or expression needs too many registers near '"Test::Simple/1.302168"'
     Please check the modulefile and especially if there is a the line number specified in the above message
While processing the following module(s):
    Module fullname            Module Filename
    ---------------            ---------------
    Perl/5.30.0-GCCcore-8.3.0  /tmp/eb-idlfoc6k/tmp2s1c6_jv/all/Perl/5.30.0-GCCcore-8.3.0.lua
; stdout:
false
 (at easybuild/tools/modules.py:758 in run_module)
```

It may have something to do with the complete module file being too large, since we include the list of extensions 3 times now (in description, in `whatis`, in `extensions`)...

So for now, let's make including an `extensions` statement in the generated module file opt-in, until we figure out this issue (or have a fix in Lmod).