### PR TITLE
add support for creating an index & using it when searching for easyconfigs

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -61,7 +61,8 @@ from easybuild.tools.build_log import EasyBuildError, print_warning, print_msg
 from easybuild.tools.config import LOCAL_VAR_NAMING_CHECK_ERROR, LOCAL_VAR_NAMING_CHECK_LOG, LOCAL_VAR_NAMING_CHECK_WARN
 from easybuild.tools.config import Singleton, build_option, get_module_naming_scheme
 from easybuild.tools.filetools import EASYBLOCK_CLASS_PREFIX, copy_file, decode_class_name, encode_class_name
-from easybuild.tools.filetools import find_backup_name_candidate, find_easyconfigs, read_file, write_file
+from easybuild.tools.filetools import create_index, find_backup_name_candidate, find_easyconfigs, load_index
+from easybuild.tools.filetools import read_file, write_file
 from easybuild.tools.hooks import PARSE, load_hooks, run_hook
 from easybuild.tools.module_naming_scheme.mns import DEVEL_MODULE_SUFFIX
 from easybuild.tools.module_naming_scheme.utilities import avail_module_naming_schemes, det_full_ec_version
@@ -102,6 +103,7 @@ except ImportError as err:
 
 _easyconfig_files_cache = {}
 _easyconfigs_cache = {}
+_path_indexes = {}
 
 
 def handle_deprecated_or_replaced_easyconfig_parameters(ec_method):
@@ -1890,10 +1892,19 @@ def robot_find_easyconfig(name, version):
 
     res = None
     for path in paths:
+        if path in _path_indexes:
+            path_index = _path_indexes[path]
+            _log.info("Found loaded index for %s", path)
+        else:
+            path_index = load_index(path)
+            if path_index:
+                _path_indexes[path] = path_index
+                _log.info("Loaded index for %s", path)
+
         easyconfigs_paths = create_paths(path, name, version)
         for easyconfig_path in easyconfigs_paths:
             _log.debug("Checking easyconfig path %s" % easyconfig_path)
-            if os.path.isfile(easyconfig_path):
+            if easyconfig_path in path_index or os.path.isfile(easyconfig_path):
                 _log.debug("Found easyconfig file for name %s, version %s at %s" % (name, version, easyconfig_path))
                 _easyconfig_files_cache[key] = os.path.abspath(easyconfig_path)
                 res = _easyconfig_files_cache[key]

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1897,9 +1897,13 @@ def robot_find_easyconfig(name, version):
             _log.info("Found loaded index for %s", path)
         else:
             path_index = load_index(path)
-            if path_index:
-                _path_indexes[path] = path_index
+            if path_index is None:
+                _log.info("No index found for %s, so creating it...", path)
+                path_index = create_index(path)
+            else:
                 _log.info("Loaded index for %s", path)
+
+            _path_indexes[path] = path_index
 
         easyconfigs_paths = create_paths(path, name, version)
         for easyconfig_path in easyconfigs_paths:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1895,7 +1895,7 @@ def robot_find_easyconfig(name, version):
         if path in _path_indexes:
             path_index = _path_indexes[path]
             _log.info("Found loaded index for %s", path)
-        else:
+        elif os.path.exists(path):
             path_index = load_index(path)
             if path_index is None:
                 _log.info("No index found for %s, so creating it...", path)
@@ -1904,6 +1904,8 @@ def robot_find_easyconfig(name, version):
                 _log.info("Loaded index for %s", path)
 
             _path_indexes[path] = path_index
+        else:
+            path_index = []
 
         easyconfigs_paths = create_paths(path, name, version)
         for easyconfig_path in easyconfigs_paths:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1901,7 +1901,11 @@ def robot_find_easyconfig(name, version):
 
     res = None
     for path in paths:
-        if path in _path_indexes:
+
+        if build_option('ignore_index'):
+            _log.info("Ignoring index for %s...", path)
+            path_index = []
+        elif path in _path_indexes:
             path_index = _path_indexes[path]
             _log.info("Found loaded index for %s", path)
         elif os.path.exists(path):

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -62,8 +62,8 @@ from easybuild.tools.build_log import EasyBuildError, print_warning, print_msg
 from easybuild.tools.config import GENERIC_EASYBLOCK_PKG, LOCAL_VAR_NAMING_CHECK_ERROR, LOCAL_VAR_NAMING_CHECK_LOG
 from easybuild.tools.config import LOCAL_VAR_NAMING_CHECK_WARN
 from easybuild.tools.config import Singleton, build_option, get_module_naming_scheme
