### PR TITLE
Deprecate failure to resolve a template value

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -599,19 +599,16 @@ class EasyBlock(object):
                     template_values = copy.deepcopy(self.cfg.template_values)
                     template_values.update(template_constant_dict(ext_src))
 
-                    # resolve templates in extension options
-                    ext_options = resolve_template(ext_options, template_values)
-
-                    source_urls = ext_options.get('source_urls', [])
+                    source_urls = resolve_template(ext_options.get('source_urls', []), template_values)
                     checksums = ext_options.get('checksums', [])
 
-                    download_instructions = ext_options.get('download_instructions')
+                    download_instructions = resolve_template(ext_options.get('download_instructions'), template_values)
 
                     if ext_options.get('nosource', None):
                         self.log.debug("No sources for extension %s, as indicated by 'nosource'", ext_name)
 
                     elif ext_options.get('sources', None):
-                        sources = ext_options['sources']
+                        sources = resolve_template(ext_options['sources'], template_values)
 
                         # only a single source file is supported for extensions currently,
                         # see https://github.com/easybuilders/easybuild-framework/issues/3463
@@ -648,16 +645,17 @@ class EasyBlock(object):
                             })
 
                     else:
-                        # use default template for name of source file if none is specified
-                        default_source_tmpl = resolve_template('%(name)s-%(version)s.tar.gz', template_values)
 
                         # if no sources are specified via 'sources', fall back to 'source_tmpl'
                         src_fn = ext_options.get('source_tmpl')
                         if src_fn is None:
-                            src_fn = default_source_tmpl
+                            # use default template for name of source file if none is specified
+                            src_fn = '%(name)s-%(version)s.tar.gz'
                         elif not isinstance(src_fn, string_type):
                             error_msg = "source_tmpl value must be a string! (found value of type '%s'): %s"
                             raise EasyBuildError(error_msg, type(src_fn).__name__, src_fn)
+
+                        src_fn = resolve_template(src_fn, template_values)
 
                         if fetch_files:
                             src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,
@@ -689,7 +687,7 @@ class EasyBlock(object):
                             raise EasyBuildError('Checksum verification for extension source %s failed', src_fn)
 
                     # locate extension patches (if any), and verify checksums
-                    ext_patches = ext_options.get('patches', [])
+                    ext_patches = resolve_template(ext_options.get('patches', []), template_values)
                     if fetch_files:
                         ext_patches = self.fetch_patches(patch_specs=ext_patches, extension=True)
                     else:
@@ -2879,7 +2877,7 @@ class EasyBlock(object):
 
             fake_mod_data = self.load_fake_module(purge=True, extra_modules=build_dep_mods)
 
-        start_progress_bar(PROGRESS_BAR_EXTENSIONS, len(self.cfg['exts_list']))
+        start_progress_bar(PROGRESS_BAR_EXTENSIONS, len(self.cfg.get_ref('exts_list')))
 
         self.prepare_for_extensions()
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -2032,7 +2032,9 @@ def resolve_template(value, tmpl_dict):
             try:
                 value = value % tmpl_dict
             except KeyError:
-                _log.warning("Unable to resolve template value %s with dict %s", value, tmpl_dict)
+                depr_msg = ('Ignoring failure to resolve template value %s with dict %s.' % (value, tmpl_dict) +
+                            '\n\tThis is deprecated and will lead to build failure. Check for correct escaping.')
+                _log.deprecated(depr_msg, '5.0')
                 value = orig_value  # Undo "%"-escaping
     else:
         # this block deals with references to objects and returns other references

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -2046,7 +2046,10 @@ def resolve_template(value, tmpl_dict, expect_resolved=True):
                 if expect_resolved:
                     depr_msg = ('Ignoring failure to resolve template value %s with dict %s.' % (value, tmpl_dict) +
                                 '\n\tThis is deprecated and will lead to build failure. Check for correct escaping.')
-                    _log.deprecated(depr_msg, '5.0')
+                    if 'resolve-templates' in build_option('silence_deprecation_warnings'):
+                        _log.warning(depr_msg, '5.0')
+                    else:
+                        _log.deprecated(depr_msg, '5.0')
                 value = orig_value  # Undo "%"-escaping
     else:
         # this block deals with references to objects and returns other references

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -129,7 +129,10 @@ class Extension(object):
         self.src = resolve_template(self.ext.get('src', []), self.cfg.template_values)
         self.src_extract_cmd = self.ext.get('extract_cmd', None)
         self.patches = resolve_template(self.ext.get('patches', []), self.cfg.template_values)
