### PR TITLE
make ModulesTool.exist more robust w.r.t. module wrappers, aliases, defaults, etc.

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -489,7 +489,8 @@ class ModulesTool(object):
         Only .modulerc file in Tcl syntax is considered here.
         DEPRECATED. Use exists()
         """
-        self.log.deprecated('module_wrapper_exists is unreliable and should no longer be used', '5.0')
+        self.log.deprecated('module_wrapper_exists is unreliable and should no longer be used. ' +
+                            'Use exists instead to check for an existing module or alias.', '5.0')
 
         if mod_wrapper_regex_template is None:
             mod_wrapper_regex_template = "^[ ]*module-version (?P<wrapped_mod>[^ ]*) %s$"

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -541,6 +541,9 @@ class ModulesTool(object):
         :param skip_avail: skip checking through 'module avail', only check via 'module show'
         :param maybe_partial: indicates if the module name may be a partial module name
         """
+        if mod_exists_regex_template is not None:
+            self.log.deprecated('mod_exists_regex_template is no longer used', '5.0')
+
         def mod_exists_via_show(mod_name):
             """
             Helper function to check whether specified module name exists through 'module show'.
@@ -563,9 +566,6 @@ class ModulesTool(object):
                     res = True
                 break
             return res
-
-        if mod_exists_regex_template is not None:
-            self.log.deprecated('mod_exists_regex_template is no longer used', '5.0')
 
         if skip_avail:
             avail_mod_names = []

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -487,7 +487,10 @@ class ModulesTool(object):
         """
         Determine whether a module wrapper with specified name exists.
         Only .modulerc file in Tcl syntax is considered here.
+        DEPRECATED. Use exists()
         """
+        self.log.deprecated('module_wrapper_exists is unreliable and should no longer be used', '5.0')
+
         if mod_wrapper_regex_template is None:
             mod_wrapper_regex_template = "^[ ]*module-version (?P<wrapped_mod>[^ ]*) %s$"
 
@@ -581,15 +584,6 @@ class ModulesTool(object):
                 # hidden modules are not visible in 'avail', need to use 'show' instead
                 self.log.debug("checking whether hidden module %s exists via 'show'..." % mod_name)
                 mod_exists = mod_exists_via_show(mod_name)
-
-            # if no module file was found, check whether specified module name can be a 'wrapper' module...
-            if not mod_exists:
-                self.log.debug("Module %s not found via module avail/show, checking whether it is a wrapper", mod_name)
-                wrapped_mod = self.module_wrapper_exists(mod_name)
-                if wrapped_mod is not None:
-                    # module wrapper only really exists if the wrapped module file is also available
-                    mod_exists = wrapped_mod in avail_mod_names or mod_exists_via_show(wrapped_mod)
-                    self.log.debug("Result for existence check of wrapped module %s: %s", wrapped_mod, mod_exists)
 
             self.log.debug("Result for existence check of %s module: %s", mod_name, mod_exists)
 
@@ -1408,7 +1402,7 @@ class Lmod(ModulesTool):
     def module_wrapper_exists(self, mod_name):
         """
         Determine whether a module wrapper with specified name exists.
