### PR TITLE
check easyconfig itself as well as deps for versionsuffix when using --try-update-deps

### DIFF
--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -958,7 +958,7 @@ def map_easyconfig_to_target_tc_hierarchy(ec_spec, toolchain_mapping, targetdir=
     versonsuffix_mapping = {}
     # We only need to map versionsuffixes if we are updating dependency versions and if there are
     # versionsuffixes being used in dependencies
-    if update_dep_versions and list_deps_versionsuffixes(ec_spec):
+    if update_dep_versions and (list_deps_versionsuffixes(ec_spec) or parsed_ec['versionsuffix']):
         # We may need to update the versionsuffix if it is like, for example, `-Python-2.7.8`
         versonsuffix_mapping = map_common_versionsuffixes('Python', parsed_ec['toolchain'], toolchain_mapping)
 


### PR DESCRIPTION
This is required as we may need to use the versionsuffix mapping for the easyconfig versionsuffix.

Fix bug introduced by #3326:
```
alanc@~$ eb --experimental --dry-run --robot --try-toolchain=foss,2019a --minimal-toolchains --try-update-deps --try-software-version=2.2.5 Keras-2.2.4-foss-2018b-Python-3.6.6.eb
== temporary log file in case of crash /tmp/eb-omkGKx/easybuild-rhrl3H.log
ERROR: Failed to process easyconfig /tmp/eb-omkGKx/tweaked_easyconfigs/Keras-2.2.5-foss-2019a-Python-3.7.2.eb: Failed to determine minimal toolchain for dep Theano 1.0.3-Python-3.7.2
```

This was due to the filename of Theano not being correct when writing the tweaked easyconfig.