### PR TITLE
make EasyConfig.dump aware of toolchain hierarchy, to avoid hardcoded subtoolchains in dependencies easyconfig parameters

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3295,7 +3295,7 @@ def reproduce_build(app, reprod_dir_root):
     reprod_dir = find_backup_name_candidate(os.path.join(reprod_dir_root, REPROD))
     reprod_spec = os.path.join(reprod_dir, ec_filename)
     try:
-        app.cfg.dump(reprod_spec)
+        app.cfg.dump(reprod_spec, explicit_toolchains=True)
         _log.info("Dumped easyconfig instance to %s", reprod_spec)
     except NotImplementedError as err:
         _log.warning("Unable to dump easyconfig instance to %s: %s", reprod_spec, err)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1129,7 +1129,7 @@ class EasyConfig(object):
         try:
             toolchain_hierarchy = get_toolchain_hierarchy(self['toolchain'])
         except EasyBuildError as err:
-            # don't fail hardjust because we can't get the hierarchy
+            # don't fail hard just because we can't get the hierarchy
             self.log.warning('Could not generate toolchain hierarchy for %s to use in easyconfig dump method, '
                              'error:\n%s', self['toolchain'], str(err))
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1125,16 +1125,17 @@ class EasyConfig(object):
             if self.template_values[key] not in templ_val and len(self.template_values[key]) > 2:
                 templ_val[self.template_values[key]] = key
 
+        toolchain_hierarchy = None
+        try:
+            toolchain_hierarchy = get_toolchain_hierarchy(self['toolchain'])
+        except EasyBuildError as err:
+            # don't fail hardjust because we can't get the hierarchy
+            self.log.warning('Could not generate toolchain hierarchy for %s to use in easyconfig dump method, '
+                             'error:\n%s', self['toolchain'], str(err))
+
         try:
             ectxt = self.parser.dump(self, default_values, templ_const, templ_val,
-                                     toolchain_hierarchy=get_toolchain_hierarchy(self['toolchain']))
-        except EasyBuildError as err:
-            if 'No version found for subtoolchain' in str(err):
-                self.log.warning('Could not generate toolchain hierarchy for %s to use in easyconfig dump',
-                                 self['toolchain'])
-                ectxt = self.parser.dump(self, default_values, templ_const, templ_val)
-            else:
-                raise err
+                                     toolchain_hierarchy=toolchain_hierarchy)
         except NotImplementedError as err:
             # need to restore enable_templating value in case this method is caught in a try/except block and ignored
             # (the ability to dump is not a hard requirement for build success)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1128,6 +1128,13 @@ class EasyConfig(object):
         try:
             ectxt = self.parser.dump(self, default_values, templ_const, templ_val,
                                      toolchain_hierarchy=get_toolchain_hierarchy(self['toolchain']))
+        except EasyBuildError as err:
+            if 'No version found for subtoolchain' in str(err):
+                self.log.warning('Could not generate toolchain hierarchy for %s to use in easyconfig dump',
+                                 self['toolchain'])
+                ectxt = self.parser.dump(self, default_values, templ_const, templ_val)
+            else:
+                raise err
         except NotImplementedError as err:
             # need to restore enable_templating value in case this method is caught in a try/except block and ignored
             # (the ability to dump is not a hard requirement for build success)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1126,7 +1126,8 @@ class EasyConfig(object):
                 templ_val[self.template_values[key]] = key
 
         try:
-            ectxt = self.parser.dump(self, default_values, templ_const, templ_val)
+            ectxt = self.parser.dump(self, default_values, templ_const, templ_val,
+                                     toolchain_hierarchy=get_toolchain_hierarchy(self.toolchain))
         except NotImplementedError as err:
             # need to restore enable_templating value in case this method is caught in a try/except block and ignored
             # (the ability to dump is not a hard requirement for build success)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1096,7 +1096,7 @@ class EasyConfig(object):
 
         return self._all_dependencies
 
