### PR TITLE
fix running command as 'easybuild' user in generated Singularity definition file

### DIFF
--- a/easybuild/tools/containers/singularity.py
+++ b/easybuild/tools/containers/singularity.py
@@ -94,8 +94,8 @@ scDescriptT = {
 }
 EOF
 
-# change to 'easybuild' user
-su - easybuild
+# switch to 'easybuild' user for following commands
+su - easybuild << 'EOF'
 
 # verbose commands, exit on first error
 set -ve
@@ -122,8 +122,8 @@ eb %(easyconfigs)s --robot %(eb_args)s
 mkdir -p /app/lmodcache
 $LMOD_DIR/update_lmod_system_cache_files -d /app/lmodcache -t /app/lmodcache/timestamp /app/modules/all
 
-# exit from 'easybuild' user
-exit
+# end of set of commands to run as 'easybuild' user
+EOF
 
 # cleanup, everything in /scratch is assumed to be temporary
 rm -rf /scratch/*

--- a/easybuild/tools/containers/singularity.py
+++ b/easybuild/tools/containers/singularity.py
@@ -95,6 +95,7 @@ scDescriptT = {
 EOF
 
 # switch to 'easybuild' user for following commands
+# quotes around EOF delimiter are important to ensure environment variables are not expanded prematurely!
 su - easybuild << 'EOF'
 
 # verbose commands, exit on first error


### PR DESCRIPTION
fixes #3171

Switching to another user no longer works, and after consulting with the Singularity developers it seems this was actually working by accident in earlier versions of Singularity.

As an alternative, we run a set of commands as the `easybuild` user by using a here document.

The quoted `'EOF'` is important to ensure that `$LMOD_DIR` does not get resolved too early, which leads to a confusing error like:

```
/update_lmod_system_cache_files -d /app/lmodcache -t /app/lmodcache/timestamp /app/modules/all
-bash: line 28: /update_lmod_system_cache_files: No such file or directory
FATAL:   failed to execute %post proc: exit status 1
```