### PR TITLE
Constants for osdependecies.

### DIFF
--- a/easybuild/framework/easyconfig/constants.py
+++ b/easybuild/framework/easyconfig/constants.py
@@ -51,4 +51,7 @@ EASYCONFIG_CONSTANTS = {
     'OS_VERSION': (get_os_version(), "System version"),
     'SYS_PYTHON_VERSION': (platform.python_version(), "System Python version (platform.python_version())"),
     'SYSTEM': ({'name': 'system', 'version': 'system'}, "System toolchain"),
+
+    'OSPKGS_IBVERBS': (('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel'), "OS packages providing ibverbs support"),
+    'OSPKGS_OPENSSL': (('openssl-devel', 'libssl-dev', 'libopenssl-devel'), "OS packages providing openSSL support"),
 }

--- a/easybuild/framework/easyconfig/constants.py
+++ b/easybuild/framework/easyconfig/constants.py
@@ -53,7 +53,7 @@ EASYCONFIG_CONSTANTS = {
     'SYSTEM': ({'name': 'system', 'version': 'system'}, "System toolchain"),
 
     'OSPACKAGES_IBVERBS': (('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel'),
-                        "OS packages providing ibverbs support"),
+                           "OS packages providing ibverbs support"),
     'OSPACKAGES_OPENSSL': (('openssl-devel', 'libssl-dev', 'libopenssl-devel'),
-                        "OS packages providing openSSL support"),
+                           "OS packages providing openSSL support"),
 }

--- a/easybuild/framework/easyconfig/constants.py
+++ b/easybuild/framework/easyconfig/constants.py
@@ -52,6 +52,8 @@ EASYCONFIG_CONSTANTS = {
     'SYS_PYTHON_VERSION': (platform.python_version(), "System Python version (platform.python_version())"),
     'SYSTEM': ({'name': 'system', 'version': 'system'}, "System toolchain"),
 
-    'OSPKGS_IBVERBS': (('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel'), "OS packages providing ibverbs support"),
-    'OSPKGS_OPENSSL': (('openssl-devel', 'libssl-dev', 'libopenssl-devel'), "OS packages providing openSSL support"),
+    'OSPKGS_IBVERBS': (('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel'),
+                        "OS packages providing ibverbs support"),
+    'OSPKGS_OPENSSL': (('openssl-devel', 'libssl-dev', 'libopenssl-devel'),
+                        "OS packages providing openSSL support"),
 }

--- a/easybuild/framework/easyconfig/constants.py
+++ b/easybuild/framework/easyconfig/constants.py
@@ -52,8 +52,12 @@ EASYCONFIG_CONSTANTS = {
     'SYS_PYTHON_VERSION': (platform.python_version(), "System Python version (platform.python_version())"),
     'SYSTEM': ({'name': 'system', 'version': 'system'}, "System toolchain"),
 
-    'OSPACKAGES_IBVERBS': (('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel'),
-                           "OS packages providing ibverbs support"),
-    'OSPACKAGES_OPENSSL': (('openssl-devel', 'libssl-dev', 'libopenssl-devel'),
-                           "OS packages providing openSSL support"),
+    'OS_PKG_IBVERBS_DEV': (('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel'),
+                           "OS packages providing ibverbs/infiniband development support"),
+    'OS_PKG_OPENSSL_BIN': (('openssl'),
+                           "OS packages providing the openSSL binary"),
+    'OS_PKG_OPENSSL_LIB': (('libssl', 'libopenssl'),
+                           "OS packages providing openSSL libraries"),
+    'OS_PKG_OPENSSL_DEV': (('openssl-devel', 'libssl-dev', 'libopenssl-devel'),
+                           "OS packages providing openSSL developement support"),
 }

