### PR TITLE
[bootstrap] Fix building setuptools

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -156,7 +156,7 @@ jobs:
           EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
           EB_BOOTSTRAP_SHA256SUM=$(sha256sum easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
           EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-          EB_BOOTSTRAP_EXPECTED="20200820.01 d490d229a18bd5eaa717bb8d5684d754729143d5e995e35a40c84d03ffb1de50"
+          EB_BOOTSTRAP_EXPECTED="20200914.01 8b89f828d034f9f0a175a1551f71bc3034db487e781e2f41a0f14b747a72b0ee"
           test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
 
           # test bootstrap script

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20200820.01 d490d229a18bd5eaa717bb8d5684d754729143d5e995e35a40c84d03ffb1de50"
+    - EB_BOOTSTRAP_EXPECTED="20200914.01 8b89f828d034f9f0a175a1551f71bc3034db487e781e2f41a0f14b747a72b0ee"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -756,6 +756,10 @@ def stage2(tmpdir, templates, install_path, distribute_egg_dir, sourcepath):
     sources_tmpl = "%(easybuild-framework)s%(easybuild-easyblocks)s%(easybuild-easyconfigs)s"
     if eb_looseversion < LooseVersion('4.0'):
         sources_tmpl = "%(vsc-install)s%(vsc-base)s" + sources_tmpl
+        templates['toolchain'] = EASYBUILD_EASYCONFIG_TOOLCHAIN_PRE4
+    else:
+        templates['toolchain'] = EASYBUILD_EASYCONFIG_TOOLCHAIN
+
 
     templates.update({
         'source_urls': '\n'.join(["'%s'," % x for x in pkg_urls]),
@@ -833,7 +837,7 @@ def stage2(tmpdir, templates, install_path, distribute_egg_dir, sourcepath):
     eb_spec = {
         'name': 'EasyBuild',
         'hidden': False,
-        'toolchain': {'name': 'dummy', 'version': 'dummy'},
+        'toolchain': templates['toolchain'],
         'version': templates['version'],
         'versionprefix': '',
         'versionsuffix': '',
@@ -1000,7 +1004,7 @@ description = \"\"\"EasyBuild is a software build and installation framework
 written in Python that allows you to install software in a structured,
 repeatable and robust way.\"\"\"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = %(toolchain)s
 
 source_urls = [%(source_urls)s]
 sources = [%(sources)s]
@@ -1018,6 +1022,10 @@ sanity_check_paths = {
 
 moduleclass = 'tools'
 """
+# Toolchain to be used for EasyBuild < 4.0
+EASYBUILD_EASYCONFIG_TOOLCHAIN_PRE4 = {'name': 'dummy', 'version': 'dummy'}
+# Toolchain to be used for EasyBuild >= 4.0 (new default)
+EASYBUILD_EASYCONFIG_TOOLCHAIN = {'name': 'system', 'version': ''}
 
 # check Python version
 loose_pyver = LooseVersion(python_version())

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -62,7 +62,7 @@ else:
     import urllib.request as std_urllib
 
 
-EB_BOOTSTRAP_VERSION = '20200820.01'
+EB_BOOTSTRAP_VERSION = '20200914.01'
 
 # argparse preferrred, optparse deprecated >=2.7
 HAVE_ARGPARSE = False

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -334,32 +334,33 @@ def check_setuptools():
     #       So, we'll check things by running commands through os.system rather than importing setuptools directly.
     cmd_tmpl = "%s -c '%%s' > %s 2>&1" % (sys.executable, outfile)
 
-    # check setuptools version
-    try:
-        os.system(cmd_tmpl % "import setuptools; print(setuptools.__version__)")
-        setuptools_ver = LooseVersion(open(outfile).read().strip())
-        debug("Found setuptools version %s" % setuptools_ver)
-
-        min_setuptools_ver = '0.6c11'
-        if setuptools_ver < LooseVersion(min_setuptools_ver):
-            debug("Minimal setuptools version %s not satisfied, found '%s'" % (min_setuptools_ver, setuptools_ver))
-            res = False
-    except Exception as err:
-        debug("Failed to check setuptools version: %s" % err)
-        res = False
-
     os.system(cmd_tmpl % "from setuptools.command import easy_install; print(easy_install.__file__)")
     out = open(outfile).read().strip()
-    debug("Location of setuptools' easy_install module: %s" % out)
     if 'setuptools/command/easy_install' not in out:
         debug("Module 'setuptools.command.easy_install not found")
         res = False
+    else:
+        debug("Location of setuptools' easy_install module: %s" % out)
 
-    if res is None:
-        os.system(cmd_tmpl % "import setuptools; print(setuptools.__file__)")
-        setuptools_loc = open(outfile).read().strip()
-        res = os.path.dirname(os.path.dirname(setuptools_loc))
-        debug("Location of setuptools installation: %s" % res)
+        # check setuptools version
+        try:
+            os.system(cmd_tmpl % "import setuptools; print(setuptools.__version__)")
+            setuptools_ver = LooseVersion(open(outfile).read().strip())
+            debug("Found setuptools version %s" % setuptools_ver)
+
+            min_setuptools_ver = '0.6c11'
+            if setuptools_ver < LooseVersion(min_setuptools_ver):
+                debug("Minimal setuptools version %s not satisfied, found '%s'" % (min_setuptools_ver, setuptools_ver))
+                res = False
+        except Exception as err:
+            debug("Failed to check setuptools version: %s" % err)
+            res = False
+
+        if res is None:
+            os.system(cmd_tmpl % "import setuptools; print(setuptools.__file__)")
+            setuptools_loc = open(outfile).read().strip()
+            res = os.path.dirname(os.path.dirname(setuptools_loc))
+            debug("Location of setuptools installation: %s" % res)
 
     try:
         os.remove(outfile)

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -376,6 +376,10 @@ def run_easy_install(args):
     debug("Active setuptools installation: %s" % setuptools.__file__)
     from setuptools.command import easy_install
 
+    # PyPi no longer supports http but setuptools 0.6.x easy_install defaults to that
+    if LooseVersion(setuptools.__version__) < LooseVersion('0.7.0'):
+        args.insert(0, '--index-url=https://pypi.python.org/simple')
+
     orig_stdout, orig_stderr = mock_stdout_stderr()
     try:
         easy_install.main(args)
@@ -432,6 +436,9 @@ def stage0(tmpdir):
                      txt)
         # silence distribute_setup.py completely by setting high log level threshold
         txt = re.sub(r'([^\n]*)(# extracting the tarball[^\n]*)', r'\1log.set_verbosity(1000)\n\1\2', txt)
+
+    # PyPi no longer supports http
+    txt = txt.replace('http://', 'https://')
 
     # write distribute_setup.py to file (with correct header)
     distribute_setup = os.path.join(tmpdir, 'distribute_setup.py')

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -1151,8 +1151,10 @@ i9tGe6+O/V0LCkGXvNkrKK2++u9qLFyTkO2sp7xSt/Bfil9os3SeOlY5fvv9mLcFj5zSNUqsRZfU
 7lwukTHLpfpLDH2GT+yCCf8D2cp1xw==
 """
 if IS_PY3:
-    DISTRIBUTE_SETUP_PY = DISTRIBUTE_SETUP_PY.encode('ascii')
+    DISTRIBUTE_SETUP_PY = DISTRIBUTE_SETUP_PY.encode()
 DISTRIBUTE_SETUP_PY = codecs.decode(codecs.decode(DISTRIBUTE_SETUP_PY, "base64"), "zlib")
+if IS_PY3:
+    DISTRIBUTE_SETUP_PY = DISTRIBUTE_SETUP_PY.decode()
 
 # run main function as body of script
 main()


### PR DESCRIPTION
Fixes #3200
Fixes #2428

This started as a fix for #3200 but falls a bit short of solving the installation for a Python3 environment without setuptools already installed.

What works/got fixed:
- Installation on Python2
  - Use https for PyPi (they dropped support for http) to fix installing/using distribute
- Use correct string type for setup_distribute unpacked blob (#3200)
- Reduce some noise when checking for setuptools
- Use system toolchain instead of dummy toolchain for EB >= 4.0

Problems to be resolved in follow-up:   
TLDR: Don't use easy_install anymore

The `distribute` package used installs an incredibly ancient version of setuptools which doesn't work out of the box anymore (see above and the need for patching setuptools and the setup_distribute script). There was/is even an ez_setup.py script which seems to superseed this: https://bootstrap.pypa.io/ez_setup.py   
However even that is deprecated: https://github.com/pypa/setuptools/issues/581

I started to use the https://bootstrap.pypa.io/get-pip.py to install pip (if missing) and then use `pip` to install setuptools just as `distribute` would have. But I hit another, currently hidden problem: The EB `bootstrap` script has a function `prep` which sets up PYTHONPATH for some temporary location where `stage{0,1,2}` are going to be installed to. It then proceeds to **import** easy_install and start installing dependencies and packages of EB (e.g. vsc-*) into that environment. The problem: This environment is **not** part of the current environment (`sys.path`). Hence easy_install fails to find the dependencies it just installed and tries to redownload them, which then fails because it doesn't find the `wheels` package which is also part of the stage0 environment (and would be part of a `system()` invoked environment) This is (at least partially) due to the mismatch of the environments, i.e. python core libs check for support of features and then run `system()` but those features are not part of that sub-process to to mismatch of PYTHONPATH vs sys.path.

IMO the easiest solution would be just use pip run via `system` and install pip if it is missing. Potentially (very probably required) also upgrade pip and setuptools into the stage1 directory.

Summary of proposed EB bootstrap procedure:
- Prepare stage1 environment in new temporary folder
  - Check for pip and if non-existant install into stage1 via get-pip script
  - Upgrade pip and setuptools with `--prefix` set to the temporary folder using pip
  - Install EB and its dependencies into that stage1 folder using pip
- In stage2
  - Use `system("eb ...")` to install the real EasyBuild via stage1 EB
  - double-check if the workarounds for pre 4.0 EB setting PYTHONPATH and force-installing vsc-install and setuptools are still required for this setup. I'd expect EB to handle that. If that is required use `pip` instead to do that.

In addition: Setup CI for the boostrap script   
- Use a dedicated .github file for those tests instead of duplicates in travis and github testing in non-clean environments
- For all python versions test in default environment AND in stripped environment where all packages are removed