### PR TITLE
cryptography: require 2.9.2 for Python 2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -54,5 +54,6 @@ requests
 archspec; python_version >= '2.7'
 
 # cryptography 3.0 deprecates Python 2.7
-cryptography==2.9.2; python_version < '3.5'
+# and cryptography is not needed at all for Python 2.6
+cryptography==2.9.2; python_version >= 2.7, < '3.5'
 cryptography; python_version >= '3.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,5 +55,5 @@ archspec; python_version >= '2.7'
 
 # cryptography 3.0 deprecates Python 2.7
 # and cryptography is not needed at all for Python 2.6
-cryptography==2.9.2; python_version >= 2.7, < '3.5'
+cryptography==2.9.2; python_version == '2.7'
 cryptography; python_version >= '3.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,3 +52,7 @@ python-hglib
 requests
 
 archspec; python_version >= '2.7'
+
+# cryptography 3.0 deprecates Python 2.7
+cryptography==2.9.2; python_version < '3.5'
+cryptography; python_version >= '3.5'


### PR DESCRIPTION
The new 3.0 release deprecates support for Python 2.7 so is noisy,
which breaks tests.