### PR TITLE
fix broken test_toy_lock_cleanup_signals & properly clean up after using SIGALRM signal in tests

### DIFF
--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -206,6 +206,8 @@ class RunTest(EnhancedTestCase):
         def handler(signum, _):
             raise RuntimeError("Signal handler called with signal %s" % signum)
 
+        orig_sigalrm_handler = signal.getsignal(signal.SIGALRM)
+
         try:
             # set the signal handler and a 3-second alarm
             signal.signal(signal.SIGALRM, handler)
@@ -223,7 +225,7 @@ class RunTest(EnhancedTestCase):
 
         finally:
             # cleanup: disable the alarm + reset signal handler for SIGALRM
-            signal.signal(signal.SIGALRM, signal.SIG_DFL)
+            signal.signal(signal.SIGALRM, orig_sigalrm_handler)
             signal.alarm(0)
 
     def test_run_cmd_bis(self):

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -206,22 +206,25 @@ class RunTest(EnhancedTestCase):
         def handler(signum, _):
             raise RuntimeError("Signal handler called with signal %s" % signum)
 
-        # set the signal handler and a 3-second alarm
-        signal.signal(signal.SIGALRM, handler)
-        signal.alarm(3)
+        try:
+            # set the signal handler and a 3-second alarm
+            signal.signal(signal.SIGALRM, handler)
+            signal.alarm(3)
 
-        (_, ec) = run_cmd("kill -9 $$", log_ok=False)
-        self.assertEqual(ec, -9)
+            (_, ec) = run_cmd("kill -9 $$", log_ok=False)
+            self.assertEqual(ec, -9)
 
-        # reset the alarm
-        signal.alarm(0)
-        signal.alarm(3)
+            # reset the alarm
+            signal.alarm(0)
+            signal.alarm(3)
 
-        (_, ec) = run_cmd_qa("kill -9 $$", {}, log_ok=False)
-        self.assertEqual(ec, -9)
+            (_, ec) = run_cmd_qa("kill -9 $$", {}, log_ok=False)
+            self.assertEqual(ec, -9)
 
-        # disable the alarm
-        signal.alarm(0)
+        finally:
+            # cleanup: disable the alarm + reset signal handler for SIGALRM
+            signal.signal(signal.SIGALRM, signal.SIG_DFL)
+            signal.alarm(0)
 
     def test_run_cmd_bis(self):
         """More 'complex' test for run_cmd function."""

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -51,7 +51,8 @@ from easybuild.framework.easyconfig.parser import EasyConfigParser
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import get_module_syntax, get_repositorypath
 from easybuild.tools.environment import modify_env
-from easybuild.tools.filetools import adjust_permissions, mkdir, read_file, remove_dir, remove_file, which, write_file
+from easybuild.tools.filetools import adjust_permissions, change_dir, mkdir, read_file, remove_dir, remove_file
+from easybuild.tools.filetools import which, write_file
 from easybuild.tools.module_generator import ModuleGeneratorTcl
 from easybuild.tools.modules import Lmod
 from easybuild.tools.py2vs3 import reload, string_type
@@ -2851,6 +2852,8 @@ class ToyBuildTest(EnhancedTestCase):
     def test_toy_lock_cleanup_signals(self):
         """Test cleanup of locks after EasyBuild session gets a cancellation signal."""
 
+        orig_wd = os.getcwd()
+
         locks_dir = os.path.join(self.test_installpath, 'software', '.locks')
         self.assertFalse(os.path.exists(locks_dir))
 
@@ -2890,6 +2893,9 @@ class ToyBuildTest(EnhancedTestCase):
             stderr = ''
 
             with wait_and_signal(1, signum):
+
+                # change back to original working directory before each test
+                change_dir(orig_wd)
 
                 self.mock_stderr(True)
                 self.mock_stdout(True)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2758,7 +2758,8 @@ class ToyBuildTest(EnhancedTestCase):
                 signal.alarm(self.seconds)
 
             def __exit__(self, type, value, traceback):
-                # cancel scheduled alarm (just for cleanup sake)
+                # clean up SIGALRM signal handler, and cancel scheduled alarm
+                signal.signal(signal.SIGALRM, signal.SIG_DFL)
                 signal.alarm(0)
 
         # wait for lock to be removed, with 1 second interval of checking;
@@ -2871,7 +2872,8 @@ class ToyBuildTest(EnhancedTestCase):
                 signal.alarm(self.seconds)
 
             def __exit__(self, type, value, traceback):
