### PR TITLE
Only calculate the mapping of version suffixes if they are actually used

### DIFF
--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -1073,9 +1073,6 @@ def list_deps_versionsuffixes(ec_spec):
 
     versionsuffix_list = []
     for key in DEPENDENCY_PARAMETERS:
-        # loop over a *copy* of dependency dicts (with resolved templates);
-
-        # to update the original dep dict, we need to get a reference with templating disabled...
         val = parsed_ec[key]
 
         if key in parsed_ec.iterate_options:

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -951,8 +951,9 @@ def map_easyconfig_to_target_tc_hierarchy(ec_spec, toolchain_mapping, targetdir=
     parsed_ec = process_easyconfig(ec_spec, validate=False)[0]['ec']
 
     versonsuffix_mapping = {}
-
-    if update_dep_versions:
+    # We only need to map versionsuffixes if we are updating dependency versions and if there are
+    # versionsuffixes being used in dependencies
+    if update_dep_versions and list_deps_versionsuffixes(ec_spec):
         # We may need to update the versionsuffix if it is like, for example, `-Python-2.7.8`
         versonsuffix_mapping = map_common_versionsuffixes('Python', parsed_ec['toolchain'], toolchain_mapping)
 
@@ -1057,6 +1058,34 @@ def map_easyconfig_to_target_tc_hierarchy(ec_spec, toolchain_mapping, targetdir=
     _log.debug("Dumped easyconfig tweaked via --try-* to %s", tweaked_spec)
 
     return tweaked_spec
+
+
+def list_deps_versionsuffixes(ec_spec):
+    """
+    Take an easyconfig spec, parse it, extracts the list of version suffixes used in its dependencies
+
+    :param ec_spec: location of original easyconfig file
+
+    :return: The list of versionsuffixes used by the dependencies of this recipe
+    """
+    # Fully parse the original easyconfig
+    parsed_ec = process_easyconfig(ec_spec, validate=False)[0]['ec']
+
+    versionsuffix_list = []
+    for key in DEPENDENCY_PARAMETERS:
+        # loop over a *copy* of dependency dicts (with resolved templates);
+
+        # to update the original dep dict, we need to get a reference with templating disabled...
+        val = parsed_ec[key]
+
+        if key in parsed_ec.iterate_options:
+            val = flatten(val)
+
+        for dep in val:
+            if dep['versionsuffix']:
+                versionsuffix_list += [dep['versionsuffix']]
+
+    return list(set(versionsuffix_list))
 
 
 def find_potential_version_mappings(dep, toolchain_mapping, versionsuffix_mapping=None, highest_versions_only=True):

--- a/test/framework/tweak.py
+++ b/test/framework/tweak.py
@@ -40,6 +40,7 @@ from easybuild.framework.easyconfig.tweak import get_dep_tree_of_toolchain, map_
 from easybuild.framework.easyconfig.tweak import get_matching_easyconfig_candidates, map_toolchain_hierarchies
 from easybuild.framework.easyconfig.tweak import find_potential_version_mappings
 from easybuild.framework.easyconfig.tweak import map_easyconfig_to_target_tc_hierarchy
+from easybuild.framework.easyconfig.tweak import list_deps_versionsuffixes
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import module_classes
 from easybuild.tools.filetools import change_dir, write_file
@@ -482,6 +483,24 @@ class TweakTest(EnhancedTestCase):
                 self.assertFalse('checksums' in extension[2])
                 hit_extension += 1
         self.assertEqual(hit_extension, 1, "Should only have updated one extension")
+
+    def test_list_deps_versionsuffixes(self):
+        """Test listing of dependencies' version suffixes"""
+        test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+        build_options = {
+            'robot_path': [test_easyconfigs],
+            'silent': True,
+            'valid_module_classes': module_classes(),
+        }
+        init_config(build_options=build_options)
+        get_toolchain_hierarchy.clear()
+
+        ec_spec = os.path.join(test_easyconfigs, 'g', 'golf', 'golf-2018a.eb')
+        self.assertEqual(list_deps_versionsuffixes(ec_spec), ['-serial'])
+        ec_spec = os.path.join(test_easyconfigs, 't', 'toy', 'toy-0.0-deps.eb')
+        self.assertEqual(list_deps_versionsuffixes(ec_spec), [])
+        ec_spec = os.path.join(test_easyconfigs, 'g', 'gzip', 'gzip-1.4-GCC-4.6.3.eb')
+        self.assertEqual(list_deps_versionsuffixes(ec_spec), ['-deps'])
 
 def suite():
     """ return all the tests in this file """


### PR DESCRIPTION
Otherwise, at our site, when using multiple paths in `EASYBUILD_ROBOT_PATHS`, this fails with 
`ERROR: No unique versionsuffix mapping for -Python-2.7.10 in {'name': 'GCC', 'version': '7.3.0'} toolchain hierarchy to {'name': 'GCC', 'version': '9.3.0'} toolchain hierarchy` 

While this may or may not be a bug in the easyconfigs we have in our robot_paths (we may have duplicated -Python version suffixes for example), we don't usually use versionsuffixes, and for the easyconfig I was trying to build, there are absolutely no need to have `versionsuffix` mapped, since none is used. 