-        First check for wrapper defined in .modulerc.lua, fall back to also checking .modulerc (Tcl syntax).
+        DEPRECATED. Use exists()
         """
         res = None
 

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -771,8 +771,8 @@ class ModulesTool(object):
         # also catch and check exit code
         exit_code = proc.returncode
         if kwargs.get('check_exit_code', True) and exit_code != 0:
-            raise EasyBuildError("Module command 'module %s' failed with exit code %s; stderr: %s; stdout: %s",
-                                 ' '.join(cmd_list[2:]), exit_code, stderr, stdout)
+            raise EasyBuildError("Module command '%s' failed with exit code %s; stderr: %s; stdout: %s",
+                                 ' '.join(cmd_list), exit_code, stderr, stdout)
 
         if kwargs.get('check_output', True):
             self.check_module_output(full_cmd, stdout, stderr)

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -317,12 +317,6 @@ class ModulesTest(EnhancedTestCase):
         # And completely different name
         self.assertEqual(self.modtool.exist(['JavaAlias']), [True])
 
-        # Allow for now...
-        self.allow_deprecated_behaviour()
-        self.assertEqual(self.modtool.module_wrapper_exists('Java/1.8'), 'Java/1.8.0_181')
-        self.assertEqual(self.modtool.module_wrapper_exists('Java/site_default'), 'Java/1.8.0_181')
-        self.disallow_deprecated_behaviour()
-
         reset_module_caches()
 
         # what if we're in an HMNS setting...
@@ -333,11 +327,6 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(self.modtool.exist(['Core/Java/1.8.0_181']), [True])
         self.assertEqual(self.modtool.exist(['Core/Java/1.8']), [True])
         self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
-
-        self.allow_deprecated_behaviour()
-        self.assertEqual(self.modtool.module_wrapper_exists('Core/Java/1.8'), 'Core/Java/1.8.0_181')
-        self.assertEqual(self.modtool.module_wrapper_exists('Core/Java/site_default'), 'Core/Java/1.8.0_181')
-        self.disallow_deprecated_behaviour()
 
         # also check with .modulerc.lua for Lmod 7.8 or newer
         if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.8'):
@@ -362,11 +351,6 @@ class ModulesTest(EnhancedTestCase):
             # And completely different name
             self.assertEqual(self.modtool.exist(['JavaAlias']), [True])
 
-            self.allow_deprecated_behaviour()
-            self.assertEqual(self.modtool.module_wrapper_exists('Java/1.8'), 'Java/1.8.0_181')
-            self.assertEqual(self.modtool.module_wrapper_exists('Java/site_default'), 'Java/1.8.0_181')
-            self.disallow_deprecated_behaviour()
-
             reset_module_caches()
 
             # back to HMNS setup
@@ -375,11 +359,6 @@ class ModulesTest(EnhancedTestCase):
             self.assertEqual(self.modtool.exist(['Core/Java/1.8.0_181']), [True])
             self.assertEqual(self.modtool.exist(['Core/Java/1.8']), [True])
             self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
-
-            self.allow_deprecated_behaviour()
-            self.assertEqual(self.modtool.module_wrapper_exists('Core/Java/1.8'), 'Core/Java/1.8.0_181')
-            self.assertEqual(self.modtool.module_wrapper_exists('Core/Java/site_default'), 'Core/Java/1.8.0_181')
-            self.disallow_deprecated_behaviour()
 
         # Test alias in home directory .modulerc
         if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.0'):

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -722,24 +722,6 @@ class ModulesTest(EnhancedTestCase):
             res = modtool.modulefile_path('bzip2/.1.0.6', strip_ext=True)
             self.assertTrue(res.endswith('test/framework/modules/bzip2/.1.0.6'))
 
-        # hack into 'module show GCC/6.4.0-2.28' cache and inject alternate output that modulecmd.tcl sometimes produces
-        # make sure we only extract the module file path, nothing else...
-        # cfr. https://github.com/easybuilders/easybuild/issues/368
-        modulepath = os.environ['MODULEPATH'].split(':')
-        mod_show_cache_key = modtool.mk_module_cache_key('GCC/6.4.0-2.28')
-        mod.MODULE_SHOW_CACHE[mod_show_cache_key] = '\n'.join([
-            "import os",
-            "os.environ['MODULEPATH_modshare'] = '%s'" % ':'.join(m + ':1' for m in modulepath),
-            "os.environ['MODULEPATH'] = '%s'" % ':'.join(modulepath),
-            "------------------------------------------------------------------------------",
-            "%s:" % gcc_mod_file,
-            "------------------------------------------------------------------------------",
-            # remainder of output doesn't really matter in this context
-            "setenv		EBROOTGCC /prefix/GCC/6.4.0-2.28"
-        ])
-        res = modtool.modulefile_path('GCC/6.4.0-2.28')
-        self.assertTrue(os.path.samefile(res, os.path.join(test_dir, 'modules', 'GCC', '6.4.0-2.28')))
-
         reset_module_caches()
 
     def test_path_to_top_of_module_tree(self):

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -148,9 +148,9 @@ class ModulesTest(EnhancedTestCase):
         res = self.modtool.run_module('list')
         self.assertEqual(res, [{'mod_name': 'GCC/6.4.0-2.28', 'default': None}])
 
-        res = self.modtool.run_module('avail', 'GCC/4.6')
+        res = self.modtool.run_module('avail', 'GCC/4.6.3')
         self.assertTrue(isinstance(res, list))
-        self.assertEqual(sorted([x['mod_name'] for x in res]), ['GCC/4.6.3', 'GCC/4.6.4'])
+        self.assertEqual(sorted([x['mod_name'] for x in res]), ['GCC/4.6.3'])
 
         # loading a module produces no output, so we get an empty list
         res = self.modtool.run_module('load', 'OpenMPI/2.1.2-GCC-6.4.0-2.28')

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -277,12 +277,16 @@ class ModulesTest(EnhancedTestCase):
                 'if {"Java/site_default" eq [module-info version Java/site_default]} {',
                 '    module-version Java/1.8.0_181 site_default',
                 '}',
+                'if {"JavaAlias" eq [module-info version JavaAlias]} {',
+                '    module-alias JavaAlias Java/1.8.0_181',
+                '}',
             ])
         else:
             modulerc_tcl_txt = '\n'.join([
                 '#%Module',
                 'module-version Java/1.8.0_181 1.8',
                 'module-version Java/1.8.0_181 site_default',
+                'module-alias JavaAlias Java/1.8.0_181',
             ])
 
         write_file(os.path.join(java_mod_dir, '.modulerc'), modulerc_tcl_txt)
@@ -292,11 +296,14 @@ class ModulesTest(EnhancedTestCase):
         if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.0'):
             self.assertTrue('Java/1.8' in avail_mods)
             self.assertTrue('Java/site_default' in avail_mods)
+            self.assertTrue('JavaAlias' in avail_mods)
 
         self.assertEqual(self.modtool.exist(['Java/1.8', 'Java/1.8.0_181']), [True, True])
 
         # check for an alias with a different version suffix than the base module
         self.assertEqual(self.modtool.exist(['Java/site_default']), [True])
+        # And completely different name
+        self.assertEqual(self.modtool.exist(['JavaAlias']), [True])
 
         self.assertEqual(self.modtool.module_wrapper_exists('Java/1.8'), 'Java/1.8.0_181')
         self.assertEqual(self.modtool.module_wrapper_exists('Java/site_default'), 'Java/1.8.0_181')
@@ -324,6 +331,7 @@ class ModulesTest(EnhancedTestCase):
                        '\n'.join([
                             'module_version("Java/1.8.0_181", "1.8")',
                             'module_version("Java/1.8.0_181", "site_default")',
+                            'module_alias("JavaAlias", "Java/1.8")',
                         ]))
 
             avail_mods = self.modtool.available()
@@ -333,6 +341,8 @@ class ModulesTest(EnhancedTestCase):
 
             # check for an alias with a different version suffix than the base module
             self.assertEqual(self.modtool.exist(['Java/site_default']), [True])
+            # And completely different name
+            self.assertEqual(self.modtool.exist(['JavaAlias']), [True])
 
             self.assertEqual(self.modtool.module_wrapper_exists('Java/1.8'), 'Java/1.8.0_181')
             self.assertEqual(self.modtool.module_wrapper_exists('Java/site_default'), 'Java/1.8.0_181')

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -325,8 +325,12 @@ class ModulesTest(EnhancedTestCase):
 
         self.assertTrue('Core/Java/1.8.0_181' in self.modtool.available())
         self.assertEqual(self.modtool.exist(['Core/Java/1.8.0_181']), [True])
-        self.assertEqual(self.modtool.exist(['Core/Java/1.8']), [True])
-        self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
+        # module-version only works for EnvironmentModules(C) as LMod and EnvironmentModulesTcl would need updating
+        # to full path, see https://github.com/TACC/Lmod/issues/446
+        if isinstance(self.modtool, Lmod) or self.modtool.__class__ == EnvironmentModulesTcl:
+            self.assertEqual(self.modtool.exist(['Core/Java/1.8', 'Core/Java/site_default']), [False, False])
+        else:
+            self.assertEqual(self.modtool.exist(['Core/Java/1.8', 'Core/Java/site_default']), [True, True])
 
         # also check with .modulerc.lua for Lmod 7.8 or newer
         if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.8'):
@@ -357,8 +361,8 @@ class ModulesTest(EnhancedTestCase):
             shutil.move(java_mod_dir, os.path.join(self.test_prefix, 'Core', 'Java'))
             self.assertTrue('Core/Java/1.8.0_181' in self.modtool.available())
             self.assertEqual(self.modtool.exist(['Core/Java/1.8.0_181']), [True])
-            self.assertEqual(self.modtool.exist(['Core/Java/1.8']), [True])
-            self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
+            self.assertEqual(self.modtool.exist(['Core/Java/1.8']), [False])
+            self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [False])
 
         # Test alias in home directory .modulerc
         if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.0'):

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -175,11 +175,15 @@ class ModulesTest(EnhancedTestCase):
                 'if {"Java/1.8" eq [module-info version Java/1.8]} {',
                 '    module-version Java/1.8.0_181 1.8',
                 '}',
+                'if {"Java/site_default" eq [module-info version Java/site_default]} {',
+                '    module-version Java/1.8.0_181 site_default',
+                '}',
             ])
         else:
             modulerc_tcl_txt = '\n'.join([
                 '#%Module',
                 'module-version Java/1.8.0_181 1.8',
+                'module-version Java/1.8.0_181 site_default',
             ])
 
         write_file(os.path.join(java_mod_dir, '.modulerc'), modulerc_tcl_txt)
@@ -189,6 +193,8 @@ class ModulesTest(EnhancedTestCase):
         if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.0'):
             self.assertTrue('Java/1.8' in avail_mods)
         self.assertEqual(self.modtool.exist(['Java/1.8', 'Java/1.8.0_181']), [True, True])
+        # Check for an alias with a different version suffix than the base module
+        self.assertEqual(self.modtool.exist(['Java/site_default']), [True])
         self.assertEqual(self.modtool.module_wrapper_exists('Java/1.8'), 'Java/1.8.0_181')
 
         reset_module_caches()
@@ -200,6 +206,7 @@ class ModulesTest(EnhancedTestCase):
         self.assertTrue('Core/Java/1.8.0_181' in self.modtool.available())
         self.assertEqual(self.modtool.exist(['Core/Java/1.8.0_181']), [True])
         self.assertEqual(self.modtool.exist(['Core/Java/1.8']), [True])
+        self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
         self.assertEqual(self.modtool.module_wrapper_exists('Core/Java/1.8'), 'Core/Java/1.8.0_181')
 
         # also check with .modulerc.lua for Lmod 7.8 or newer
@@ -208,12 +215,18 @@ class ModulesTest(EnhancedTestCase):
             reset_module_caches()
 
             remove_file(os.path.join(java_mod_dir, '.modulerc'))
-            write_file(os.path.join(java_mod_dir, '.modulerc.lua'), 'module_version("Java/1.8.0_181", "1.8")')
+            write_file(os.path.join(java_mod_dir, '.modulerc.lua'),
+                       '\n'.join([
+                            'module_version("Java/1.8.0_181", "1.8")',
+                            'module_version("Java/1.8.0_181", "site_default")',
+                        ]))
 
             avail_mods = self.modtool.available()
             self.assertTrue('Java/1.8.0_181' in avail_mods)
             self.assertTrue('Java/1.8' in avail_mods)
             self.assertEqual(self.modtool.exist(['Java/1.8', 'Java/1.8.0_181']), [True, True])
+            # Check for an alias with a different version suffix than the base module
+            self.assertEqual(self.modtool.exist(['Java/site_default']), [True])
             self.assertEqual(self.modtool.module_wrapper_exists('Java/1.8'), 'Java/1.8.0_181')
 
             reset_module_caches()
@@ -223,6 +236,7 @@ class ModulesTest(EnhancedTestCase):
             self.assertTrue('Core/Java/1.8.0_181' in self.modtool.available())
             self.assertEqual(self.modtool.exist(['Core/Java/1.8.0_181']), [True])
             self.assertEqual(self.modtool.exist(['Core/Java/1.8']), [True])
+            self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
             self.assertEqual(self.modtool.module_wrapper_exists('Core/Java/1.8'), 'Core/Java/1.8.0_181')
 
     def test_load(self):

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -317,8 +317,11 @@ class ModulesTest(EnhancedTestCase):
         # And completely different name
         self.assertEqual(self.modtool.exist(['JavaAlias']), [True])
 
+        # Allow for now...
+        self.allow_deprecated_behaviour()
         self.assertEqual(self.modtool.module_wrapper_exists('Java/1.8'), 'Java/1.8.0_181')
         self.assertEqual(self.modtool.module_wrapper_exists('Java/site_default'), 'Java/1.8.0_181')
+        self.disallow_deprecated_behaviour()
 
         reset_module_caches()
 
@@ -330,8 +333,11 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(self.modtool.exist(['Core/Java/1.8.0_181']), [True])
         self.assertEqual(self.modtool.exist(['Core/Java/1.8']), [True])
         self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
+
+        self.allow_deprecated_behaviour()
         self.assertEqual(self.modtool.module_wrapper_exists('Core/Java/1.8'), 'Core/Java/1.8.0_181')
         self.assertEqual(self.modtool.module_wrapper_exists('Core/Java/site_default'), 'Core/Java/1.8.0_181')
+        self.disallow_deprecated_behaviour()
 
         # also check with .modulerc.lua for Lmod 7.8 or newer
         if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.8'):
@@ -356,8 +362,10 @@ class ModulesTest(EnhancedTestCase):
             # And completely different name
             self.assertEqual(self.modtool.exist(['JavaAlias']), [True])
 
+            self.allow_deprecated_behaviour()
             self.assertEqual(self.modtool.module_wrapper_exists('Java/1.8'), 'Java/1.8.0_181')
             self.assertEqual(self.modtool.module_wrapper_exists('Java/site_default'), 'Java/1.8.0_181')
+            self.disallow_deprecated_behaviour()
 
             reset_module_caches()
 
@@ -367,8 +375,11 @@ class ModulesTest(EnhancedTestCase):
             self.assertEqual(self.modtool.exist(['Core/Java/1.8.0_181']), [True])
             self.assertEqual(self.modtool.exist(['Core/Java/1.8']), [True])
             self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
+
+            self.allow_deprecated_behaviour()
             self.assertEqual(self.modtool.module_wrapper_exists('Core/Java/1.8'), 'Core/Java/1.8.0_181')
             self.assertEqual(self.modtool.module_wrapper_exists('Core/Java/site_default'), 'Core/Java/1.8.0_181')
+            self.disallow_deprecated_behaviour()
 
         # Test alias in home directory .modulerc
         if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.0'):

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1362,7 +1362,7 @@ class ToyBuildTest(EnhancedTestCase):
         write_file(toy_ec, ectxt + extraectxt)
 
         if isinstance(self.modtool, Lmod):
-            err_msg = r"Module command \\'module load nosuchbuilddep/0.0.0\\' failed"
+            err_msg = r"Module command \\'.*load nosuchbuilddep/0.0.0\\' failed"
         else:
             err_msg = r"Unable to locate a modulefile for 'nosuchbuilddep/0.0.0'"
 
@@ -1374,7 +1374,7 @@ class ToyBuildTest(EnhancedTestCase):
         write_file(toy_ec, ectxt + extraectxt)
 
         if isinstance(self.modtool, Lmod):
-            err_msg = r"Module command \\'module load nosuchmodule/1.2.3\\' failed"
+            err_msg = r"Module command \\'.*load nosuchmodule/1.2.3\\' failed"
         else:
             err_msg = r"Unable to locate a modulefile for 'nosuchmodule/1.2.3'"
 

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -125,9 +125,8 @@ class EnhancedTestCase(TestCase):
         os.environ['EASYBUILD_ROBOT_PATHS'] = os.path.join(testdir, 'easyconfigs', 'test_ecs')
 
         # make sure no deprecated behaviour is being triggered (unless intended by the test)
-        # trip *all* log.deprecated statements by setting deprecation version ridiculously high
         self.orig_current_version = eb_build_log.CURRENT_VERSION
-        os.environ['EASYBUILD_DEPRECATED'] = '10000000'
+        self.disallow_deprecated_behaviour()
 
         init_config()
 
@@ -180,6 +179,11 @@ class EnhancedTestCase(TestCase):
         self.modtool = modules_tool()
         self.reset_modulepath([os.path.join(testdir, 'modules')])
         reset_module_caches()
+
+    def disallow_deprecated_behaviour(self):
+        """trip *all* log.deprecated statements by setting deprecation version ridiculously high"""
+        os.environ['EASYBUILD_DEPRECATED'] = '10000000'
+        eb_build_log.CURRENT_VERSION = os.environ['EASYBUILD_DEPRECATED']
 
     def allow_deprecated_behaviour(self):
         """Restore EasyBuild version to what it was originally, to allow triggering deprecated behaviour."""


### PR DESCRIPTION
Allows to find Java/whatver-11 from "module show Java/11" as well as `AIModule` aliased to `TensorFlow/2.1.0` or similar.

The scope widened during the course of this PR trying to fix various test failures with different module tools resulting in a complete implementation which is much more robust.

This now fixes #3215

Proposal: Remove the previous check via `module avail` and solely rely on `module show` as the true source which handles broken aliases by returning false instead of True for `module avail` in Lmod and False otherwise.