### PR TITLE
Fix or avoid warnings that commonly arise in build log

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -61,6 +61,7 @@ from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconf
 from easybuild.framework.easyconfig.style import MAX_LINE_LENGTH
 from easybuild.framework.easyconfig.tools import get_paths_for
 from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_EASYBLOCK_RUN_STEP, template_constant_dict
+from easybuild.framework.extension import resolve_exts_filter_template
 from easybuild.tools import config, filetools
 from easybuild.tools.build_details import get_build_stats
 from easybuild.tools.build_log import EasyBuildError, dry_run_msg, dry_run_warning, dry_run_set_dirs
@@ -1446,43 +1447,18 @@ class EasyBlock(object):
 
         if not exts_filter or len(exts_filter) == 0:
             raise EasyBuildError("Skipping of extensions, but no exts_filter set in easyconfig")
-        elif isinstance(exts_filter, string_type) or len(exts_filter) != 2:
-            raise EasyBuildError('exts_filter should be a list or tuple of ("command","input")')
-        cmdtmpl = exts_filter[0]
-        cmdinputtmpl = exts_filter[1]
 
         res = []
         for ext in self.exts:
-            name = ext['name']
-            if 'options' in ext and 'modulename' in ext['options']:
-                modname = ext['options']['modulename']
-            else:
-                modname = name
-            tmpldict = {
-                'ext_name': modname,
-                'ext_version': ext.get('version'),
-                'src': ext.get('source'),
-            }
-
-            try:
-                cmd = cmdtmpl % tmpldict
-            except KeyError as err:
-                msg = "KeyError occurred on completing extension filter template: %s; "
-                msg += "'name'/'version' keys are no longer supported, should use 'ext_name'/'ext_version' instead"
-                self.log.nosupport(msg % err, '2.0')
-
-            if cmdinputtmpl:
-                stdin = cmdinputtmpl % tmpldict
-                (cmdstdouterr, ec) = run_cmd(cmd, log_all=False, log_ok=False, simple=False, inp=stdin, regexp=False)
-            else:
-                (cmdstdouterr, ec) = run_cmd(cmd, log_all=False, log_ok=False, simple=False, regexp=False)
+            cmd, stdin = resolve_exts_filter_template(exts_filter, ext)
+            (cmdstdouterr, ec) = run_cmd(cmd, log_all=False, log_ok=False, simple=False, inp=stdin, regexp=False)
             self.log.info("exts_filter result %s %s", cmdstdouterr, ec)
             if ec:
-                self.log.info("Not skipping %s" % name)
+                self.log.info("Not skipping %s" % ext['name'])
                 self.log.debug("exit code: %s, stdout/err: %s" % (ec, cmdstdouterr))
                 res.append(ext)
             else:
-                self.log.info("Skipping %s" % name)
+                self.log.info("Skipping %s" % ext['name'])
         self.exts = res
 
     #

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1576,7 +1576,7 @@ class EasyBlock(object):
 
     def det_iter_cnt(self):
         """Determine iteration count based on configure/build/install options that may be lists."""
-        # Using get_ref to avoid template substitution (and possible failures)
+        # Using get_ref to avoid resolving templates as their required attributes may not be available yet
         iter_opt_counts = [len(self.cfg.get_ref(opt)) for opt in ITERATE_OPTIONS
                            if opt not in ['builddependencies'] and isinstance(self.cfg.get_ref(opt), (list, tuple))]
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1576,8 +1576,9 @@ class EasyBlock(object):
 
     def det_iter_cnt(self):
         """Determine iteration count based on configure/build/install options that may be lists."""
