### PR TITLE
Only remove folders that contain no files recursively

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -75,7 +75,7 @@ from easybuild.tools.filetools import change_dir, convert_name, compute_checksum
 from easybuild.tools.filetools import diff_files, download_file, encode_class_name, extract_file
 from easybuild.tools.filetools import find_backup_name_candidate, get_source_tarball_from_git, is_alt_pypi_url
 from easybuild.tools.filetools import is_sha256_checksum, mkdir, move_file, move_logs, read_file, remove_dir
-from easybuild.tools.filetools import remove_file, rmtree2, verify_checksum, weld_paths, write_file, is_empty_folder
+from easybuild.tools.filetools import remove_file, rmtree2, verify_checksum, weld_paths, write_file, dir_contains_files
 from easybuild.tools.hooks import BUILD_STEP, CLEANUP_STEP, CONFIGURE_STEP, EXTENSIONS_STEP, FETCH_STEP, INSTALL_STEP
 from easybuild.tools.hooks import MODULE_STEP, PACKAGE_STEP, PATCH_STEP, PERMISSIONS_STEP, POSTITER_STEP, POSTPROC_STEP
 from easybuild.tools.hooks import PREPARE_STEP, READY_STEP, SANITYCHECK_STEP, SOURCE_STEP, TEST_STEP, TESTCASES_STEP
@@ -1309,7 +1309,7 @@ class EasyBlock(object):
                             retained_paths = [
                                 path for path in paths
                                 if os.path.isdir(os.path.join(self.installdir, path))
-                                and not is_empty_folder(os.path.join(self.installdir, path))
+                                and dir_contains_files(os.path.join(self.installdir, path))
                             ]
                             self.log.info("Only retaining paths for %s that contain at least one file: %s -> %s",
                                           key, paths, retained_paths)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -681,6 +681,14 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filen
     return var_defs, hits
 
 
+def is_empty_folder(folder_path):
+    """Return true if the given folder does not contain any files"""
+    for _root, _dirs, files in os.walk(folder_path):
+        if files:
+            return False
+    return True
+
+
 def find_eb_script(script_name):
     """Find EasyBuild script with given name (in easybuild/scripts subdirectory)."""
     filetools, eb_dir = __file__, None
@@ -746,7 +754,7 @@ def calc_block_checksum(path, algorithm):
     try:
         # in hashlib, blocksize is a class parameter
         blocksize = algorithm.blocksize * 262144  # 2^18
-    except AttributeError as err:
+    except AttributeError:
         blocksize = 16777216  # 2^24
     _log.debug("Using blocksize %s for calculating the checksum" % blocksize)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -681,9 +681,9 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filen
     return var_defs, hits
 
 
-def dir_contains_files(folder_path):
-    """Return true if the given folder does not contain any files"""
-    return any(files for _root, _dirs, files in os.walk(folder_path))
+def dir_contains_files(path):
+    """Return True if the given directory does contain any file in itself or any subdirectory"""
+    return any(files for _root, _dirs, files in os.walk(path))
 
 
 def find_eb_script(script_name):

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -681,12 +681,9 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filen
     return var_defs, hits
 
 
-def is_empty_folder(folder_path):
+def dir_contains_files(folder_path):
     """Return true if the given folder does not contain any files"""
-    for _root, _dirs, files in os.walk(folder_path):
-        if files:
-            return False
-    return True
+    return any(files for _root, _dirs, files in os.walk(folder_path))
 
 
 def find_eb_script(script_name):

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1724,29 +1724,29 @@ class FileToolsTest(EnhancedTestCase):
         for pattern in ['*foo', '(foo', ')foo', 'foo)', 'foo(']:
             self.assertErrorRegex(EasyBuildError, "Invalid search query", ft.search_file, [test_ecs], pattern)
 
-    def test_is_empty_folder(self):
+    def test_dir_contains_files(self):
         def makedirs_in_test(*paths):
             """Make dir specified by paths and return top-level folder"""
             os.makedirs(os.path.join(self.test_prefix, *paths))
             return os.path.join(self.test_prefix, paths[0])
 
         empty_dir = makedirs_in_test('empty_dir')
-        self.assertTrue(ft.is_empty_folder(empty_dir))
+        self.assertFalse(ft.dir_contains_files(empty_dir))
 
         dir_w_subdir = makedirs_in_test('dir_w_subdir', 'sub_dir')
-        self.assertTrue(ft.is_empty_folder(dir_w_subdir))
+        self.assertFalse(ft.dir_contains_files(dir_w_subdir))
 
         dir_subdir_file = makedirs_in_test('dir_subdir_file', 'sub_dir_w_file')
         ft.write_file(os.path.join(dir_subdir_file, 'sub_dir_w_file', 'file.h'), '')
-        self.assertFalse(ft.is_empty_folder(dir_subdir_file))
+        self.assertTrue(ft.dir_contains_files(dir_subdir_file))
 
         dir_w_file = makedirs_in_test('dir_w_file')
         ft.write_file(os.path.join(dir_w_file, 'file.h'), '')
-        self.assertFalse(ft.is_empty_folder(dir_w_file))
+        self.assertTrue(ft.dir_contains_files(dir_w_file))
 
         dir_w_dir_and_file = makedirs_in_test('dir_w_dir_and_file', 'sub_dir')
         ft.write_file(os.path.join(dir_w_dir_and_file, 'file.h'), '')
