### PR TITLE
reinstate fallback to ModulesTool.module_wrapper_exists in ModulesTool.exist

### DIFF
--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -318,12 +318,11 @@ class ModulesTest(EnhancedTestCase):
 
         self.assertTrue('Core/Java/1.8.0_181' in self.modtool.available())
         self.assertEqual(self.modtool.exist(['Core/Java/1.8.0_181']), [True])
-        # module-version only works for EnvironmentModules(C) as LMod and EnvironmentModulesTcl would need updating
-        # to full path, see https://github.com/TACC/Lmod/issues/446
-        if isinstance(self.modtool, Lmod) or self.modtool.__class__ == EnvironmentModulesTcl:
-            self.assertEqual(self.modtool.exist(['Core/Java/1.8', 'Core/Java/site_default']), [False, False])
-        else:
-            self.assertEqual(self.modtool.exist(['Core/Java/1.8', 'Core/Java/site_default']), [True, True])
+        # there's a workaround to ensure that module wrappers/aliases are recognized when they're
+        # being checked with the full module name (see https://github.com/TACC/Lmod/issues/446);
+        # that's necessary when using a hierarchical module naming scheme,
+        # see https://github.com/easybuilders/easybuild-framework/issues/3335
+        self.assertEqual(self.modtool.exist(['Core/Java/1.8', 'Core/Java/site_default']), [True, True])
 
         # also check with .modulerc.lua for Lmod 7.8 or newer
         if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.8'):
@@ -354,8 +353,8 @@ class ModulesTest(EnhancedTestCase):
             shutil.move(java_mod_dir, os.path.join(self.test_prefix, 'Core', 'Java'))
             self.assertTrue('Core/Java/1.8.0_181' in self.modtool.available())
             self.assertEqual(self.modtool.exist(['Core/Java/1.8.0_181']), [True])
-            self.assertEqual(self.modtool.exist(['Core/Java/1.8']), [False])
-            self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [False])
+            self.assertEqual(self.modtool.exist(['Core/Java/1.8']), [True])
+            self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
 
         # Test alias in home directory .modulerc
         if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.0'):


### PR DESCRIPTION
This reinstates the fallback mechanism that was removed in #3216, since it's required to correctly recognize existing module wrappers when using Lmod and a hierarchical module naming scheme.

fixes #3335