-    def dump(self, fp, always_overwrite=True, backup=False):
+    def dump(self, fp, always_overwrite=True, backup=False, explicit_toolchains=False):
         """
         Dump this easyconfig to file, with the given filename.
 
@@ -1126,12 +1126,13 @@ class EasyConfig(object):
                 templ_val[self.template_values[key]] = key
 
         toolchain_hierarchy = None
-        try:
-            toolchain_hierarchy = get_toolchain_hierarchy(self['toolchain'])
-        except EasyBuildError as err:
-            # don't fail hard just because we can't get the hierarchy
-            self.log.warning('Could not generate toolchain hierarchy for %s to use in easyconfig dump method, '
-                             'error:\n%s', self['toolchain'], str(err))
+        if not explicit_toolchains:
+            try:
+                toolchain_hierarchy = get_toolchain_hierarchy(self['toolchain'])
+            except EasyBuildError as err:
+                # don't fail hard just because we can't get the hierarchy
+                self.log.warning('Could not generate toolchain hierarchy for %s to use in easyconfig dump method, '
+                                 'error:\n%s', self['toolchain'], str(err))
 
         try:
             ectxt = self.parser.dump(self, default_values, templ_const, templ_val,

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1127,7 +1127,7 @@ class EasyConfig(object):
 
         try:
             ectxt = self.parser.dump(self, default_values, templ_const, templ_val,
-                                     toolchain_hierarchy=get_toolchain_hierarchy(self.toolchain))
+                                     toolchain_hierarchy=get_toolchain_hierarchy(self['toolchain']))
         except NotImplementedError as err:
             # need to restore enable_templating value in case this method is caught in a try/except block and ignored
             # (the ability to dump is not a hard requirement for build success)

--- a/easybuild/framework/easyconfig/format/format.py
+++ b/easybuild/framework/easyconfig/format/format.py
@@ -632,7 +632,7 @@ class EasyConfigFormat(object):
         """Parse the txt according to this format. This is highly version specific"""
         raise NotImplementedError
 
-    def dump(self, ecfg, default_values, templ_const, templ_val):
+    def dump(self, ecfg, default_values, templ_const, templ_val, toolchain_hierarchy=None):
         """Dump easyconfig according to this format. This is higly version specific"""
         raise NotImplementedError
 

--- a/easybuild/framework/easyconfig/format/format.py
+++ b/easybuild/framework/easyconfig/format/format.py
@@ -633,7 +633,7 @@ class EasyConfigFormat(object):
         raise NotImplementedError
 
     def dump(self, ecfg, default_values, templ_const, templ_val, toolchain_hierarchy=None):
-        """Dump easyconfig according to this format. This is higly version specific"""
+        """Dump easyconfig according to this format. This is highly version specific"""
         raise NotImplementedError
 
     def extract_comments(self, rawtxt):

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -65,15 +65,17 @@ REFORMAT_ORDERED_ITEM_KEYS = {
 _log = fancylogger.getLogger('easyconfig.format.one', fname=False)
 
 
-def dump_dependency(dep, toolchain):
+def dump_dependency(dep, toolchain, toolchain_hierarchy=[]):
     """Dump parsed dependency in tuple format"""
+    if not toolchain_hierarchy:
+        toolchain_hierarchy = [toolchain]
 
     if dep['external_module']:
         res = "(%s, EXTERNAL_MODULE)" % quote_py_str(dep['full_mod_name'])
     else:
-        # mininal spec: (name, version)
+        # minimal spec: (name, version)
         tup = (dep['name'], dep['version'])
-        if dep['toolchain'] != toolchain:
+        if all(dep['toolchain'] != subtoolchain for subtoolchain in toolchain_hierarchy):
             if dep[SYSTEM_TOOLCHAIN_NAME]:
                 tup += (dep['versionsuffix'], True)
             else:
@@ -260,7 +262,7 @@ class FormatOneZero(EasyConfigFormatConfigObj):
 
         return res
 
-    def _find_defined_params(self, ecfg, keyset, default_values, templ_const, templ_val):
+    def _find_defined_params(self, ecfg, keyset, default_values, templ_const, templ_val, toolchain_hierarchy=[]):
         """
         Determine parameters in the dumped easyconfig file which have a non-default value.
         """
@@ -279,12 +281,18 @@ class FormatOneZero(EasyConfigFormatConfigObj):
                                 # the way that builddependencies are constructed with multi_deps
                                 # we just need to dump the first entry without the dependencies
                                 # that are listed in multi_deps
-                                valstr = [dump_dependency(d, ecfg['toolchain']) for d in val[0]
-                                          if d['name'] not in ecfg['multi_deps']]
+                                valstr = [
+                                    dump_dependency(d, ecfg['toolchain'], toolchain_hierarchy=toolchain_hierarchy)
+                                    for d in val[0] if d['name'] not in ecfg['multi_deps']
+                                ]
                             else:
-                                valstr = [[dump_dependency(d, ecfg['toolchain']) for d in dep] for dep in val]
+                                valstr = [
+                                    [dump_dependency(d, ecfg['toolchain'], toolchain_hierarchy=toolchain_hierarchy)
+                                     for d in dep] for dep in val
+                                ]
                         else:
-                            valstr = [dump_dependency(d, ecfg['toolchain']) for d in val]
+                            valstr = [dump_dependency(d, ecfg['toolchain'], toolchain_hierarchy=toolchain_hierarchy)
+                                      for d in val]
                     elif key == 'toolchain':
                         valstr = "{'name': '%(name)s', 'version': '%(version)s'}" % ecfg[key]
                     else:
@@ -299,7 +307,7 @@ class FormatOneZero(EasyConfigFormatConfigObj):
 
         return eclines, printed_keys
 
-    def dump(self, ecfg, default_values, templ_const, templ_val):
+    def dump(self, ecfg, default_values, templ_const, templ_val, toolchain_hierarchy=[]):
         """
         Dump easyconfig in format v1.
 
