### PR TITLE
also copy template values in EasyConfig.copy method to ensure they are defined when installing extensions

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2128,7 +2128,7 @@ class EasyBlock(object):
         """Install built software (abstract method)."""
         raise NotImplementedError
 
-    def extensions_step(self, fetch=False):
+    def extensions_step(self, fetch=False, install=True):
         """
         After make install, run this.
         - only if variable len(exts_list) > 0
@@ -2142,7 +2142,7 @@ class EasyBlock(object):
 
         # load fake module
         fake_mod_data = None
-        if not self.dry_run:
+        if install and not self.dry_run:
 
             # load modules for build dependencies as extra modules
             build_dep_mods = [dep['short_mod_name'] for dep in self.cfg.dependencies(build_only=True)]
@@ -2255,11 +2255,12 @@ class EasyBlock(object):
                                       rpath_filter_dirs=self.rpath_filter_dirs)
 
             # real work
-            ext.prerun()
-            txt = ext.run()
-            if txt:
-                self.module_extra_extensions += txt
-            ext.postrun()
+            if install:
+                ext.prerun()
+                txt = ext.run()
+                if txt:
+                    self.module_extra_extensions += txt
+                ext.postrun()
 
         # cleanup (unload fake module, remove fake module dir)
         if fake_mod_data:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -570,6 +570,9 @@ class EasyConfig(object):
         if self.path:
             ec.path = self.path
 
+        # also copy template values, since re-generating them may not give the same set of template values straight away
+        ec.template_values = copy.deepcopy(self.template_values)
+
         return ec
 
     def update(self, key, value, allow_duplicate=True):

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3573,7 +3573,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertTrue('pyshortver' in ec.template_values)
         self.assertEqual(ec.template_values['pyshortver'], '3.6')
 
-        # check that extensions enherit these template values too
+        # check that extensions inherit these template values too
         # cfr. https://github.com/easybuilders/easybuild-framework/issues/3317
         eb = EasyBlock(ec)
         eb.silent = True


### PR DESCRIPTION
This fixes #3317, see https://github.com/easybuilders/easybuild-framework/issues/3317#issuecomment-653655133 for more details.

~~Before merging, I want to cover this in the tests properly...~~ done!