-        iter_opt_counts = [len(self.cfg[opt]) for opt in ITERATE_OPTIONS
-                           if opt not in ['builddependencies'] and isinstance(self.cfg[opt], (list, tuple))]
+        # Using get_ref to avoid template substitution (and possible failures)
+        iter_opt_counts = [len(self.cfg.get_ref(opt)) for opt in ITERATE_OPTIONS
+                           if opt not in ['builddependencies'] and isinstance(self.cfg.get_ref(opt), (list, tuple))]
 
         # we need to take into account that builddependencies is always a list
         # we're only iterating over it if it's a list of lists

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -167,7 +167,7 @@ DEFAULT_CONFIG = {
     'exts_defaultclass': [None, "List of module for and name of the default extension class", EXTENSIONS],
     'exts_default_options': [{}, "List of default options for extensions", EXTENSIONS],
     'exts_filter': [None, ("Extension filter details: template for cmd and input to cmd "
-                           "(templates for name, version and src)."), EXTENSIONS],
+                           "(templates for ext_name, ext_version and src)."), EXTENSIONS],
     'exts_list': [[], 'List with extensions added to the base installation', EXTENSIONS],
 
     # MODULES easyconfig parameters

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -809,6 +809,10 @@ class EasyConfig(object):
         Configure/build/install options specified as lists should have same length.
         """
 
+        # Disable templating as only the existance is of interest, the actual resolved value is not
+        prev_enable_templating = self.enable_templating
+        self.enable_templating = False
+
         # configure/build/install options may be lists, in case of an iterated build
         # when lists are used, they should be all of same length
         # list of length 1 are treated as if it were strings in EasyBlock
@@ -821,6 +825,7 @@ class EasyConfig(object):
 
             # anticipate changes in available easyconfig parameters (e.g. makeopts -> buildopts?)
             if self.get(opt, None) is None:
+                self.enable_templating = prev_enable_templating
                 raise EasyBuildError("%s not available in self.cfg (anymore)?!", opt)
 
             # keep track of list, supply first element as first option to handle
@@ -830,7 +835,10 @@ class EasyConfig(object):
         # make sure that options that specify lists have the same length
         list_opt_lengths = [length for (opt, length) in opt_counts if length > 1]
         if len(nub(list_opt_lengths)) > 1:
+            self.enable_templating = prev_enable_templating
             raise EasyBuildError("Build option lists for iterated build should have same length: %s", opt_counts)
+
+        self.enable_templating = prev_enable_templating
 
         return True
 

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -168,11 +168,7 @@ class Extension(object):
                         'ext_name': modname,
                         'ext_version': self.version,
                         'src': self.src,
-                        # the ones below are only there for legacy purposes
-                        # TODO deprecated, remove in v2.0
                         # TODO same dict is used in easyblock.py skip_extensions, resolve this
-                        'name': modname,
-                        'version': self.version,
                        }
             cmd = cmd % template
 

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -144,10 +144,8 @@ class Extension(object):
         if os.path.isdir(self.installdir):
             change_dir(self.installdir)
 
-        # disabling templating is required here to support legacy string templates like name/version
-        self.cfg.enable_templating = False
-        exts_filter = self.cfg['exts_filter']
-        self.cfg.enable_templating = True
+        # Get raw value to translate ext_name, ext_version, src
+        exts_filter = self.cfg.get_ref('exts_filter')
 
         if exts_filter is not None:
             cmd, inp = exts_filter

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -41,6 +41,7 @@ from easybuild.framework.easyconfig.templates import template_constant_dict
 from easybuild.tools.build_log import EasyBuildError, raise_nosupport
 from easybuild.tools.filetools import change_dir
 from easybuild.tools.run import run_cmd
+from easybuild.tools.py2vs3 import string_type
 
 
 def resolve_exts_filter_template(exts_filter, ext):
@@ -51,7 +52,7 @@ def resolve_exts_filter_template(exts_filter, ext):
     :return (cmd, input) as a tuple of strings
     """
 
-    if isinstance(exts_filter, str) or len(exts_filter) != 2:
+    if isinstance(exts_filter, string_type) or len(exts_filter) != 2:
         raise EasyBuildError('exts_filter should be a list or tuple of ("command","input")')
 
     cmd, cmdinput = exts_filter
