### PR TITLE
Changing 'dummy' toolchain in bootstrap to 'system'

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -153,7 +153,7 @@ jobs:
           EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
           EB_BOOTSTRAP_SHA256SUM=$(sha256sum easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
           EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-          EB_BOOTSTRAP_EXPECTED="20200203.01 616bf3ce812c0844bf9ea3e690f9d88b394ed48f834ddb8424a73cf45fc64ea5"
+          EB_BOOTSTRAP_EXPECTED="20200315.01 f8c5958b9ce839a9aa1defe968f7c1d84d10b6befc4da697c3cd2571172cf86d"
           test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
 
           # test bootstrap script

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20200203.01 616bf3ce812c0844bf9ea3e690f9d88b394ed48f834ddb8424a73cf45fc64ea5"
+    - EB_BOOTSTRAP_EXPECTED="20200203.02 e4701f917ff038604d4abe72cafd3797eae67f1cdf4269edfd80b0d1b8622fb4"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -104,7 +104,7 @@ script:
     - EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
     - EB_BOOTSTRAP_SHA256SUM=$(sha256sum $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
     - EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-    - EB_BOOTSTRAP_EXPECTED="20200203.02 e4701f917ff038604d4abe72cafd3797eae67f1cdf4269edfd80b0d1b8622fb4"
+    - EB_BOOTSTRAP_EXPECTED="20200315.01 f8c5958b9ce839a9aa1defe968f7c1d84d10b6befc4da697c3cd2571172cf86d"
     - test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
     # test bootstrap script
     - python $TRAVIS_BUILD_DIR/easybuild/scripts/bootstrap_eb.py /tmp/$TRAVIS_JOB_ID/eb_bootstrap

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -824,7 +824,7 @@ def stage2(tmpdir, templates, install_path, distribute_egg_dir, sourcepath):
     eb_spec = {
         'name': 'EasyBuild',
         'hidden': False,
-        'toolchain': {'name': 'dummy', 'version': 'dummy'},
+        'toolchain': {'name': 'system', 'version': 'system'},
         'version': templates['version'],
         'versionprefix': '',
         'versionsuffix': '',
@@ -991,7 +991,7 @@ description = \"\"\"EasyBuild is a software build and installation framework
 written in Python that allows you to install software in a structured,
 repeatable and robust way.\"\"\"
 
-toolchain = {'name': 'dummy', 'version': 'dummy'}
+toolchain = {'name': 'system', 'version': 'system'}
 
 source_urls = [%(source_urls)s]
 sources = [%(sources)s]

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -62,7 +62,7 @@ else:
     import urllib.request as std_urllib
 
 
-EB_BOOTSTRAP_VERSION = '20200203.02'
+EB_BOOTSTRAP_VERSION = '20200315.01'
 
 # argparse preferrred, optparse deprecated >=2.7
 HAVE_ARGPARSE = False

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -62,7 +62,7 @@ else:
     import urllib.request as std_urllib
 
 
-EB_BOOTSTRAP_VERSION = '20200203.01'
+EB_BOOTSTRAP_VERSION = '20200203.02'
 
 # argparse preferrred, optparse deprecated >=2.7
 HAVE_ARGPARSE = False


### PR DESCRIPTION
The `dummy` toolchain was being used in the bootstrap script and generating a deprecation warning.

Changed to `system`.  Warning is no longer issued.