### PR TITLE
ignore imports from vsc namespace made from pkgutil.py

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1902,6 +1902,7 @@ def install_fake_vsc():
     fake_vsc_path = os.path.join(tempfile.mkdtemp(prefix='fake_vsc_'))
 
     fake_vsc_init = '\n'.join([
+        'import os',
         'import sys',
         'import inspect',
         '',
@@ -1914,10 +1915,15 @@ def install_fake_vsc():
         '        filename, lineno = cand_filename, cand_lineno',
         '        break',
         '',
-        'sys.stderr.write("\\nERROR: Detected import from \'vsc\' namespace in %s (line %s)\\n" % (filename, lineno))',
-        'sys.stderr.write("vsc-base & vsc-install were ingested into the EasyBuild framework in EasyBuild v4.0\\n")',
-        'sys.stderr.write("The functionality you need may be available in the \'easybuild.base.*\' namespace.\\n")',
-        'sys.exit(1)',
+        '# ignore imports from pkgutil.py (part of Python standard library),',
+        '# which may happen due to a system-wide installation of vsc-base',
+        '# even if it is not actually actively used...',
+        'if os.path.basename(filename) != "pkgutil.py":',
+        '    error_msg = "\\nERROR: Detected import from \'vsc\' namespace in %s (line %s)\\n" % (filename, lineno)',
+        '    error_msg += "vsc-base & vsc-install were ingested into the EasyBuild framework in EasyBuild v4.0\\n"',
+        '    error_msg += "The functionality you need may be available in the \'easybuild.base.*\' namespace.\\n"',
+        '    sys.stderr.write(error_msg)',
+        '    sys.exit(1)',
     ])
 
     fake_vsc_init_path = os.path.join(fake_vsc_path, 'vsc', '__init__.py')


### PR DESCRIPTION
The fake `vsc` Python package that is put in place after `vsc-base` was ingested (see #2790) apparently gets tripped by `pkgutil` (part of Python standard library) in some situations (probably when a `vsc-base` is installed system-wide), see https://lists.ugent.be/wws/arc/easybuild/2019-12/msg00044.html.

There's no point in exiting with an error in that case, so let's ignore imports from `vsc` triggered by `pkgutil.py`...