### PR TITLE
skip lines that start with 'module-version' when determining whether a module exists in ModulesTool.exist

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -575,12 +575,13 @@ class ModulesTool(object):
 
                 # skip lines that start with 'module-' (like 'module-version'),
                 # see https://github.com/easybuilders/easybuild-framework/issues/3376
-                if line.startswith('module- '):
+                if line.startswith('module-'):
                     self.log.debug("Skipping line '%s' since it starts with 'module-version'", line)
                     continue
 
                 # if line matches pattern that indicates an existing module file, the module file exists
-                self.log.debug("Determining whether module %s exists using line '%s'", mod_name, line)
+                self.log.debug("Determining whether module %s exists using 'module show' output line '%s'",
+                               mod_name, line)
                 res = bool(re.match(mod_exists_regex, line))
                 self.log.debug("Result for existence check of %s based on 'module show' output: %s", mod_name, res)
                 break

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -547,7 +547,7 @@ class ModulesTool(object):
 
             :param mod_name: module name
             """
-            self.log.info("Checking whether %s exists based on output of 'module show", mod_name)
+            self.log.info("Checking whether %s exists based on output of 'module show'", mod_name)
             stderr = self.show(mod_name)
             res = False
             # Parse the output:

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -598,7 +598,8 @@ class ModulesTool(object):
                 if mod_exists:
                     self.log.info("Module %s exists (found in list of available modules)", mod_name)
                 elif not mod_exists and maybe_partial:
-                    self.log.info("Module %s not found in list of available modules, checking via 'module show'...", mod_name)
+                    self.log.info("Module %s not found in list of available modules, checking via 'module show'...",
+                                  mod_name)
                     mod_exists = mod_exists_via_show(mod_name)
             else:
                 # hidden modules are not visible in 'avail', need to use 'show' instead

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -547,7 +547,7 @@ class ModulesTool(object):
 
             :param mod_name: module name
             """
-            self.log.info("Checking whether %s exists based on output of 'module show'", mod_name)
+            self.log.debug("Checking whether %s exists based on output of 'module show'", mod_name)
             stderr = self.show(mod_name)
             res = False
             # Parse the output:
@@ -609,13 +609,13 @@ class ModulesTool(object):
                 # module name may be partial, so also check via 'module show' as fallback
                 if mod_exists:
                     self.log.info("Module %s exists (found in list of available modules)", mod_name)
-                elif not mod_exists and maybe_partial:
+                elif maybe_partial:
                     self.log.info("Module %s not found in list of available modules, checking via 'module show'...",
                                   mod_name)
                     mod_exists = mod_exists_via_show(mod_name)
             else:
                 # hidden modules are not visible in 'avail', need to use 'show' instead
-                self.log.debug("checking whether hidden module %s exists via 'show'..." % mod_name)
+                self.log.info("Checking whether hidden module %s exists via 'show'..." % mod_name)
                 mod_exists = mod_exists_via_show(mod_name)
 
             # if no module file was found, check whether specified module name can be a 'wrapper' module...
@@ -624,14 +624,14 @@ class ModulesTool(object):
             # Lmod will report module wrappers as non-existent when full module name is used,
             # see https://github.com/TACC/Lmod/issues/446
             if not mod_exists:
-                self.log.debug("Module %s not found via module avail/show, checking whether it is a wrapper", mod_name)
+                self.log.info("Module %s not found via module avail/show, checking whether it is a wrapper", mod_name)
                 wrapped_mod = self.module_wrapper_exists(mod_name)
                 if wrapped_mod is not None:
                     # module wrapper only really exists if the wrapped module file is also available
                     mod_exists = wrapped_mod in avail_mod_names or mod_exists_via_show(wrapped_mod)
                     self.log.debug("Result for existence check of wrapped module %s: %s", wrapped_mod, mod_exists)
 
-            self.log.debug("Result for existence check of %s module: %s", mod_name, mod_exists)
+            self.log.info("Result for existence check of %s module: %s", mod_name, mod_exists)
 
             mods_exist.append(mod_exists)
 

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -556,15 +556,18 @@ class ModulesTool(object):
             # - Check first non-whitespace line for something that looks like an absolute path terminated by a colon
             mod_exists_regex = r'\s*/.+:\s*'
             for line in stderr.split('\n'):
-                # skip whitespace lines
+
                 self.log.debug("Checking line '%s' to determine whether %s exists...", line, mod_name)
+
+                # skip whitespace lines
                 if OUTPUT_MATCHES['whitespace'].search(line):
                     self.log.debug("Treating line '%s' as whitespace, so skipping it", line)
                     continue
 
                 # if any errors occured, conclude that module doesn't exist
                 if OUTPUT_MATCHES['error'].search(line):