-from easybuild.tools.filetools import EASYBLOCK_CLASS_PREFIX, copy_file, decode_class_name, encode_class_name
-from easybuild.tools.filetools import create_index, find_backup_name_candidate, find_easyconfigs, load_index
+from easybuild.tools.filetools import copy_file, create_index, decode_class_name, encode_class_name
+from easybuild.tools.filetools import find_backup_name_candidate, find_easyconfigs, load_index
 from easybuild.tools.filetools import read_file, write_file
 from easybuild.tools.hooks import PARSE, load_hooks, run_hook
 from easybuild.tools.module_naming_scheme.mns import DEVEL_MODULE_SUFFIX

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -258,7 +258,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
 
     elif options.create_index:
         print_msg("Creating index for %s..." % options.create_index, prefix=False)
-        index_fp = dump_index(options.create_index)
+        index_fp = dump_index(options.create_index, max_age_sec=options.index_max_age)
         index = load_index(options.create_index)
         print_msg("Index created at %s (%d files)" % (index_fp, len(index)), prefix=False)
 

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -56,7 +56,8 @@ from easybuild.framework.easyconfig.tweak import obtain_ec_for, tweak
 from easybuild.tools.config import find_last_log, get_repository, get_repositorypath, build_option
 from easybuild.tools.containers.common import containerize
 from easybuild.tools.docs import list_software
-from easybuild.tools.filetools import adjust_permissions, cleanup, copy_file, copy_files, read_file, write_file
+from easybuild.tools.filetools import adjust_permissions, cleanup, copy_file, copy_files, dump_index, load_index
+from easybuild.tools.filetools import read_file, write_file
 from easybuild.tools.github import check_github, close_pr, new_branch_github, find_easybuild_easyconfig
 from easybuild.tools.github import install_github_token, list_prs, new_pr, new_pr_from_branch, merge_pr
 from easybuild.tools.github import sync_branch_with_develop, sync_pr_with_develop, update_branch, update_pr
@@ -255,9 +256,16 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     elif options.list_software:
         print(list_software(output_format=options.output_format, detailed=options.list_software == 'detailed'))
 
