### PR TITLE
also escape backslashes in quote_py_str()

### DIFF
--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -54,7 +54,7 @@ def flatten(lst):
     return res
 
 
-def quote_str(val, escape_newline=False, prefer_single_quotes=False, tcl=False):
+def quote_str(val, escape_newline=False, prefer_single_quotes=False, escape_backslash=False, tcl=False):
     """
     Obtain a new value to be used in string replacement context.
 
@@ -66,10 +66,14 @@ def quote_str(val, escape_newline=False, prefer_single_quotes=False, tcl=False):
 
     :param escape_newline: wrap strings that include a newline in triple quotes
     :param prefer_single_quotes: if possible use single quotes
+    :param escape_backslash: escape backslash characters in the string
     :param tcl: Boolean for whether we are quoting for Tcl syntax
     """
 
     if isinstance(val, string_type):
+        # escape backslashes
+        if escape_backslash:
+            val = val.replace('\\', '\\\\')
         # forced triple double quotes
         if ("'" in val and '"' in val) or (escape_newline and '\n' in val):
             return '"""%s"""' % val
@@ -92,13 +96,7 @@ def quote_str(val, escape_newline=False, prefer_single_quotes=False, tcl=False):
 
 def quote_py_str(val):
     """Version of quote_str specific for generating use in Python context (e.g., easyconfig parameters)."""
-    quoted_str = quote_str(val, escape_newline=True, prefer_single_quotes=True)
-
-    if isinstance(val, string_type):
-        # escape backslashes in strings
-        quoted_str = quoted_str.replace('\\', '\\\\')
-
-    return quoted_str
+    return quote_str(val, escape_newline=True, prefer_single_quotes=True, escape_backslash=True)
 
 
 def shell_quote(token):

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -100,6 +100,7 @@ def quote_py_str(val):
 
     return quoted_str
 
+
 def shell_quote(token):
     """
     Wrap provided token in single quotes (to escape space and characters with special meaning in a shell),

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -92,8 +92,13 @@ def quote_str(val, escape_newline=False, prefer_single_quotes=False, tcl=False):
 
 def quote_py_str(val):
     """Version of quote_str specific for generating use in Python context (e.g., easyconfig parameters)."""
-    return quote_str(val, escape_newline=True, prefer_single_quotes=True)
+    quoted_str = quote_str(val, escape_newline=True, prefer_single_quotes=True)
 
+    if isinstance(val, string_type):
+        # escape backslashes in strings
+        quoted_str = quoted_str.replace('\\', '\\\\')
+
+    return quoted_str
 
 def shell_quote(token):
     """

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -73,7 +73,7 @@ from easybuild.tools.py2vs3 import OrderedDict, reload
 from easybuild.tools.robot import resolve_dependencies
 from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.toolchain.utilities import search_toolchain
-from easybuild.tools.utilities import quote_str
+from easybuild.tools.utilities import quote_str, quote_py_str
 from test.framework.utilities import find_full_path
 
 try:
@@ -1774,7 +1774,8 @@ class EasyConfigTest(EnhancedTestCase):
             'foo\'bar': '"foo\'bar"',
             'foo\'bar"baz': '"""foo\'bar"baz"""',
             "foo\nbar": '"foo\nbar"',
-            'foo bar': '"foo bar"'
+            'foo bar': '"foo bar"',
+            'foo\\bar': '"foo\\bar"',
         }
 
         for t in teststrings:
@@ -1789,11 +1790,24 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(quote_str('foo bar', prefer_single_quotes=True), '"foo bar"')
         self.assertEqual(quote_str("foo'bar", prefer_single_quotes=True), '"foo\'bar"')
 
+        # test escape_backslash
+        self.assertEqual(quote_str('foo\\bar', escape_backslash=False), '"foo\\bar"')
+        self.assertEqual(quote_str('foo\\bar', escape_backslash=True), '"foo\\\\bar"')
+
         # non-string values
         n = 42
         self.assertEqual(quote_str(n), 42)
         self.assertEqual(quote_str(["foo", "bar"]), ["foo", "bar"])
         self.assertEqual(quote_str(('foo', 'bar')), ('foo', 'bar'))
+
+    def test_quote_py_str(self):
+        """Test quote_py_str function."""
+
+        res = quote_py_str('description = """Example of\n multi-line\n description with \' quotes"""')
+        self.assertEqual(res, '"""description = """Example of\n multi-line\n description with \' quotes""""""')
+
+        res = quote_py_str('preconfigopts = "sed -i \'s/`which \\([a-z_]*\\)`/\\1/g;s/`//g\' foo.c && "')
+        self.assertEqual(res, '"""preconfigopts = "sed -i \'s/`which \\\\([a-z_]*\\\\)`/\\\\1/g;s/`//g\' foo.c && """"')
 
     def test_dump(self):
         """Test EasyConfig's dump() method."""


### PR DESCRIPTION
This PR enhances `quote_py_str()` to also escape all backslashes. Otherwise parse tests may fail due to divergences between the provided and dumped easyconfig. That's because `quote_py_str()` is limited to quotes and new lines, while several options such as `preconfigopts`, `prebuildopts` or `postintallcmds` can potentially contain any string literal.

This fixes the failed tests of https://github.com/easybuilders/easybuild-easyconfigs/pull/10965?notification_referrer_id=MDE4Ok5vdGlmaWNhdGlvblRocmVhZDk4ODg3MTQ0Mzo0OTczNzk0#issuecomment-658010559