@@ -71,11 +72,13 @@ def resolve_exts_filter_template(exts_filter, ext):
     }
 
     try:
-        return (cmd % tmpldict, cmdinput % tmpldict if cmdinput else None)
+        cmd = cmd % tmpldict
+        cmdinput = cmdinput % tmpldict if cmdinput else None
     except KeyError as err:
         msg = "KeyError occurred on completing extension filter template: %s; "
         msg += "'name'/'version' keys are no longer supported, should use 'ext_name'/'ext_version' instead"
         raise_nosupport(msg % err, '2.0')
+    return cmd, cmdinput
 
 
 class Extension(object):

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -38,9 +38,44 @@ import os
 
 from easybuild.framework.easyconfig.easyconfig import resolve_template
 from easybuild.framework.easyconfig.templates import template_constant_dict
-from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.build_log import EasyBuildError, raise_nosupport
 from easybuild.tools.filetools import change_dir
 from easybuild.tools.run import run_cmd
+
+
+def resolve_exts_filter_template(exts_filter, ext):
+    """
+    Resolve the exts_filter tuple by replacing the template values using the extension
+    :param exts_filter: Tuple of (command, input) using template values (ext_name, ext_version, src)
+    :param ext: Instance of Extension or dictionary like with 'name' and optionally 'options', 'version', 'source' keys
+    :return (cmd, input) as a tuple of strings
+    """
+
+    if isinstance(exts_filter, str) or len(exts_filter) != 2:
+        raise EasyBuildError('exts_filter should be a list or tuple of ("command","input")')
+
+    cmd, cmdinput = exts_filter
+
+    if not isinstance(ext, dict):
+        ext = {'name': ext.name, 'version': ext.version, 'src': ext.src, 'options': ext.options}
+
+    name = ext['name']
+    if 'options' in ext and 'modulename' in ext['options']:
+        modname = ext['options']['modulename']
+    else:
+        modname = name
+    tmpldict = {
+        'ext_name': modname,
+        'ext_version': ext.get('version'),
+        'src': ext.get('src'),
+    }
+
+    try:
+        return (cmd % tmpldict, cmdinput % tmpldict if cmdinput else None)
+    except KeyError as err:
+        msg = "KeyError occurred on completing extension filter template: %s; "
+        msg += "'name'/'version' keys are no longer supported, should use 'ext_name'/'ext_version' instead"
+        raise_nosupport(msg % err, '2.0')
 
 
 class Extension(object):
@@ -147,11 +182,8 @@ class Extension(object):
         # Get raw value to translate ext_name, ext_version, src
         exts_filter = self.cfg.get_ref('exts_filter')
 
-        if exts_filter is not None:
-            cmd, inp = exts_filter
-        else:
+        if exts_filter is None:
             self.log.debug("no exts_filter setting found, skipping sanitycheck")
-            cmd = None
 
         if 'modulename' in self.options:
             modname = self.options['modulename']
@@ -163,18 +195,8 @@ class Extension(object):
         # allow skipping of sanity check by setting module name to False
         if modname is False:
             self.log.info("modulename set to False for '%s' extension, so skipping sanity check", self.name)
-        elif cmd:
-            template = {
-                        'ext_name': modname,
-                        'ext_version': self.version,
-                        'src': self.src,
-                        # TODO same dict is used in easyblock.py skip_extensions, resolve this
-                       }
-            cmd = cmd % template
-
-            stdin = None
-            if inp:
-                stdin = inp % template
+        elif exts_filter:
+            cmd, stdin = resolve_exts_filter_template(exts_filter, self)
             # set log_ok to False so we can catch the error instead of run_cmd
             (output, ec) = run_cmd(cmd, log_ok=False, simple=False, regexp=False, inp=stdin)
 

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -116,9 +116,9 @@ class ExtensionEasyBlock(EasyBlock, Extension):
         """
         Custom sanity check for extensions, whether installed as stand-alone module or not
         """
