### PR TITLE
added code to support multi_deps for extensions only

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2832,7 +2832,7 @@ class EasyBlock(object):
             raise StopException(step)
 
     @staticmethod
-    def get_steps(run_test_cases=True, iteration_count=1):
+    def get_steps(run_test_cases=True, iteration_count=1, multi_deps_extensions_only=False):
         """Return a list of all steps to be performed."""
 
         def get_step(tag, descr, substeps, skippable, initial=True):
@@ -2898,17 +2898,25 @@ class EasyBlock(object):
         # part 2: iterated part, from 2nd iteration onwards
         # repeat core procedure again depending on specified iteration count
         # not all parts of all steps need to be rerun (see e.g., ready, prepare)
-        steps_part2 = [
-            ready_step_spec(False),
-            source_step_spec(False),
-            patch_step_spec,
-            prepare_step_spec,
-            configure_step_spec,
-            build_step_spec,
-            test_step_spec,
-            install_step_spec(False),
-            extensions_step_spec,
-        ] * (iteration_count - 1)
+        if multi_deps_extensions_only:
+            steps_part2 = [
+                ready_step_spec(False),
+                source_step_spec(False),
+                prepare_step_spec,
+                extensions_step_spec,
+            ] * (iteration_count - 1)
+        else:
+            steps_part2 = [
+                ready_step_spec(False),
+                source_step_spec(False),
+                patch_step_spec,
+                prepare_step_spec,
+                configure_step_spec,
+                build_step_spec,
+                test_step_spec,
+                install_step_spec(False),
+                extensions_step_spec,
+            ] * (iteration_count - 1)
         # part 3: post-iteration part
         steps_part3 = [
             (POSTITER_STEP, 'restore after iterating', [lambda x: x.post_iter_step], False),
@@ -2939,7 +2947,8 @@ class EasyBlock(object):
         if self.cfg['stop'] and self.cfg['stop'] == 'cfg':
             return True
 
-        steps = self.get_steps(run_test_cases=run_test_cases, iteration_count=self.det_iter_cnt())
+        steps = self.get_steps(run_test_cases=run_test_cases, iteration_count=self.det_iter_cnt(),
+                               multi_deps_extensions_only=self.cfg["multi_deps_extensions_only"])
 
         print_msg("building and installing %s..." % self.full_mod_name, log=self.log, silent=self.silent)
         trace_msg("installation prefix: %s" % self.installdir)

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -152,6 +152,7 @@ DEFAULT_CONFIG = {
     'hiddendependencies': [[], "List of dependencies available as hidden modules", DEPENDENCIES],
     'multi_deps': [{}, "Dict of lists of dependency versions over which to iterate", DEPENDENCIES],
     'multi_deps_load_default': [True, "Load module for first version listed in multi_deps by default", DEPENDENCIES],
+    'multi_deps_extensions_only': [False, "Use multiple dependencies for extensions only", DEPENDENCIES],
     'osdependencies': [[], "OS dependencies that should be present on the system", DEPENDENCIES],
 
     # LICENSE easyconfig parameters


### PR DESCRIPTION
This can save valuable time when only the extensions require multi_deps. For example, this could be used to install Matlab, or TensorRT with python bindings, without re-installing those for each version of python. 

Ideally, in this case, I would want to skip extracting the source, and keep the version that was built in the previous iteration, but I could not figure out the right combination of options for that, so I kept extracting the source here. 

I tested this with the TensorRT recipe, which installs python wheels that are part of the extracted binary. 

I would like @bartoldeman and @boegel's comments on this PR. 