-        self.assertFalse(ft.is_empty_folder(dir_w_dir_and_file))
+        self.assertTrue(ft.dir_contains_files(dir_w_dir_and_file))
 
     def test_find_eb_script(self):
         """Test find_eb_script function."""

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1725,30 +1725,28 @@ class FileToolsTest(EnhancedTestCase):
             self.assertErrorRegex(EasyBuildError, "Invalid search query", ft.search_file, [test_ecs], pattern)
 
     def test_is_empty_folder(self):
-        tmpdir = tempfile.mkdtemp()
-        self.assertTrue(ft.is_empty_folder(tmpdir))
-        # Containing a folder is still empty
-        subdir = tempfile.mkdtemp(dir=tmpdir)
-        self.assertTrue(ft.is_empty_folder(tmpdir))
-        # A file in a subfolder makes it non-empty
-        sub_filename = os.path.join(subdir, 'testfile.h')
-        ft.write_file(sub_filename, '')
-        self.assertFalse(ft.is_empty_folder(tmpdir))
-        # A file in the folder makes it non-empty
-        filename = os.path.join(tmpdir, 'testfile.h')
-        ft.write_file(filename, '')
-        self.assertFalse(ft.is_empty_folder(tmpdir))
-        # And even when the file in the subfolder or the subfolder is removed
-        # as 'filename' stays
-        os.remove(sub_filename)
-        self.assertFalse(ft.is_empty_folder(tmpdir))
-        os.rmdir(subdir)
-        self.assertFalse(ft.is_empty_folder(tmpdir))
-        # And true again when the file is removed
-        os.remove(filename)
-        self.assertTrue(ft.is_empty_folder(tmpdir))
-        # Cleanup
-        os.rmdir(tmpdir)
+        def makedirs_in_test(*paths):
+            """Make dir specified by paths and return top-level folder"""
+            os.makedirs(os.path.join(self.test_prefix, *paths))
+            return os.path.join(self.test_prefix, paths[0])
+
+        empty_dir = makedirs_in_test('empty_dir')
+        self.assertTrue(ft.is_empty_folder(empty_dir))
+
+        dir_w_subdir = makedirs_in_test('dir_w_subdir', 'sub_dir')
+        self.assertTrue(ft.is_empty_folder(dir_w_subdir))
+
+        dir_subdir_file = makedirs_in_test('dir_subdir_file', 'sub_dir_w_file')
+        ft.write_file(os.path.join(dir_subdir_file, 'sub_dir_w_file', 'file.h'), '')
+        self.assertFalse(ft.is_empty_folder(dir_subdir_file))
+
+        dir_w_file = makedirs_in_test('dir_w_file')
+        ft.write_file(os.path.join(dir_w_file, 'file.h'), '')
+        self.assertFalse(ft.is_empty_folder(dir_w_file))
+
+        dir_w_dir_and_file = makedirs_in_test('dir_w_dir_and_file', 'sub_dir')
+        ft.write_file(os.path.join(dir_w_dir_and_file, 'file.h'), '')
+        self.assertFalse(ft.is_empty_folder(dir_w_dir_and_file))
 
     def test_find_eb_script(self):
         """Test find_eb_script function."""

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1724,6 +1724,32 @@ class FileToolsTest(EnhancedTestCase):
         for pattern in ['*foo', '(foo', ')foo', 'foo)', 'foo(']:
             self.assertErrorRegex(EasyBuildError, "Invalid search query", ft.search_file, [test_ecs], pattern)
 
+    def test_is_empty_folder(self):
+        tmpdir = tempfile.mkdtemp()
+        self.assertTrue(ft.is_empty_folder(tmpdir))
+        # Containing a folder is still empty
+        subdir = tempfile.mkdtemp(dir=tmpdir)
+        self.assertTrue(ft.is_empty_folder(tmpdir))
+        # A file in a subfolder makes it non-empty
+        sub_filename = os.path.join(subdir, 'testfile.h')
+        ft.write_file(sub_filename, '')
+        self.assertFalse(ft.is_empty_folder(tmpdir))
+        # A file in the folder makes it non-empty
+        filename = os.path.join(tmpdir, 'testfile.h')
+        ft.write_file(filename, '')
+        self.assertFalse(ft.is_empty_folder(tmpdir))
+        # And even when the file in the subfolder or the subfolder is removed
+        # as 'filename' stays
+        os.remove(sub_filename)
+        self.assertFalse(ft.is_empty_folder(tmpdir))
+        os.rmdir(subdir)
+        self.assertFalse(ft.is_empty_folder(tmpdir))
+        # And true again when the file is removed
+        os.remove(filename)
+        self.assertTrue(ft.is_empty_folder(tmpdir))
+        # Cleanup
+        os.rmdir(tmpdir)
+
     def test_find_eb_script(self):
         """Test find_eb_script function."""
         self.assertTrue(os.path.exists(ft.find_eb_script('rpath_args.py')))


### PR DESCRIPTION
Otherwise 'include/libfoo/foo.h'  would be removed from `$CPATH`

Bug introduced in https://github.com/easybuilders/easybuild-framework/pull/3145