### PR TITLE
Fix EasyConfig.update code to handle both strings and lists as input.

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -566,8 +566,7 @@ class EasyConfig(object):
                 if allow_duplicate or (not prev_value.startswith('%s ' % item)
                                        and not prev_value.endswith(' %s' % item)
                                        and ' %s ' % item not in prev_value):
-                    prev_value += ' %s' % item
-            prev_value += ' '
+                    prev_value += ' %s ' % item
         elif isinstance(prev_value, list):
             for item in lval:
                 if allow_duplicate or item not in prev_value:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -565,9 +565,7 @@ class EasyConfig(object):
         prev_value = self[key]
         if isinstance(prev_value, string_type):
             for item in lval:
-                if allow_duplicate or (not prev_value.startswith('%s ' % item) and
-                                       not prev_value.endswith(' %s' % item) and
-                                       ' %s ' % item not in prev_value):
+                if allow_duplicate or (not re.search(r'(^|\s+)%s(\s+|$)' % item, prev_value)):
                     prev_value += ' %s ' % item
         elif isinstance(prev_value, list):
             for item in lval:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -565,7 +565,7 @@ class EasyConfig(object):
         prev_value = self[key]
         if isinstance(prev_value, string_type):
             for item in lval:
-                if allow_duplicate or (not re.search(r'(^|\s+)%s(\s+|$)' % item, prev_value)):
+                if allow_duplicate or (not re.search(r'(^|\s+)%s(\s+|$)' % re.escape(item), prev_value)):
                     prev_value += ' %s ' % item
         elif isinstance(prev_value, list):
             for item in lval:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -562,19 +562,20 @@ class EasyConfig(object):
             msg += "attempted update value, '%s', is not a string or list."
             raise EasyBuildError(msg, key, value)
 
-        prev_value = self[key]
-        if isinstance(prev_value, string_type):
+        param_value = self[key]
+        if isinstance(param_value, string_type):
             for item in lval:
-                if allow_duplicate or (not re.search(r'(^|\s+)%s(\s+|$)' % re.escape(item), prev_value)):
-                    prev_value += ' %s ' % item
-        elif isinstance(prev_value, list):
+                # re.search: only add value to string if it's not there yet (surrounded by whitespace)
+                if allow_duplicate or (not re.search(r'(^|\s+)%s(\s+|$)' % re.escape(item), param_value)):
+                    param_value = param_value + ' %s ' % item
+        elif isinstance(param_value, list):
             for item in lval:
-                if allow_duplicate or item not in prev_value:
-                    prev_value.append(item)
+                if allow_duplicate or item not in param_value:
+                    param_value = param_value + [item]
         else:
             raise EasyBuildError("Can't update configuration value for %s, because it's not a string or list.", key)
 
-        self[key] = prev_value
+        self[key] = param_value
 
     def set_keys(self, params):
         """

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -558,14 +558,16 @@ class EasyConfig(object):
         elif isinstance(value, list):
             lval = value
         else:
-            raise EasyBuildError("Can't update configuration value for %s, because the attempted update value, '%s', is not a string or list.", key, value)
+            msg = "Can't update configuration value for %s, because the "
+            msg += "attempted update value, '%s', is not a string or list."
+            raise EasyBuildError(msg, key, value)
 
         prev_value = self[key]
         if isinstance(prev_value, string_type):
             for item in lval:
-                if allow_duplicate or (not prev_value.startswith('%s ' % item)
-                                       and not prev_value.endswith(' %s' % item)
-                                       and ' %s ' % item not in prev_value):
+                if allow_duplicate or (not prev_value.startswith('%s ' % item) and
+                                       not prev_value.endswith(' %s' % item) and
+                                       ' %s ' % item not in prev_value):
                     prev_value += ' %s ' % item
         elif isinstance(prev_value, list):
             for item in lval:

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1519,16 +1519,21 @@ class EasyConfigTest(EnhancedTestCase):
         ec.update('configopts', 'CC="$CC"')
         ec.update('configopts', 'CXX="$CXX"')
         self.assertTrue(ec['configopts'].strip().endswith('CC="$CC"  CXX="$CXX"'))
+        # spaces in between multiple updates for string values from list
+        ec.update('configopts', ['MORE_VALUE', 'EVEN_MORE'])
+        self.assertTrue(ec['configopts'].strip().endswith('MORE_VALUE  EVEN_MORE'))
 
         # for list values: extend
         ec.update('patches', ['foo.patch', 'bar.patch'])
         toy_patch_fn = 'toy-0.0_fix-silly-typo-in-printf-statement.patch'
         self.assertEqual(ec['patches'], [toy_patch_fn, ('toy-extra.txt', 'toy-0.0'), 'foo.patch', 'bar.patch'])
 
-        # for unallowed duplicates
+        # for unallowed duplicates on string values
         ec.update('configopts', 'SOME_VALUE')
         configopts_tmp = ec['configopts']
         ec.update('configopts', 'SOME_VALUE', allow_duplicate=False)
+        self.assertEqual(ec['configopts'], configopts_tmp)
+        ec.update('configopts', ['CC="$CC"', 'SOME_VALUE'], allow_duplicate=False)
         self.assertEqual(ec['configopts'], configopts_tmp)
 
         # for unallowed duplicates when a list is used

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1515,7 +1515,7 @@ class EasyConfigTest(EnhancedTestCase):
         ec.update('description', "- just a test")
         self.assertEqual(ec['description'].strip(), "Toy C program, 100% toy. - just a test")
 
-        # spaces in between multiple updates for stirng values
+        # spaces in between multiple updates for string values
         ec.update('configopts', 'CC="$CC"')
         ec.update('configopts', 'CXX="$CXX"')
         self.assertTrue(ec['configopts'].strip().endswith('CC="$CC"  CXX="$CXX"'))


### PR DESCRIPTION
Correctly handle allow_duplicate=False when "value" is a partial match
for an item in key when key is a string.