-                # cancel scheduled alarm (just for cleanup sake)
+                # clean up SIGALRM signal handler, and cancel scheduled alarm
+                signal.signal(signal.SIGALRM, signal.SIG_DFL)
                 signal.alarm(0)
 
         # add extra sleep command to ensure session takes long enough

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2867,7 +2867,8 @@ class ToyBuildTest(EnhancedTestCase):
                 signal.alarm(self.seconds)
 
             def __exit__(self, type, value, traceback):
-                pass
+                # cancel scheduled alarm (just for cleanup sake)
+                signal.alarm(0)
 
         # add extra sleep command to ensure session takes long enough
         test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
@@ -2883,7 +2884,12 @@ class ToyBuildTest(EnhancedTestCase):
             (signal.SIGQUIT, SystemExit),
         ]
         for (signum, exc) in signums:
+
+            # avoid recycling stderr of previous test
+            stderr = ''
+
             with wait_and_signal(1, signum):
+
                 self.mock_stderr(True)
                 self.mock_stdout(True)
                 self.assertErrorRegex(exc, '.*', self.test_toy_build, ec_file=test_ec, verify=False,

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2744,7 +2744,7 @@ class ToyBuildTest(EnhancedTestCase):
         self.test_toy_build(extra_args=extra_args + ['--ignore-locks'], verify=True, raise_error=True)
 
         # define a context manager that remove a lock after a while, so we can check the use of --wait-for-lock
-        class remove_lock_after:
+        class remove_lock_after(object):
             def __init__(self, seconds, lock_fp):
                 self.seconds = seconds
                 self.lock_fp = lock_fp
@@ -2757,7 +2757,8 @@ class ToyBuildTest(EnhancedTestCase):
                 signal.alarm(self.seconds)
 
             def __exit__(self, type, value, traceback):
-                pass
+                # cancel scheduled alarm (just for cleanup sake)
+                signal.alarm(0)
 
         # wait for lock to be removed, with 1 second interval of checking;
         # check with both --wait-on-lock-interval and deprecated --wait-on-lock options
@@ -2854,7 +2855,7 @@ class ToyBuildTest(EnhancedTestCase):
         self.assertFalse(os.path.exists(locks_dir))
 
         # context manager which stops the function being called with the specified signal
-        class wait_and_signal:
+        class wait_and_signal(object):
             def __init__(self, seconds, signum):
                 self.seconds = seconds
                 self.signum = signum

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2744,6 +2744,8 @@ class ToyBuildTest(EnhancedTestCase):
         # also test use of --ignore-locks
         self.test_toy_build(extra_args=extra_args + ['--ignore-locks'], verify=True, raise_error=True)
 
+        orig_sigalrm_handler = signal.getsignal(signal.SIGALRM)
+
         # define a context manager that remove a lock after a while, so we can check the use of --wait-for-lock
         class remove_lock_after(object):
             def __init__(self, seconds, lock_fp):
@@ -2759,7 +2761,7 @@ class ToyBuildTest(EnhancedTestCase):
 
             def __exit__(self, type, value, traceback):
                 # clean up SIGALRM signal handler, and cancel scheduled alarm
-                signal.signal(signal.SIGALRM, signal.SIG_DFL)
+                signal.signal(signal.SIGALRM, orig_sigalrm_handler)
                 signal.alarm(0)
 
         # wait for lock to be removed, with 1 second interval of checking;
@@ -2858,6 +2860,8 @@ class ToyBuildTest(EnhancedTestCase):
         locks_dir = os.path.join(self.test_installpath, 'software', '.locks')
         self.assertFalse(os.path.exists(locks_dir))
 
+        orig_sigalrm_handler = signal.getsignal(signal.SIGALRM)
+
         # context manager which stops the function being called with the specified signal
         class wait_and_signal(object):
             def __init__(self, seconds, signum):
@@ -2873,7 +2877,7 @@ class ToyBuildTest(EnhancedTestCase):
 
             def __exit__(self, type, value, traceback):
                 # clean up SIGALRM signal handler, and cancel scheduled alarm
-                signal.signal(signal.SIGALRM, signal.SIG_DFL)
+                signal.signal(signal.SIGALRM, orig_sigalrm_handler)
                 signal.alarm(0)
 
         # add extra sleep command to ensure session takes long enough


### PR DESCRIPTION
2nd test case in `test_toy_lock_cleanup_signals` was failing with `Can't change back to non-existing directory` (due to changes to `extract_file` in #3292).

Before the alarm wasn't disabled properly, which caused the alarm to trip when the next test (`test_toy_modaltsoftname`) was running, leading to a lot of confusion...