### PR TITLE
also mention CPU architecture (x86_64, POWER) in comment for test reports

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -770,6 +770,7 @@ def get_system_info():
     return {
         'core_count': get_avail_core_count(),
         'total_memory': get_total_memory(),
+        'cpu_arch': get_cpu_architecture(),
         'cpu_arch_name': get_cpu_arch_name(),
         'cpu_model': get_cpu_model(),
         'cpu_speed': get_cpu_speed(),

--- a/easybuild/tools/testing.py
+++ b/easybuild/tools/testing.py
@@ -268,12 +268,11 @@ def post_easyconfigs_pr_test_report(pr_nr, test_report, msg, init_session_state,
     if system_info['cpu_arch_name'] != UNKNOWN:
         system_info['cpu_model'] += " (%s)" % system_info['cpu_arch_name']
 
-    short_system_info = "%(hostname)s - %(os_type)s %(os_name)s %(os_version)s, %(cpu_model)s, Python %(pyver)s" % {
+    os_info = '%(hostname)s - %(os_type)s %(os_name)s %(os_version)s' % system_info
+    short_system_info = "%(os_info)s, %(cpu_arch)s, %(cpu_model)s, Python %(pyver)s" % {
+        'os_info': os_info,
+        'cpu_arch': system_info['cpu_arch'],
         'cpu_model': system_info['cpu_model'],
-        'hostname': system_info['hostname'],
-        'os_name': system_info['os_name'],
-        'os_type': system_info['os_type'],
-        'os_version': system_info['os_version'],
         'pyver': system_info['python_version'].split(' ')[0],
     }
 


### PR DESCRIPTION
In https://github.com/easybuilders/easybuild-easyconfigs/pull/9830 I noted that the architecture is now included in the test report, so it's hard to tell which reports are from x86 and which are from power.

Yes there is CPU model stuff via archspec, but that needs an (undocumented?) external dependency.

This PR uses the already available `get_cpu_architecture` which is also used in various EasyBlocks to change behavior and adds it to the report.

Example: https://github.com/easybuilders/easybuild-easyconfigs/pull/10397#issuecomment-614557953

> Build succeeded for 8 out of 8 (8 easyconfigs in this PR)
taurusml1 - Linux RHEL 7.6, POWER, 8335-GTX, Python 2.7.5

and 

> Build succeeded for 8 out of 8 (8 easyconfigs in this PR)
taurusa5 - Linux centos linux 7.7.1908, x86_64, Intel(R) Xeon(R) CPU E5-2603 v4 @ 1.70GHz, Python 2.7.5