### PR TITLE
get pr_title and pr_descr built_options in new_pr_from_branch instead of new_pr (and commit_msg in both)

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1333,10 +1333,17 @@ def new_branch_github(paths, ecs, commit_msg=None):
 
 
 @only_if_module_is_available('git', pkgname='GitPython')
-def new_pr_from_branch(branch_name, title=None, descr=None, pr_target_repo=None, pr_metadata=None):
+def new_pr_from_branch(branch_name, title=None, descr=None, pr_target_repo=None, pr_metadata=None, commit_msg=None):
     """
     Create new pull request from specified branch on GitHub.
     """
+
+    if descr is None:
+        descr = build_option('pr_descr')
+    if commit_msg is None:
+        commit_msg = build_option('pr_commit_msg')
+    if title is None:
+        title = build_option('pr_title') or commit_msg
 
     pr_target_account = build_option('pr_target_account')
     pr_target_branch = build_option('pr_target_branch')
@@ -1550,19 +1557,15 @@ def new_pr(paths, ecs, title=None, descr=None, commit_msg=None):
     :param commit_msg: commit message to use
     """
 
-    if descr is None:
-        descr = build_option('pr_descr')
     if commit_msg is None:
         commit_msg = build_option('pr_commit_msg')
-    if title is None:
-        title = build_option('pr_title') or commit_msg
 
     # create new branch in GitHub
     res = new_branch_github(paths, ecs, commit_msg=commit_msg)
     file_info, deleted_paths, _, branch_name, diff_stat, pr_target_repo = res
 
     new_pr_from_branch(branch_name, title=title, descr=descr, pr_target_repo=pr_target_repo,
-                       pr_metadata=(file_info, deleted_paths, diff_stat))
+                       pr_metadata=(file_info, deleted_paths, diff_stat), commit_msg=commit_msg)
 
 
 def det_account_branch_for_pr(pr_id, github_user=None, pr_target_repo=None):

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3308,6 +3308,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--new-pr-from-branch=%s' % test_branch,
             '--github-user=%s' % GITHUB_TEST_ACCOUNT,  # used to get GitHub token
             '--github-org=boegel',  # used to determine account to grab branch from
+            '--pr-descr="an easyconfig for toy"',
             '-D',
         ]
         txt, _ = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False)
@@ -3326,6 +3327,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             r"\* target: easybuilders/easybuild-easyconfigs:develop$",
             r"^\* from: boegel/easybuild-easyconfigs:test_new_pr_from_branch_DO_NOT_REMOVE$",
             r'^\* title: "\{tools\}\[system/system\] toy v0\.0"$',
+            r'^"an easyconfig for toy"$',
             r"^ 1 file changed, 32 insertions\(\+\)$",
             r"^\* overview of changes:\n  easybuild/easyconfigs/t/toy/toy-0\.0\.eb | 32",
         ]


### PR DESCRIPTION
fix for https://github.com/easybuilders/easybuild-framework/issues/3295