### PR TITLE
Add OS_PKG_PAM_DEV constant for osdependencies

### DIFF
--- a/easybuild/framework/easyconfig/constants.py
+++ b/easybuild/framework/easyconfig/constants.py
@@ -60,4 +60,6 @@ EASYCONFIG_CONSTANTS = {
                            "OS packages providing openSSL libraries"),
     'OS_PKG_OPENSSL_DEV': (('openssl-devel', 'libssl-dev', 'libopenssl-devel'),
                            "OS packages providing openSSL developement support"),
+    'OS_PKG_PAM_DEV': (('pam-devel', 'libpam0g-dev'),
+                       "OS packages providing Pluggable Authentication Module (PAM) developement support"),
 }


### PR DESCRIPTION
Added a constant for `('pam-devel',  'libpam0g-dev')` to be used for `osdependencies` for your consideration, as suggested in https://github.com/easybuilders/easybuild-easyconfigs/pull/10608.

Currently, there are only two easyconfigs using `osdependencies = [('pam-devel', 'libpam0g-dev')]`, which are 

- [rstudio-1.2.5033-fosscuda-2019b-Java-11.eb](https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/r/rstudio/rstudio-1.2.5033-fosscuda-2019b-Java-11.eb)
- [TurboVNC-2.2.3-GCCcore-8.2.0.eb ](https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/t/TurboVNC/TurboVNC-2.2.3-GCCcore-8.2.0.eb )

Best,
crubb