### PR TITLE
Show EC names for parallel build

### DIFF
--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -68,7 +68,7 @@ def build_easyconfigs_in_parallel(build_command, easyconfigs, output_dir='easybu
     :param output_dir: output directory
     :param prepare_first: prepare by runnning fetch step first for each easyconfig
     """
-    _log.info("going to build these easyconfigs in parallel: %s", easyconfigs)
+    _log.info("going to build these easyconfigs in parallel: %s", [os.path.basename(ec['spec']) for ec in easyconfigs])
 
     active_job_backend = job_backend()
     if active_job_backend is None:
@@ -94,7 +94,7 @@ def build_easyconfigs_in_parallel(build_command, easyconfigs, output_dir='easybu
             prepare_easyconfig(easyconfig)
 
         # the new job will only depend on already submitted jobs
-        _log.info("creating job for ec: %s" % easyconfig['ec'])
+        _log.info("creating job for ec: %s" % os.path.basename(easyconfig['spec']))
         new_job = create_job(active_job_backend, build_command, easyconfig, output_dir=output_dir)
 
         # filter out dependencies marked as external modules


### PR DESCRIPTION
Currently the class is show which means some generic output like the address of the object. This shows the actual name(s) of the EC/module