### PR TITLE
fix broken test for --review-pr by using different PR to test with

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2710,17 +2710,17 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         self.mock_stdout(True)
         self.mock_stderr(True)
-        # PR for CMake 3.12.1 easyconfig, see https://github.com/easybuilders/easybuild-easyconfigs/pull/6660
+        # PR for gzip 1.10 easyconfig, see https://github.com/easybuilders/easybuild-easyconfigs/pull/9921
         args = [
             '--color=never',
             '--github-user=%s' % GITHUB_TEST_ACCOUNT,
-            '--review-pr=6660',
+            '--review-pr=9921',
         ]
         self.eb_main(args, raise_error=True)
         txt = self.get_stdout()
         self.mock_stdout(False)
         self.mock_stderr(False)
-        regex = re.compile(r"^Comparing CMake-3.12.1-\S* with CMake-3.12.1-")
+        regex = re.compile(r"^Comparing gzip-1.10-\S* with gzip-1.10-")
         self.assertTrue(regex.search(txt), "Pattern '%s' not found in: %s" % (regex.pattern, txt))
 
     def test_set_tmpdir(self):


### PR DESCRIPTION
`test_review_pr` is broken since CMake easyconfigs require a custom easyblock (see https://github.com/easybuilders/easybuild-easyconfigs/pull/9923):

```
ERROR: test_review_pr (__main__.CommandLineOptionsTest)
Test --review-pr.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/work/easybuild-framework/test/framework/options.py", line 2719, in test_review_pr
    self.eb_main(args, raise_error=True)
  File "test/framework/utilities.py", line 297, in eb_main
    raise myerr
EasyBuildError: "Failed to process easyconfig /tmp/eb-2CkwCb/eb-9LDged/eb-GkRZEb/eb-pm6zll/tmpOGHyGY/c/CMake/CMake-3.12.1-GCCcore-7.3.0.eb: No software-specific easyblock 'EB_CMake' found for CMake"
```

fixed by using https://github.com/easybuilders/easybuild-easyconfigs/pull/9921 instead (which uses `ConfigureMake`, and we have a dummy `ConfigureMake` easyblock included in the framework tests)

This test is skipped when testing framework PRs because it requires a GitHub token to run (to avoid hitting GitHub rate limits when running the tests), but I verified the fix locally.