### PR TITLE
Add check_log_for_errors to detect and handle multiple errors

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -539,7 +539,7 @@ def parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp):
     if use_regexp or regexp:
         res = parse_log_for_error(stdouterr, regexp, msg="Command used: %s" % cmd)
         if len(res) > 0:
-            message = "Found %s errors in command output (output: %s)" % (len(res), ", ".join([r[0] for r in res]))
+            message = "Found %s errors in command output (output: %s)" % (len(res), "\n\t".join([r[0] for r in res]))
             if use_regexp:
                 raise EasyBuildError(message)
             else:
@@ -643,7 +643,7 @@ def check_log_for_errors(log_txt, reg_exps):
     errors_found_in_log += len(warnings) + len(errors)
     if warnings:
         _log.warning("Found %s potential error(s) in command output (output: %s)",
-                     len(warnings), ", ".join(warnings))
+                     len(warnings), "\n\t".join(warnings))
     if errors:
         raise EasyBuildError("Found %s error(s) in command output (output: %s)",
-                             len(errors), ", ".join(errors))
+                             len(errors), "\n\t".join(errors))

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -600,8 +600,10 @@ def extract_errors_from_log(log_txt, reg_exps):
     :return (warnings, errors) as lists of lines containing a match
     """
 
-    # Avoid accidentally passing a single element
-    assert isinstance(reg_exps, list), "reg_exps must be a list"
+    # promote single string value to list, since code below expects a list
+    if isinstance(reg_exps, string_type):
+        reg_exps = [reg_exps]
+
     re_tuples = []
     for cur in reg_exps:
         try:
@@ -614,6 +616,7 @@ def extract_errors_from_log(log_txt, reg_exps):
             re_tuples.append((re.compile(reg_exp), action))
         except Exception as e:
             raise EasyBuildError("Invalid input: No RegExp or tuple of RegExp and action '%s' (%s)", str(cur), e)
+
     warnings = []
     errors = []
     for line in log_txt.split('\n'):

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -593,7 +593,8 @@ def parse_log_for_error(txt, regExp=None, stdout=True, msg=None):
 
 def extract_errors_from_log(log_txt, reg_exps):
     """
-    Check log_txt for messages matching regExps and return warnings and errors
+    Check provided string (command output) for messages matching specified regular expressions,
+    and return 2-tuple with list of warnings and errors.
     :param log_txt: String containing the log, will be split into individual lines
     :param reg_exps: List of: regular expressions (as strings) to error on,
                     or tuple of regular expression and action (any of [IGNORE, WARN, ERROR])
@@ -609,16 +610,21 @@ def extract_errors_from_log(log_txt, reg_exps):
     for cur in reg_exps:
         try:
             if isinstance(cur, str):
+                # use ERROR as default action if only regexp pattern is specified
                 reg_exp, action = cur, ERROR
-            else:
+            elif isinstance(cur, tuple) and len(cur) == 2:
                 reg_exp, action = cur
+            else:
+                raise TypeError("Incorrect type of value, expected string or 2-tuple")
+
             if not isinstance(reg_exp, str):
-                raise TypeError("RegExp must be passed as string")
+                raise TypeError("Regular expressions must be passed as string, got %s" % type(reg_exp))
             if action not in actions:
-                raise TypeError("action must be one of %s" % action)
+                raise TypeError("action must be one of %s, got %s" % (actions, action))
+
             re_tuples.append((re.compile(reg_exp), action))
