### PR TITLE
Add a check for files not existing in the verify_checksum function

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -771,6 +771,10 @@ def verify_checksum(path, checksums):
 
     filename = os.path.basename(path)
 
+    # if file does not exist (typo) report it as such
+    if not os.path.isfile(filename):
+        raise EasyBuildError("File %s does not exist", filename)
+
     # if no checksum is provided, pretend checksum to be valid, unless presence of checksums to verify is enforced
     if checksums is None:
         if build_option('enforce_checksums'):

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -772,8 +772,8 @@ def verify_checksum(path, checksums):
     filename = os.path.basename(path)
 
     # if file does not exist (typo) report it as such
-    if not os.path.isfile(filename):
-        raise EasyBuildError("File %s does not exist", filename)
+    if not os.path.isfile(path):
+        raise EasyBuildError("File %s does not exist", path)
 
     # if no checksum is provided, pretend checksum to be valid, unless presence of checksums to verify is enforced
     if checksums is None:


### PR DESCRIPTION
Before the patch I got this error for a patch file when its name was not correct in the easyconfig file:
```ERROR: Build of /scicore/home/scicore/easybuild/easyconfigs/PSIPRED/PSIPRED-4.02-foss-2018b-BLAST-2.2.26.eb failed (err: 'build failed (first 300 chars): Checksum verification for /export/soft/source/p/PSIPRED/PSIRED-scripts-path.patch using ed712bb2d536ebe4d4acf18a1c75ab253915dc8f77c1c12a37a5183fbfb6510f failed.')```

After the change, the error points to the filename and not the checksum:
```ERROR: Build of /scicore/home/scicore/easybuild/easyconfigs/PSIPRED/PSIPRED-4.02-foss-2018b-BLAST-2.2.26.eb failed (err: 'build failed (first 300 chars): File PSIRED-scripts-path.patch does not exist')```