### PR TITLE
use shutil.copyfile to just copy file contents if target path exists and is owned by someone else

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -138,6 +138,9 @@ jobs:
           eb --show-system-info
           # check GitHub configuration
           eb --check-github --github-user=easybuild_test
+          # create file owned by root but writable by anyone (used by test_copy_file)
+          sudo touch /tmp/file_to_overwrite_for_easybuild_test_copy_file.txt
+          sudo chmod o+w /tmp/file_to_overwrite_for_easybuild_test_copy_file.txt
           # run test suite
           python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
           # try and make sure output of running tests is clean (no printed messages/warnings)

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,6 +85,9 @@ script:
     - EB_VERBOSE=1 eb --version
     # check GitHub configuration
     - eb --check-github --github-user=easybuild_test
+    # create file owned by root but writable by anyone (used by test_copy_file)
+    - sudo touch /tmp/file_to_overwrite_for_easybuild_test_copy_file.txt
+    - sudo chmod o+w /tmp/file_to_overwrite_for_easybuild_test_copy_file.txt
     # run test suite
     - python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
     # try and make sure output of running tests is clean (no printed messages/warnings)


### PR DESCRIPTION
This fixes an issue we had on `generoso`, @verdurin can confirm the fix works (on top of the fix in #3125).

It's difficult to get this case covered in the tests though, because I can't think of a way to create a temporary file owned by another use where we have write permissions to...