### PR TITLE
retain order of paths in when generating prepend_path statements for module file (don't sort them alphabetically)

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1378,7 +1378,7 @@ class EasyBlock(object):
             else:
                 # Expand globs but only if the string is non-empty
                 # empty string is a valid value here (i.e. to prepend the installation prefix, cfr $CUDA_HOME)
-                paths = sorted(sum((glob.glob(path) if path else [path] for path in reqs), []))  # sum flattens to list
+                paths = sum((glob.glob(path) if path else [path] for path in reqs), [])  # sum flattens to list
 
                 # If lib64 is just a symlink to lib we fixup the paths to avoid duplicates
                 lib64_is_symlink = (all(os.path.isdir(path) for path in ['lib', 'lib64'])
@@ -1396,7 +1396,7 @@ class EasyBlock(object):
                         self.log.info("Fixed symlink lib64 in paths for %s: %s -> %s", key, paths, fixed_paths)
                         paths = fixed_paths
                 # Use a set to remove duplicates, e.g. by having lib64 and lib which get fixed to lib and lib above
-                paths = sorted(set(paths))
+                paths = set(paths)
                 if key in keys_requiring_files:
                     # only retain paths that contain at least one file
                     retained_paths = [

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1401,20 +1401,21 @@ class EasyBlock(object):
                 for path in paths:
                     if path not in uniq_paths:
                         uniq_paths.append(path)
+                paths = uniq_paths
                 if key in keys_requiring_files:
                     # only retain paths that contain at least one file
                     retained_paths = [
-                        path for path in uniq_paths
+                        path for path in paths
                         if os.path.isdir(os.path.join(self.installdir, path))
                         and dir_contains_files(os.path.join(self.installdir, path))
                     ]
-                    if retained_paths != uniq_paths:
+                    if retained_paths != paths:
                         self.log.info("Only retaining paths for %s that contain at least one file: %s -> %s",
                                       key, paths, retained_paths)
-                        uniq_paths = retained_paths
+                        paths = retained_paths
 
-            if uniq_paths:
-                lines.append(self.module_generator.prepend_paths(key, uniq_paths))
+            if paths:
+                lines.append(self.module_generator.prepend_paths(key, paths))
         if self.dry_run:
             self.dry_run_msg('')
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -425,7 +425,7 @@ class EasyBlockTest(EnhancedTestCase):
         eb.make_module_req_guess = lambda: {'LD_LIBRARY_PATH': ['lib/pathC', 'lib/pathA', 'lib/pathB', 'lib/pathA']}
         for path in ['pathA', 'pathB', 'pathC']:
             os.mkdir(os.path.join(eb.installdir, 'lib', path))
-            open(os.path.join(eb.installdir, 'lib', path,'libfoo.so'), 'w').write('test')
+            open(os.path.join(eb.installdir, 'lib', path, 'libfoo.so'), 'w').write('test')
         txt = eb.make_module_req()
         if get_module_syntax() == 'Tcl':
             self.assertTrue(re.search(r"\nprepend-path\s+LD_LIBRARY_PATH\s+\$root/lib/pathC\n" +


### PR DESCRIPTION
Fixes #3366 