### PR TITLE
always take into account builddependencies when generating template values, also when we're not iteraring over builddependencies

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1593,6 +1593,7 @@ class EasyConfig(object):
     def generate_template_values(self):
         """Try to generate all template values."""
 
+        self.log.info("Generating template values...")
         self._generate_template_values()
 
         # recursive call, until there are no more changes to template values;
@@ -1610,6 +1611,8 @@ class EasyConfig(object):
                 except KeyError:
                     # KeyError's may occur when not all templates are defined yet, but these are safe to ignore
                     pass
+
+        self.log.info("Template values: %s", ', '.join("%s='%s'" % x for x in sorted(self.template_values.items())))
 
     def _generate_template_values(self, ignore=None):
         """Actual code to generate the template values"""

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -223,7 +223,8 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
         # first, determine if we have an EasyConfig instance
         # (indirectly by checking for 'iterating' and 'iterate_options' attributes,
         #  because we can't import the EasyConfig class here without introducing
-        #  a cyclic import...)
+        #  a cyclic import...);
+        # we need to know to determine whether we're iterating over a list of build dependencies
         is_easyconfig = hasattr(config, 'iterating') and hasattr(config, 'iterate_options')
 
         if is_easyconfig:
@@ -234,11 +235,6 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
                     deps += config.get('builddependencies', [])
             else:
                 deps += config.get('builddependencies', [])
-
-        # if we're not dealing with an EasyConfig instance,
-        # we can just add list of builddependencies directly (no list of lists in that case)
-        else:
-            deps += config.get('builddependencies', [])
 
         for dep in deps:
             if isinstance(dep, dict):

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -227,7 +227,7 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
         is_easyconfig = hasattr(config, 'iterating') and hasattr(config, 'iterate_options')
 
         if is_easyconfig:
-           # if we're iterating over different lists of build dependencies,
+            # if we're iterating over different lists of build dependencies,
             # only consider build dependencies when we're actually in iterative mode!
             if 'builddependencies' in config.iterate_options:
                 if config.iterating:

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -227,7 +227,7 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
         is_easyconfig = hasattr(config, 'iterating') and hasattr(config, 'iterate_options')
 
         if is_easyconfig:
-            # if we're iterating of different lists of build dependencies,
+           # if we're iterating over different lists of build dependencies,
             # only consider build dependencies when we're actually in iterative mode!
             if 'builddependencies' in config.iterate_options:
                 if config.iterating:

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -215,10 +215,7 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
 
         # copy to avoid changing original list below
         deps = copy.copy(config.get('dependencies', []))
-
-        # only consider build dependencies for defining *ver and *shortver templates if we're in iterative mode
-        if hasattr(config, 'iterating') and config.iterating:
-            deps += config.get('builddependencies', [])
+        deps += config.get('builddependencies', [])
 
         for dep in deps:
             if isinstance(dep, dict):

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -217,10 +217,11 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
         deps = copy.copy(config.get('dependencies', []))
 
         if hasattr(config, 'iterating'):
-            if config.iterating:
+            if 'builddependencies' in config.iterate_options:
+                if config.iterating:
+                    deps += config.get('builddependencies', [])
+            else:
                 deps += config.get('builddependencies', [])
-        else:
-            deps += config.get('builddependencies', [])
 
         for dep in deps:
             if isinstance(dep, dict):

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -215,7 +215,12 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
 
         # copy to avoid changing original list below
         deps = copy.copy(config.get('dependencies', []))
-        deps += config.get('builddependencies', [])
+
+        if hasattr(config, 'iterating'):
+            if config.iterating:
+                deps += config.get('builddependencies', [])
+        else:
+            deps += config.get('builddependencies', [])
 
         for dep in deps:
             if isinstance(dep, dict):

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -965,6 +965,8 @@ class EasyConfigTest(EnhancedTestCase):
             '   ("Java", "1.7.80"),'
             '   ("Perl", "5.22.0"),'
             '   ("Python", "2.7.10"),'
+            ']',
+            'builddependencies = ['
             '   ("R", "3.2.3"),'
             ']',
             'modloadmsg = "%s"' % '; '.join([


### PR DESCRIPTION
fixes #3300, fixes #2114