### PR TITLE
Adding sorting to rst output of list_toolchains to match txt and none

### DIFF
--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -744,30 +744,58 @@ def list_toolchains_rst(tcs):
     """ Returns overview of all toolchains in rst format """
     title = "List of known toolchains"
 
-    # figure out column names
-    table_titles = ['name', 'compiler', 'MPI']
-    for tc in tcs.values():
-        table_titles.extend(tc.keys())
+    # Specify the column names for the table
+    table_titles = ['name', 'compiler', 'MPI', 'BLAS', 'FFT']
 
+    # Set up column name : display name pairs
     col_names = {
-        'COMPILER_CUDA': 'CUDA compiler',
-        'SCALAPACK': 'ScaLAPACK',
+        'name': 'Name',
+        'compiler': 'Compiler(s)',
+        'BLAS': "BLAS/LAPACK/ScaLAPACK",
     }
 
+    # removes duplicate entries
     table_titles = nub(table_titles)
 
+    # Initialize an empty list of lists for the table data
     table_values = [[] for i in range(len(table_titles))]
-    table_values[0] = ['**%s**' % tcname for tcname in sorted(tcs.keys())]
 
+    # Fill in the first column with the names of the toolchains
+    table_values[0] = ['**%s**' % tcname for tcname in tcs.keys()]
+
+    # Fill in the other table values
     for idx in range(1, len(table_titles)):
         for tc in tcs.values():
-            table_values[idx].append(', '.join(tc.get(table_titles[idx].upper(), [])))
+            table_values[idx].append(', '.join(tc.get(table_titles[idx].upper(), ["(*none*)"])))
 
+    # We want to combine the display for linear algebra, so create a new list
+    # with a list of BLAS, LAPACK, and ScaLAPACK included.
+    blas = []
+    for tc in tcs.values():
+        entry = list(tc.get('BLAS', ['(*none*)']))
+        entry.extend(list(tc.get('LAPACK', [])))
+        entry.extend(list(tc.get('SCALAPACK', [])))
+        blas.append(", ".join(nub(entry)))
+
+    # Put the combined BLAS/LAPACK/ScaLAPACK entry in the proper column
+    # of table_values
+    table_values[3] = blas
+
+    # To sort, we need to first transpose the column major list, sort on
+    # the toolchain name, then transpose back.
+    tmp_values = list(map(list, zip(*table_values)))
+    sorted_values = sorted(tmp_values, key=lambda x: str.lower(x[0]))
+    table_values = list(map(list, zip(*sorted_values)))
+
+    # Set the table titles to the pretty ones
     table_titles = [col_names.get(col, col) for col in table_titles]
+
+    # Pass the data to the rst formatter, wich is returned as a list, each element
+    # is an rst formatted text row.
     doc = rst_title_and_table(title, table_titles, table_values)
 
+    # Make a string with line endings suitable to write to document file
     return '\n'.join(doc)
-
 
 def list_toolchains_txt(tcs):
     """ Returns overview of all toolchains in txt format """

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -757,7 +757,7 @@ def list_toolchains_rst(tcs):
     table_titles = nub(table_titles)
 
     table_values = [[] for i in range(len(table_titles))]
-    table_values[0] = ['**%s**' % tcname for tcname in tcs.keys()]
+    table_values[0] = ['**%s**' % tcname for tcname in sorted(tcs.keys())]
 
     for idx in range(1, len(table_titles)):
         for tc in tcs.values():

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -777,7 +777,7 @@ def list_toolchains_rst(tcs):
                     if col_name == 'COMPILER':
                         entry = 'PrgEnv-cray'
                     elif col_name == 'MPI':
-                        entry = 'cray-MPI'
+                        entry = 'cray-mpich'
                     elif col_name == 'linalg':
                         entry = 'cray-libsci'
                 # Combine the linear algebra libraries into a single column

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -750,17 +750,15 @@ def list_toolchains_rst(tcs):
     # Set up column name : display name pairs
     col_names = {
         'name': 'Name',
-        'compiler': 'Compiler(s)',
+        'COMPILER': 'Compiler(s)',
         'linalg': "Linear algebra",
     }
 
     # Create sorted list of toolchain names
     sorted_tc_names = sorted(tcs.keys(), key=str.lower)
 
