### PR TITLE
add support for enhancing existing sanity check

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2509,7 +2509,8 @@ class EasyBlock(object):
         """
         paths, path_keys_and_check, commands = self._sanity_check_step_common(custom_paths, custom_commands)
 
-        for key, (typ, _) in path_keys_and_check.items():
+        for key in [SANITY_CHECK_PATHS_FILES, SANITY_CHECK_PATHS_DIRS]:
+            (typ, _) = path_keys_and_check[key]
             self.dry_run_msg("Sanity check paths - %s ['%s']", typ, key)
             entries = paths[key]
             if entries:

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -90,6 +90,8 @@ DEFAULT_CONFIG = {
     'easyblock': [None, "EasyBlock to use for building; if set to None, an easyblock is selected "
                         "based on the software name", BUILD],
     'easybuild_version': [None, "EasyBuild-version this spec-file was written for", BUILD],
+    'enhance_sanity_check': [False, "Indicate that additional sanity check commands & paths should enhance "
+                             "the existin sanity check, not replace it", BUILD],
     'fix_perl_shebang_for': [None, "List of files for which Perl shebang should be fixed "
                                    "to '#!/usr/bin/env perl' (glob patterns supported)", BUILD],
     'fix_python_shebang_for': [None, "List of files for which Python shebang should be fixed "

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -53,6 +53,7 @@ from easybuild.tools.utilities import time2str
 from easybuild.tools.version import get_git_revision, this_is_easybuild
 from easybuild.tools.py2vs3 import string_type
 
+
 class EasyBlockTest(EnhancedTestCase):
     """ Baseclass for easyblock testcases """
 
@@ -1927,6 +1928,73 @@ class EasyBlockTest(EnhancedTestCase):
 
         error_pattern = "Incorrect value type provided to time2str, should be datetime.timedelta: <.* 'int'>"
         self.assertErrorRegex(EasyBuildError, error_pattern, time2str, 123)
+
+    def test_sanity_check_paths_verification(self):
+        """Test verification of sanity_check_paths w.r.t. keys & values."""
+
+        testdir = os.path.abspath(os.path.dirname(__file__))
+        toy_ec = os.path.join(testdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
+        eb = EasyBlock(EasyConfig(toy_ec))
+        eb.dry_run = True
+
+        error_pattern = r"Incorrect format for sanity_check_paths: "
+        error_pattern += r"should \(only\) have 'dirs', 'files' keys, "
+        error_pattern += r"values should be lists \(at least one non-empty\)."
+
+        def run_sanity_check_step(sanity_check_paths, enhance_sanity_check):
+            """Helper function to run sanity check step, and do trivial check on generated output."""
+            self.mock_stderr(True)
+            self.mock_stdout(True)
+            eb.cfg['sanity_check_paths'] = sanity_check_paths
+            eb.cfg['enhance_sanity_check'] = enhance_sanity_check
+            eb.sanity_check_step()
+            stderr, stdout = self.get_stderr(), self.get_stdout()
+            self.mock_stderr(False)
+            self.mock_stdout(False)
+            self.assertFalse(stderr)
+            self.assertTrue(stdout.startswith("Sanity check paths"))
+
+        # partial sanity_check_paths, only allowed when using enhance_sanity_check
+        test_cases = [
+            {'dirs': ['foo']},
+            {'files': ['bar']},
+            {'dirs': []},
+            {'files': []},
+            {'files': [], 'dirs': []},
+        ]
+        for test_case in test_cases:
+            # without enhanced sanity check, these are all invalid sanity_check_paths values
+            self.assertErrorRegex(EasyBuildError, error_pattern, run_sanity_check_step, test_case, False)
+
+            # if enhance_sanity_check is enabled, these are acceptable sanity_check_step values
+            run_sanity_check_step(test_case, True)
+
+        # some inputs are always invalid, regardless of enhance_sanity_check, due to wrong keys/values
+        test_cases = [
+            {'foo': ['bar']},
+            {'files': ['foo'], 'dirs': [], 'libs': ['libfoo.a']},
+            {'files': ['foo'], 'libs': ['libfoo.a']},
+            {'dirs': [], 'libs': ['libfoo.a']},
+        ]
+        for test_case in test_cases:
+            self.assertErrorRegex(EasyBuildError, error_pattern, run_sanity_check_step, test_case, False)
+            self.assertErrorRegex(EasyBuildError, error_pattern, run_sanity_check_step, test_case, True)
+
+        # non-list values yield different errors with/without enhance_sanity_check
+        error_pattern_bis = r"Incorrect value type in sanity_check_paths, should be a list: .*"
+        test_cases = [
+            {'files': 123, 'dirs': []},
+            {'files': [], 'dirs': 123},
+            {'files': 'foo', 'dirs': []},
+            {'files': [], 'dirs': 'foo'},
+        ]
+        for test_case in test_cases:
+            self.assertErrorRegex(EasyBuildError, error_pattern, run_sanity_check_step, test_case, False)
+            self.assertErrorRegex(EasyBuildError, error_pattern_bis, run_sanity_check_step, test_case, True)
+
+        # empty sanity_check_paths is always OK, since then the fallback to default bin + lib/lib64 kicks in
+        run_sanity_check_step({}, False)
+        run_sanity_check_step({}, True)
 
 
 def suite():

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -46,7 +46,7 @@ class EB_toy(ExtensionEasyBlock):
 
     @staticmethod
     def extra_options(extra_vars=None):
-        """Custom easyconfig parameters for toytoy."""
+        """Custom easyconfig parameters for toy."""
         if extra_vars is None:
             extra_vars = {}
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -87,10 +87,13 @@ class ToyBuildTest(EnhancedTestCase):
         # (like test_toy_build_enhanced_sanity_check)
         import easybuild.easyblocks.toy
         reload(easybuild.easyblocks.toy)
+        import easybuild.easyblocks.toytoy
+        reload(easybuild.easyblocks.toytoy)
         import easybuild.easyblocks.generic.toy_extension
         reload(easybuild.easyblocks.generic.toy_extension)
 
         del sys.modules['easybuild.easyblocks.toy']
+        del sys.modules['easybuild.easyblocks.toytoy']
         del sys.modules['easybuild.easyblocks.generic.toy_extension']
 
         super(ToyBuildTest, self).tearDown()


### PR DESCRIPTION
Following the issue that was raised by @ocaisa in https://github.com/easybuilders/easybuild-easyconfigs/pull/10418, where defining `sanity_check_commands` in a LAMMPS easyconfig causes other checks that are run by the easyblock to be skipped, I think it's time to add support for specifying that the `sanity_check_commands` and `sanity_check_paths` specified in the easyconfig file should be run *in addition* to what the easyblock already checks, rather than overriding them.

This PR adds support for doing so, via:

```python
enhance_sanity_check = True