### PR TITLE
use correct target account/repo when creating test report & posting comment in PR

### DIFF
--- a/easybuild/tools/testing.py
+++ b/easybuild/tools/testing.py
@@ -140,7 +140,10 @@ def session_state():
 
 def create_test_report(msg, ecs_with_res, init_session_state, pr_nr=None, gist_log=False):
     """Create test report for easyconfigs PR, in Markdown format."""
-    user = build_option('github_user')
+
+    github_user = build_option('github_user')
+    pr_target_account = build_option('pr_target_account')
+    pr_target_repo = build_option('pr_target_repo')
 
     end_time = gmtime()
 
@@ -148,7 +151,7 @@ def create_test_report(msg, ecs_with_res, init_session_state, pr_nr=None, gist_l
     test_report = []
     if pr_nr is not None:
         test_report.extend([
-            "Test report for https://github.com/easybuilders/easybuild-easyconfigs/pull/%s" % pr_nr,
+            "Test report for https://github.com/%s/%s/pull/%s" % (pr_target_account, pr_target_repo, pr_nr),
             "",
         ])
     test_report.extend([
@@ -182,7 +185,7 @@ def create_test_report(msg, ecs_with_res, init_session_state, pr_nr=None, gist_l
                 if pr_nr is not None:
                     descr += " (PR #%s)" % pr_nr
                 fn = '%s_partial.log' % os.path.basename(ec['spec'])[:-3]
-                gist_url = create_gist(partial_log_txt, fn, descr=descr, github_user=user)
+                gist_url = create_gist(partial_log_txt, fn, descr=descr, github_user=github_user)
                 test_log = "(partial log available at %s)" % gist_url
 
         build_overview.append(" * **%s** _%s_ %s" % (test_result, os.path.basename(ec['spec']), test_log))
@@ -239,15 +242,16 @@ def upload_test_report_as_gist(test_report, descr=None, fn=None):
     if fn is None:
         fn = 'easybuild_test_report_%s.md' % strftime("%Y%M%d-UTC-%H-%M-%S", gmtime())
 
-    user = build_option('github_user')
+    github_user = build_option('github_user')
+    gist_url = create_gist(test_report, descr=descr, fn=fn, github_user=github_user)
 
-    gist_url = create_gist(test_report, descr=descr, fn=fn, github_user=user)
     return gist_url
 
 
 def post_easyconfigs_pr_test_report(pr_nr, test_report, msg, init_session_state, success):
     """Post test report in a gist, and submit comment in easyconfigs PR."""
-    user = build_option('github_user')
+
+    github_user = build_option('github_user')
 
     # create gist with test report
     descr = "EasyBuild test report for easyconfigs PR #%s" % pr_nr
@@ -265,14 +269,18 @@ def post_easyconfigs_pr_test_report(pr_nr, test_report, msg, init_session_state,
         'pyver': system_info['python_version'].split(' ')[0],
     }
     comment_lines = [
-        "Test report by @%s" % user,
+        "Test report by @%s" % github_user,
         ('**FAILED**', '**SUCCESS**')[success],
         msg,
         short_system_info,
         "See %s for a full test report." % gist_url,
     ]
     comment = '\n'.join(comment_lines)
-    post_comment_in_issue(pr_nr, comment, github_user=user)
+
+    pr_target_account = build_option('pr_target_account')
+    pr_target_repo = build_option('pr_target_repo')
+
+    post_comment_in_issue(pr_nr, comment, account=pr_target_account, repo=pr_target_repo, github_user=github_user)
 
     msg = "Test report uploaded to %s and mentioned in a comment in easyconfigs PR#%s" % (gist_url, pr_nr)
     return msg


### PR DESCRIPTION
 (fixes #3233)

This is quite difficult to cover in the tests, since i) we need to use `--dry-run` to prevent that each run of the test suite adds a new comment to whichever PR we're using for the test, ii) we need to perform an actual installation in order to obtain a test report that can be uploaded, which implies we can not use `--dry-run` in the test...