-    # Create text placeholder to use for missing entries.
-    # Not good documentation style to italicize the parentheses enclosing
-    # italic text unless surrouning text is also italic.
-    none_txt = '(*none*)'
+    # Create text placeholder to use for missing entries
+    none_txt = '*(none)*'
 
     # Initialize an empty list of lists for the table data
     table_values = [[] for i in range(len(table_titles))]
@@ -772,10 +770,9 @@ def list_toolchains_rst(tcs):
         else:
             for tc_name in sorted_tc_names:
                 tc = tcs[tc_name]
-                # Cray is a special snowflake
-                if tc_name.find('Cray') >= 0:
+                if 'cray' in tc_name.lower():
                     if col_name == 'COMPILER':
-                        entry = 'PrgEnv-cray'
+                        entry = ', '.join(tc[col_name.upper()])
                     elif col_name == 'MPI':
                         entry = 'cray-mpich'
                     elif col_name == 'linalg':
@@ -784,11 +781,8 @@ def list_toolchains_rst(tcs):
                 elif col_name == 'linalg':
                     linalg = []
                     for col in ['BLAS', 'LAPACK', 'SCALAPACK']:
-                        linalg.extend(tc.get(col, [none_txt]))
-                    # Doing this by iterating over the columns results in multiple 'none'
-                    # entries, so reduce those to one.
-                    linalg = nub(linalg)
-                    entry = ', '.join(linalg)
+                        linalg.extend(tc.get(col, []))
+                    entry = ', '.join(linalg) or none_txt
                 else:
                     # for other columns, we can grab the values via 'tc'
                     # key = col_name

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -745,13 +745,13 @@ def list_toolchains_rst(tcs):
     title = "List of known toolchains"
 
     # Specify the column names for the table
-    table_titles = ['name', 'COMPILER', 'MPI', 'linalg', 'FFT']
+    table_titles = ['NAME', 'COMPILER', 'MPI', 'LINALG', 'FFT']
 
     # Set up column name : display name pairs
     col_names = {
-        'name': 'Name',
+        'NAME': 'Name',
         'COMPILER': 'Compiler(s)',
-        'linalg': "Linear algebra",
+        'LINALG': "Linear algebra",
     }
 
     # Create sorted list of toolchain names
@@ -764,7 +764,7 @@ def list_toolchains_rst(tcs):
     table_values = [[] for i in range(len(table_titles))]
 
     for col_id, col_name in enumerate(table_titles):
-        if col_name == 'name':
+        if col_name == 'NAME':
             # toolchain names column gets bold face entry
             table_values[col_id] = ['**%s**' % tcname for tcname in sorted_tc_names]
         else:
@@ -775,10 +775,10 @@ def list_toolchains_rst(tcs):
                         entry = ', '.join(tc[col_name.upper()])
                     elif col_name == 'MPI':
                         entry = 'cray-mpich'
-                    elif col_name == 'linalg':
+                    elif col_name == 'LINALG':
                         entry = 'cray-libsci'
                 # Combine the linear algebra libraries into a single column
-                elif col_name == 'linalg':
+                elif col_name == 'LINALG':
                     linalg = []
                     for col in ['BLAS', 'LAPACK', 'SCALAPACK']:
                         linalg.extend(tc.get(col, []))

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -782,11 +782,11 @@ def list_toolchains_rst(tcs):
                     linalg = []
                     for col in ['BLAS', 'LAPACK', 'SCALAPACK']:
                         linalg.extend(tc.get(col, []))
-                    entry = ', '.join(linalg) or none_txt
+                    entry = ', '.join(nub(linalg)) or none_txt
                 else:
                     # for other columns, we can grab the values via 'tc'
                     # key = col_name
-                    entry = ', '.join(tc.get(col_name, [none_txt]))
+                    entry = ', '.join(tc.get(col_name, [])) or none_txt
                 table_values[col_id].append(entry)
 
     # Set the table titles to the pretty ones

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -556,9 +556,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
             # full 'intel' toolchain (imkl appears twice, in linalg + FFT columns)
             r"\*\*intel\*\*\s+icc,\s+ifort\s+impi\s+imkl\s+imkl\s*\n",
             # fosscuda toolchain, also lists CUDA in compilers column
