### PR TITLE
fix --list-software=detailed when using Python 3 by leveraging sort_looseversions function from py2vs3 module

### DIFF
--- a/easybuild/tools/py2vs3/py2.py
+++ b/easybuild/tools/py2vs3/py2.py
@@ -82,3 +82,10 @@ def mk_wrapper_baseclass(metaclass):
         __wraps__ = None
 
     return WrapperBase
+
+
+def sort_looseversions(looseversions):
+    """Sort list of (values including) LooseVersion instances."""
+    # with Python 2, we can safely use 'sorted' on LooseVersion instances
+    # (but we can't in Python 3, see https://bugs.python.org/issue14894)
+    return sorted(looseversions)


### PR DESCRIPTION
fixes #3112