### PR TITLE
mention --disable-* option in --help output for boolean options enabled by default

### DIFF
--- a/easybuild/base/generaloption.py
+++ b/easybuild/base/generaloption.py
@@ -1088,11 +1088,15 @@ class GeneralOption(object):
 
             if default is not None:
                 if len(str(default)) == 0:
-                    extra_help.append("def ''")  # empty string
+                    extra_help.append("default: ''")  # empty string
                 elif typ in ExtOption.TYPE_STRLIST:
-                    extra_help.append("def %s" % sep.join(default))
+                    extra_help.append("default: %s" % sep.join(default))
                 else:
-                    extra_help.append("def %s" % default)
+                    extra_help.append("default: %s" % default)
+
+                # for boolean options enabled by default, mention that they can be disabled using --disable-*
+                if default is True:
+                    extra_help.append("disable with --disable-%s" % key)
 
             if len(extra_help) > 0:
                 hlp += " (%s)" % ("; ".join(extra_help))

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -150,7 +150,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         topt = EasyBuildOptions(
                                 go_args=['-H'],
                                 go_nosystemexit=True,  # when printing help, optparse ends with sys.exit
-                                go_columns=100,  # fix col size for reproducible unittest output
+                                go_columns=200,  # fix col size for reproducible unittest output
                                 help_to_string=True,  # don't print to stdout, but to StingIO fh,
                                 prog='easybuildoptions_test',  # generate as if called from generaloption.py
                                )
@@ -164,6 +164,10 @@ class CommandLineOptionsTest(EnhancedTestCase):
                         "Not all option groups included in short help (1)")
         self.assertTrue(re.search("Regression test options", outtxt),
                         "Not all option groups included in short help (2)")
+
+        # for boolean options, we mention in the help text how to disable them
+        regex = re.compile("default: True; disable with --disable-cleanup-builddir", re.M)
+        self.assertTrue(regex.search(outtxt), "Pattern '%s' found in: %s" % (regex.pattern, outtxt))
 
     def test_no_args(self):
         """Test using no arguments."""


### PR DESCRIPTION
fixes #3150

Output in `--help` before this change:

```
    --cleanup-builddir  Cleanup build dir after successful installation. (def True)
```

after:

```
    --cleanup-builddir  Cleanup build dir after successful installation.
                        (default: True; disable with --disable-cleanup-builddir)
```