@@ -307,12 +315,14 @@ class FormatOneZero(EasyConfigFormatConfigObj):
         :param default_values: default values for easyconfig parameters
         :param templ_const: known template constants
         :param templ_val: known template values
+        :param toolchain_hierarchy: hierarchy of toolchains for easyconfig
         """
         # include header comments first
         dump = self.comments['header'][:]
 
         # print easyconfig parameters ordered and in groups specified above
-        params, printed_keys = self._find_defined_params(ecfg, GROUPED_PARAMS, default_values, templ_const, templ_val)
+        params, printed_keys = self._find_defined_params(ecfg, GROUPED_PARAMS, default_values, templ_const, templ_val,
+                                                         toolchain_hierarchy=toolchain_hierarchy)
         dump.extend(params)
 
         # print other easyconfig parameters at the end

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -65,7 +65,7 @@ REFORMAT_ORDERED_ITEM_KEYS = {
 _log = fancylogger.getLogger('easyconfig.format.one', fname=False)
 
 
-def dump_dependency(dep, toolchain, toolchain_hierarchy=[]):
+def dump_dependency(dep, toolchain, toolchain_hierarchy=None):
     """Dump parsed dependency in tuple format"""
     if not toolchain_hierarchy:
         toolchain_hierarchy = [toolchain]
@@ -262,7 +262,7 @@ class FormatOneZero(EasyConfigFormatConfigObj):
 
         return res
 
-    def _find_defined_params(self, ecfg, keyset, default_values, templ_const, templ_val, toolchain_hierarchy=[]):
+    def _find_defined_params(self, ecfg, keyset, default_values, templ_const, templ_val, toolchain_hierarchy=None):
         """
         Determine parameters in the dumped easyconfig file which have a non-default value.
         """
@@ -307,7 +307,7 @@ class FormatOneZero(EasyConfigFormatConfigObj):
 
         return eclines, printed_keys
 
-    def dump(self, ecfg, default_values, templ_const, templ_val, toolchain_hierarchy=[]):
+    def dump(self, ecfg, default_values, templ_const, templ_val, toolchain_hierarchy=None):
         """
         Dump easyconfig in format v1.
 

--- a/easybuild/framework/easyconfig/format/yeb.py
+++ b/easybuild/framework/easyconfig/format/yeb.py
@@ -126,7 +126,7 @@ class FormatYeb(EasyConfigFormat):
 
         return full_txt
 