-            r"\*\*fosscuda\*\*\s+GCC,\s+CUDA\s+OpenMPI\s+OpenBLAS,\s+ScaLAPACK\s+FFTW\s*\n"
+            r"\*\*fosscuda\*\*\s+GCC,\s+CUDA\s+OpenMPI\s+OpenBLAS,\s+ScaLAPACK\s+FFTW\s*\n",
             # system toolchain: 'none' in every column
-            r"\*\*system\*\*\s+\*\(none\)\*\s+\*\(none\)\*\s+\*\(none\)\*\s+\*\(none\)\*\s*\n"
+            r"\*\*system\*\*\s+\*\(none\)\*\s+\*\(none\)\*\s+\*\(none\)\*\s+\*\(none\)\*\s*\n",
             # Cray special case
             r"\n\*\*CrayGNU\*\*\s+PrgEnv-gnu\s+cray-mpich\s+cray-libsci\s+\*\(none\)\*\s*\n",
             # footer

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -516,6 +516,58 @@ class CommandLineOptionsTest(EnhancedTestCase):
         if os.path.exists(dummylogfn):
             os.remove(dummylogfn)
 
+    def test_list_toolchains_rst(self):
+        """Test --list-toolchains --output-format=rst."""
+
+        args = [
+            '--list-toolchains',
+            '--output-format=rst',
+        ]
+        self.mock_stderr(True)
+        self.mock_stdout(True)
+        self.eb_main(args, raise_error=True)
+        stderr, stdout = self.get_stderr(), self.get_stdout().strip()
+        self.mock_stderr(False)
+        self.mock_stdout(False)
+
+        self.assertFalse(stderr)
+
+        title = "List of known toolchains"
+
+        # separator line: starts/ends with sequence of '=', 4 spaces in between columns
+        sep_line = r'=(=+\s{4})+[=]+='
+
+        col_names = ['Name', r'Compiler\(s\)', 'MPI', 'Linear algebra', 'FFT']
+        col_names_line = r'\s+'.join(col_names) + r'\s*'
+
+        patterns = [
+            # title
+            '^' + title + '\n' + '-' * len(title) + '\n',
+            # header
+            '\n' + '\n'.join([sep_line, col_names_line, sep_line]) + '\n',
+            # compiler-only GCC toolchain
+            r"\n\*\*GCC\*\*\s+GCC\s+\*\(none\)\*\s+\*\(none\)\*\s+\*\(none\)\*\s*\n",
+            # gompi compiler + MPI toolchain
+            r"\n\*\*gompi\*\*\s+GCC\s+OpenMPI\s+\*\(none\)\*\s+\*\(none\)\*\s*\n",
+            # full 'foss' toolchain
+            r"\*\*foss\*\*\s+GCC\s+OpenMPI\s+OpenBLAS,\s+ScaLAPACK\s+FFTW\s*\n",
+            # compiler-only iccifort toolchain
+            r"\*\*iccifort\*\*\s+icc,\s+ifort\s+\*\(none\)\*\s+\*\(none\)\*\s+\*\(none\)\*\s*\n",
+            # full 'intel' toolchain (imkl appears twice, in linalg + FFT columns)
+            r"\*\*intel\*\*\s+icc,\s+ifort\s+impi\s+imkl\s+imkl\s*\n",
+            # fosscuda toolchain, also lists CUDA in compilers column
+            r"\*\*fosscuda\*\*\s+GCC,\s+CUDA\s+OpenMPI\s+OpenBLAS,\s+ScaLAPACK\s+FFTW\s*\n"
+            # system toolchain: 'none' in every column
+            r"\*\*system\*\*\s+\*\(none\)\*\s+\*\(none\)\*\s+\*\(none\)\*\s+\*\(none\)\*\s*\n"
+            # Cray special case
+            r"\n\*\*CrayGNU\*\*\s+PrgEnv-gnu\s+cray-mpich\s+cray-libsci\s+\*\(none\)\*\s*\n",
+            # footer
+            '\n' + sep_line + '$',
+        ]
+        for pattern in patterns:
+            regex = re.compile(pattern, re.M)
+            self.assertTrue(regex.search(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
+
     def test_avail_lists(self):
         """Test listing available values of certain types."""
 


### PR DESCRIPTION
When requesting `--output-format=rst`, the list of available toolchains was
not being sorted.  That output will be used to create a table of available
toolchains for the documentation and needs to be sorted.  I wrapped the
list of keys in `sorted()` to match the ouput of `eb --list-toolchains`
with no options and when `txt` is requested.