### PR TITLE
take into account dependencies marked as external modules when composing template values like %(pyver)s

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -222,12 +222,24 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
         for dep in deps:
             if isinstance(dep, dict):
                 dep_name, dep_version = dep['name'], dep['version']
+
+                # take into account dependencies marked as external modules,
+                # where name/version may have to be harvested from metadata available for that external module
+                if dep.get('external_module', False):
+                    metadata = dep.get('external_module_metadata', {})
+                    if dep_name is None:
+                        # name is a list in metadata, just take first value (if any)
+                        dep_name = metadata.get('name', [None])[0]
+                    if dep_version is None:
+                        # version is a list in metadata, just take first value (if any)
+                        dep_version = metadata.get('version', [None])[0]
+
             elif isinstance(dep, (list, tuple)):
                 dep_name, dep_version = dep[0], dep[1]
             else:
                 raise EasyBuildError("Unexpected type for dependency: %s", dep)
 
-            if isinstance(dep_name, string_type) and dep_name.lower() == name.lower():
+            if isinstance(dep_name, string_type) and dep_name.lower() == name.lower() and dep_version:
                 dep_version = pick_dep_version(dep_version)
                 template_values['%sver' % pref] = dep_version
                 dep_version_parts = dep_version.split('.')


### PR DESCRIPTION
fixes #3263