-        if not self.cfg['exts_filter']:
+        if not self.cfg.get_ref('exts_filter'):
             self.cfg['exts_filter'] = exts_filter
-        self.log.debug("starting sanity check for extension with filter %s", self.cfg['exts_filter'])
+        self.log.debug("starting sanity check for extension with filter %s", self.cfg.get_ref('exts_filter'))
 
         # for stand-alone installations that were done for multiple dependency versions (via multi_deps),
         # we need to perform the extension sanity check for each of them, by loading the corresponding modules first

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -95,6 +95,7 @@ def raise_nosupport(msg, ver):
     nosupport_msg = "NO LONGER SUPPORTED since v%s: %s; see %s for more information"
     raise_easybuilderror(nosupport_msg, ver, msg, DEPRECATED_DOC_URL)
 
+
 class EasyBuildLog(fancylogger.FancyLogger):
     """
     The EasyBuild logger, with its own error and exception functions.

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -90,6 +90,11 @@ def raise_easybuilderror(msg, *args):
     raise EasyBuildError(msg, *args)
 
 
+def raise_nosupport(msg, ver):
+    """Construct error message for no longer supported behaviour, and raise an EasyBuildError."""
+    nosupport_msg = "NO LONGER SUPPORTED since v%s: %s; see %s for more information"
+    raise_easybuilderror(nosupport_msg, ver, msg, DEPRECATED_DOC_URL)
+
 class EasyBuildLog(fancylogger.FancyLogger):
     """
     The EasyBuild logger, with its own error and exception functions.
@@ -154,9 +159,8 @@ class EasyBuildLog(fancylogger.FancyLogger):
             fancylogger.FancyLogger.deprecated(self, msg, ver, max_ver, *args, **kwargs)
 
     def nosupport(self, msg, ver):
-        """Print error message for no longer supported behaviour, and raise an EasyBuildError."""
-        nosupport_msg = "NO LONGER SUPPORTED since v%s: %s; see %s for more information"
-        raise EasyBuildError(nosupport_msg, ver, msg, DEPRECATED_DOC_URL)
+        """Raise error message for no longer supported behaviour, and raise an EasyBuildError."""
+        raise_nosupport(msg, ver)
 
     def error(self, msg, *args, **kwargs):
         """Print error message and raise an EasyBuildError."""

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -384,12 +384,14 @@ def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False, forced
     return find_base_dir()
 
 
-def which(cmd, retain_all=False, check_perms=True):
+def which(cmd, retain_all=False, check_perms=True, log_ok=True, log_error=True):
     """
     Return (first) path in $PATH for specified command, or None if command is not found
 
     :param retain_all: returns *all* locations to the specified command in $PATH, not just the first one
     :param check_perms: check whether candidate path has read/exec permissions before accepting it as a match
+    :param log_ok: Log an info message where the command has been found (if any)
+    :param log_error: Log a warning message when command hasn't been found
     """
     if retain_all:
         res = []
@@ -401,7 +403,8 @@ def which(cmd, retain_all=False, check_perms=True):
         cmd_path = os.path.join(path, cmd)
         # only accept path if command is there
         if os.path.isfile(cmd_path):
-            _log.info("Command %s found at %s", cmd, cmd_path)
+            if log_ok:
+                _log.info("Command %s found at %s", cmd, cmd_path)
             if check_perms:
                 # check if read/executable permissions are available
                 if not os.access(cmd_path, os.R_OK | os.X_OK):
@@ -413,7 +416,7 @@ def which(cmd, retain_all=False, check_perms=True):
                 res = cmd_path
                 break
 
