### PR TITLE
significantly speed up -D/--dry-run by avoiding useless 'module show'

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -90,7 +90,7 @@ _log = fancylogger.getLogger('easyconfig.tools', fname=False)
 def skip_available(easyconfigs, modtool):
     """Skip building easyconfigs for existing modules."""
     module_names = [ec['full_mod_name'] for ec in easyconfigs]
-    modules_exist = modtool.exist(module_names)
+    modules_exist = modtool.exist(module_names, maybe_partial=False)
     retained_easyconfigs = []
     for ec, mod_name, mod_exists in zip(easyconfigs, module_names, modules_exist):
         if mod_exists:


### PR DESCRIPTION
`ModulesTool.exist` falls back to use `module show` by default since the module names it is passed may be partial module names which won't show up in `module avail`.

In `skip_available` we're always passing full module names though, so there we can tell it the module names are *not* partial...

This results in a speedup of about 2x for `eb -D`!