+    elif options.create_index:
+        print_msg("Creating index for %s..." % options.create_index, prefix=False)
+        index_fp = dump_index(options.create_index)
+        index = load_index(options.create_index)
+        print_msg("Index created at %s (%d files)" % (index_fp, len(index)), prefix=False)
+
     # non-verbose cleanup after handling GitHub integration stuff or printing terse info
     early_stop_options = [
         options.check_github,
+        options.create_index,
         options.install_github_token,
         options.list_installed_software,
         options.list_software,

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -78,6 +78,7 @@ CONT_TYPE_SINGULARITY = 'singularity'
 CONT_TYPES = [CONT_TYPE_DOCKER, CONT_TYPE_SINGULARITY]
 DEFAULT_CONT_TYPE = CONT_TYPE_SINGULARITY
 
+DEFAULT_INDEX_MAX_AGE = 7 * 24 * 60 * 60  # 1 week (in seconds)
 DEFAULT_JOB_BACKEND = 'GC3Pie'
 DEFAULT_LOGFILE_FORMAT = ("easybuild", "easybuild-%(name)s-%(version)s-%(date)s.%(time)s.log")
 DEFAULT_MAX_FAIL_RATIO_PERMS = 0.5
@@ -269,6 +270,9 @@ BUILD_OPTIONS_CMDLINE = {
     ],
     DEFAULT_CONT_TYPE: [
         'container_type',
+    ],
+    DEFAULT_INDEX_MAX_AGE: [
+        'index_max_age',
     ],
     DEFAULT_MAX_FAIL_RATIO_PERMS: [
         'max_fail_ratio_adjust_permissions',

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -226,6 +226,7 @@ BUILD_OPTIONS_CMDLINE = {
         'group_writable_installdir',
         'hidden',
         'ignore_checksums',
+        'ignore_index',
         'install_latest_eb_release',
         'lib64_fallback_sanity_check',
         'logtostdout',

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -764,8 +764,11 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filen
 
         path_index = load_index(path, ignore_dirs=ignore_dirs)
         if path_index is None:
-            _log.info("No index found for %s, creating one...", path)
-            path_index = create_index(path, ignore_dirs=ignore_dirs)
+            if os.path.exists(path):
+                _log.info("No index found for %s, creating one...", path)
+                path_index = create_index(path, ignore_dirs=ignore_dirs)
+            else:
+                path_index = []
         else:
             _log.info("Index found for %s, so using it...", path)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -59,7 +59,7 @@ from easybuild.base import fancylogger
 from easybuild.tools import run
 # import build_log must stay, to use of EasyBuildLog
 from easybuild.tools.build_log import EasyBuildError, dry_run_msg, print_msg, print_warning
-from easybuild.tools.config import ,GENERIC_EASYBLOCK_PKG build_option
+from easybuild.tools.config import GENERIC_EASYBLOCK_PKG, build_option
 from easybuild.tools.py2vs3 import std_urllib, string_type
 from easybuild.tools.utilities import nub, remove_unwanted_chars
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -611,15 +611,15 @@ def create_index(path, ignore_dirs=None):
     elif not os.path.isdir(path):
         raise EasyBuildError("Specified path is not a directory: %s", path)
 
-    for (dirpath, dirnames, filenames) in os.walk(path, topdown=True):
+    for (dirpath, dirnames, filenames) in os.walk(path, topdown=True, followlinks=True):
         for filename in filenames:
             # use relative paths in index
-            index.add(os.path.join(dirpath[len(path) + 1:], filename))
+            index.add(os.path.join(os.path.relpath(dirpath, path), filename))
 
         # do not consider (certain) hidden directories
         # note: we still need to consider e.g., .local !
         # replace list elements using [:], so os.walk doesn't process deleted directories
-        # see http://stackoverflow.com/questions/13454164/os-walk-without-hidden-folders
+        # see https://stackoverflow.com/questions/13454164/os-walk-without-hidden-folders
         dirnames[:] = [d for d in dirnames if d not in ignore_dirs]
 
     return index

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -614,7 +614,11 @@ def create_index(path, ignore_dirs=None):
     for (dirpath, dirnames, filenames) in os.walk(path, topdown=True, followlinks=True):
         for filename in filenames:
             # use relative paths in index
-            index.add(os.path.join(os.path.relpath(dirpath, path), filename))
+            rel_dirpath = os.path.relpath(dirpath, path)
+            # avoid that relative paths start with './'
+            if rel_dirpath == '.':
+                rel_dirpath = ''
+            index.add(os.path.join(rel_dirpath, filename))
 
         # do not consider (certain) hidden directories
         # note: we still need to consider e.g., .local !

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -614,7 +614,7 @@ def create_index(path, ignore_dirs=None):
     for (dirpath, dirnames, filenames) in os.walk(path, topdown=True):
         for filename in filenames:
             # use relative paths in index
-            index.add(os.path.join(dirpath[len(path)+1:], filename))
+            index.add(os.path.join(dirpath[len(path) + 1:], filename))
 
         # do not consider (certain) hidden directories
         # note: we still need to consider e.g., .local !

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -770,7 +770,7 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filen
             print_msg("Searching (case-insensitive) for '%s' in %s " % (query.pattern, path), log=_log, silent=silent)
 
         path_index = load_index(path, ignore_dirs=ignore_dirs)
-        if path_index is None:
+        if path_index is None or build_option('ignore_index'):
             if os.path.exists(path):
                 _log.info("No index found for %s, creating one...", path)
                 path_index = create_index(path, ignore_dirs=ignore_dirs)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -691,6 +691,8 @@ def load_index(path, ignore_dirs=None):
             if curr_ts > valid_ts:
                 print_warning("Index for %s is no longer valid (too old), so ignoring it...", path)
                 index = None
+            else:
+                print_msg("found valid index for %s, so using it...", path)
 
     return index or None
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -684,7 +684,10 @@ def load_index(path, ignore_dirs=None):
     index_fp = os.path.join(path, PATH_INDEX_FILENAME)
     index = set()
 
-    if os.path.exists(index_fp):
+    if build_option('ignore_index'):
+        _log.info("Ignoring index for %s...", path)
+
+    elif os.path.exists(index_fp):
         lines = read_file(index_fp).splitlines()
 
         valid_ts_regex = re.compile("^# valid until: (.*)", re.M)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -681,6 +681,7 @@ class EasyBuildOptions(GeneralOption):
         descr = ("Options for Easyconfigs", "Options that affect all specified easyconfig files.")
 
         opts = OrderedDict({
+            'create-index': ("Create index for files in specified directory", None, 'store', None),
             'fix-deprecated-easyconfigs': ("Fix use of deprecated functionality in specified easyconfig files.",
                                            None, 'store_true', False),
             'inject-checksums': ("Inject checksums of specified type for sources/patches into easyconfig file(s)",

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -684,6 +684,7 @@ class EasyBuildOptions(GeneralOption):
             'create-index': ("Create index for files in specified directory", None, 'store', None),
             'fix-deprecated-easyconfigs': ("Fix use of deprecated functionality in specified easyconfig files.",
                                            None, 'store_true', False),
+            'ignore-index': ("Ignore index when searching for files", None, 'store_true', False),
             'index-max-age': ("Maximum age for index before it is considered stale (in seconds)",
                               int, 'store', DEFAULT_INDEX_MAX_AGE),
             'inject-checksums': ("Inject checksums of specified type for sources/patches into easyconfig file(s)",

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -59,9 +59,9 @@ from easybuild.tools import build_log, run  # build_log should always stay there
 from easybuild.tools.build_log import DEVEL_LOG_LEVEL, EasyBuildError
 from easybuild.tools.build_log import init_logging, log_start, print_warning, raise_easybuilderror
 from easybuild.tools.config import CONT_IMAGE_FORMATS, CONT_TYPES, DEFAULT_CONT_TYPE
-from easybuild.tools.config import DEFAULT_ALLOW_LOADED_MODULES, DEFAULT_FORCE_DOWNLOAD, DEFAULT_JOB_BACKEND
-from easybuild.tools.config import DEFAULT_LOGFILE_FORMAT, DEFAULT_MAX_FAIL_RATIO_PERMS, DEFAULT_MNS
-from easybuild.tools.config import DEFAULT_MODULE_SYNTAX, DEFAULT_MODULES_TOOL, DEFAULT_MODULECLASSES
+from easybuild.tools.config import DEFAULT_ALLOW_LOADED_MODULES, DEFAULT_FORCE_DOWNLOAD, DEFAULT_INDEX_MAX_AGE
+from easybuild.tools.config import DEFAULT_JOB_BACKEND, DEFAULT_LOGFILE_FORMAT, DEFAULT_MAX_FAIL_RATIO_PERMS
+from easybuild.tools.config import DEFAULT_MNS, DEFAULT_MODULE_SYNTAX, DEFAULT_MODULES_TOOL, DEFAULT_MODULECLASSES
 from easybuild.tools.config import DEFAULT_PATH_SUBDIRS, DEFAULT_PKG_RELEASE, DEFAULT_PKG_TOOL, DEFAULT_PKG_TYPE
 from easybuild.tools.config import DEFAULT_PNS, DEFAULT_PREFIX, DEFAULT_REPOSITORY, EBROOT_ENV_VAR_ACTIONS, ERROR
 from easybuild.tools.config import FORCE_DOWNLOAD_CHOICES, GENERAL_CLASS, IGNORE, JOB_DEPS_TYPE_ABORT_ON_ERROR
@@ -684,6 +684,8 @@ class EasyBuildOptions(GeneralOption):
             'create-index': ("Create index for files in specified directory", None, 'store', None),
             'fix-deprecated-easyconfigs': ("Fix use of deprecated functionality in specified easyconfig files.",
                                            None, 'store_true', False),
+            'index-max-age': ("Maximum age for index before it is considered stale (in seconds)",
+                              int, 'store', DEFAULT_INDEX_MAX_AGE),
             'inject-checksums': ("Inject checksums of specified type for sources/patches into easyconfig file(s)",
                                  'choice', 'store_or_None', CHECKSUM_TYPE_SHA256, CHECKSUM_TYPES),
             'local-var-naming-check': ("Mode to use when checking whether local variables follow the recommended "

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1690,20 +1690,22 @@ class FileToolsTest(EnhancedTestCase):
         # load_index just returns None if there is no index in specified directory
         self.assertEqual(ft.load_index(self.test_prefix), None)
 
-        # create index for test easyconfigs
-        index = ft.create_index(test_ecs)
-        self.assertEqual(len(index), 79)
+        # create index for test easyconfigs;
+        # test with specified path with and without trailing '/'s
+        for path in [test_ecs, test_ecs + '/', test_ecs + '//']:
+            index = ft.create_index(path)
+            self.assertEqual(len(index), 79)
 
-        expected = [
-            os.path.join('b', 'bzip2', 'bzip2-1.0.6-GCC-4.9.2.eb'),
-            os.path.join('t', 'toy', 'toy-0.0.eb'),
-            os.path.join('s', 'ScaLAPACK', 'ScaLAPACK-2.0.2-gompi-2018a-OpenBLAS-0.2.20.eb'),
-        ]
-        for fn in expected:
-            self.assertTrue(fn in index)
+            expected = [
+                os.path.join('b', 'bzip2', 'bzip2-1.0.6-GCC-4.9.2.eb'),
+                os.path.join('t', 'toy', 'toy-0.0.eb'),
+                os.path.join('s', 'ScaLAPACK', 'ScaLAPACK-2.0.2-gompi-2018a-OpenBLAS-0.2.20.eb'),
+            ]
+            for fn in expected:
+                self.assertTrue(fn in index)
 
-        for fp in index:
-            self.assertTrue(fp.endswith('.eb'))
+            for fp in index:
+                self.assertTrue(fp.endswith('.eb'))
 
         # set up some files to create actual index file for
         ft.copy_dir(os.path.join(test_ecs, 'g'), os.path.join(self.test_prefix, 'g'))

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1794,6 +1794,10 @@ class FileToolsTest(EnhancedTestCase):
         regex = re.compile(r"WARNING: Index for %s is no longer valid \(too old\), so ignoring it" % self.test_prefix)
         self.assertTrue(regex.search(stderr), "Pattern '%s' found in: %s" % (regex.pattern, stderr))
 
+        # check whether load_index takes into account --ignore-index
+        init_config(build_options={'ignore_index': True})
+        self.assertEqual(ft.load_index(self.test_prefix), None)
+
     def test_search_file(self):
         """Test search_file function."""
         test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1707,7 +1707,18 @@ class FileToolsTest(EnhancedTestCase):
             self.assertTrue(regex.search(index_txt), "Pattern '%s' found in: %s" % (regex.pattern, index_txt))
 
         # test load_index function
+        self.mock_stderr(True)
+        self.mock_stdout(True)
         index = ft.load_index(self.test_prefix)
+        stderr = self.get_stderr()
+        stdout = self.get_stdout()
+        self.mock_stderr(False)
+        self.mock_stdout(False)
+
+        self.assertFalse(stderr)
+        regex = re.compile("^== found valid index for %s, so using it\.\.\.$" % self.test_prefix)
+        self.assertTrue(regex.match(stdout.strip()), "Pattern '%s' matches with: %s" % (regex.pattern, stdout))
+
         self.assertEqual(len(index), 24)
         for fn in expected:
             self.assertTrue(fn in index, "%s should be found in %s" % (fn, sorted(index)))
@@ -1725,7 +1736,19 @@ class FileToolsTest(EnhancedTestCase):
         for fn in expected_header + expected:
             regex = re.compile('^%s$' % fn, re.M)
             self.assertTrue(regex.search(index_txt), "Pattern '%s' found in: %s" % (regex.pattern, index_txt))
+
+        self.mock_stderr(True)
+        self.mock_stdout(True)
         index = ft.load_index(self.test_prefix)
+        stderr = self.get_stderr()
+        stdout = self.get_stdout()
+        self.mock_stderr(False)
+        self.mock_stdout(False)
+
+        self.assertFalse(stderr)
+        regex = re.compile("^== found valid index for %s, so using it\.\.\.$" % self.test_prefix)
+        self.assertTrue(regex.match(stdout.strip()), "Pattern '%s' matches with: %s" % (regex.pattern, stdout))
+
         self.assertEqual(len(index), 24)
         for fn in expected:
             self.assertTrue(fn in index, "%s should be found in %s" % (fn, sorted(index)))

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1657,7 +1657,17 @@ class FileToolsTest(EnhancedTestCase):
 
         test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
 
-        # first test create_index function
+        # create_index checks whether specified path is an existing directory
+        doesnotexist = os.path.join(self.test_prefix, 'doesnotexist')
+        self.assertErrorRegex(EasyBuildError, "Specified path does not exist", ft.create_index, doesnotexist)
+
+        toy_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
+        self.assertErrorRegex(EasyBuildError, "Specified path is not a directory", ft.create_index, toy_ec)
+
+        # load_index just returns None if there is no index in specified directory
+        self.assertEqual(ft.load_index(self.test_prefix), None)
+
+        # create index for test easyconfigs
         index = ft.create_index(test_ecs)
         self.assertEqual(len(index), 79)
 
@@ -1676,10 +1686,9 @@ class FileToolsTest(EnhancedTestCase):
         ft.copy_dir(os.path.join(test_ecs, 'g'), os.path.join(self.test_prefix, 'g'))
 
         # test dump_index function
-        ft.dump_index(self.test_prefix)
-
-        index_fp = os.path.join(self.test_prefix, '.eb-path-index')
+        index_fp = ft.dump_index(self.test_prefix)
         self.assertTrue(os.path.exists(index_fp))
+        self.assertTrue(os.path.samefile(self.test_prefix, os.path.dirname(index_fp)))
 
         index_txt = ft.read_file(index_fp)
         expected = [

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1738,7 +1738,7 @@ class FileToolsTest(EnhancedTestCase):
         self.mock_stdout(False)
 
         self.assertFalse(stderr)
-        regex = re.compile("^== found valid index for %s, so using it\.\.\.$" % self.test_prefix)
+        regex = re.compile(r"^== found valid index for %s, so using it\.\.\.$" % self.test_prefix)
         self.assertTrue(regex.match(stdout.strip()), "Pattern '%s' matches with: %s" % (regex.pattern, stdout))
 
         self.assertEqual(len(index), 24)
@@ -1754,7 +1754,7 @@ class FileToolsTest(EnhancedTestCase):
         # test creating index file that's infinitely valid
         index_fp = ft.dump_index(self.test_prefix, max_age_sec=0)
         index_txt = ft.read_file(index_fp)
-        expected_header[1] = "# valid until: 9999-12-31 23:59:59\.9+"
+        expected_header[1] = r"# valid until: 9999-12-31 23:59:59\.9+"
         for fn in expected_header + expected:
             regex = re.compile('^%s$' % fn, re.M)
             self.assertTrue(regex.search(index_txt), "Pattern '%s' found in: %s" % (regex.pattern, index_txt))
@@ -1768,7 +1768,7 @@ class FileToolsTest(EnhancedTestCase):
         self.mock_stdout(False)
 
         self.assertFalse(stderr)
-        regex = re.compile("^== found valid index for %s, so using it\.\.\.$" % self.test_prefix)
+        regex = re.compile(r"^== found valid index for %s, so using it\.\.\.$" % self.test_prefix)
         self.assertTrue(regex.match(stdout.strip()), "Pattern '%s' matches with: %s" % (regex.pattern, stdout))
 
         self.assertEqual(len(index), 24)

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1652,6 +1652,51 @@ class FileToolsTest(EnhancedTestCase):
 
         ft.adjust_permissions(self.test_prefix, stat.S_IWUSR, add=True)
 
+    def test_index_functions(self):
+        """Test *_index functions."""
+
+        test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+
+        # first test create_index function
+        index = ft.create_index(test_ecs)
+        self.assertEqual(len(index), 79)
+
+        expected = [
+            os.path.join('b', 'bzip2', 'bzip2-1.0.6-GCC-4.9.2.eb'),
+            os.path.join('t', 'toy', 'toy-0.0.eb'),
+            os.path.join('s', 'ScaLAPACK', 'ScaLAPACK-2.0.2-gompi-2018a-OpenBLAS-0.2.20.eb'),
+        ]
+        for fn in expected:
+            self.assertTrue(fn in index)
+
+        for fp in index:
+            self.assertTrue(fp.endswith('.eb'))
+
+        # set up some files to create actual index file for
+        ft.copy_dir(os.path.join(test_ecs, 'g'), os.path.join(self.test_prefix, 'g'))
+
+        # test dump_index function
+        ft.dump_index(self.test_prefix)
+
+        index_fp = os.path.join(self.test_prefix, '.eb-path-index')
+        self.assertTrue(os.path.exists(index_fp))
+
+        index_txt = ft.read_file(index_fp)
+        expected = [
+            os.path.join('g', 'gzip', 'gzip-1.4.eb'),
+            os.path.join('g', 'GCC', 'GCC-7.3.0-2.30.eb'),
+            os.path.join('g', 'gompic', 'gompic-2018a.eb'),
+        ]
+        for fn in expected:
+            regex = re.compile('^%s$' % fn, re.M)
+            self.assertTrue(regex.search(index_txt), "Pattern '%s' found in: %s" % (regex.pattern, index_txt))
+
+        # test load_index function
+        index = ft.load_index(self.test_prefix)
+        self.assertEqual(len(index), 24)
+        for fn in expected:
+            self.assertTrue(fn in index)
+
     def test_search_file(self):
         """Test search_file function."""
         test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5016,7 +5016,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, error_pattern, self._run_mock_eb, args, raise_error=True)
 
         # also test creating index that's infinitely valid
-        args.extend(['--index-max-ag=0', '--force'])
+        args.extend(['--index-max-age=0', '--force'])
         self._run_mock_eb(args, raise_error=True)
         index_txt = read_file(index_fp)
         regex = re.compile(r"^# valid until: 9999-12-31 23:59:59", re.M)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -4676,6 +4676,25 @@ class CommandLineOptionsTest(EnhancedTestCase):
         regex = re.compile(r"^cuda-compute-capabilities\s*\(C\)\s*=\s*3\.5, 6\.2, 7\.0$", re.M)
         self.assertTrue(regex.search(txt), "Pattern '%s' not found in: %s" % (regex.pattern, txt))
 
+    def test_create_index(self):
+        """Test --create-index option."""
+        test_ecs = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'easyconfigs', 'test_ecs')
+        remove_dir(self.test_prefix)
+        copy_dir(test_ecs, self.test_prefix)
+
+        args = ['--create-index', self.test_prefix]
+        stdout, stderr = self._run_mock_eb(args, raise_error=True)
+
+        self.assertEqual(stderr, '')
+
+        patterns = [
+            r"^Creating index for %s\.\.\.$",
+            r"^Index created at %s/\.eb-path-index \([0-9]+ files\)$",
+        ]
+        for pattern in patterns:
+            regex = re.compile(pattern % self.test_prefix, re.M)
+            self.assertTrue(regex.search(stdout), "Pattern %s matches in: %s" % (regex.pattern, stdout))
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -785,13 +785,11 @@ class CommandLineOptionsTest(EnhancedTestCase):
         toy_ec = os.path.join(test_ecs_dir, 'test_ecs', 't', 'toy', 'toy-0.0.eb')
         copy_file(toy_ec, self.test_prefix)
 
+        toy_ec_list = ['toy-0.0.eb', 'toy-1.2.3.eb', 'toy-4.5.6.eb']
+
         # install index that list more files than are actually available,
         # so we can check whether it's used
-        index_txt = '\n'.join([
-            'toy-0.0.eb',
-            'toy-1.2.3.eb',
-            'toy-4.5.6.eb',
-        ])
+        index_txt = '\n'.join(toy_ec_list)
         write_file(os.path.join(self.test_prefix, '.eb-path-index'), index_txt)
 
         args = [
@@ -803,7 +801,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         stdout = self.get_stdout()
         self.mock_stdout(False)
 
-        for toy_ec_fn in ['toy-0.0.eb', 'toy-1.2.3.eb', 'toy-4.5.6.eb']:
+        for toy_ec_fn in toy_ec_list:
             regex = re.compile(re.escape(os.path.join(self.test_prefix, toy_ec_fn)), re.M)
             self.assertTrue(regex.search(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
 


### PR DESCRIPTION
With `--create-index` you can create an index file that significantly speeds up searching for (easyconfig) files (& patches) on slow filesystems. You can control how long the index is valid via `--index-max-age` (in seconds), where 1 week (604800 seconds) is the default, and `0` indicates that the index remains valid indefinitely.

If an index is available, it's used both for `--search` and `--robot`.