### PR TITLE
increase default number of chars/bytes read in asyncprocess.Popen

### DIFF
--- a/easybuild/tools/asyncprocess.py
+++ b/easybuild/tools/asyncprocess.py
@@ -89,7 +89,7 @@ class Popen(subprocess.Popen):
 
     def get_conn_maxsize(self, which, maxsize):
         if maxsize is None:
-            maxsize = 1024
+            maxsize = 10240
         elif maxsize < 1:
             maxsize = 1
         return getattr(self, which), maxsize


### PR DESCRIPTION
I was grinding my teeth on trying to figure out why the interactive `./configure` command that is run while installing `WRF` was failing when running EasyBuild on top of Python 3, and it turns out it boils down to a too small default number of bytes/characters that is read every time the output of the interactive command is read.

It seems that if the command produces a significant amount of output shortly after it was started, only the first chunk of the output (basically exactly the first 1024 characters) is picked up when running on top of Python 3. Subsequent polls then don't receive the rest of the output (which is where the actual bug is, probably).

It's not entirely clear yet why to me this happens, it doesn't occur at all when using Python 2 (in fact, there it seems that all output is received at the first poll, even though it's significantly more than 1204 characters, it's on the order of 3.5k).
I hope to dive in deeper some other time, but for now this fix will have to do.

The current default of only picking up max. 1024 bytes/characters seems rather low to me anyway, so we might as well increase it...