### PR TITLE
Update copy_dir to include option to merge directories

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -40,7 +40,6 @@ Set of file tools.
 """
 import datetime
 import difflib
-import distutils
 import fileinput
 import glob
 import hashlib
@@ -52,6 +51,7 @@ import sys
 import tempfile
 import time
 import zlib
+from distutils.dir_util import copy_tree
 from xml.etree import ElementTree
 
 from easybuild.base import fancylogger
@@ -1847,7 +1847,7 @@ def copy_dir(path, target_path, force_in_dry_run=False, dirs_exist_ok=False, **k
                 # Check if there are other named arguments
                 if len(kwargs) > 0:
                     raise EasyBuildError("You can't use 'dirs_exist_ok=True' with other named arguments: %s", kwargs)
-                distutils.dir_util.copy_tree(path, target_path, preserve_symlinks=preserve_symlinks)
+                copy_tree(path, target_path, preserve_symlinks=preserve_symlinks)
 
             else:
                 # Use shutil.copytree WITHOUT 'dirs_exist_ok'

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -40,6 +40,7 @@ Set of file tools.
 """
 import datetime
 import difflib
+import distutils
 import fileinput
 import glob
 import hashlib

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1834,23 +1834,24 @@ def copy_dir(path, target_path, force_in_dry_run=False, dirs_exist_ok=False, **k
             if not dirs_exist_ok and os.path.exists(target_path):
                 raise EasyBuildError("Target location %s to copy %s to already exists", target_path, path)
 
-            # On Python >= 3.8
             if sys.version_info >= (3, 8):
-                # Use the shutil.copytree WITH 'dirs_exist_ok'
+                # on Python >= 3.8, shutil.copytree works fine, thanks to availability of dirs_exist_ok named argument
                 shutil.copytree(path, target_path, dirs_exist_ok=dirs_exist_ok, **kwargs)
 
             elif dirs_exist_ok:
-                # Get symlinks named argument and use distutils.dir_util.copy_tree instead.
+                # use distutils.dir_util.copy_tree with Python < 3.8 if dirs_exist_ok is enabled
+
+                # first get value for symlinks named argument (if any)
                 preserve_symlinks = kwargs.pop('symlinks', False)
 
-                # Check if there are other named arguments
+                # check if there are other named arguments (there shouldn't be, only 'symlinks' is supported)
                 if kwargs:
-                    raise EasyBuildError("You can't use 'dirs_exist_ok=True' with other named arguments: %s",
-                                         list(kwargs.keys()))
+                    raise EasyBuildError("Unknown named arguments passed to copy_dir with dirs_exist_ok=True: %s",
+                                         ', '.join(sorted(kwargs.keys())))
                 distutils.dir_util.copy_tree(path, target_path, preserve_symlinks=preserve_symlinks)
 
             else:
-                # Use shutil.copytree WITHOUT 'dirs_exist_ok'
+                # if dirs_exist_ok is not enabled, just use shutil.copytree
                 shutil.copytree(path, target_path, **kwargs)
 
             _log.info("%s copied to %s", path, target_path)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -40,6 +40,7 @@ Set of file tools.
 """
 import datetime
 import difflib
+import distutils.dir_util
 import fileinput
 import glob
 import hashlib
@@ -51,7 +52,6 @@ import sys
 import tempfile
 import time
 import zlib
-from distutils.dir_util import copy_tree
 from xml.etree import ElementTree
 
 from easybuild.base import fancylogger
@@ -1835,20 +1835,19 @@ def copy_dir(path, target_path, force_in_dry_run=False, dirs_exist_ok=False, **k
                 raise EasyBuildError("Target location %s to copy %s to already exists", target_path, path)
 
             # On Python >= 3.8
-            if (sys.version_info[0] == 3 and sys.version_info[1] >= 8) or sys.version_info[0] > 3:
+            if sys.version_info >= (3, 8):
                 # Use the shutil.copytree WITH 'dirs_exist_ok'
                 shutil.copytree(path, target_path, dirs_exist_ok=dirs_exist_ok, **kwargs)
 
             elif dirs_exist_ok:
-                preserve_symlinks = False
                 # Get symlinks named argument and use distutils.dir_util.copy_tree instead.
-                if 'symlinks' in kwargs:
-                    preserve_symlinks = kwargs.pop('symlinks', False)
+                preserve_symlinks = kwargs.pop('symlinks', False)
+
                 # Check if there are other named arguments
-                if len(kwargs) > 0:
+                if kwargs:
                     raise EasyBuildError("You can't use 'dirs_exist_ok=True' with other named arguments: %s",
                                          list(kwargs.keys()))
-                copy_tree(path, target_path, preserve_symlinks=preserve_symlinks)
+                distutils.dir_util.copy_tree(path, target_path, preserve_symlinks=preserve_symlinks)
 
             else:
                 # Use shutil.copytree WITHOUT 'dirs_exist_ok'

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1846,7 +1846,8 @@ def copy_dir(path, target_path, force_in_dry_run=False, dirs_exist_ok=False, **k
                     preserve_symlinks = kwargs.pop('symlinks', False)
                 # Check if there are other named arguments
                 if len(kwargs) > 0:
-                    raise EasyBuildError("You can't use 'dirs_exist_ok=True' with other named arguments: %s", kwargs)
+                    raise EasyBuildError("You can't use 'dirs_exist_ok=True' with other named arguments: %s",
+                                         list(kwargs.keys()))
                 copy_tree(path, target_path, preserve_symlinks=preserve_symlinks)
 
             else:

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1477,16 +1477,17 @@ class FileToolsTest(EnhancedTestCase):
         # if the directory already exists and 'dirs_exist_ok' is True and there is another named argument (ignore)
         # we expect clean error on Python < 3.8 and pass the test on Python >= 3.8
         # NOTE: reused ignore from previous test
+        def ignore_func(_, names):
+            return [x for x in names if '6.4.0-2.28' in x]
         shutil.rmtree(testdir)
         ft.mkdir(testdir)
-        if (sys.version_info[0] == 3 and sys.version_info[1] >= 8) or sys.version_info[0] > 3:
-            ft.copy_dir(to_copy, testdir, dirs_exist_ok=True,
-                        ignore=lambda src, names: [x for x in names if '6.4.0-2.28' in x])
+        if sys.version_info >= (3, 8):
+            ft.copy_dir(to_copy, testdir, dirs_exist_ok=True, ignore=ignore_func)
             self.assertEqual(sorted(os.listdir(testdir)), expected)
             self.assertFalse(os.path.exists(os.path.join(testdir, 'GCC-6.4.0-2.28.eb')))
         else:
             self.assertErrorRegex(EasyBuildError, "You can't use 'dirs_exist_ok=True' with other named arguments:.*",
-                                  ft.copy_dir, to_copy, testdir, dirs_exist_ok=True, ignore=lambda src, names: [])
+                                  ft.copy_dir, to_copy, testdir, dirs_exist_ok=True, ignore=ignore_func)
 
         # also test behaviour of copy_file under --dry-run
         build_options = {

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1479,6 +1479,7 @@ class FileToolsTest(EnhancedTestCase):
         # NOTE: reused ignore from previous test
         def ignore_func(_, names):
             return [x for x in names if '6.4.0-2.28' in x]
+
         shutil.rmtree(testdir)
         ft.mkdir(testdir)
         if sys.version_info >= (3, 8):
@@ -1486,8 +1487,9 @@ class FileToolsTest(EnhancedTestCase):
             self.assertEqual(sorted(os.listdir(testdir)), expected)
             self.assertFalse(os.path.exists(os.path.join(testdir, 'GCC-6.4.0-2.28.eb')))
         else:
-            self.assertErrorRegex(EasyBuildError, "You can't use 'dirs_exist_ok=True' with other named arguments:.*",
-                                  ft.copy_dir, to_copy, testdir, dirs_exist_ok=True, ignore=ignore_func)
+            error_pattern = "Unknown named arguments passed to copy_dir with dirs_exist_ok=True: ignore"
+            self.assertErrorRegex(EasyBuildError, error_pattern, ft.copy_dir, to_copy, testdir,
+                                  dirs_exist_ok=True, ignore=ignore_func)
 
         # also test behaviour of copy_file under --dry-run
         build_options = {

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1485,7 +1485,7 @@ class FileToolsTest(EnhancedTestCase):
             self.assertEqual(sorted(os.listdir(testdir)), expected)
             self.assertFalse(os.path.exists(os.path.join(testdir, 'GCC-6.4.0-2.28.eb')))
         else:
-            self.assertErrorRegex(EasyBuildError, "You can't use 'dirs_exist_ok=True' with other named arguments .*",
+            self.assertErrorRegex(EasyBuildError, "You can't use 'dirs_exist_ok=True' with other named arguments:.*",
                                   ft.copy_dir, to_copy, testdir, dirs_exist_ok=True, ignore=lambda src, names: [])
 
         # also test behaviour of copy_file under --dry-run


### PR DESCRIPTION
copy_dir is using shutils.copy_tree which throws error when target directory exists.
In Python 3.8 new `dirs_exist_ok` parameter was added to be able to merge folders as well.

The cleanest solution was to mimic this option with distutils copy_tree which does exactly that.

This is needed for Tarball installation in Bundles, because Tarball removes the whole folder, effectively wiping previous installed bundle components. (Fix for Tarball EB will follow)

Please Squash the merge if possible.