-    if not res:
+    if not res and log_error:
         _log.warning("Could not find command '%s' (with permissions to read/execute it) in $PATH (%s)" % (cmd, paths))
     return res
 

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -184,9 +184,9 @@ class ModulesTool(object):
             cmd_path = which(self.cmd, log_ok=False, log_error=False)
             # only use command path in environment variable if command in not available in $PATH
             if cmd_path is None:
+                self.cmd = env_cmd_path
                 self.log.debug("Set %s command via environment variable %s: %s",
                                self.NAME, self.COMMAND_ENVIRONMENT, self.cmd)
-                self.cmd = env_cmd_path
             # check whether paths obtained via $PATH and $LMOD_CMD are different
             elif cmd_path != env_cmd_path:
                 self.log.debug("Different paths found for %s command '%s' via which/$PATH and $%s: %s vs %s",

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -180,18 +180,17 @@ class ModulesTool(object):
         if mod_paths is not None:
             self.set_mod_paths(mod_paths)
 
-        cmd_path = which(self.cmd, log_ok=False, log_error=False)
-        # only use command path in environment variable if command in not available in $PATH
-        if which(self.cmd) is None:
-            if env_cmd_path is not None:
+        if env_cmd_path:
+            cmd_path = which(self.cmd, log_ok=False, log_error=False)
+            # only use command path in environment variable if command in not available in $PATH
+            if cmd_path is None:
                 self.log.debug("Set %s command via environment variable %s: %s",
                                self.NAME, self.COMMAND_ENVIRONMENT, self.cmd)
                 self.cmd = env_cmd_path
-
-        # check whether paths obtained via $PATH and $LMOD_CMD are different
-        elif env_cmd_path and cmd_path != env_cmd_path:
-            self.log.debug("Different paths found for %s command '%s' via which/$PATH and $%s: %s vs %s",
-                           self.NAME, self.COMMAND, self.COMMAND_ENVIRONMENT, cmd_path, env_cmd_path)
+            # check whether paths obtained via $PATH and $LMOD_CMD are different
+            elif cmd_path != env_cmd_path:
+                self.log.debug("Different paths found for %s command '%s' via which/$PATH and $%s: %s vs %s",
+                               self.NAME, self.COMMAND, self.COMMAND_ENVIRONMENT, cmd_path, env_cmd_path)
 
         # make sure the module command was found
         if self.cmd is None:
@@ -676,7 +675,7 @@ class ModulesTool(object):
         :param strip_ext: strip (.lua) extension from module fileame (if present)"""
         # (possible relative) path is always followed by a ':', and may be prepended by whitespace
         # this works for both environment modules and Lmod
-        modpath_re = re.compile('^\s*(?P<modpath>[^/\n]*/[^\s]+):$', re.M)
+        modpath_re = re.compile(r'^\s*(?P<modpath>[^/\n]*/[^\s]+):$', re.M)
         modpath = self.get_value_from_modulefile(mod_name, modpath_re)
 
         if strip_ext and modpath.endswith('.lua'):
@@ -941,7 +940,7 @@ class ModulesTool(object):
             """Helper function to compose joined path."""
             return os.path.join(*[x.strip('"') for x in res.groups()])
 
-        res = re.sub('\[\s+file\s+join\s+(.*)\s+(.*)\s+\]', file_join, res)
+        res = re.sub(r'\[\s+file\s+join\s+(.*)\s+(.*)\s+\]', file_join, res)
 
         # also interpret all $env(...) parts
         res = re.sub(r'\$env\((?P<key>[^)]*)\)', lambda res: os.getenv(res.group('key'), ''), res)
@@ -1160,7 +1159,7 @@ class EnvironmentModulesTcl(EnvironmentModulesC):
         # this is required for the DEISA variant of modulecmd.tcl which is commonly used
         def tweak_stdout(txt):
             """Tweak stdout before it's exec'ed as Python code."""
-            modulescript_regex = "^exec\s+[\"'](?P<modulescript>/tmp/modulescript_[0-9_]+)[\"']$"
+            modulescript_regex = r"^exec\s+[\"'](?P<modulescript>/tmp/modulescript_[0-9_]+)[\"']$"
             return re.sub(modulescript_regex, r"execfile('\1')", txt)
 
         tweak_stdout_fn = None
@@ -1368,7 +1367,7 @@ class Lmod(ModulesTool):
 
         # first consider .modulerc.lua with Lmod 7.8 (or newer)
         if StrictVersion(self.version) >= StrictVersion('7.8'):
-            mod_wrapper_regex_template = '^module_version\("(?P<wrapped_mod>.*)", "%s"\)$'
+            mod_wrapper_regex_template = r'^module_version\("(?P<wrapped_mod>.*)", "%s"\)$'
             res = super(Lmod, self).module_wrapper_exists(mod_name, modulerc_fn='.modulerc.lua',
                                                           mod_wrapper_regex_template=mod_wrapper_regex_template)
 

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -180,16 +180,18 @@ class ModulesTool(object):
         if mod_paths is not None:
             self.set_mod_paths(mod_paths)
 
+        cmd_path = which(self.cmd, log_ok=False, log_error=False)
         # only use command path in environment variable if command in not available in $PATH
-        if which(self.cmd) is None and env_cmd_path is not None:
-            self.log.debug("Set %s command via environment variable %s: %s",
-                           self.NAME, self.COMMAND_ENVIRONMENT, self.cmd)
-            self.cmd = env_cmd_path
+        if which(self.cmd) is None:
+            if env_cmd_path is not None:
+                self.log.debug("Set %s command via environment variable %s: %s",
+                               self.NAME, self.COMMAND_ENVIRONMENT, self.cmd)
+                self.cmd = env_cmd_path
 
         # check whether paths obtained via $PATH and $LMOD_CMD are different
-        elif which(self.cmd) != env_cmd_path:
+        elif env_cmd_path and cmd_path != env_cmd_path:
             self.log.debug("Different paths found for %s command '%s' via which/$PATH and $%s: %s vs %s",
-                           self.NAME, self.COMMAND, self.COMMAND_ENVIRONMENT, self.cmd, env_cmd_path)
+                           self.NAME, self.COMMAND, self.COMMAND_ENVIRONMENT, cmd_path, env_cmd_path)
 
         # make sure the module command was found
         if self.cmd is None:
@@ -284,7 +286,7 @@ class ModulesTool(object):
 
     def check_cmd_avail(self):
         """Check whether modules tool command is available."""
-        cmd_path = which(self.cmd)
+        cmd_path = which(self.cmd, log_ok=False)
         if cmd_path is not None:
             self.cmd = cmd_path
             self.log.info("Full path for %s command is %s, so using it", self.NAME, self.cmd)

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -114,6 +114,9 @@ VENDOR_IDS = {
     'AuthenticAMD': AMD,
     'GenuineIntel': INTEL,
     'IBM': IBM,
+    # IBM POWER9
+    '8335-GTH': IBM,
+    '8335-GTX': IBM,
 }
 # ARM Cortex part numbers from the corresponding ARM Processor Technical Reference Manuals,
 # see http://infocenter.arm.com - Cortex-A series processors, Section "Main ID Register"
@@ -276,7 +279,7 @@ def get_cpu_vendor():
         if arch == X86_64:
             vendor_regex = re.compile(r"vendor_id\s+:\s*(\S+)")
         elif arch == POWER:
-            vendor_regex = re.compile(r"model\s+:\s*(\w+)")
+            vendor_regex = re.compile(r"model\s+:\s*((\w|-)+)")
         elif arch in [AARCH32, AARCH64]:
             vendor_regex = re.compile(r"CPU implementer\s+:\s*(\S+)")
 

--- a/easybuild/tools/toolchain/options.py
+++ b/easybuild/tools/toolchain/options.py
@@ -86,7 +86,12 @@ class ToolchainOptions(dict):
         """Return option value"""
         value = self.get(name, None)
         if value is None and name not in self.options_map:
-            self.log.warning("option: option with name %s returns None" % name)
+            msg = "option: option with name %s returns None" % name
+            # Empty options starting with _opt_ are allowed, so don't warn
+            if name.startswith('_opt_'):
+                self.log.devel(msg)
+            else:
+                self.log.warning(msg)
             res = None
         elif name in self.options_map:
             res = self.options_map[name]

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -36,8 +36,9 @@ from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
 
 from easybuild.base.fancylogger import getLogger, logToFile, setLogFormat
-from easybuild.tools.build_log import LOGGING_FORMAT, EasyBuildError, EasyBuildLog, dry_run_msg, dry_run_warning
-from easybuild.tools.build_log import init_logging, print_error, print_msg, print_warning, stop_logging, time_str_since
+from easybuild.tools.build_log import (
+    LOGGING_FORMAT, EasyBuildError, EasyBuildLog, dry_run_msg, dry_run_warning, init_logging, print_error, print_msg,
+    print_warning, stop_logging, time_str_since, raise_nosupport)
 from easybuild.tools.filetools import read_file, write_file
 
 
@@ -146,9 +147,10 @@ class BuildLogTest(EnhancedTestCase):
         logtxt_regex = re.compile(r'^%s' % expected_logtxt, re.M)
         self.assertTrue(logtxt_regex.search(logtxt), "Pattern '%s' found in %s" % (logtxt_regex.pattern, logtxt))
 
-        self.assertErrorRegex(EasyBuildError, "DEPRECATED \(since .*: kaput", log.deprecated, "kaput", older_ver)
-        self.assertErrorRegex(EasyBuildError, "DEPRECATED \(since .*: 2>1", log.deprecated, "2>1", '2.0', '1.0')
-        self.assertErrorRegex(EasyBuildError, "DEPRECATED \(since .*: 2>1", log.deprecated, "2>1", '2.0', max_ver='1.0')
+        self.assertErrorRegex(EasyBuildError, r"DEPRECATED \(since .*: kaput", log.deprecated, "kaput", older_ver)
+        self.assertErrorRegex(EasyBuildError, r"DEPRECATED \(since .*: 2>1", log.deprecated, "2>1", '2.0', '1.0')
+        self.assertErrorRegex(EasyBuildError, r"DEPRECATED \(since .*: 2>1", log.deprecated, "2>1", '2.0',
+                              max_ver='1.0')
 
         # wipe log so we can reuse it
         write_file(tmplog, '')
@@ -421,6 +423,10 @@ class BuildLogTest(EnhancedTestCase):
         self.assertTrue(isinstance(log, EasyBuildLog))
 
         stop_logging(logfile, logtostdout=True)
+
+    def test_raise_nosupport(self):
+        self.assertErrorRegex(EasyBuildError, 'NO LONGER SUPPORTED since v42: foobar;',
+                              raise_nosupport, 'foobar', 42)
 
 
 def suite():


### PR DESCRIPTION
The log of any software contains a lot of warnings from EasyBuild. This PR reduces those considerably. Every change is in its own commit, but all have this common goal, so they are bundled here.

- Fix usage of `exts_filter`, fixes #3124
  - Fix docu mentioning wrong templates
  - Remove deprecated (and anounced as removed) templates
  - Unify function to fill this template
  - Access with templating disabled (as templating is done with a different dict)
- Allow and use less verbose `which` when existance of command is checked and (semi-)expected to fail. This avoids duplicate log messages and warnings
- Add vendor for our POWER9 CPUs avoiding warning about unknown vendor
- `det_iter_cnt` and `validate_iterate_opt_lists` don't need templating and produce warnings if they use it
- Fix checking for `_opt_CC` and friends producing warnings although empty values are ok
