### PR TITLE
New variable 'moddependpaths' to resolve dependencies at load time.

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1022,8 +1022,8 @@ class EasyBlock(object):
         deppaths = self.cfg['moddependpaths']
         if not deppaths:
             return ''
-        elif not isinstance(deppaths, (str, tuple, list)):
-            raise EasyBuildError("moddependpaths value %s (type: %s) is not a string or collection",
+        elif not isinstance(deppaths, (str, list, tuple)):
+            raise EasyBuildError("moddependpaths value %s (type: %s) is not a string, list or tuple",
                                  deppaths, type(deppaths))
 
         if isinstance(deppaths, str):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1014,6 +1014,25 @@ class EasyBlock(object):
         # cleanup: unload fake module, remove fake module dir
         self.clean_up_fake_module(fake_mod_data)
 
+    def make_module_deppaths(self):
+        """
+        Add specific 'module use' actions to module file, in order to find
+        dependencies outside the end user's MODULEPATH.
+        """
+        deppaths = self.cfg['moddependpaths']
+        if not deppaths:
+            return ''
+        elif not isinstance(deppaths, (str, tuple, list)):
+            raise EasyBuildError("moddependpaths value %s (type: %s) is not a string or collection",
+                                 deppaths, type(deppaths))
+
+        if isinstance(deppaths, str):
+            txt = self.module_generator.use([deppaths], guarded=True)
+        else:
+            txt = self.module_generator.use(deppaths, guarded=True)
+            
+        return txt
+
     def make_module_dep(self, unload_info=None):
         """
         Make the dependencies for the module file.
@@ -2771,6 +2790,7 @@ class EasyBlock(object):
 
         txt += self.make_module_description()
         txt += self.make_module_group_check()
+        txt += self.make_module_deppaths()
         txt += self.make_module_dep()
         txt += self.make_module_extend_modpath()
         txt += self.make_module_req()

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1030,7 +1030,7 @@ class EasyBlock(object):
             txt = self.module_generator.use([deppaths], guarded=True)
         else:
             txt = self.module_generator.use(deppaths, guarded=True)
-            
+
         return txt
 
     def make_module_dep(self, unload_info=None):

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -154,6 +154,7 @@ DEFAULT_CONFIG = {
     'multi_deps': [{}, "Dict of lists of dependency versions over which to iterate", DEPENDENCIES],
     'multi_deps_load_default': [True, "Load module for first version listed in multi_deps by default", DEPENDENCIES],
     'osdependencies': [[], "OS dependencies that should be present on the system", DEPENDENCIES],
+    'moddependpaths': [None, "Absolute path or paths that should be searched for dependencies", DEPENDENCIES],
 
     # LICENSE easyconfig parameters
     'group': [None, "Name of the user group for which the software should be available; "

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -154,7 +154,7 @@ DEFAULT_CONFIG = {
     'multi_deps': [{}, "Dict of lists of dependency versions over which to iterate", DEPENDENCIES],
     'multi_deps_load_default': [True, "Load module for first version listed in multi_deps by default", DEPENDENCIES],
     'osdependencies': [[], "OS dependencies that should be present on the system", DEPENDENCIES],
-    'moddependpaths': [None, "Absolute path or paths that should be searched for dependencies", DEPENDENCIES],
+    'moddependpaths': [None, "Absolute path or paths to prepend to MODULEPATH before loading the module's dependencies", DEPENDENCIES],
 
     # LICENSE easyconfig parameters
     'group': [None, "Name of the user group for which the software should be available; "

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -154,7 +154,7 @@ DEFAULT_CONFIG = {
     'multi_deps': [{}, "Dict of lists of dependency versions over which to iterate", DEPENDENCIES],
     'multi_deps_load_default': [True, "Load module for first version listed in multi_deps by default", DEPENDENCIES],
     'osdependencies': [[], "OS dependencies that should be present on the system", DEPENDENCIES],
-    'moddependpaths': [None, "Absolute path or paths to prepend to MODULEPATH before loading the module's dependencies", DEPENDENCIES],
+    'moddependpaths': [None, "Absolute path(s) to prepend to MODULEPATH before loading dependencies", DEPENDENCIES],
 
     # LICENSE easyconfig parameters
     'group': [None, "Name of the user group for which the software should be available; "

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -543,7 +543,7 @@ class EasyBlockTest(EnhancedTestCase):
         if get_module_syntax() == 'Tcl':
             use_load = '\n'.join([
                 "if { [ file isdirectory /path/to/mods ] } {",
-		"    module use /path/to/mods",
+                "    module use /path/to/mods",
                 "}",
             ])
         elif get_module_syntax() == 'Lua':
@@ -557,7 +557,7 @@ class EasyBlockTest(EnhancedTestCase):
 
         expected = use_load
         self.assertEqual(eb.make_module_deppaths().strip(), expected)
-            
+
     def test_make_module_dep(self):
         """Test for make_module_dep"""
         init_config(build_options={'silent': True})

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -542,9 +542,9 @@ class EasyBlockTest(EnhancedTestCase):
 
         if get_module_syntax() == 'Tcl':
             use_load = '\n'.join([
-                "if { [ file isdirectory /path/to/mods ] } {",
-                "    module use /path/to/mods",
-                "}",
+                'if { [ file isdirectory "/path/to/mods" ] } {',
+                '    module use "/path/to/mods"',
+                '}',
             ])
         elif get_module_syntax() == 'Lua':
             use_load = '\n'.join([


### PR DESCRIPTION
Following #3323 , a new EasyConfig parameter is introduced in the DEPENDENCIES section to allow EasyConfig writers to specify an additional path to find dependency modules within the EasyConfig.  The `moddependpaths` path (or paths, it may be either a string or a list/tuple) is prepended(*) to MODULEPATH _before_ load actions in the generated Lmod file.

A new function in `easyblock.py`, `make_module_deppaths()` is introduced to support this, and a unit test for it is provided.

(*) `module_generator.use()` is invoked, rather than explicitly specifying MODULEPATH.