### PR TITLE
fix crash in --avail-easyconfig-constants when using --output-format=rst + ensure sorted output

### DIFF
--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -143,7 +143,7 @@ def avail_easyconfig_constants(output_format=FORMAT_TXT):
 def avail_easyconfig_constants_txt():
     """Generate easyconfig constant documentation in txt format"""
     doc = ["Constants that can be used in easyconfigs"]
-    for cst, (val, descr) in EASYCONFIG_CONSTANTS.items():
+    for cst, (val, descr) in sorted(EASYCONFIG_CONSTANTS.items()):
         doc.append('%s%s: %s (%s)' % (INDENT_4SPACES, cst, val, descr))
 
     return '\n'.join(doc)
@@ -159,10 +159,12 @@ def avail_easyconfig_constants_rst():
         "Description",
     ]
 
+    sorted_keys = sorted(EASYCONFIG_CONSTANTS.keys())
+
     table_values = [
-        ["``%s``" % cst for cst in EASYCONFIG_CONSTANTS.keys()],
-        ["``%s``" % cst[0] for cst in EASYCONFIG_CONSTANTS.values()],
-        [cst[1] for cst in EASYCONFIG_CONSTANTS.values()],
+        ["``%s``" % key for key in sorted_keys],
+        ["``%s``" % str(EASYCONFIG_CONSTANTS[key][0]) for key in sorted_keys],
+        [EASYCONFIG_CONSTANTS[key][1] for key in sorted_keys],
     ]
 
     doc = rst_title_and_table(title, table_titles, table_values)

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -159,7 +159,7 @@ def avail_easyconfig_constants_rst():
         "Description",
     ]
 
-    sorted_keys = sorted(EASYCONFIG_CONSTANTS.keys())
+    sorted_keys = sorted(EASYCONFIG_CONSTANTS)
 
     table_values = [
         ["``%s``" % key for key in sorted_keys],

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -412,6 +412,44 @@ class CommandLineOptionsTest(EnhancedTestCase):
         if os.path.exists(dummylogfn):
             os.remove(dummylogfn)
 
+    def test_avail_easyconfig_constants(self):
+        """Test listing available easyconfig file constants."""
+
+        def run_test(fmt=None):
+            """Helper function to test --avail-easyconfig-constants."""
+
+            args = ['--avail-easyconfig-constants']
+            if fmt is not None:
+                args.append('--output-format=%s' % fmt)
+
+            self.mock_stderr(True)
+            self.mock_stdout(True)
+            self.eb_main(args, verbose=True, raise_error=True)
+            stderr, stdout = self.get_stderr(), self.get_stdout()
+            self.mock_stderr(False)
+            self.mock_stdout(False)
+
+            self.assertFalse(stderr)
+
+            if fmt == 'rst':
+                pattern_lines = [
+                    r'^``HOME``.*',
+                    r'``OS_NAME``.*',
+                    r'``OS_PKG_IBVERBS_DEV``.*',
+                ]
+            else:
+                pattern_lines = [
+                    r'^\s*HOME:.*',
+                    r'\s*OS_NAME: .*',
+                    r'\s*OS_PKG_IBVERBS_DEV: .*',
+                ]
+
+            regex = re.compile('\n'.join(pattern_lines), re.M)
+            self.assertTrue(regex.search(stdout), "Pattern '%s' should match in: %s" % (regex.pattern, stdout))
+
+        for fmt in [None, 'txt', 'rst']:
+            run_test(fmt=fmt)
+
     def test_avail_easyconfig_params(self):
         """Test listing available easyconfig parameters."""
 


### PR DESCRIPTION
Fix for:
```
$ eb --avail-easyconfig-constants --output-format rst
ERROR: Failed to parse configuration options: not all arguments converted during string formatting
```

Side effect of #3309, went unnoticed because there was no test yet for `--avail-easyconfig-constants`...