### PR TITLE
make --merge-pr take into account --pr-target-branch

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -78,6 +78,7 @@ CONT_TYPE_SINGULARITY = 'singularity'
 CONT_TYPES = [CONT_TYPE_DOCKER, CONT_TYPE_SINGULARITY]
 DEFAULT_CONT_TYPE = CONT_TYPE_SINGULARITY
 
+DEFAULT_BRANCH = 'develop'
 DEFAULT_JOB_BACKEND = 'GC3Pie'
 DEFAULT_LOGFILE_FORMAT = ("easybuild", "easybuild-%(name)s-%(version)s-%(date)s.%(time)s.log")
 DEFAULT_MAX_FAIL_RATIO_PERMS = 0.5
@@ -195,7 +196,6 @@ BUILD_OPTIONS_CMDLINE = {
         'pr_commit_msg',
         'pr_descr',
         'pr_target_account',
-        'pr_target_branch',
         'pr_target_repo',
         'pr_title',
         'rpath_filter',
@@ -269,6 +269,9 @@ BUILD_OPTIONS_CMDLINE = {
     ],
     DEFAULT_CONT_TYPE: [
         'container_type',
+    ],
+    DEFAULT_BRANCH: [
+        'pr_target_branch',
     ],
     DEFAULT_MAX_FAIL_RATIO_PERMS: [
         'max_fail_ratio_adjust_permissions',

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -991,9 +991,10 @@ def check_pr_eligible_to_merge(pr_data):
     target = '%s/%s' % (pr_data['base']['repo']['owner']['login'], pr_data['base']['repo']['name'])
     print_msg("Checking eligibility of %s PR #%s for merging..." % (target, pr_data['number']), prefix=False)
 
-    # check target branch, must be 'develop'
-    msg_tmpl = "* targets develop branch: %s"
-    if pr_data['base']['ref'] == 'develop':
+    # check target branch, must be branch name specified in --pr-target-branch (usually 'develop')
+    pr_target_branch = build_option('pr_target_branch')
+    msg_tmpl = "* targets %s branch: %%s" % pr_target_branch
+    if pr_data['base']['ref'] == pr_target_branch:
         print_msg(msg_tmpl % 'OK', prefix=False)
     else:
         res = not_eligible(msg_tmpl % "FAILED; found '%s'" % pr_data['base']['ref'])

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -60,9 +60,9 @@ from easybuild.tools import build_log, run  # build_log should always stay there
 from easybuild.tools.build_log import DEVEL_LOG_LEVEL, EasyBuildError
 from easybuild.tools.build_log import init_logging, log_start, print_warning, raise_easybuilderror
 from easybuild.tools.config import CONT_IMAGE_FORMATS, CONT_TYPES, DEFAULT_CONT_TYPE
-from easybuild.tools.config import DEFAULT_ALLOW_LOADED_MODULES, DEFAULT_FORCE_DOWNLOAD, DEFAULT_JOB_BACKEND
-from easybuild.tools.config import DEFAULT_LOGFILE_FORMAT, DEFAULT_MAX_FAIL_RATIO_PERMS, DEFAULT_MNS
-from easybuild.tools.config import DEFAULT_MODULE_SYNTAX, DEFAULT_MODULES_TOOL, DEFAULT_MODULECLASSES
+from easybuild.tools.config import DEFAULT_ALLOW_LOADED_MODULES, DEFAULT_BRANCH, DEFAULT_FORCE_DOWNLOAD
+from easybuild.tools.config import DEFAULT_JOB_BACKEND, DEFAULT_LOGFILE_FORMAT, DEFAULT_MAX_FAIL_RATIO_PERMS
+from easybuild.tools.config import DEFAULT_MNS, DEFAULT_MODULE_SYNTAX, DEFAULT_MODULES_TOOL, DEFAULT_MODULECLASSES
 from easybuild.tools.config import DEFAULT_PATH_SUBDIRS, DEFAULT_PKG_RELEASE, DEFAULT_PKG_TOOL, DEFAULT_PKG_TYPE
 from easybuild.tools.config import DEFAULT_PNS, DEFAULT_PREFIX, DEFAULT_REPOSITORY, EBROOT_ENV_VAR_ACTIONS, ERROR
 from easybuild.tools.config import FORCE_DOWNLOAD_CHOICES, GENERAL_CLASS, IGNORE, JOB_DEPS_TYPE_ABORT_ON_ERROR
@@ -611,7 +611,7 @@ class EasyBuildOptions(GeneralOption):
             'pr-commit-msg': ("Commit message for new/updated pull request created with --new-pr", str, 'store', None),
             'pr-descr': ("Description for new pull request created with --new-pr", str, 'store', None),
             'pr-target-account': ("Target account for new PRs", str, 'store', GITHUB_EB_MAIN),
-            'pr-target-branch': ("Target branch for new PRs", str, 'store', 'develop'),
+            'pr-target-branch': ("Target branch for new PRs", str, 'store', DEFAULT_BRANCH),
             'pr-target-repo': ("Target repository for new/updating PRs", str, 'store', GITHUB_EASYCONFIGS_REPO),
             'pr-title': ("Title for new pull request created with --new-pr", str, 'store', None),
             'preview-pr': ("Preview a new pull request", None, 'store_true', False),

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3429,6 +3429,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '4781',  # PR for easyconfig for EasyBuild-3.3.0.eb
             '-D',
             '--github-user=%s' % GITHUB_TEST_ACCOUNT,
+            '--pr-target-branch=some_branch',
         ]
 
         # merged PR for EasyBuild-3.3.0.eb, is missing approved review
@@ -3436,12 +3437,12 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         expected_stdout = '\n'.join([
             "Checking eligibility of easybuilders/easybuild-easyconfigs PR #4781 for merging...",
-            "* targets develop branch: OK",
             "* test suite passes: OK",
             "* last test report is successful: OK",
             "* milestone is set: OK (3.3.1)",
         ])
         expected_stderr = '\n'.join([
+            "* targets some_branch branch: FAILED; found 'develop' => not eligible for merging!",
             "* approved review: MISSING => not eligible for merging!",
             '',
             "WARNING: Review indicates this PR should not be merged (use -f/--force to do so anyway)",
@@ -3449,7 +3450,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertEqual(stderr.strip(), expected_stderr)
         self.assertTrue(stdout.strip().endswith(expected_stdout), "'%s' ends with '%s'" % (stdout, expected_stdout))
 
-        # full eligible merged PR
+        # full eligible merged PR, default target branch
+        del args[-1]
         args[1] = '4832'
 
         stdout, stderr = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False)


### PR DESCRIPTION
While merging easyconfigs PRs to the `2020a` branch, I'm quite annoyed that `--merge-pr` fails because the target branch isn't `develop`.

So, let's make `--merge-pr` honor `--pr-target-branch`, so we can merge PRs that target `2020a` using `eb --pr-target-branch 2020a --merge-pr`...

Of course the default is still `develop` (which is the default value for `--pr-target-branch`).