### PR TITLE
Add gcccorecuda toolchain.

### DIFF
--- a/easybuild/toolchains/gcccorecuda.py
+++ b/easybuild/toolchains/gcccorecuda.py
@@ -23,20 +23,21 @@
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 ##
 """
-EasyBuild support for a GCC+CUDA compiler toolchain.
+EasyBuild support for a GCCcore+CUDAcore compiler toolchain.
 
 :author: Kenneth Hoste (Ghent University)
 :author: Bart Oldeman (McGill University, Calcul Quebec, Compute Canada)
 """
 
 from easybuild.toolchains.compiler.cuda import Cuda
-from easybuild.toolchains.gcc import GccToolchain
-from easybuild.toolchains.gcccorecuda import GCCcoreCUDA
+from easybuild.toolchains.gcccore import GCCcore
 
 
-class GccCUDA(GccToolchain, Cuda):
-    """Compiler toolchain with GCC and CUDA."""
-    NAME = 'gcccuda'
+class GCCcoreCUDA(GCCcore, Cuda):
+    """Compiler toolchain with GCCcore and CUDAcore."""
+    NAME = 'gcccorecuda'
 
-    COMPILER_MODULE_NAME = ['GCC', 'CUDA']
-    SUBTOOLCHAIN = [GccToolchain.NAME, GCCcoreCUDA.NAME]
+    COMPILER_MODULE_NAME = ['GCCcore', 'CUDAcore']
+    COMPILER_CUDA_MODULE_NAME = ['CUDAcore']
+    SUBTOOLCHAIN = GCCcore.NAME
+    OPTIONAL = True

--- a/easybuild/toolchains/iccifortcuda.py
+++ b/easybuild/toolchains/iccifortcuda.py
@@ -26,10 +26,12 @@
 EasyBuild support for a iccifort+CUDA compiler toolchain.
 
 :author: Ake Sandgren (HPC2N)