-    def dump(self, ecfg, default_values, templ_const, templ_val, toolchain_hierarchy=[]):
+    def dump(self, ecfg, default_values, templ_const, templ_val, toolchain_hierarchy=None):
         """Dump parsed easyconfig in .yeb format"""
         raise NotImplementedError("Dumping of .yeb easyconfigs not supported yet")
 

--- a/easybuild/framework/easyconfig/format/yeb.py
+++ b/easybuild/framework/easyconfig/format/yeb.py
@@ -126,7 +126,7 @@ class FormatYeb(EasyConfigFormat):
 
         return full_txt
 
-    def dump(self, ecfg, default_values, templ_const, templ_val):
+    def dump(self, ecfg, default_values, templ_const, templ_val, toolchain_hierarchy=[]):
         """Dump parsed easyconfig in .yeb format"""
         raise NotImplementedError("Dumping of .yeb easyconfigs not supported yet")
 

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -226,6 +226,7 @@ class EasyConfigParser(object):
 
         return cfg
 
-    def dump(self, ecfg, default_values, templ_const, templ_val):
+    def dump(self, ecfg, default_values, templ_const, templ_val, toolchain_hierarchy=[]):
         """Dump easyconfig in format it was parsed from."""
-        return self._formatter.dump(ecfg, default_values, templ_const, templ_val)
+        return self._formatter.dump(ecfg, default_values, templ_const, templ_val,
+                                    toolchain_hierarchy=toolchain_hierarchy)

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -226,7 +226,7 @@ class EasyConfigParser(object):
 
         return cfg
 
-    def dump(self, ecfg, default_values, templ_const, templ_val, toolchain_hierarchy=[]):
+    def dump(self, ecfg, default_values, templ_const, templ_val, toolchain_hierarchy=None):
         """Dump easyconfig in format it was parsed from."""
         return self._formatter.dump(ecfg, default_values, templ_const, templ_val,
                                     toolchain_hierarchy=toolchain_hierarchy)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1684,7 +1684,16 @@ class EasyConfigTest(EnhancedTestCase):
         # dict representation of EasyConfig instance should not change after dump
         self.assertEqual(ecdict, ec.asdict())
         ectxt = read_file(test_ec)
+        dumped_ec = EasyConfig(test_ec)
+        self.assertEqual(ecdict, dumped_ec.asdict())
         self.assertTrue(r"'toy', '0.0')," in ectxt)
+        # test case where we ask for explicit toolchains
+        ec.dump(test_ec, explicit_toolchains=True)
+        self.assertEqual(ecdict, ec.asdict())
+        ectxt = read_file(test_ec)
+        dumped_ec = EasyConfig(test_ec)
+        self.assertEqual(ecdict, dumped_ec.asdict())
+        self.assertTrue(r"'toy', '0.0', '', ('gompi', '2018a'))," in ectxt)
 
     def test_dump_order(self):
         """Test order of easyconfig parameters in dumped easyconfig."""

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1642,6 +1642,50 @@ class EasyConfigTest(EnhancedTestCase):
                 if param in ec:
                     self.assertEqual(ec[param], dumped_ec[param])
 
