### PR TITLE
don't filter out None values in to_checksums, leave them in place

### DIFF
--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -446,9 +446,11 @@ def to_checksums(checksums):
     res = []
     for checksum in checksums:
         # each list entry can be:
-        # * a string (MD5 checksum)
+        # * None (indicates no checksum)
+        # * a string (MD5 or SHA256 checksum)
         # * a tuple with 2 elements: checksum type + checksum value
         # * a list of checksums (i.e. multiple checksums for a single file)
+        # * a dict (filename to checksum mapping)
         if isinstance(checksum, string_type):
             res.append(checksum)
         elif isinstance(checksum, (list, tuple)):

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -462,6 +462,8 @@ def to_checksums(checksums):
             for key, value in checksum.items():
                 validated_dict[key] = to_checksums(value)
             res.append(validated_dict)
+        else:
+            res.append(checksum)
 
     return res
 

--- a/test/framework/type_checking.py
+++ b/test/framework/type_checking.py
@@ -658,6 +658,8 @@ class TypeCheckingTest(EnhancedTestCase):
             ['be662daa971a640e40be5c804d9d7d10', ('adler32', '0x998410035'), ('crc32', '0x1553842328'),
              ('md5', 'be662daa971a640e40be5c804d9d7d10'), ('sha1', 'f618096c52244539d0e89867405f573fdb0b55b0'),
              ('size', 273)],
+            # None values should not be filtered out, but left in place
+            [None, 'fa618be8435447a017fd1bf2c7ae922d0428056cfc7449f7a8641edf76b48265', None],
         ]
         for checksums in test_inputs:
             self.assertEqual(to_checksums(checksums), checksums)


### PR DESCRIPTION
This is required for https://github.com/easybuilders/easybuild-easyconfigs/pull/9963, where we need to use `None` as checksum value for the source tarball because it's created from a Git repository (no direct downloadable source tarball available), and we do want proper SHA256 checksums for the patch files...