### PR TITLE
Improve raised error in remove_dir and deprecate rmtree2

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -76,7 +76,7 @@ from easybuild.tools.filetools import change_dir, convert_name, compute_checksum
 from easybuild.tools.filetools import diff_files, download_file, encode_class_name, extract_file
 from easybuild.tools.filetools import find_backup_name_candidate, get_source_tarball_from_git, is_alt_pypi_url
 from easybuild.tools.filetools import is_binary, is_sha256_checksum, mkdir, move_file, move_logs, read_file, remove_dir
-from easybuild.tools.filetools import remove_file, rmtree2, verify_checksum, weld_paths, write_file, dir_contains_files
+from easybuild.tools.filetools import remove_file, verify_checksum, weld_paths, write_file, dir_contains_files
 from easybuild.tools.hooks import BUILD_STEP, CLEANUP_STEP, CONFIGURE_STEP, EXTENSIONS_STEP, FETCH_STEP, INSTALL_STEP
 from easybuild.tools.hooks import MODULE_STEP, PACKAGE_STEP, PATCH_STEP, PERMISSIONS_STEP, POSTITER_STEP, POSTPROC_STEP
 from easybuild.tools.hooks import PREPARE_STEP, READY_STEP, SANITYCHECK_STEP, SOURCE_STEP, TEST_STEP, TESTCASES_STEP
@@ -1437,7 +1437,7 @@ class EasyBlock(object):
             try:
                 self.modules_tool.unload([self.short_mod_name])
                 self.modules_tool.remove_module_path(os.path.join(fake_mod_path, self.mod_subdir))
-                rmtree2(os.path.dirname(fake_mod_path))
+                remove_dir(os.path.dirname(fake_mod_path))
             except OSError as err:
                 raise EasyBuildError("Failed to clean up fake module dir %s: %s", fake_mod_path, err)
         elif self.short_mod_name is None:
@@ -2666,7 +2666,7 @@ class EasyBlock(object):
             self.log.info("Cleaning up builddir %s (in %s)", self.builddir, os.getcwd())
 
             try:
-                rmtree2(self.builddir)
+                remove_dir(self.builddir)
                 base = os.path.dirname(self.builddir)
 
                 # keep removing empty directories until we either find a non-empty one

--- a/easybuild/tools/containers/docker.py
+++ b/easybuild/tools/containers/docker.py
@@ -34,7 +34,7 @@ from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import DOCKER_BASE_IMAGE_CENTOS, DOCKER_BASE_IMAGE_UBUNTU
 from easybuild.tools.containers.base import ContainerGenerator
 from easybuild.tools.containers.utils import det_os_deps
-from easybuild.tools.filetools import rmtree2
+from easybuild.tools.filetools import remove_dir
 from easybuild.tools.run import run_cmd
 
 
@@ -157,4 +157,4 @@ class DockerContainer(ContainerGenerator):
         run_cmd(docker_cmd, path=tempdir, stream_output=True)
         print_msg("Docker image created at %s" % container_name, log=self.log)
 
-        rmtree2(tempdir)
+        remove_dir(tempdir)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1384,6 +1384,7 @@ def rmtree2(path, n=3):
     """Wrapper around shutil.rmtree to make it more robust when used on NFS mounted file systems."""
 
     ok = False
+    errors = []
     for i in range(0, n):
         try:
             shutil.rmtree(path)
@@ -1391,12 +1392,14 @@ def rmtree2(path, n=3):
             break
         except OSError as err:
             _log.debug("Failed to remove path %s with shutil.rmtree at attempt %d: %s" % (path, n, err))
+            errors.append(err)
             time.sleep(2)
 
             # make sure write permissions are enabled on entire directory
             adjust_permissions(path, stat.S_IWUSR, add=True, recursive=True)
     if not ok:
-        raise EasyBuildError("Failed to remove path %s with shutil.rmtree, even after %d attempts.", path, n)
+        raise EasyBuildError("Failed to remove path %s with shutil.rmtree, even after %d attempts.\nReason(s): %s",
+                             path, n, errors)
     else:
         _log.info("Path %s successfully removed." % path)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -303,11 +303,27 @@ def remove_dir(path):
         dry_run_msg("directory %s removed" % path, silent=build_option('silent'))
         return
 
