### PR TITLE
take into account that dependency version could be a dict rather than a string value in template_constant_dict

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -68,7 +68,7 @@ from easybuild.tools.module_naming_scheme.utilities import avail_module_naming_s
 from easybuild.tools.module_naming_scheme.utilities import det_hidden_modname, is_valid_module_name
 from easybuild.tools.modules import modules_tool
 from easybuild.tools.py2vs3 import OrderedDict, create_base_metaclass, string_type
-from easybuild.tools.systemtools import check_os_dependency, get_cpu_architecture
+from easybuild.tools.systemtools import check_os_dependency, pick_dep_version
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME, is_system_toolchain
 from easybuild.tools.toolchain.toolchain import TOOLCHAIN_CAPABILITIES, TOOLCHAIN_CAPABILITY_CUDA
 from easybuild.tools.toolchain.utilities import get_toolchain, search_toolchain
@@ -1231,31 +1231,6 @@ class EasyConfig(object):
 
         return multi_deps
 
-    def find_dep_version_match(self, dep_version):
-        """Identify the correct version for this system from the choices provided. This returns the version to use."""
-        if isinstance(dep_version, string_type):
-            self.log.debug("Version is already a string ('%s'), OK", dep_version)
-            return dep_version
-        elif dep_version is None:
-            self.log.debug("Version is None, OK")
-            return None
-        elif isinstance(dep_version, dict):
-            # figure out matches based on dict keys (after splitting on '=')
-            my_arch_key = 'arch=%s' % get_cpu_architecture()
-            arch_keys = [x for x in dep_version.keys() if x.startswith('arch=')]
-            other_keys = [x for x in dep_version.keys() if x not in arch_keys]
-            if other_keys:
-                raise EasyBuildError("Unexpected keys in version: %s. Only 'arch=' keys are supported", other_keys)
-            if arch_keys:
-                if my_arch_key in dep_version:
-                    ver = dep_version[my_arch_key]
-                    self.log.info("Version selected from %s using key %s: %s", dep_version, my_arch_key, ver)
-                    return ver
-                else:
-                    raise EasyBuildError("No matches for version in %s (looking for %s)", dep_version, my_arch_key)
-
-        raise EasyBuildError("Unknown value type for version: %s", dep_version)
-
     # private method
     def _parse_dependency(self, dep, hidden=False, build_only=False):
         """
@@ -1337,7 +1312,7 @@ class EasyConfig(object):
             raise EasyBuildError("Dependency %s of unsupported type: %s", dep, type(dep))
 
         # Find the version to use on this system
-        dependency['version'] = self.find_dep_version_match(dependency['version'])
+        dependency['version'] = pick_dep_version(dependency['version'])
 
         if dependency['external_module']:
             # check whether the external module is hidden

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -38,7 +38,7 @@ import platform
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.py2vs3 import string_type
-from easybuild.tools.systemtools import get_shared_lib_ext
+from easybuild.tools.systemtools import get_shared_lib_ext, pick_dep_version
 
 
 _log = fancylogger.getLogger('easyconfig.templates', fname=False)
@@ -228,6 +228,7 @@ def template_constant_dict(config, ignore=None, skip_lower=None):
                 raise EasyBuildError("Unexpected type for dependency: %s", dep)
 
             if isinstance(dep_name, string_type) and dep_name.lower() == name.lower():
+                dep_version = pick_dep_version(dep_version)
                 template_values['%sver' % pref] = dep_version
                 dep_version_parts = dep_version.split('.')
                 template_values['%smajver' % pref] = dep_version_parts[0]

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -52,7 +52,7 @@ from easybuild.framework.easyconfig.easyconfig import is_generic_easyblock, get_
 from easybuild.framework.easyconfig.easyconfig import letter_dir_for, process_easyconfig, resolve_template
 from easybuild.framework.easyconfig.easyconfig import triage_easyconfig_params, verify_easyconfig_filename
 from easybuild.framework.easyconfig.licenses import License, LicenseGPLv3
-from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconfig
+from easybuild.framework.easyconfig.parser import EasyConfigParser, fetch_parameters_from_easyconfig
 from easybuild.framework.easyconfig.templates import template_constant_dict, to_template_str
 from easybuild.framework.easyconfig.style import check_easyconfigs_style
 from easybuild.framework.easyconfig.tools import categorize_files_by_type, check_sha256_checksums, dep_graph
@@ -2582,11 +2582,10 @@ class EasyConfigTest(EnhancedTestCase):
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         write_file(test_ec, toy_ec_txt)
 
-        ec = EasyConfig(test_ec)
+        # only perform shallow/quick parse (as is done in list_software function)
+        ec = EasyConfigParser(filename=test_ec).get_config_dict()
 
         expected = {
-            'bitbucket_account': 'toy',
-            'github_account': 'toy',
             'javamajver': '1',
             'javashortver': '1.8',
             'javaver': '1.8.0_221',
@@ -2596,7 +2595,6 @@ class EasyConfigTest(EnhancedTestCase):
             'toolchain_name': 'system',
             'toolchain_version': 'system',
             'nameletterlower': 't',
-            'parallel': None,
             'pymajver': '3',
             'pyshortver': '3.7',
             'pyver': '3.7.2',
@@ -2604,7 +2602,6 @@ class EasyConfigTest(EnhancedTestCase):
             'version_major': '0',
             'version_major_minor': '0.01',
             'version_minor': '01',
-            'versionprefix': '',
             'versionsuffix': '-deps',
         }
         res = template_constant_dict(ec)


### PR DESCRIPTION
`template_constant_dict` didn't take into account yet that dependency versions can now also be dictionaries (see https://github.com/easybuilders/easybuild-framework/pull/3047), which results in this crash when running `eb --list-software` when it hits the modified `Java` easyconfig from https://github.com/easybuilders/easybuild-easyconfigs/pull/9081:

```
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Volumes/work/easybuild-framework/easybuild/main.py", line 485, in <module>
    main()
  File "/Volumes/work/easybuild-framework/easybuild/main.py", line 256, in main
    print(list_software(output_format=options.output_format, detailed=options.list_software == 'detailed'))
  File "easybuild/tools/docs.py", line 544, in list_software
    template_values = template_constant_dict(ec)
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyconfig/templates.py", line 232, in template_constant_dict
    dep_version_parts = dep_version.split('.')
AttributeError: 'dict' object has no attribute 'split'
```