-                    self.log.debug("Line '%s' looks like an error, so concluding that %s doesn't exist", mod_name)
+                    self.log.debug("Line '%s' looks like an error, so concluding that %s doesn't exist",
+                                   line, mod_name)
                     break
 
                 # skip warning lines, which may be produced by modules tool but should not be used
@@ -576,14 +579,13 @@ class ModulesTool(object):
                 # skip lines that start with 'module-' (like 'module-version'),
                 # see https://github.com/easybuilders/easybuild-framework/issues/3376
                 if line.startswith('module-'):
-                    self.log.debug("Skipping line '%s' since it starts with 'module-version'", line)
+                    self.log.debug("Skipping line '%s' since it starts with 'module-'", line)
                     continue
 
                 # if line matches pattern that indicates an existing module file, the module file exists
-                self.log.debug("Determining whether module %s exists using 'module show' output line '%s'",
-                               mod_name, line)
                 res = bool(re.match(mod_exists_regex, line))
-                self.log.debug("Result for existence check of %s based on 'module show' output: %s", mod_name, res)
+                self.log.debug("Result for existence check of %s based on 'module show' output line '%s': %s",
+                               mod_name, line, res)
                 break
 
             return res

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -560,7 +560,8 @@ class ModulesTool(object):
                 if OUTPUT_MATCHES['whitespace'].search(line):
                     self.log.debug("Treating line '%s' as whitespace, so skipping it", line)
                     continue
-                # skip lines that start with 'module-version', see https://github.com/easybuilders/easybuild-framework/issues/3376
+                # skip lines that start with 'module-version',
+                # see https://github.com/easybuilders/easybuild-framework/issues/3376
                 elif line.startswith('module-version '):
                     self.log.debug("Skipping line '%s' since it starts with 'module-version'", line)
                     continue

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -557,14 +557,21 @@ class ModulesTool(object):
             mod_exists_regex = r'\s*/.+:\s*'
             for line in stderr.split('\n'):
                 # skip whitespace lines
-                self.log.debug("Checking line '%s' to determine whether %s exists...", line)
+                self.log.debug("Checking line '%s' to determine whether %s exists...", line, mod_name)
                 if OUTPUT_MATCHES['whitespace'].search(line):
                     self.log.debug("Treating line '%s' as whitespace, so skipping it", line)
                     continue
 
                 # if any errors occured, conclude that module doesn't exist
                 if OUTPUT_MATCHES['error'].search(line):
+                    self.log.debug("Line '%s' looks like an error, so concluding that %s doesn't exist", mod_name)
                     break
+
+                # skip warning lines, which may be produced by modules tool but should not be used
+                # to determine whether a module file exists
+                if line.startswith('WARNING: '):
+                    self.log.debug("Skipping warning line '%s'", line)
+                    continue
 
                 # skip lines that start with 'module-' (like 'module-version'),
                 # see https://github.com/easybuilders/easybuild-framework/issues/3376
@@ -573,7 +580,9 @@ class ModulesTool(object):
                     continue
 
                 # if line matches pattern that indicates an existing module file, the module file exists
+                self.log.debug("Determining whether module %s exists using line '%s'", mod_name, line)
                 res = bool(re.match(mod_exists_regex, line))
+                self.log.debug("Result for existence check of %s based on 'module show' output: %s", mod_name, res)
                 break
 
             return res

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -555,11 +555,20 @@ class ModulesTool(object):
             # - Check first non-whitespace line for something that looks like an absolute path terminated by a colon
             mod_exists_regex = r'\s*/.+:\s*'
             for line in stderr.split('\n'):
+                # skip whitespace lines
+                self.log.debug("Checking line '%s' to determine whether %s exists...", line)
                 if OUTPUT_MATCHES['whitespace'].search(line):
+                    self.log.debug("Treating line '%s' as whitespace, so skipping it", line)
                     continue
-                if OUTPUT_MATCHES['error'].search(line):
+                # skip lines that start with 'module-version', see https://github.com/easybuilders/easybuild-framework/issues/3376
+                elif line.startswith('module-version '):
+                    self.log.debug("Skipping line '%s' since it starts with 'module-version'", line)
+                    continue
+                # if any errors occured, conclude that module doesn't exist
+                elif OUTPUT_MATCHES['error'].search(line):
                     break
-                if re.match(mod_exists_regex, line):
+                # if line matches pattern that indicates an existing module file, the module file exists
+                elif re.match(mod_exists_regex, line):
                     res = True
                 break
             return res


### PR DESCRIPTION
fixes #3376