### PR TITLE
fix posting of comment in PR with --upload-test-report

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -493,6 +493,9 @@ def fetch_files_from_pr(pr, path=None, github_user=None, github_repo=None):
 
 def create_gist(txt, fn, descr=None, github_user=None, github_token=None):
     """Create a gist with the provided text."""
+
+    dry_run = build_option('dry_run') or build_option('extended_dry_run')
+
     if descr is None:
         descr = "(none)"
 
@@ -508,8 +511,12 @@ def create_gist(txt, fn, descr=None, github_user=None, github_token=None):
             }
         }
     }
-    g = RestClient(GITHUB_API_URL, username=github_user, token=github_token)
-    status, data = g.gists.post(body=body)
+
+    if dry_run:
+        status, data = HTTP_STATUS_CREATED, {'html_url': 'https://gist.github.com/DRY_RUN'}
+    else:
+        g = RestClient(GITHUB_API_URL, username=github_user, token=github_token)
+        status, data = g.gists.post(body=body)
 
     if status != HTTP_STATUS_CREATED:
         raise EasyBuildError("Failed to create gist; status %s, data: %s", status, data)

--- a/easybuild/tools/testing.py
+++ b/easybuild/tools/testing.py
@@ -46,7 +46,7 @@ from easybuild.framework.easyconfig.tools import skip_available
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.filetools import find_easyconfigs, mkdir, read_file, write_file
-from easybuild.tools.github import create_gist, post_comment_in_issue
+from easybuild.tools.github import GITHUB_EASYCONFIGS_REPO, create_gist, post_comment_in_issue
 from easybuild.tools.jenkins import aggregate_xml_in_dirs
 from easybuild.tools.parallelbuild import build_easyconfigs_in_parallel
 from easybuild.tools.robot import resolve_dependencies
@@ -143,7 +143,7 @@ def create_test_report(msg, ecs_with_res, init_session_state, pr_nr=None, gist_l
 
     github_user = build_option('github_user')
     pr_target_account = build_option('pr_target_account')
-    pr_target_repo = build_option('pr_target_repo')
+    pr_target_repo = build_option('pr_target_repo') or GITHUB_EASYCONFIGS_REPO
 
     end_time = gmtime()
 
@@ -252,10 +252,13 @@ def post_easyconfigs_pr_test_report(pr_nr, test_report, msg, init_session_state,
     """Post test report in a gist, and submit comment in easyconfigs PR."""
 
     github_user = build_option('github_user')
+    pr_target_account = build_option('pr_target_account')
+    pr_target_repo = build_option('pr_target_repo') or GITHUB_EASYCONFIGS_REPO
 
     # create gist with test report
-    descr = "EasyBuild test report for easyconfigs PR #%s" % pr_nr
-    fn = 'easybuild_test_report_easyconfigs_pr%s_%s.md' % (pr_nr, strftime("%Y%M%d-UTC-%H-%M-%S", gmtime()))
+    descr = "EasyBuild test report for %s/%s PR #%s" % (pr_target_account, pr_target_repo, pr_nr)
+    timestamp = strftime("%Y%M%d-UTC-%H-%M-%S", gmtime())
+    fn = 'easybuild_test_report_%s_%s_pr%s_%s.md' % (pr_nr, pr_target_account, pr_target_repo, timestamp)
     gist_url = upload_test_report_as_gist(test_report, descr=descr, fn=fn)
 
     # post comment to report test result
@@ -282,9 +285,6 @@ def post_easyconfigs_pr_test_report(pr_nr, test_report, msg, init_session_state,
         "See %s for a full test report." % gist_url,
     ]
     comment = '\n'.join(comment_lines)
-
-    pr_target_account = build_option('pr_target_account')
-    pr_target_repo = build_option('pr_target_repo')
 
     post_comment_in_issue(pr_nr, comment, account=pr_target_account, repo=pr_target_repo, github_user=github_user)
 

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -43,6 +43,7 @@ from easybuild.tools.config import build_option, module_classes
 from easybuild.tools.configobj import ConfigObj
 from easybuild.tools.filetools import read_file, write_file
 from easybuild.tools.github import VALID_CLOSE_PR_REASONS
+from easybuild.tools.testing import post_easyconfigs_pr_test_report, session_state
 from easybuild.tools.py2vs3 import HTTPError, URLError, ascii_letters
 import easybuild.tools.github as gh
 
@@ -777,6 +778,39 @@ class GithubTest(EnhancedTestCase):
         ]) + r'$'
         regex = re.compile(pattern)
         self.assertTrue(regex.match(stdout.strip()), "Pattern '%s' doesn't match: %s" % (regex.pattern, stdout))
