### PR TITLE
make tests use easybuilders/testrepository rather than hpcugent/testrepository after it was moved

### DIFF
--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1893,7 +1893,7 @@ class FileToolsTest(EnhancedTestCase):
 
         git_config = {
             'repo_name': 'testrepository',
-            'url': 'https://github.com/hpcugent',
+            'url': 'https://github.com/easybuilders',
             'tag': 'master',
         }
         target_dir = os.path.join(self.test_prefix, 'target')
@@ -1918,7 +1918,7 @@ class FileToolsTest(EnhancedTestCase):
 
         git_config = {
             'repo_name': 'testrepository',
-            'url': 'git@github.com:hpcugent',
+            'url': 'git@github.com:easybuilders',
             'tag': 'master',
         }
         args = ['test.tar.gz', self.test_prefix, git_config]
@@ -1972,11 +1972,11 @@ class FileToolsTest(EnhancedTestCase):
 
         git_config = {
             'repo_name': 'testrepository',
-            'url': 'git@github.com:hpcugent',
+            'url': 'git@github.com:easybuilders',
             'tag': 'master',
         }
         expected = '\n'.join([
-            r'  running command "git clone --branch master git@github.com:hpcugent/testrepository.git"',
+            r'  running command "git clone --branch master git@github.com:easybuilders/testrepository.git"',
             r"  \(in .*/tmp.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
             r"  \(in .*/tmp.*\)",
@@ -1985,7 +1985,7 @@ class FileToolsTest(EnhancedTestCase):
 
         git_config['recursive'] = True
         expected = '\n'.join([
-            r'  running command "git clone --branch master --recursive git@github.com:hpcugent/testrepository.git"',
+            r'  running command "git clone --branch master --recursive git@github.com:easybuilders/testrepository.git"',
             r"  \(in .*/tmp.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
             r"  \(in .*/tmp.*\)",
@@ -1994,7 +1994,7 @@ class FileToolsTest(EnhancedTestCase):
 
         git_config['keep_git_dir'] = True
         expected = '\n'.join([
-            r'  running command "git clone --branch master --recursive git@github.com:hpcugent/testrepository.git"',
+            r'  running command "git clone --branch master --recursive git@github.com:easybuilders/testrepository.git"',
             r"  \(in .*/tmp.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz testrepository"',
             r"  \(in .*/tmp.*\)",
@@ -2005,7 +2005,7 @@ class FileToolsTest(EnhancedTestCase):
         del git_config['tag']
         git_config['commit'] = '8456f86'
         expected = '\n'.join([
-            r'  running command "git clone --recursive git@github.com:hpcugent/testrepository.git"',
+            r'  running command "git clone --recursive git@github.com:easybuilders/testrepository.git"',
             r"  \(in .*/tmp.*\)",
             r'  running command "git checkout 8456f86 && git submodule update"',
             r"  \(in testrepository\)",
@@ -2016,7 +2016,7 @@ class FileToolsTest(EnhancedTestCase):
 
         del git_config['recursive']
         expected = '\n'.join([
-            r'  running command "git clone git@github.com:hpcugent/testrepository.git"',
+            r'  running command "git clone git@github.com:easybuilders/testrepository.git"',
             r"  \(in .*/tmp.*\)",
             r'  running command "git checkout 8456f86"',
             r"  \(in testrepository\)",

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -54,8 +54,8 @@ except ImportError:
 
 # test account, for which a token may be available
 GITHUB_TEST_ACCOUNT = 'easybuild_test'
-# the user & repo to use in this test (https://github.com/hpcugent/testrepository)
-GITHUB_USER = "hpcugent"
+# the user & repo to use in this test (https://github.com/easybuilders/testrepository)
+GITHUB_USER = "easybuilders"
 GITHUB_REPO = "testrepository"
 # branch to test
 GITHUB_BRANCH = 'master'
@@ -220,10 +220,10 @@ class GithubTest(EnhancedTestCase):
         self.mock_stdout(False)
 
         patterns = [
-            "hpcugent/testrepository PR #2 was submitted by migueldiascosta",
+            "easybuilders/testrepository PR #2 was submitted by migueldiascosta",
             "[DRY RUN] Adding comment to testrepository issue #2: '" +
             "@migueldiascosta, this PR is being closed for the following reason(s): just a test",
-            "[DRY RUN] Closed hpcugent/testrepository PR #2",
+            "[DRY RUN] Closed easybuilders/testrepository PR #2",
         ]
         for pattern in patterns:
             self.assertTrue(pattern in stdout, "Pattern '%s' found in: %s" % (pattern, stdout))
@@ -236,11 +236,11 @@ class GithubTest(EnhancedTestCase):
         self.mock_stdout(False)
 
         patterns = [
-            "hpcugent/testrepository PR #2 was submitted by migueldiascosta",
+            "easybuilders/testrepository PR #2 was submitted by migueldiascosta",
             "[DRY RUN] Adding comment to testrepository issue #2: '" +
             "@migueldiascosta, this PR is being closed for the following reason(s): %s" % retest_msg,
-            "[DRY RUN] Closed hpcugent/testrepository PR #2",
-            "[DRY RUN] Reopened hpcugent/testrepository PR #2",
+            "[DRY RUN] Closed easybuilders/testrepository PR #2",
+            "[DRY RUN] Reopened easybuilders/testrepository PR #2",
         ]
         for pattern in patterns:
             self.assertTrue(pattern in stdout, "Pattern '%s' found in: %s" % (pattern, stdout))
@@ -597,7 +597,7 @@ class GithubTest(EnhancedTestCase):
 
         client = RestClient('https://api.github.com', username=GITHUB_TEST_ACCOUNT, token=self.github_token)
 
-        status, body = client.repos['hpcugent']['testrepository'].contents.a_directory['a_file.txt'].get()
+        status, body = client.repos['easybuilders']['testrepository'].contents.a_directory['a_file.txt'].get()
         self.assertEqual(status, 200)
         # base64.b64encode requires & produces a 'bytes' value in Python 3,
         # but we need a string value hence the .decode() (also works in Python 2)

--- a/test/framework/repository.py
+++ b/test/framework/repository.py
@@ -79,7 +79,7 @@ class RepositoryTest(EnhancedTestCase):
             print("(skipping GitRepository test)")
             return
 
-        test_repo_url = 'https://github.com/hpcugent/testrepository'
+        test_repo_url = 'https://github.com/easybuilders/testrepository'
 
         # URL
         repo = GitRepository(test_repo_url)
@@ -122,7 +122,7 @@ class RepositoryTest(EnhancedTestCase):
             return
 
         # GitHub also supports SVN
-        test_repo_url = 'https://github.com/hpcugent/testrepository'
+        test_repo_url = 'https://github.com/easybuilders/testrepository'
 
         repo = SvnRepository(test_repo_url)
         repo.init()


### PR DESCRIPTION
https://github.com/hpcugent/testrepository was moved out of the `hpcugent` organization to https://github.com/easybuilders/testrepository .

Even though this doesn't break the tests (because GitHub does an auto-redirect), it's better to change the tests accordingly...