### PR TITLE
increase timeout & use api.github.com for connectivity check in check_github

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1611,7 +1611,7 @@ def check_github():
     # check whether we're online; if not, half of the checks are going to fail...
     try:
         print_msg("Making sure we're online...", log=_log, prefix=False, newline=False)
-        urlopen(GITHUB_URL, timeout=30)
+        urlopen(GITHUB_API_URL, timeout=30)
         print_msg("OK\n", log=_log, prefix=False)
     except URLError as err:
         print_msg("FAIL (%s)", err, log=_log, prefix=False)

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1611,10 +1611,10 @@ def check_github():
     # check whether we're online; if not, half of the checks are going to fail...
     try:
         print_msg("Making sure we're online...", log=_log, prefix=False, newline=False)
-        urlopen(GITHUB_URL, timeout=5)
+        urlopen(GITHUB_URL, timeout=30)
         print_msg("OK\n", log=_log, prefix=False)
     except URLError as err:
-        print_msg("FAIL")
+        print_msg("FAIL", log=_log, prefix=False)
         raise EasyBuildError("checking status of GitHub integration must be done online")
 
     # GitHub user

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1614,7 +1614,7 @@ def check_github():
         urlopen(GITHUB_URL, timeout=30)
         print_msg("OK\n", log=_log, prefix=False)
     except URLError as err:
-        print_msg("FAIL", log=_log, prefix=False)
+        print_msg("FAIL (%s)", err, log=_log, prefix=False)
         raise EasyBuildError("checking status of GitHub integration must be done online")
 
     # GitHub user


### PR DESCRIPTION
This should fix flaky test failures like in https://github.com/easybuilders/easybuild-framework/pull/3191