### PR TITLE
add support for software minver template (like %(pyminver)s, etc.)

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -245,7 +245,7 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
                 template_values['%sver' % pref] = dep_version
                 dep_version_parts = dep_version.split('.')
                 template_values['%smajver' % pref] = dep_version_parts[0]
-                template_values['%sminver' % pref] = dep_version_parts[0]
+                template_values['%sminver' % pref] = dep_version_parts[1]
                 template_values['%sshortver' % pref] = '.'.join(dep_version_parts[:2])
                 break
 

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -245,6 +245,7 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
                 template_values['%sver' % pref] = dep_version
                 dep_version_parts = dep_version.split('.')
                 template_values['%smajver' % pref] = dep_version_parts[0]
+                template_values['%sminver' % pref] = dep_version_parts[0]
                 template_values['%sshortver' % pref] = '.'.join(dep_version_parts[:2])
                 break
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -968,11 +968,11 @@ class EasyConfigTest(EnhancedTestCase):
             '   ("R", "3.2.3"),'
             ']',
             'modloadmsg = "%s"' % '; '.join([
-                'CUDA: %%(cudaver)s, %%(cudamajver)s, %%(cudashortver)s',
-                'Java: %%(javaver)s, %%(javamajver)s, %%(javashortver)s',
-                'Python: %%(pyver)s, %%(pymajver)s, %%(pyshortver)s',
-                'Perl: %%(perlver)s, %%(perlmajver)s, %%(perlshortver)s',
-                'R: %%(rver)s, %%(rmajver)s, %%(rshortver)s',
+                'CUDA: %%(cudaver)s, %%(cudamajver)s, %%(cudaminver)s, %%(cudashortver)s',
+                'Java: %%(javaver)s, %%(javamajver)s, %%(javaminver)s, %%(javashortver)s',
+                'Python: %%(pyver)s, %%(pymajver)s, %%(pyminver)s, %%(pyshortver)s',
+                'Perl: %%(perlver)s, %%(perlmajver)s, %%(perlminver)s, %%(perlshortver)s',
+                'R: %%(rver)s, %%(rmajver)s, %%(rminver)s, %%(rshortver)s',
             ]),
             'license_file = HOME + "/licenses/PI/license.txt"',
             "github_account = 'easybuilders'",
@@ -1002,11 +1002,11 @@ class EasyConfigTest(EnhancedTestCase):
         dirs1 = eb['sanity_check_paths']['dirs'][1]
         self.assertTrue(lib_arch_regex.match(dirs1), "Pattern '%s' matches '%s'" % (lib_arch_regex.pattern, dirs1))
         self.assertEqual(eb['homepage'], "http://example.com/P/p/v3/")
-        expected = ("CUDA: 10.1.105, 10, 10.1; "
-                    "Java: 1.7.80, 1, 1.7; "
-                    "Python: 2.7.10, 2, 2.7; "
-                    "Perl: 5.22.0, 5, 5.22; "
-                    "R: 3.2.3, 3, 3.2")
+        expected = ("CUDA: 10.1.105, 10, 1, 10.1; "
+                    "Java: 1.7.80, 1, 7, 1.7; "
+                    "Python: 2.7.10, 2, 7, 2.7; "
+                    "Perl: 5.22.0, 5, 22, 5.22; "
+                    "R: 3.2.3, 3, 2, 3.2")
         self.assertEqual(eb['modloadmsg'], expected)
         self.assertEqual(eb['license_file'], os.path.join(os.environ['HOME'], 'licenses', 'PI', 'license.txt'))
 
@@ -1668,9 +1668,11 @@ class EasyConfigTest(EnhancedTestCase):
 
         expected_template_values = {
             'perlmajver': '5',
+            'perlminver': '30',
             'perlshortver': '5.30',
             'perlver': '5.30.0',
             'pymajver': '3',
+            'pyminver': '6'
             'pyshortver': '3.6',
             'pyver': '3.6.5',
         }
@@ -2822,6 +2824,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         expected = {
             'javamajver': '1',
+            'javaminver': '8',
             'javashortver': '1.8',
             'javaver': '1.8.0_221',
             'name': 'toy',
@@ -2831,6 +2834,7 @@ class EasyConfigTest(EnhancedTestCase):
             'toolchain_version': 'system',
             'nameletterlower': 't',
             'pymajver': '3',
+            'pyminver': '7'
             'pyshortver': '3.7',
             'pyver': '3.7.2',
             'version': '0.01',

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1672,7 +1672,7 @@ class EasyConfigTest(EnhancedTestCase):
             'perlshortver': '5.30',
             'perlver': '5.30.0',
             'pymajver': '3',
-            'pyminver': '6'
+            'pyminver': '6',
             'pyshortver': '3.6',
             'pyver': '3.6.5',
         }
@@ -2834,7 +2834,7 @@ class EasyConfigTest(EnhancedTestCase):
             'toolchain_version': 'system',
             'nameletterlower': 't',
             'pymajver': '3',
-            'pyminver': '7'
+            'pyminver': '7',
             'pyshortver': '3.7',
             'pyver': '3.7.2',
             'version': '0.01',


### PR DESCRIPTION
It would be useful to have `minver` as a template parameter for software dependencies, like `Python`, `CUDA` etc.