+    def test_toolchain_hierarchy_aware_dump(self):
+        """Test that EasyConfig's dump() method is aware of the toolchain hierarchy."""
+        test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+        build_options = {
+            'check_osdeps': False,
+            'robot_path': [test_ecs_dir],
+            'valid_module_classes': module_classes(),
+        }
+        init_config(build_options=build_options)
+        rawtxt = '\n'.join([
+            "easyblock = 'EB_foo'",
+            '',
+            "name = 'foo'",
+            "version = '0.0.1'",
+            '',
+            "toolchain = {'name': 'foss', 'version': '2018a'}",
+            '',
+            "homepage = 'http://foo.com/'",
+            'description = "foo description"',
+            '',
+            'sources = [SOURCE_TAR_GZ]',
+            'source_urls = ["http://example.com"]',
+            'checksums = ["6af6ab95ce131c2dd467d2ebc8270e9c265cc32496210b069e51d3749f335f3d"]',
+            '',
+            "dependencies = [",
+            "    ('toy', '0.0', '', ('gompi', '2018a')),",
+            "    ('bar', '1.0'),",
+            "    ('foobar/1.2.3', EXTERNAL_MODULE),",
+            "]",
+            '',
+            "foo_extra1 = 'foobar'",
+            '',
+            'moduleclass = "tools"',
+        ])
+
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        ec = EasyConfig(None, rawtxt=rawtxt)
+        ecdict = ec.asdict()
+        ec.dump(test_ec)
+        # dict representation of EasyConfig instance should not change after dump
+        self.assertEqual(ecdict, ec.asdict())
+        ectxt = read_file(test_ec)
+        self.assertTrue(r"'toy', '0.0')," in ectxt)
+
     def test_dump_order(self):
         """Test order of easyconfig parameters in dumped easyconfig."""
         rawtxt = '\n'.join([


### PR DESCRIPTION
This PR was created to provide prettier easyconfig dumps for #2599, since in that PR the toolchains used for dependencies are fully resolved. If those resolved toolchains exist in the toolchain hierarchy then there is no need to explicitly dump them, and the results look more like standard easyconfigs.

So, for example, we would go from
```
easyblock = 'ConfigureMake'

name = 'fastq-tools'
version = '6.30.2'

homepage = 'https://homes.cs.washington.edu/~dcjones/%(name)s/'
description = """This package provides a number of small and efficient programs to perform
 common tasks with high throughput sequencing data in the FASTQ format. All of the programs
 work with typical FASTQ files as well as gzipped FASTQ files."""

toolchain = {'name': 'foss', 'version': '2019b'}
toolchainopts = {'pic': True}

source_urls = ['https://github.com/dcjones/%(name)s/archive/']
sources = ['v%(version)s.tar.gz']

builddependencies = [
    ('Autotools', '20180311', '', ('GCCcore', '8.3.0')),
]
dependencies = [
    ('PCRE', '8.43', '', ('GCCcore', '8.3.0')),
    ('zlib', '1.2.11', '', ('GCCcore', '8.3.0')),
]

# unsetting LIBS is needed because configure script can't handle it properly if it is already defined
preconfigopts = "./autogen.sh && unset LIBS && "


sanity_check_paths = {
    'files': ['bin/fastq-grep', 'bin/fastq-kmers', 'bin/fastq-match', 'bin/fastq-qscale', 'bin/fastq-qual', 'bin/fastq-qualadj', 'bin/fastq-sample', 'bin/fastq-sort', 'bin/fastq-uniq'],
    'dirs': ['share/man/man1'],
}

moduleclass = 'bio'
```
to
```
easyblock = 'ConfigureMake'

name = 'fastq-tools'
version = '6.30.2'

homepage = 'https://homes.cs.washington.edu/~dcjones/%(name)s/'
description = """This package provides a number of small and efficient programs to perform
 common tasks with high throughput sequencing data in the FASTQ format. All of the programs
 work with typical FASTQ files as well as gzipped FASTQ files."""

toolchain = {'name': 'foss', 'version': '2019b'}
toolchainopts = {'pic': True}

source_urls = ['https://github.com/dcjones/%(name)s/archive/']
sources = ['v%(version)s.tar.gz']

builddependencies = [
    ('Autotools', '20180311'),
]
dependencies = [
    ('PCRE', '8.43'),
    ('zlib', '1.2.11'),
]

# unsetting LIBS is needed because configure script can't handle it properly if it is already defined
preconfigopts = "./autogen.sh && unset LIBS && "


sanity_check_paths = {
    'files': ['bin/fastq-grep', 'bin/fastq-kmers', 'bin/fastq-match', 'bin/fastq-qscale', 'bin/fastq-qual', 'bin/fastq-qualadj', 'bin/fastq-sample', 'bin/fastq-sort', 'bin/fastq-uniq'],
    'dirs': ['share/man/man1'],
}

moduleclass = 'bio'
```

This is a somewhat convoluted alternative to #3260 to avoid circular dependencies (to get a hierarchy we need to be able to read easyconfigs, but the place where we define this PR tells us how to do that).