-        self.options = resolve_template(copy.deepcopy(self.ext.get('options', {})), self.cfg.template_values)
+        # Some options may not be resolvable yet
+        self.options = resolve_template(copy.deepcopy(self.ext.get('options', {})),
+                                        self.cfg.template_values,
+                                        expect_resolved=False)
 
         if extra_params:
             self.cfg.extend_params(extra_params, overwrite=False)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -340,7 +340,7 @@ class EasyBuildOptions(GeneralOption):
         # override options
         descr = ("Override options", "Override default EasyBuild behavior.")
 
-        all_deprecations = ('python2', 'Lmod6', 'easyconfig', 'toolchain')
+        all_deprecations = ('python2', 'Lmod6', 'easyconfig', 'toolchain', 'resolve-templates')
 
         opts = OrderedDict({
             'accept-eula': ("Accept EULA for specified software [DEPRECATED, use --accept-eula-for instead!]",

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1086,7 +1086,7 @@ class EasyBlockTest(EnhancedTestCase):
         eb = EasyBlock(EasyConfig(self.eb_file))
 
         error_pattern = r"source_tmpl value must be a string! "
-        error_pattern += r"\(found value of type 'list'\): \['bar-0\.0\.tar\.gz'\]"
+        error_pattern += r"\(found value of type 'list'\): \['%\(name\)s-%\(version\)s.tar.gz'\]"
         self.assertErrorRegex(EasyBuildError, error_pattern, eb.fetch_step)
 
         self.contents = self.contents.replace("'source_tmpl': [SOURCE_TAR_GZ]", "'source_tmpl': SOURCE_TAR_GZ")

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3676,7 +3676,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         # On unknown values the value is returned unchanged
         for value in ('%(invalid)s', '%(name)s %(invalid)s', '%%%(invalid)s', '% %(invalid)s', '%s %(invalid)s'):
-            self.assertEqual(resolve_template(value, tmpl_dict), value)
+            self.assertEqual(resolve_template(value, tmpl_dict, expect_resolved=False), value)
 
     def test_det_subtoolchain_version(self):
         """Test det_subtoolchain_version function"""

--- a/test/framework/easyconfigs/yeb/Python-2.7.10-intel-2018a.yeb
+++ b/test/framework/easyconfigs/yeb/Python-2.7.10-intel-2018a.yeb
@@ -15,7 +15,7 @@ description: |
 toolchain: {name: intel, version: 2018a}
 toolchainopts: {pic: True, opt: True, optarch: True}
 
-source_urls: ['http://www.python.org/ftp/python/%(version)s/']
+source_urls: ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
 sources: [*SOURCE_TGZ]
 
 # python needs bzip2 to build the bz2 package

--- a/test/framework/easyconfigs/yeb/SQLite-3.8.10.2-foss-2018a.yeb
+++ b/test/framework/easyconfigs/yeb/SQLite-3.8.10.2-foss-2018a.yeb
@@ -1,5 +1,5 @@
 _internal_variables_:
-    - &versionstr 3081002
+    - &versionstr '%(version_major)s081002'
 
 easyblock: ConfigureMake
 

--- a/test/framework/yeb.py
+++ b/test/framework/yeb.py
@@ -102,8 +102,8 @@ class YebTest(EnhancedTestCase):
             ec_eb = EasyConfig(ec_file)
 
             for key in sorted(ec_yeb.asdict()):
-                eb_val = ec_eb[key]
-                yeb_val = ec_yeb[key]
+                eb_val = ec_eb.get_ref(key)
+                yeb_val = ec_yeb.get_ref(key)
                 if key == 'description':
                     # multi-line string is always terminated with '\n' in YAML, so strip it off
                     yeb_val = yeb_val.strip()


### PR DESCRIPTION
A failure in template resolving is currently hidden in the log although it is likely a bug in the code (either EasyBuild, EasyBlock or EasyConfig)
This may lead to cryptic error messages later on or misbehave silently which is even worse.
To not break builds completely deprecate continuing for now and promote to a hard error later. The message is now highly visible and existing cases can be fixed until the next release.

I did an extensive run during development of https://github.com/easybuilders/easybuild-framework/pull/3129 with this issue promoted to a hard failure and did not encounter a single instance. So I think there should be no issues with existing ECs (or very few)

@boegel To have enough time to check for existing issues until next release I recommend merging this soon.
