### PR TITLE
Add support for updating dictionary or tuple keys in self.cfg

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -587,7 +587,7 @@ class EasyConfig(object):
             raise EasyBuildError(msg, key, value)
 
         # For dictionaries, input value cannot be a string; must be iterable
-        if isinstance(self[key], dict) and not isinstance(value, string_type):
+        if isinstance(self[key], dict) and isinstance(value, string_type):
             msg = "Can't update configuration value for %s, because the attempted"
             msg += "update value, '%s', is not iterable (list, tuple, dict)."
             raise EasyBuildError(msg, key, value)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -575,14 +575,15 @@ class EasyConfig(object):
     def update(self, key, value, allow_duplicate=True):
         """
         Update a string configuration value with a value (i.e. append to it).
+        NOTE: For dictionaries, 'allow_duplicate' will be ignored.
         """
         if isinstance(value, string_type):
             lval = [value]
-        elif isinstance(value, list):
+        elif isinstance(value, (list, dict, tuple)):
             lval = value
         else:
-            msg = "Can't update configuration value for %s, because the "
-            msg += "attempted update value, '%s', is not a string or list."
+            msg = "Can't update configuration value for %s, because the attempted"
+            msg += " update value, '%s', is not a string, list or dictionary."
             raise EasyBuildError(msg, key, value)
 
         param_value = self[key]
@@ -595,8 +596,17 @@ class EasyConfig(object):
             for item in lval:
                 if allow_duplicate or item not in param_value:
                     param_value = param_value + [item]
+        elif isinstance(param_value, tuple):
+            param_value = list(param_value)
+            for item in lval:
+                if allow_duplicate or item not in param_value:
+                    param_value.append(item)
+            param_value = tuple(param_value)
+        elif isinstance(param_value, dict):
+            param_value.update(lval)
         else:
-            raise EasyBuildError("Can't update configuration value for %s, because it's not a string or list.", key)
+            msg = "Can't update configuration value for %s, because it's not a string, list or dictionary."
+            raise EasyBuildError(msg, key)
 
         self[key] = param_value
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -604,7 +604,7 @@ class EasyConfig(object):
             for item in inval:
                 if allow_duplicate or item not in param_value:
                     param_value.append(item)
-            if isinstance(self[key], tuple):	# Cast back to original type
+            if isinstance(self[key], tuple):     # Cast back to original type
                 param_value = tuple(param_value)
         elif isinstance(param_value, dict):
             param_value.update(inval)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1746,7 +1746,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         # for dictionary values: extend
         ec.update('sanity_check_paths', {'key1': 'value1'})
-        self.assertTrue(ec['sanity_check_paths'].endswith("'key1': 'value1'}"))
+        self.assertTrue(ec['sanity_check_paths'].strip().endswith("'key1': 'value1'}"))
 
     def test_hide_hidden_deps(self):
         """Test use of --hide-deps on hiddendependencies."""

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1746,7 +1746,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         # for dictionary values: extend
         ec.update('sanity_check_paths', {'key1': 'value1'})
-        self.assertTrue(ec['sanity_check_paths'].strip().endswith("'key1': 'value1'}"))
+        self.assertTrue(str(ec['sanity_check_paths']).endswith("'key1': 'value1'}"))
 
     def test_hide_hidden_deps(self):
         """Test use of --hide-deps on hiddendependencies."""

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1744,6 +1744,10 @@ class EasyConfigTest(EnhancedTestCase):
         ec.update('patches', ['foo2.patch', 'bar2.patch'], allow_duplicate=False)
         self.assertEqual(ec['patches'], patches_tmp)
 
+        # for dictionary values: extend
+        ec.update('sanity_check_paths', {'key1': 'value1'})
+        self.assertTrue(ec['sanity_check_paths'].endswith("'key1': 'value1'}"))
+
     def test_hide_hidden_deps(self):
         """Test use of --hide-deps on hiddendependencies."""
         test_dir = os.path.dirname(os.path.abspath(__file__))

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1746,7 +1746,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         # for dictionary values: extend, test for existence (not ordering)
         ec.update('sanity_check_paths', {'key1': 'value1'})
-        self.assertTrue(ec['sanity_check_paths']['key1']=='value1')
+        self.assertTrue(ec['sanity_check_paths']['key1'] == 'value1')
 
     def test_hide_hidden_deps(self):
         """Test use of --hide-deps on hiddendependencies."""

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1744,9 +1744,9 @@ class EasyConfigTest(EnhancedTestCase):
         ec.update('patches', ['foo2.patch', 'bar2.patch'], allow_duplicate=False)
         self.assertEqual(ec['patches'], patches_tmp)
 
-        # for dictionary values: extend
+        # for dictionary values: extend, test for existence (not ordering)
         ec.update('sanity_check_paths', {'key1': 'value1'})
-        self.assertTrue(str(ec['sanity_check_paths']).endswith("'key1': 'value1'}"))
+        self.assertTrue(ec['sanity_check_paths']['key1']=='value1')
 
     def test_hide_hidden_deps(self):
         """Test use of --hide-deps on hiddendependencies."""


### PR DESCRIPTION
Following #3348 , I've added the necessary `elif` blocks to allow updating of dictionary-type keys (like 'sources' or 'modextravars') in EasyBlock `self.cfg`.  For completeness, I've also added support for extending tuples (using the cast-to-list-and-back-again method).