### PR TITLE
avoid crash in modify_env & unset unset_env_vars when using (older versions) of Python 3.5 & 3.6 by using list(...)

### DIFF
--- a/easybuild/tools/environment.py
+++ b/easybuild/tools/environment.py
@@ -113,7 +113,7 @@ def unset_env_vars(keys, verbose=True):
     if keys and verbose and build_option('extended_dry_run'):
         dry_run_msg("Undefining environment variables:\n", silent=build_option('silent'))
 
-    for key in keys:
+    for key in list(keys):
         if key in os.environ:
             _log.info("Unsetting environment variable %s (value: %s)" % (key, os.environ[key]))
             old_environ[key] = os.environ[key]
@@ -155,24 +155,25 @@ def read_environment(env_vars, strict=False):
 
 def modify_env(old, new, verbose=True):
     """
-    Compares 2 os.environ dumps. Adapts final environment.
+    Compares two os.environ dumps. Adapts final environment.
     """
-    oldKeys = old.keys()
-    newKeys = new.keys()
-    for key in newKeys:
+    old_keys = list(old.keys())
+    new_keys = list(new.keys())
+
+    for key in new_keys:
         # set them all. no smart checking for changed/identical values
-        if key in oldKeys:
+        if key in old_keys:
             # hmm, smart checking with debug logging
             if not new[key] == old[key]:
-                _log.debug("Key in new environment found that is different from old one: %s (%s)" % (key, new[key]))
+                _log.debug("Key in new environment found that is different from old one: %s (%s)", key, new[key])
                 setvar(key, new[key], verbose=verbose)
         else:
-            _log.debug("Key in new environment found that is not in old one: %s (%s)" % (key, new[key]))
+            _log.debug("Key in new environment found that is not in old one: %s (%s)", key, new[key])
             setvar(key, new[key], verbose=verbose)
 
-    for key in oldKeys:
-        if key not in newKeys:
-            _log.debug("Key in old environment found that is not in new one: %s (%s)" % (key, old[key]))
+    for key in old_keys:
+        if key not in new_keys:
+            _log.debug("Key in old environment found that is not in new one: %s (%s)", key, old[key])
             os.unsetenv(key)
             del os.environ[key]
 

--- a/test/framework/environment.py
+++ b/test/framework/environment.py
@@ -71,6 +71,66 @@ class EnvironmentTest(EnhancedTestCase):
         self.assertEqual(os.environ['FOO'], 'barfoo')
         self.assertEqual(txt, '')
 
+    def test_modify_env(self):
+        """Test for modify_env function."""
+
+        old_env_vars = {
+            'TEST_ENV_VAR_TO_UNSET1': 'foobar',
+            'TEST_ENV_VAR_TO_UNSET2': 'value does not matter',
+            'TEST_COMMON_ENV_VAR_CHANGED': 'old_value',
+            'TEST_COMMON_ENV_VAR_SAME_VALUE': 'this_value_stays',
+        }
+        new_env_vars = {
+            'TEST_COMMON_ENV_VAR_CHANGED': 'new_value',
+            'TEST_NEW_ENV_VAR1': '1',
+            'TEST_NEW_ENV_VAR2': 'two 2 two',
+            'TEST_COMMON_ENV_VAR_SAME_VALUE': 'this_value_stays',
+        }
+
+        # prepare test environment first:
+        # keys in new_env should not be set yet, keys in old_env are expected to be set
+        for key in new_env_vars:
+            if key in os.environ:
+                del os.environ[key]
+        for key in old_env_vars:
+            os.environ[key] = old_env_vars[key]
+
+        env.modify_env(os.environ, new_env_vars)
+
+        self.assertEqual(os.environ.get('TEST_ENV_VAR_TO_UNSET1'), None)
+        self.assertEqual(os.environ.get('TEST_ENV_VAR_TO_UNSET2'), None)
+        self.assertEqual(os.environ.get('TEST_COMMON_ENV_VAR_CHANGED'), 'new_value')
+        self.assertEqual(os.environ.get('TEST_COMMON_ENV_VAR_SAME_VALUE'), 'this_value_stays')
+        self.assertEqual(os.environ.get('TEST_NEW_ENV_VAR1'), '1')
+        self.assertEqual(os.environ.get('TEST_NEW_ENV_VAR2'), 'two 2 two')
+
+        # extreme test case: empty entire environment (original env is restored for next tests)
+        env.modify_env(os.environ, {})
+
+    def test_unset_env_vars(self):
+        """Test unset_env_vars function."""
+
+        os.environ['TEST_ENV_VAR'] = 'test123'
+        # it's fair to assume $HOME will always be set
+        home = os.getenv('HOME')
+        self.assertTrue(home)
+
+        key_not_set = 'NO_SUCH_ENV_VAR'
+        if key_not_set in os.environ:
+            del os.environ[key_not_set]
+
+        res = env.unset_env_vars(['HOME', 'NO_SUCH_ENV_VAR', 'TEST_ENV_VAR'])
+
+        self.assertFalse('HOME' in os.environ)
+        self.assertFalse('NO_SUCH_ENV_VAR' in os.environ)
+        self.assertFalse('TEST_ENV_VAR' in os.environ)
+
+        expected = {
+            'HOME': home,
+            'TEST_ENV_VAR': 'test123',
+        }
+        self.assertEqual(res, expected)
+
 
 def suite():
     """ returns all the testcases in this module """


### PR DESCRIPTION
fixes #3138 reported by @rsarm