+
+    def test_post_easyconfigs_pr_test_report(self):
+        """Test for post_easyconfigs_pr_test_report function."""
+        if self.skip_github_tests:
+            print("Skipping test_post_easyconfigs_pr_test_report, no GitHub token available?")
+            return
+
+        init_config(build_options={
+            'dry_run': True,
+            'github_user': GITHUB_TEST_ACCOUNT,
+        })
+
+        test_report = os.path.join(self.test_prefix, 'test_report.txt')
+        write_file(test_report, "This is a test report!")
+
+        init_session_state = session_state()
+
+        self.mock_stderr(True)
+        self.mock_stdout(True)
+        post_easyconfigs_pr_test_report('1234', test_report, "OK!", init_session_state, True)
+        stderr, stdout = self.get_stderr(), self.get_stdout()
+        self.mock_stderr(False)
+        self.mock_stdout(False)
+
+        self.assertEqual(stderr, '')
+
+        patterns = [
+            r"^\[DRY RUN\] Adding comment to easybuild-easyconfigs issue #1234: 'Test report by @easybuild_test",
+            r"^See https://gist.github.com/DRY_RUN for a full test report.'",
+        ]
+        for pattern in patterns:
+            regex = re.compile(pattern, re.M)
+            self.assertTrue(regex.search(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
 
 
 def suite():


### PR DESCRIPTION
fix for bug that was introduced in recently merged PR #3189 that occurs when `--upload-test-report`:

```
Traceback (most recent call last):
  File "/usr/lib64/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/lib/python2.7/site-packages/easybuild_framework-4.2.0.dev0-py2.7.egg/easybuild/main.py", line 518, in <module>
    main()
  File "/lib/python2.7/site-packages/easybuild_framework-4.2.0.dev0-py2.7.egg/easybuild/main.py", line 497, in main
    test_report_msg = overall_test_report(ecs_with_res, len(paths), overall_success, success_msg, init_session_state)
  File "/lib/python2.7/site-packages/easybuild_framework-4.2.0.dev0-py2.7.egg/easybuild/tools/testing.py", line 313, in overall_test_report
    txt = post_easyconfigs_pr_test_report(pr_nr, test_report, msg, init_session_state, success)
  File "/lib/python2.7/site-packages/easybuild_framework-4.2.0.dev0-py2.7.egg/easybuild/tools/testing.py", line 289, in post_easyconfigs_pr_test_report
    post_comment_in_issue(pr_nr, comment, account=pr_target_account, repo=pr_target_repo, github_user=github_user)
  File "/lib/python2.7/site-packages/easybuild_framework-4.2.0.dev0-py2.7.egg/easybuild/tools/github.py", line 554, in post_comment_in_issue
    status, data = pr_url.comments.post(body={'body': txt})
  File "/lib/python2.7/site-packages/easybuild_framework-4.2.0.dev0-py2.7.egg/easybuild/base/rest.py", line 137, in post
    return self.request(self.POST, url, json.dumps(body), headers, content_type='application/json')
  File "lib/python2.7/site-packages/easybuild_framework-4.2.0.dev0-py2.7.egg/easybuild/base/rest.py", line 174, in request
    conn = self.get_connection(method, url, body, headers)
  File "/lib/python2.7/site-packages/easybuild_framework-4.2.0.dev0-py2.7.egg/easybuild/base/rest.py", line 215, in get_connection
    connection = self.opener.open(request)
  File "/usr/lib64/python3.6/urllib/request.py", line 532, in open
    response = meth(req, response)
  File "/usr/lib64/python3.6/urllib/request.py", line 642, in http_response
    'http', request, response, code, msg, hdrs)
  File "/usr/lib64/python3.6/urllib/request.py", line 570, in error
    return self._call_chain(*args)
  File "/usr/lib64/python3.6/urllib/request.py", line 504, in _call_chain
    result = func(*args)
  File "/usr/lib64/python3.6/urllib/request.py", line 650, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
```

The underlying cause was the use of `None` in the URL composed to post the comment by the `post_comment_in_issue` function (called by `post_easyconfigs_pr_test_report`), for example:

```
== 2020-04-08 19:56:13,905 rest.py:214 DEBUG opening request:  https://api.github.com/repos/easybuilders/None/issues/10354/comments
```

This occurs because the default value for `--pr-target-repo` was changed to `None` in #3189...