### PR TITLE
Fix os_name_map for RHEL8.

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -563,6 +563,7 @@ def get_os_name():
 
     os_name_map = {
         'red hat enterprise linux server': 'RHEL',
+        'red hat enterprise linux': 'RHEL', # RHEL8 has no server/client
         'scientific linux sl': 'SL',
         'scientific linux': 'SL',
         'suse linux enterprise server': 'SLES',

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -563,7 +563,7 @@ def get_os_name():
 
     os_name_map = {
         'red hat enterprise linux server': 'RHEL',
-        'red hat enterprise linux': 'RHEL', # RHEL8 has no server/client
+        'red hat enterprise linux': 'RHEL',  # RHEL8 has no server/client
         'scientific linux sl': 'SL',
         'scientific linux': 'SL',
         'suse linux enterprise server': 'SLES',


### PR DESCRIPTION
  - RHEL8 no longer has a distinction between server and client,
    so the contents of /etc/redhat-release and similar files no
    longer contain such labels.