### PR TITLE
Fix gitdb dependency on Python 2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,10 @@ keyring==5.7.1; python_version < '2.7'
 keyring<=9.1; python_version >= '2.7'
 keyrings.alt; python_version >= '2.7'
 
+# GitDB 4.0.1 no longer supports Python 2.6
+gitdb==0.6.4; python_version < '2.7'
+gitdb; python_version >= '2.7'
+
 # GitPython 2.1.9 no longer supports Python 2.6
 GitPython==2.1.8; python_version < '2.7'
 GitPython; python_version >= '2.7'


### PR DESCRIPTION
GitDB 4.0.1 was recently released (23.2.20) which does not work with Python 2.6 making CI tests fail
Pin to last known working version