+:author: Bart Oldeman (McGill University, Calcul Quebec, Compute Canada)
 """
 
 from easybuild.toolchains.compiler.cuda import Cuda
 from easybuild.toolchains.iccifort import IccIfort
+from easybuild.toolchains.gcccorecuda import GCCcoreCUDA
 
 
 class IccIfortCUDA(IccIfort, Cuda):
@@ -37,4 +39,4 @@ class IccIfortCUDA(IccIfort, Cuda):
     NAME = 'iccifortcuda'
 
     COMPILER_MODULE_NAME = IccIfort.COMPILER_MODULE_NAME + Cuda.COMPILER_CUDA_MODULE_NAME
-    SUBTOOLCHAIN = IccIfort.NAME
+    SUBTOOLCHAIN = [IccIfort.NAME, GCCcoreCUDA.NAME]

--- a/easybuild/tools/module_naming_scheme/hierarchical_mns.py
+++ b/easybuild/tools/module_naming_scheme/hierarchical_mns.py
@@ -57,7 +57,7 @@ COMP_NAME_VERSION_TEMPLATES = {
     # required for use of ClangGCC toolchain
     'Clang,GCC': ('Clang-GCC', '%(Clang)s-%(GCC)s'),
     # required for use of gcccorecuda toolchain
-    'CUDAcore,GCCcore' : ('GCCcore-CUDAcore', '%(GCCcore)s-%(CUDAcore)s'),
+    'CUDAcore,GCCcore': ('GCCcore-CUDAcore', '%(GCCcore)s-%(CUDAcore)s'),
     # required for use of gcccuda toolchain, and for CUDA installed with GCC toolchain
     'CUDA,GCC': ('GCC-CUDA', '%(GCC)s-%(CUDA)s'),
     # required for use of iccifortcuda toolchain

--- a/easybuild/tools/module_naming_scheme/hierarchical_mns.py
+++ b/easybuild/tools/module_naming_scheme/hierarchical_mns.py
@@ -56,6 +56,8 @@ COMP_NAME_VERSION_TEMPLATES = {
     'iccifort': ('intel', '%(iccifort)s'),
     # required for use of ClangGCC toolchain
     'Clang,GCC': ('Clang-GCC', '%(Clang)s-%(GCC)s'),
+    # required for use of gcccorecuda toolchain
+    'CUDAcore,GCCcore' : ('GCCcore-CUDAcore', '%(GCCcore)s-%(CUDAcore)s'),
     # required for use of gcccuda toolchain, and for CUDA installed with GCC toolchain
     'CUDA,GCC': ('GCC-CUDA', '%(GCC)s-%(CUDA)s'),
     # required for use of iccifortcuda toolchain

--- a/test/framework/easyconfigs/test_ecs/c/CUDAcore/CUDAcore-11.0.2.eb
+++ b/test/framework/easyconfigs/test_ecs/c/CUDAcore/CUDAcore-11.0.2.eb
@@ -1,0 +1,25 @@
+easyblock = "EB_toy" # for testing only
+name = 'CUDAcore'
+version = '11.0.2'
+local_nv_version = '450.51.05'
+
+homepage = 'https://developer.nvidia.com/cuda-toolkit'
+description = """CUDA (formerly Compute Unified Device Architecture) is a parallel
+ computing platform and programming model created by NVIDIA and implemented by the
+ graphics processing units (GPUs) that they produce. CUDA gives developers access
+ to the virtual instruction set and memory of the parallel computational elements in CUDA GPUs."""
+
+toolchain = SYSTEM
+
+source_urls = ['https://developer.download.nvidia.com/compute/cuda/%(version)s/local_installers/']
+sources = ['cuda_%%(version)s_%s_linux%%(cudaarch)s.run' % local_nv_version]
+checksums = [
+    {
+        'cuda_%%(version)s_%s_linux.run' % local_nv_version:
+            '48247ada0e3f106051029ae8f70fbd0c238040f58b0880e55026374a959a69c1',
+        'cuda_%%(version)s_%s_linux_ppc64le.run' % local_nv_version:
+            'db06d0f3fbf6f7aa1f106fc921ad1c86162210a26e8cb65b171c5240a3bf75da',
+    }
+]
+
+moduleclass = 'system'

--- a/test/framework/easyconfigs/test_ecs/g/gcccorecuda/gcccorecuda-2020a.eb
+++ b/test/framework/easyconfigs/test_ecs/g/gcccorecuda/gcccorecuda-2020a.eb
@@ -1,0 +1,19 @@
+easyblock = "Toolchain"
+
+name = 'gcccorecuda'
+version = '2020a'
+
+homepage = '(none)'
+description = """GNU Compiler Collection (GCC) based compiler toolchain, along with CUDA toolkit (Core level)."""
+
+toolchain = SYSTEM
+
+local_gcc_version = '4.9.3' # for testing only
+
+# compiler toolchain dependencies
+dependencies = [
+    ('GCCcore', local_gcc_version),
+    ('CUDAcore', '11.0.2'),
+]
+
+moduleclass = 'toolchain'

--- a/test/framework/easyconfigs/test_ecs/u/UCX/UCX-1.8.0-gcccorecuda-2020a.eb
+++ b/test/framework/easyconfigs/test_ecs/u/UCX/UCX-1.8.0-gcccorecuda-2020a.eb
@@ -1,0 +1,61 @@
+# Note:
+# This is an easyconfig file for EasyBuild, see https://github.com/easybuilders/easybuild
+easyblock = 'ConfigureMake'
+
+name = 'UCX'
+version = '1.8.0'
+
+homepage = 'http://www.openucx.org/'
+description = """Unified Communication X
+An open-source production grade communication framework for data centric
+and high-performance applications
+"""
+
+toolchain = {'name': 'gcccorecuda', 'version': '2020a'}
+toolchainopts = {'pic': True}
+
+source_urls = ['https://github.com/openucx/ucx/releases/download/v%(version)s']
+sources = ['%(namelower)s-%(version)s.tar.gz']
+patches = [
+    'UCX-1.7.0_binutils_2.34_api_fix.patch',
+    'UCX-1.8.0_fix-undefined-symbol.patch',
+]
+checksums = [
+    'e400f7aa5354971c8f5ac6b881dc2846143851df868088c37d432c076445628d',  # ucx-1.8.0.tar.gz
+    'c09ebe4d734d520ae23f56d95ba0b91e464a42ccbaf435675424515ebd3fa3a9',  # UCX-1.7.0_binutils_2.34_api_fix.patch
+    'eb757242ab3eecd8a851f329cb4baf3c64d46788ab61675f29ab4cc6a0274a45',  # UCX-1.8.0_fix-undefined-symbol.patch
+]
+
+# not used for tests
+#
+#builddependencies = [
+#   ('binutils', '2.34'),
+#    ('Autotools', '20180311'),
+#    ('pkg-config', '0.29.2'),
+#]
+
+osdependencies = [('libibverbs-dev', 'libibverbs-devel', 'rdma-core-devel')]
+
+#dependencies = [
+#    ('numactl', '2.0.13'),
+#]
+
+# CUDA_CFLAGS set by EB toolchain but also used differently in UCX makefiles
+# unset LIBS from EB toolchain to avoid unconditional linking to libcudart:
+# it only needs to be linked by the CUDA run-time plugins
+preconfigopts = 'autoreconf && unset CUDA_CFLAGS && unset LIBS && '
+configopts = '--enable-optimizations --enable-cma --enable-mt --with-verbs '
+configopts += '--without-java --disable-doxygen-doc '
+configopts += '--with-cuda '
+
+prebuildopts = 'unset CUDA_CFLAGS && unset LIBS && '
+buildopts = 'V=1'
+
+sanity_check_paths = {
+    'files': ['bin/ucx_info', 'bin/ucx_perftest', 'bin/ucx_read_profile'],
+    'dirs': ['include', 'lib', 'share']
+}
+
+sanity_check_commands = ["ucx_info -d"]
+
+moduleclass = 'lib'

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1816,7 +1816,7 @@ class FileToolsTest(EnhancedTestCase):
         # test with specified path with and without trailing '/'s
         for path in [test_ecs, test_ecs + '/', test_ecs + '//']:
             index = ft.create_index(path)
-            self.assertEqual(len(index), 82)
+            self.assertEqual(len(index), 85)
 
             expected = [
                 os.path.join('b', 'bzip2', 'bzip2-1.0.6-GCC-4.9.2.eb'),

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1865,7 +1865,7 @@ class FileToolsTest(EnhancedTestCase):
         regex = re.compile(r"^== found valid index for %s, so using it\.\.\.$" % self.test_prefix)
         self.assertTrue(regex.match(stdout.strip()), "Pattern '%s' matches with: %s" % (regex.pattern, stdout))
 
-        self.assertEqual(len(index), 26)
+        self.assertEqual(len(index), 27)
         for fn in expected:
             self.assertTrue(fn in index, "%s should be found in %s" % (fn, sorted(index)))
 
@@ -1895,7 +1895,7 @@ class FileToolsTest(EnhancedTestCase):
         regex = re.compile(r"^== found valid index for %s, so using it\.\.\.$" % self.test_prefix)
         self.assertTrue(regex.match(stdout.strip()), "Pattern '%s' matches with: %s" % (regex.pattern, stdout))
 
-        self.assertEqual(len(index), 26)
+        self.assertEqual(len(index), 27)
         for fn in expected:
             self.assertTrue(fn in index, "%s should be found in %s" % (fn, sorted(index)))
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1374,6 +1374,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args = [
             'gzip-1.5-foss-2018a.eb',
             'OpenMPI-2.1.2-GCC-6.4.0-2.28.eb',
+            'UCX-1.8.0-gcccorecuda-2020a.eb',
             '--dry-run',
             '--unittest-file=%s' % self.logfile,
             '--module-naming-scheme=HierarchicalMNS',
@@ -1397,6 +1398,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             ("foss-2018a.eb", "Core", "foss/2018a", 'x'),
             # listed but not there: ' '
             ("gzip-1.5-foss-2018a.eb", "MPI/GCC/6.4.0-2.28/OpenMPI/2.1.2", "gzip/1.5", ' '),
+            ("UCX-1.8.0-gcccorecuda-2020a.eb", "Compiler/GCCcore-CUDAcore/4.9.3-11.0.2", "UCX/1.8.0", ' '),
         ]
         for ec, mod_subdir, mod_name, mark in ecs_mods:
             regex = re.compile("^ \* \[%s\] \S+%s \(module: %s \| %s\)$" % (mark, ec, mod_subdir, mod_name), re.M)
@@ -1414,6 +1416,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args = [
             'gzip-1.5-foss-2018a.eb',
             'OpenMPI-2.1.2-GCC-6.4.0-2.28.eb',
+            'UCX-1.8.0-gcccorecuda-2020a.eb',
             '--dry-run',
             '--unittest-file=%s' % self.logfile,
             '--module-naming-scheme=CategorizedHMNS',
@@ -1438,6 +1441,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             ("foss-2018a.eb", "Core/toolchain", "foss/2018a", 'x'),
             # listed but not there: ' '
             ("gzip-1.5-foss-2018a.eb", "MPI/GCC/6.4.0-2.28/OpenMPI/2.1.2/tools", "gzip/1.5", ' '),
+            ("UCX-1.8.0-gcccorecuda-2020a.eb", "Compiler/GCCcore-CUDAcore/4.9.3-11.0.2/lib", "UCX/1.8.0", ' '),
         ]
         for ec, mod_subdir, mod_name, mark in ecs_mods:
             regex = re.compile("^ \* \[%s\] \S+%s \(module: %s \| %s\)$" % (mark, ec, mod_subdir, mod_name), re.M)


### PR DESCRIPTION
This is a new toolchain combining GCCcore and CUDA.
gcccuda and iccifortcuda then needed to be modified to let them
know that gcccorecuda is an optional subtoolchain.