### PR TITLE
support use of %(startdir)s template in easyconfig files (WIP)

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1490,6 +1490,11 @@ class EasyBlock(object):
     #
 
     @property
+    def startdir(self):
+        """Alias for self.start_dir."""
+        return self.start_dir
+
+    @property
     def start_dir(self):
         """Start directory in build directory"""
         return self.cfg['start_dir']

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -71,8 +71,9 @@ TEMPLATE_NAMES_LOWER = [
 ]
 # values taken from the EasyBlock before each step
 TEMPLATE_NAMES_EASYBLOCK_RUN_STEP = [
-    ('installdir', "Installation directory"),
     ('builddir', "Build directory"),
+    ('installdir', "Installation directory"),
+    ('startdir', "Start directory (directory corresponding to unpacked source)"),
 ]
 # software names for which to define <pref>ver and <pref>shortver templates
 TEMPLATE_SOFTWARE_VERSIONS = [


### PR DESCRIPTION
intends to fix #3158, but not finished (hence WIP)

TODO:
* better test? (where `%(startdir)s` is actually used in an easyconfig file)
* also support use of `startdir` easyconfig parameter (equivalent to `start_dir`)
* deprecate `start_dir` easyconfig parameter
