### PR TITLE
fix online check in --check-github: try repeatedly and with different URLs to cater for HTTP issues

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1600,9 +1600,10 @@ def check_online_status():
     # E.g. Github returned "HTTP Error 403: Forbidden" and "HTTP Error 406: Not Acceptable" randomly
     # Timeout and repeats set to total 1 minute
     urls = [GITHUB_URL, GITHUB_API_URL]
-    for i in range(6):
+    num_repeats = 6
+    for attempt in range(num_repeats):
         try:
-            urlopen(urls[i % len(urls)], timeout=10)
+            urlopen(urls[attempt % len(urls)], timeout=10)
             result = True
             break
         except URLError as err:


### PR DESCRIPTION
Follow up to #3192

There can be many failures:

-    HTTP Error 403: Forbidden
-    HTTP Error 406
-    Timeout

The first 2 are solely caused by flaky github servers, the last one might be or it might be the user.
So retrying is reasonable: After all we are checking whether there is internet connectivity. And that is the case if any of those URLs is reachable in a reasonable amount of time. This makes the check somewhat immune to the flaky HTTP errors.

Note: This helps a lot for faster contributions. If GH currently returns a HTTP error then boegelbot will restart the whole job (or even many jobs) wasting a lot of time spend in setup and other tests. So not erroring out unnecessarily reduces stress on the test servers