-    try:
-        if os.path.exists(path):
-            rmtree2(path)
-    except OSError as err:
-        raise EasyBuildError("Failed to remove directory %s: %s", path, err)
+    if os.path.exists(path):
+        ok = False
+        errors = []
+        # Try multiple times to cater for temporary failures on e.g. NFS mounted paths
+        max_attempts = 3
+        for i in range(0, max_attempts):
+            try:
+                shutil.rmtree(path)
+                ok = True
+                break
+            except OSError as err:
+                _log.debug("Failed to remove path %s with shutil.rmtree at attempt %d: %s" % (path, i, err))
+                errors.append(err)
+                time.sleep(2)
+                # make sure write permissions are enabled on entire directory
+                adjust_permissions(path, stat.S_IWUSR, add=True, recursive=True)
+        if ok:
+            _log.info("Path %s successfully removed." % path)
+        else:
+            raise EasyBuildError("Failed to remove directory %s even after %d attempts.\nReasons: %s",
+                                 path, max_attempts, errors)
 
 
 def remove(paths):
@@ -1383,25 +1399,8 @@ def path_matches(path, paths):
 def rmtree2(path, n=3):
     """Wrapper around shutil.rmtree to make it more robust when used on NFS mounted file systems."""
 
-    ok = False
-    errors = []
-    for i in range(0, n):
-        try:
-            shutil.rmtree(path)
-            ok = True
-            break
-        except OSError as err:
-            _log.debug("Failed to remove path %s with shutil.rmtree at attempt %d: %s" % (path, n, err))
-            errors.append(err)
-            time.sleep(2)
-
-            # make sure write permissions are enabled on entire directory
-            adjust_permissions(path, stat.S_IWUSR, add=True, recursive=True)
-    if not ok:
-        raise EasyBuildError("Failed to remove path %s with shutil.rmtree, even after %d attempts.\nReason(s): %s",
-                             path, n, errors)
-    else:
-        _log.info("Path %s successfully removed." % path)
+    _log.deprecated("Use 'remove_dir' rather than 'rmtree2'", '5.0')
+    remove_dir(path)
 
 
 def find_backup_name_candidate(src_file):

--- a/easybuild/tools/repository/gitrepo.py
+++ b/easybuild/tools/repository/gitrepo.py
@@ -44,7 +44,7 @@ import time
 from easybuild.base import fancylogger
 
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import rmtree2
+from easybuild.tools.filetools import remove_dir
 from easybuild.tools.repository.filerepo import FileRepository
 from easybuild.tools.utilities import only_if_module_is_available
 from easybuild.tools.version import VERSION
@@ -188,6 +188,6 @@ class GitRepository(FileRepository):
         """
         try:
             self.wc = os.path.dirname(self.wc)
-            rmtree2(self.wc)
+            remove_dir(self.wc)
         except IOError as err:
             raise EasyBuildError("Can't remove working copy %s: %s", self.wc, err)

--- a/easybuild/tools/repository/hgrepo.py
+++ b/easybuild/tools/repository/hgrepo.py
@@ -44,7 +44,7 @@ import time
 
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import rmtree2
+from easybuild.tools.filetools import remove_dir
 from easybuild.tools.repository.filerepo import FileRepository
 
 _log = fancylogger.getLogger('hgrepo', fname=False)
@@ -192,6 +192,6 @@ class HgRepository(FileRepository):
         Clean up mercurial working copy.
         """
         try:
-            rmtree2(self.wc)
+            remove_dir(self.wc)
         except IOError as err:
             raise EasyBuildError("Can't remove working copy %s: %s", self.wc, err)

--- a/easybuild/tools/repository/svnrepo.py
+++ b/easybuild/tools/repository/svnrepo.py
@@ -44,7 +44,7 @@ import time
 
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import rmtree2
+from easybuild.tools.filetools import remove_dir
 from easybuild.tools.repository.filerepo import FileRepository
 from easybuild.tools.utilities import only_if_module_is_available
 
@@ -190,6 +190,6 @@ class SvnRepository(FileRepository):
         Clean up SVN working copy.
         """
         try:
-            rmtree2(self.wc)
+            remove_dir(self.wc)
         except OSError as err:
             raise EasyBuildError("Can't remove working copy %s: %s", self.wc, err)


### PR DESCRIPTION
A look like https://gist.github.com/migueldiascosta/05c804a26b22ef266d4e577db26f19cf is not really helpful as the error is very generic:
`
ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:124 in __init__): Failed to remove path /work/maintainers/CO7/broadwell/software/R/3.6.2-fosscuda-2019b with shutil.rmtree, even after 3 attempts. (at easybuild/tools/filetools.py:1399 in rmtree2)`

This adds the actual errors thrown for further investigation like:
```
Failed to remove path /work/maintainers/CO7/broadwell/software/R/3.6.2-fosscuda-2019b with shutil.rmtree, even after 3 attempts. 
Reasons: [FileNotFoundError(2, 'No such file or directory'), FileNotFoundError(2, 'No such file or directory'), FileNotFoundError(2, 'No such file or directory')]
```