### PR TITLE
stop using apt-spy2 to pick an alternative mirror, it's expensive and may result in picking a faulty mirror...

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -49,14 +49,9 @@ jobs:
 
     - name: install OS & Python packages
       run: |
-        # use apt-spy2 to select closest apt mirror,
-        # which helps avoid connectivity issues in Azure;
-        # see https://github.com/actions/virtual-environments/issues/675
-        sudo gem install apt-spy2
-        sudo apt-spy2 check
-        sudo apt-spy2 fix --commit
-        # after selecting a specific mirror, we need to run 'apt-get update'
-        sudo apt-get update
+        # disable apt-get update, we don't really need it,
+        # and it does more harm than good (it's fairly expensive, and it results in flaky test runs)
+        # sudo apt-get update
         # for modules tool
         sudo apt-get install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
         # fix for lua-posix packaging issue, see https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082


### PR DESCRIPTION
Tests are failing now because a "faulty" mirror is being selected by `apt-spy2`:

```
The closest mirror is: http://mirrors.codec-cluster.org/ubuntu/
Updating /etc/apt/sources.list
Updated '/etc/apt/sources.list' with http://mirrors.codec-cluster.org/ubuntu/
...
E: Failed to fetch http://mirrors.codec-cluster.org/ubuntu/pool/universe/l/lua-bit32/lua-bit32_5.3.0-3_amd64.deb  403  Forbidden [IP: 65.49.71.107 80]
```

According to https://github.com/actions/virtual-environments/issues/675#issuecomment-610914822 the problems with `azure.archive.ubuntu.com` that made us start using `apt-spy2` should be largely resolved now...