### PR TITLE
disable buffering in asyncprocess.Popen using bufsize=0, to fix run_cmd_qa missing output

### DIFF
--- a/easybuild/tools/asyncprocess.py
+++ b/easybuild/tools/asyncprocess.py
@@ -78,6 +78,15 @@ import fcntl  #@UnresolvedImport
 
 
 class Popen(subprocess.Popen):
+
+    def __init__(self, *args, **kwargs):
+        # set bufsize to 0 to ensure buffering is disabled,
+        # otherwise we may not get all available output when polling in run_cmd_qa;
+        # bufsize=0 is the default in Python 2, but not in recent Python 3 versions,
+        # see https://docs.python.org/3/library/subprocess.html#subprocess.Popen
+        kwargs['bufsize'] = 0
+        super(Popen, self).__init__(*args, **kwargs)
+
     def recv(self, maxsize=None):
         return self._recv('stdout', maxsize)
 

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -310,6 +310,18 @@ class RunTest(EnhancedTestCase):
         self.assertTrue(out.startswith("question\nanswer\nfoo "))
         self.assertTrue(out.endswith('bar'))
 
+    def test_run_cmd_qa_buffering(self):
+        """Test whether run_cmd_qa uses unbuffered output."""
+
+        # command that generates a lot of output before waiting for input
+        # note: bug being fixed can be reproduced reliably using 1000, but not with too high values like 100000!
+        cmd = 'for x in $(seq 1000); do echo "This is a number you can pick: $x"; done; '
+        cmd += 'echo "Pick a number: "; read number; echo "Picked number: $number"'
+        (out, ec) = run_cmd_qa(cmd, {'Pick a number: ': '42'}, log_all=True, maxhits=5)
+
+        regex = re.compile("Picked number: 42$")
+        self.assertTrue(regex.search(out), "Pattern '%s' found in: %s" % (regex.pattern, out))
+
     def test_run_cmd_qa_log_all(self):
         """Test run_cmd_qa with log_output enabled"""
         (out, ec) = run_cmd_qa("echo 'n: '; read n; seq 1 $n", {'n: ': '5'}, log_all=True)


### PR DESCRIPTION
Proper fix for `run_cmd_qa` failing when running WRF's `configure` command using EasyBuild running on top of Python 3 (see also discussion in https://github.com/easybuilders/easybuild-framework/pull/3126).

Thanks a lot for the suggestion to use `bufsize=0` @akesandgren, I overlooked that the default there had changed in Python 3...