### PR TITLE
censor authorization part of headers before logging ReST API request

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -8,6 +8,7 @@ v4.1.2 (March 16th 2020)
 
 bugfix release
 
+- fix gitdb dependency on Python 2.6 in test configuration (#3212)
 - fix broken test for --review-pr by using different PR to test with (#3226)
 - censor authorization part of headers before logging ReST API request (#3248)
 

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -3,6 +3,14 @@ For more detailed information, please see the git log.
 
 These release notes can also be consulted at https://easybuild.readthedocs.io/en/latest/Release_notes.html.
 
+v4.1.2 (March 16th 2020)
+------------------------
+
+bugfix release
+
+- fix broken test for --review-pr by using different PR to test with (#3226)
+- censor authorization part of headers before logging ReST API request (#3248)
+
 v4.1.1 (January 16th 2020)
 --------------------------
 

--- a/easybuild/base/rest.py
+++ b/easybuild/base/rest.py
@@ -35,6 +35,7 @@ based on https://github.com/jpaugh/agithub/commit/1e2575825b165c1cb7cbd85c22e256
 :author: Jens Timmerman
 """
 import base64
+import copy
 import json
 from functools import partial
 
@@ -162,7 +163,13 @@ class Client(object):
         if self.auth_header is not None:
             headers['Authorization'] = self.auth_header
         headers['User-Agent'] = self.user_agent
-        fancylogger.getLogger().debug('cli request: %s, %s, %s, %s', method, url, body, headers)
+
+        # censor contents of 'Authorization' part of header, to avoid leaking tokens or passwords in logs
+        headers_censored = copy.deepcopy(headers)
+        headers_censored['Authorization'] = '<actual authorization header censored>'
+
+        fancylogger.getLogger().debug('cli request: %s, %s, %s, %s', method, url, body, headers_censored)
+
         # TODO: in recent python: Context manager
         conn = self.get_connection(method, url, body, headers)
         status = conn.code

--- a/easybuild/tools/version.py
+++ b/easybuild/tools/version.py
@@ -43,7 +43,7 @@ from socket import gethostname
 # recent setuptools versions will *TRANSFORM* something like 'X.Y.Zdev' into 'X.Y.Z.dev0', with a warning like
 #   UserWarning: Normalizing '2.4.0dev' to '2.4.0.dev0'
 # This causes problems further up the dependency chain...
-VERSION = LooseVersion('4.1.1')
+VERSION = LooseVersion('4.1.2')
 UNKNOWN = 'UNKNOWN'
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,10 @@ keyring==5.7.1; python_version < '2.7'
 keyring<=9.1; python_version >= '2.7'
 keyrings.alt; python_version >= '2.7'
 
+# GitDB 4.0.1 no longer supports Python 2.6
+gitdb==0.6.4; python_version < '2.7'
+gitdb; python_version >= '2.7'
+
 # GitPython 2.1.9 no longer supports Python 2.6
 GitPython==2.1.8; python_version < '2.7'
 GitPython; python_version >= '2.7'

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1242,16 +1242,13 @@ class CommandLineOptionsTest(EnhancedTestCase):
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 
-        tmpdir = tempfile.mkdtemp()
         args = [
             # PR for foss/2018b, see https://github.com/easybuilders/easybuild-easyconfigs/pull/6424/files
             '--from-pr=6424',
             '--dry-run',
             '--debug',
-            #'--logtostdout',
             # an argument must be specified to --robot, since easybuild-easyconfigs may not be installed
             '--robot=%s' % os.path.join(os.path.dirname(__file__), 'easyconfigs'),
-            #'--unittest-file=%s' % self.logfile,
             '--github-user=%s' % GITHUB_TEST_ACCOUNT,  # a GitHub token should be available for this user
         ]
         try:

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2746,17 +2746,17 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         self.mock_stdout(True)
         self.mock_stderr(True)
-        # PR for CMake 3.12.1 easyconfig, see https://github.com/easybuilders/easybuild-easyconfigs/pull/6660
+        # PR for gzip 1.10 easyconfig, see https://github.com/easybuilders/easybuild-easyconfigs/pull/9921
         args = [
             '--color=never',
             '--github-user=%s' % GITHUB_TEST_ACCOUNT,
-            '--review-pr=6660',
+            '--review-pr=9921',
         ]
         self.eb_main(args, raise_error=True)
         txt = self.get_stdout()
         self.mock_stdout(False)
         self.mock_stderr(False)
-        regex = re.compile(r"^Comparing CMake-3.12.1-\S* with CMake-3.12.1-")
+        regex = re.compile(r"^Comparing gzip-1.10-\S* with gzip-1.10-")
         self.assertTrue(regex.search(txt), "Pattern '%s' not found in: %s" % (regex.pattern, txt))
 
     def test_set_tmpdir(self):

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1233,6 +1233,42 @@ class CommandLineOptionsTest(EnhancedTestCase):
             print("Ignoring URLError '%s' in test_from_pr" % err)
             shutil.rmtree(tmpdir)
 
+    def test_from_pr_token_log(self):
+        """Check that --from-pr doesn't leak GitHub token in log."""
+        if self.github_token is None:
+            print("Skipping test_from_pr_token_log, no GitHub token available?")
+            return
+
+        fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
+        os.close(fd)
+
+        tmpdir = tempfile.mkdtemp()
+        args = [
+            # PR for foss/2018b, see https://github.com/easybuilders/easybuild-easyconfigs/pull/6424/files
+            '--from-pr=6424',
+            '--dry-run',
+            '--debug',
+            #'--logtostdout',
+            # an argument must be specified to --robot, since easybuild-easyconfigs may not be installed
+            '--robot=%s' % os.path.join(os.path.dirname(__file__), 'easyconfigs'),
+            #'--unittest-file=%s' % self.logfile,
+            '--github-user=%s' % GITHUB_TEST_ACCOUNT,  # a GitHub token should be available for this user
+        ]
+        try:
+            self.mock_stdout(True)
+            self.mock_stderr(True)
+            outtxt = self.eb_main(args, logfile=dummylogfn, raise_error=True)
+            stdout = self.get_stdout()
+            stderr = self.get_stderr()
+            self.mock_stdout(False)
+            self.mock_stderr(False)
+            self.assertFalse(self.github_token in outtxt)
+            self.assertFalse(self.github_token in stdout)
+            self.assertFalse(self.github_token in stderr)
+
+        except URLError as err:
+            print("Ignoring URLError '%s' in test_from_pr" % err)
+
     def test_from_pr_listed_ecs(self):
         """Test --from-pr in combination with specifying easyconfigs on the command line."""
         if self.github_token is None:


### PR DESCRIPTION
GitHub tokens were found to be "leaking" into the top-level log file when using `--from-pr` combined with `--debug`, as reported by @zao:

```
# relevant part of log for "eb --from-pr 10064 --debug"
== 2020-03-15 19:15:28,551 github.py:389 DEBUG Fetching easyconfigs from easybuilders/easybuild-easyconfigs PR #10064 into /tmp/eb-nqIFwJ/files_pr10064
== 2020-03-15 19:15:30,187 github.py:1843 INFO Successfully obtained GitHub token for user zao from keyring.
== 2020-03-15 19:15:30,188 rest.py:165 DEBUG cli request: GET, /repos/easybuilders/easybuild-easyconfigs/pulls/10064, None, {'Authorization': u'Token deadbeefdeadbeefdeadbeefdeadbeefde', 'User-Agent': 'vsc-rest-client'}
== 2020-03-15 19:15:30,188 rest.py:207 DEBUG opening request:  https://api.github.com/repos/easybuilders/easybuild-easyconfigs/pulls/10064
== 2020-03-15 19:15:30,691 rest.py:177 DEBUG reponse len: 46 
```

That's clearly not desirable, so the changes in this PR censor the `Authorization` part of the headers before the debug log statement.

To clarify the scope of this a bit:

* the log message only appears in the top-level log file, not in the individual software installation logs (see https://easybuild.readthedocs.io/en/latest/Logfiles.html);
  - as a consequence, tokens are *not* included in the partial log files that are uploaded into a gist when using `--upload-test-report` in combination with `--from-pr`, nor in the installation logs that are copied to the software installation directories;

* the message is only logged when using `--debug`, so it will not appear when using the default EasyBuild configuration (only `info` messages are logged by default);

* the log message is triggered via `--from-pr`, but also via various other GitHub integration options like `--new-pr`, `--merge-pr`, `--close-pr`, etc., but usually only appears in the temporary log file that is cleaned up automatically as soon as `eb` completes successfully;

* you may have several debug log files that include your GitHub token in `/tmp` (or a different location if you've set the `--tmpdir` EasyBuild configuration option) on the systems where you use EasyBuild, but they are located in a subdirectory that is only accessible to your account (permissions set to 700);

* the only way that a log file that may include your token could have been made public is if you shared it yourself, for example by copying the contents of the log file into a gist manually, or by sending a log file to someone;

* for log files uploaded to GitHub, your token would be revoked automatically when GitHub notices it (which is what happened to @zao)

**We strongly encourage that you revoke the GitHub tokens you are using currently, via https://github.com/settings/tokens, and to replace them using a new token (using `eb --install-github-token --force`).**

(this PR also includes the fixe from #3212 and #3226 which is requires to get the full test suite to pass)