--- a/easybuild/framework/easyconfig/constants.py
+++ b/easybuild/framework/easyconfig/constants.py
@@ -52,8 +52,8 @@ EASYCONFIG_CONSTANTS = {
     'SYS_PYTHON_VERSION': (platform.python_version(), "System Python version (platform.python_version())"),
     'SYSTEM': ({'name': 'system', 'version': 'system'}, "System toolchain"),
 
-    'OSPKGS_IBVERBS': (('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel'),
+    'OSPACKAGES_IBVERBS': (('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel'),
                         "OS packages providing ibverbs support"),
-    'OSPKGS_OPENSSL': (('openssl-devel', 'libssl-dev', 'libopenssl-devel'),
+    'OSPACKAGES_OPENSSL': (('openssl-devel', 'libssl-dev', 'libopenssl-devel'),
                         "OS packages providing openSSL support"),
 }

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -184,7 +184,7 @@ class EasyConfigParserTest(EnhancedTestCase):
         for constant_name in constants:
             self.assertTrue(isinstance(constant_name, string_type), "Constant name %s is a string" % constant_name)
             val = constants[constant_name]
-            self.assertTrue(isinstance(val, (string_type, dict)), "Constant value %s is a string or dict" % val)
+            self.assertTrue(isinstance(val, (string_type, dict, tuple)), "Constant value %s is a string, dict or tuple" % val)
 
         # check a couple of randomly picked constant values
         self.assertEqual(constants['SOURCE_TAR_GZ'], '%(name)s-%(version)s.tar.gz')

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -185,7 +185,7 @@ class EasyConfigParserTest(EnhancedTestCase):
             self.assertTrue(isinstance(constant_name, string_type), "Constant name %s is a string" % constant_name)
             val = constants[constant_name]
             self.assertTrue(isinstance(val, (string_type, dict, tuple)),
-                "Constant value %s is a string, a dict or a tuple" % val)
+                            "Constant value %s is a string, a dict or a tuple" % val)
 
         # check a couple of randomly picked constant values
         self.assertEqual(constants['SOURCE_TAR_GZ'], '%(name)s-%(version)s.tar.gz')

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -184,8 +184,8 @@ class EasyConfigParserTest(EnhancedTestCase):
         for constant_name in constants:
             self.assertTrue(isinstance(constant_name, string_type), "Constant name %s is a string" % constant_name)
             val = constants[constant_name]
-            fail_msg = "The constant %s should have an acceptable type, found %s (%s)"
-            % (constant_name, type(val), str(val))
+            fail_msg = "The constant %s should have an acceptable type, found %s (%s)" % (constant_name,
+                                                                                          type(val), str(val))
             self.assertTrue(isinstance(val, (string_type, dict, tuple)), fail_msg)
 
         # check a couple of randomly picked constant values

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -180,11 +180,12 @@ class EasyConfigParserTest(EnhancedTestCase):
         system_constant = constants.pop('SYSTEM')
         self.assertEqual(system_constant, {'name': 'system', 'version': 'system'})
 
-        # make sure both keys and values are only strings
+        # make sure both keys and values are of appropriate types
         for constant_name in constants:
             self.assertTrue(isinstance(constant_name, string_type), "Constant name %s is a string" % constant_name)
             val = constants[constant_name]
-            self.assertTrue(isinstance(val, (string_type, dict, tuple)), "Constant value %s is string, dict or tuple" % val)
+            self.assertTrue(isinstance(val, (string_type, dict, tuple)),
+                            "The constant %s has an acceptable type" % constant_name)
 
         # check a couple of randomly picked constant values
         self.assertEqual(constants['SOURCE_TAR_GZ'], '%(name)s-%(version)s.tar.gz')

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -184,7 +184,8 @@ class EasyConfigParserTest(EnhancedTestCase):
         for constant_name in constants:
             self.assertTrue(isinstance(constant_name, string_type), "Constant name %s is a string" % constant_name)
             val = constants[constant_name]
-            self.assertTrue(isinstance(val, (string_type, dict, tuple)), "Constant value %s is a string, dict or tuple" % val)
+            self.assertTrue(isinstance(val, (string_type, dict, tuple)),
+                "Constant value %s is a string, a dict or a tuple" % val)
 
         # check a couple of randomly picked constant values
         self.assertEqual(constants['SOURCE_TAR_GZ'], '%(name)s-%(version)s.tar.gz')

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -184,8 +184,7 @@ class EasyConfigParserTest(EnhancedTestCase):
         for constant_name in constants:
             self.assertTrue(isinstance(constant_name, string_type), "Constant name %s is a string" % constant_name)
             val = constants[constant_name]
-            self.assertTrue(isinstance(val, (string_type, dict, tuple)),
-                            "Constant value %s is a string, a dict or a tuple" % val)
+            self.assertTrue(isinstance(val, (string_type, dict, tuple)), "Constant value %s is string, dict or tuple" % val)
 
         # check a couple of randomly picked constant values
         self.assertEqual(constants['SOURCE_TAR_GZ'], '%(name)s-%(version)s.tar.gz')

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -184,8 +184,9 @@ class EasyConfigParserTest(EnhancedTestCase):
         for constant_name in constants:
             self.assertTrue(isinstance(constant_name, string_type), "Constant name %s is a string" % constant_name)
             val = constants[constant_name]
-            self.assertTrue(isinstance(val, (string_type, dict, tuple)),
-                            "The constant %s has an acceptable type" % constant_name)
+            fail_msg = "The constant %s should have an acceptable type, found %s (%s)"
+            % (constant_name, type(val), str(val))
+            self.assertTrue(isinstance(val, (string_type, dict, tuple)), fail_msg)
 
         # check a couple of randomly picked constant values
         self.assertEqual(constants['SOURCE_TAR_GZ'], '%(name)s-%(version)s.tar.gz')


### PR DESCRIPTION
  - The osdependencies relating to ibverbs and openssl are repeated
    ad nauseam in the code. Occasionally with minor mistakes added
    in.
  - ibverbs / infiniband and openssl are the most frequent
    package lists used, but their use is inconsistent as
    packages change name over time.
  - When packages change names, old easyconfigs will stop working
    unless the dependency statement is updated.
  - Moving these lists into constants allows for the lists to be
    updated in one place and at one time.