-        except Exception as e:
-            raise EasyBuildError("Invalid input: No RegExp or tuple of RegExp and action '%s' (%s)", str(cur), e)
+        except Exception as err:
+            raise EasyBuildError("Invalid input: No regexp or tuple of regexp and action '%s': %s", str(cur), err)
 
     warnings = []
     errors = []

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -599,6 +599,7 @@ def extract_errors_from_log(log_txt, reg_exps):
                     or tuple of regular expression and action (any of [IGNORE, WARN, ERROR])
     :return (warnings, errors) as lists of lines containing a match
     """
+    actions = (IGNORE, WARN, ERROR)
 
     # promote single string value to list, since code below expects a list
     if isinstance(reg_exps, string_type):
@@ -611,8 +612,10 @@ def extract_errors_from_log(log_txt, reg_exps):
                 reg_exp, action = cur, ERROR
             else:
                 reg_exp, action = cur
-            if not isinstance(reg_exp, str) or action not in (IGNORE, WARN, ERROR):
-                raise TypeError("Invalid types")
+            if not isinstance(reg_exp, str):
+                raise TypeError("RegExp must be passed as string")
+            if action not in actions:
+                raise TypeError("action must be one of %s" % action)
             re_tuples.append((re.compile(reg_exp), action))
         except Exception as e:
             raise EasyBuildError("Invalid input: No RegExp or tuple of RegExp and action '%s' (%s)", str(cur), e)

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -544,38 +544,38 @@ class RunTest(EnhancedTestCase):
             "enabling -Werror",
             "the process crashed with 0"
         ])
-        expected_error_msg = r"Found 2 error\(s\) in command output "\
-                             r"\(output: error found\n\tthe process crashed with 0\)"
+        expected_msg = r"Found 2 error\(s\) in command output "\
+                       r"\(output: error found\n\tthe process crashed with 0\)"
 
         # String promoted to list
-        self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text,
+        self.assertErrorRegex(EasyBuildError, expected_msg, check_log_for_errors, input_text,
                               r"\b(error|crashed)\b")
         # List of string(s)
-        self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text,
+        self.assertErrorRegex(EasyBuildError, expected_msg, check_log_for_errors, input_text,
                               [r"\b(error|crashed)\b"])
         # List of tuple(s)
-        self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text,
+        self.assertErrorRegex(EasyBuildError, expected_msg, check_log_for_errors, input_text,
                               [(r"\b(error|crashed)\b", ERROR)])
 
-        expected_error_msg = "Found 2 potential error(s) in command output " \
-                             "(output: error found\n\tthe process crashed with 0)"
+        expected_msg = "Found 2 potential error(s) in command output " \
+                       "(output: error found\n\tthe process crashed with 0)"
         init_logging(logfile, silent=True)
         check_log_for_errors(input_text, [(r"\b(error|crashed)\b", WARN)])
         stop_logging(logfile)
-        self.assertTrue(expected_error_msg in read_file(logfile))
+        self.assertTrue(expected_msg in read_file(logfile))
 
-        expected_error_msg = r"Found 2 error\(s\) in command output \(output: error found\n\ttest failed\)"
+        expected_msg = r"Found 2 error\(s\) in command output \(output: error found\n\ttest failed\)"
         write_file(logfile, '')
         init_logging(logfile, silent=True)
-        self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text, [
+        self.assertErrorRegex(EasyBuildError, expected_msg, check_log_for_errors, input_text, [
             r"\berror\b",
             (r"\ballowed-test failed\b", IGNORE),
             (r"(?i)\bCRASHED\b", WARN),
             "fail"
         ])
         stop_logging(logfile)
-        expected_error_msg = "Found 1 potential error(s) in command output (output: the process crashed with 0)"
-        self.assertTrue(expected_error_msg in read_file(logfile))
+        expected_msg = "Found 1 potential error(s) in command output (output: the process crashed with 0)"
+        self.assertTrue(expected_msg in read_file(logfile))
 
 
 def suite():

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -540,8 +540,13 @@ class RunTest(EnhancedTestCase):
         ])
         expected_error_msg = r"Found 2 error\(s\) in command output \(output: error found, the process crashed with 0\)"
 
+        # String promoted to list
+        self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text,
+                              r"\b(error|crashed)\b")
+        # List of string(s)
         self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text,
                               [r"\b(error|crashed)\b"])
+        # List of tuple(s)
         self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text,
                               [(r"\b(error|crashed)\b", ERROR)])
 

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -46,7 +46,13 @@ import easybuild.tools.asyncprocess as asyncprocess
 import easybuild.tools.utilities
 from easybuild.tools.build_log import EasyBuildError, init_logging, stop_logging
 from easybuild.tools.filetools import adjust_permissions, read_file, write_file
-from easybuild.tools.run import get_output_from_process, run_cmd, run_cmd_qa, parse_log_for_error, check_log_for_errors
+from easybuild.tools.run import (
+    check_log_for_errors,
+    get_output_from_process,
+    run_cmd,
+    run_cmd_qa,
+    parse_log_for_error,
+)
 from easybuild.tools.config import ERROR, IGNORE, WARN
 
 
@@ -538,7 +544,8 @@ class RunTest(EnhancedTestCase):
             "enabling -Werror",
             "the process crashed with 0"
         ])
-        expected_error_msg = r"Found 2 error\(s\) in command output \(output: error found\n\tthe process crashed with 0\)"
+        expected_error_msg = r"Found 2 error\(s\) in command output "\
+                             r"\(output: error found\n\tthe process crashed with 0\)"
 
         # String promoted to list
         self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text,

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -538,7 +538,7 @@ class RunTest(EnhancedTestCase):
             "enabling -Werror",
             "the process crashed with 0"
         ])
-        expected_error_msg = r"Found 2 error\(s\) in command output \(output: error found, the process crashed with 0\)"
+        expected_error_msg = r"Found 2 error\(s\) in command output \(output: error found\n\tthe process crashed with 0\)"
 
         # String promoted to list
         self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text,
@@ -551,13 +551,13 @@ class RunTest(EnhancedTestCase):
                               [(r"\b(error|crashed)\b", ERROR)])
 
         expected_error_msg = "Found 2 potential error(s) in command output " \
-                             "(output: error found, the process crashed with 0)"
+                             "(output: error found\n\tthe process crashed with 0)"
         init_logging(logfile, silent=True)
         check_log_for_errors(input_text, [(r"\b(error|crashed)\b", WARN)])
         stop_logging(logfile)
         self.assertTrue(expected_error_msg in read_file(logfile))
 
-        expected_error_msg = r"Found 2 error\(s\) in command output \(output: error found, test failed\)"
+        expected_error_msg = r"Found 2 error\(s\) in command output \(output: error found\n\ttest failed\)"
         write_file(logfile, '')
         init_logging(logfile, silent=True)
         self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text, [

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -538,40 +538,31 @@ class RunTest(EnhancedTestCase):
             "enabling -Werror",
             "the process crashed with 0"
         ])
-        expected_error_msg = r"Found 2 errors in command output \(output: error found, the process crashed with 0\)"
+        expected_error_msg = r"Found 2 error\(s\) in command output \(output: error found, the process crashed with 0\)"
 
         self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text,
                               [r"\b(error|crashed)\b"])
         self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text,
-                              [re.compile(r"\b(error|crashed)\b")])
-        self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text,
                               [(r"\b(error|crashed)\b", ERROR)])
-        self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text,
-                              [(re.compile(r"\b(error|crashed)\b"), ERROR)])
 
-        expected_error_msg = "Found 2 potential errors in command output " \
+        expected_error_msg = "Found 2 potential error(s) in command output " \
                              "(output: error found, the process crashed with 0)"
         init_logging(logfile, silent=True)
         check_log_for_errors(input_text, [(r"\b(error|crashed)\b", WARN)])
         stop_logging(logfile)
         self.assertTrue(expected_error_msg in read_file(logfile))
-        write_file(logfile, '')
-        init_logging(logfile, silent=True)
-        check_log_for_errors(input_text, [(re.compile(r"\b(error|crashed)\b"), WARN)])
-        stop_logging(logfile)
-        self.assertTrue(expected_error_msg in read_file(logfile))
 
-        expected_error_msg = r"Found 2 errors in command output \(output: error found, test failed\)"
+        expected_error_msg = r"Found 2 error\(s\) in command output \(output: error found, test failed\)"
         write_file(logfile, '')
         init_logging(logfile, silent=True)
         self.assertErrorRegex(EasyBuildError, expected_error_msg, check_log_for_errors, input_text, [
             r"\berror\b",
             (r"\ballowed-test failed\b", IGNORE),
-            (re.compile(r"\bCRASHED\b", re.I), WARN),
+            (r"(?i)\bCRASHED\b", WARN),
             "fail"
         ])
         stop_logging(logfile)
-        expected_error_msg = "Found 1 potential errors in command output (output: the process crashed with 0)"
+        expected_error_msg = "Found 1 potential error(s) in command output (output: the process crashed with 0)"
         self.assertTrue(expected_error_msg in read_file(logfile))
 
 


### PR DESCRIPTION
In preparation for https://github.com/easybuilders/easybuild-easyblocks/issues/157 I created this PoC.

The specification is (as documented):

```
    Check logTxt for messages matching regExps in order and do appropriate action
    :param logTxt: String containing the log, will be split into individual lines
    :param regExps: List of: regular expressions (as RE or string) to error on,
                    or tuple of regular expression and action (any of [IGNORE, WARN, ERROR])
```

In the end you'll get (if appropriate) a logged warning and an exception about the found issues.

I guess this function could even be split: 1 that returns the `(warnings, errors)` tuple and one that also increases `errors_found_in_log`, logs the warning and raises the exception (which would be the most common usage), but the name `parse_log_for_error` is already taken. Maybe name it `parse_log_for_errors`? The "old" `parse_log_for_error` can be implemented in terms of that but in can probably be simply deprecated. It is strange, does to much and yet almost nothing. Similar for `parse_cmd_output`. So for backwards compatibility I'd rather have EasyBlocks call `check_log_for_errors` directly and pass `None` as the `regExp` to `run_cmd* `