### PR TITLE
Use one argument 'module swap' statements in Tcl modulefiles (required by Modules 4.2.3+)

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -963,8 +963,8 @@ class ModuleGeneratorTcl(ModuleGenerator):
         :param guarded: guard 'swap' statement, fall back to 'load' if module being swapped out is not loaded
         """
         # In Modules 4.2.3+ a 2-argument swap 'module swap foo foo/X.Y.Z' will fail as the unloaded 'foo'
-        # means all 'foo' modules conflict and 'foo/X.Y.Z' will not load.  A 1-argument swap like 
-        # 'module swap foo/X.Y.Z' will unload any currently loaded 'foo' without it becoming conflicting 
+        # means all 'foo' modules conflict and 'foo/X.Y.Z' will not load.  A 1-argument swap like
+        # 'module swap foo/X.Y.Z' will unload any currently loaded 'foo' without it becoming conflicting
         # and successfully load the new module.
         # See: https://modules.readthedocs.io/en/latest/NEWS.html#modules-4-2-3-2019-03-23
         body = "module swap %s" % (mod_name_in)

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -962,7 +962,7 @@ class ModuleGeneratorTcl(ModuleGenerator):
         :param mod_name_in: name of module to load (swap in)
         :param guarded: guard 'swap' statement, fall back to 'load' if module being swapped out is not loaded
         """
-        body = "module swap %s %s" % (mod_name_out, mod_name_in)
+        body = "module swap %s" % (mod_name_in)
         if guarded:
             alt_body = self.LOAD_TEMPLATE % {'mod_name': mod_name_in}
             swap_statement = [self.conditional_statement(self.is_loaded(mod_name_out), body, else_body=alt_body)]

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -962,6 +962,11 @@ class ModuleGeneratorTcl(ModuleGenerator):
         :param mod_name_in: name of module to load (swap in)
         :param guarded: guard 'swap' statement, fall back to 'load' if module being swapped out is not loaded
         """
+        # In Modules 4.2.3+ a 2-argument swap 'module swap foo foo/X.Y.Z' will fail as the unloaded 'foo'
+        # means all 'foo' modules conflict and 'foo/X.Y.Z' will not load.  A 1-argument swap like 
+        # 'module swap foo/X.Y.Z' will unload any currently loaded 'foo' without it becoming conflicting 
+        # and successfully load the new module.
+        # See: https://modules.readthedocs.io/en/latest/NEWS.html#modules-4-2-3-2019-03-23
         body = "module swap %s" % (mod_name_in)
         if guarded:
             alt_body = self.LOAD_TEMPLATE % {'mod_name': mod_name_in}

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -610,7 +610,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
         if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
             expected = '\n'.join([
                 '',
-                "module swap foo bar",
+                "module swap bar",
                 '',
             ])
         else:
@@ -627,7 +627,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
             expected = '\n'.join([
                 '',
                 "if { [ is-loaded foo ] } {",
-                "    module swap foo bar",
+                "    module swap bar",
                 '} else {',
                 "    module load bar",
                 '}',

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -44,7 +44,7 @@ from easybuild.tools.module_naming_scheme.utilities import is_valid_module_name
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, ActiveMNS
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.modules import EnvironmentModulesC, Lmod
+from easybuild.tools.modules import EnvironmentModulesC, EnvironmentModulesTcl, Lmod
 from easybuild.tools.utilities import quote_str
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, find_full_path, init_config
 
@@ -648,8 +648,11 @@ class ModuleGeneratorTest(EnhancedTestCase):
         self.assertEqual(expected, self.modgen.swap_module('foo', 'bar'))
 
         # create tiny test Tcl module to make sure that tested modules tools support single-argument swap
-        # see https://github.com/easybuilders/easybuild-framework/issues/3396
-        if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
+        # see https://github.com/easybuilders/easybuild-framework/issues/3396;
+        # this is known to fail with the ancient Tcl-only implementation of environment modules,
+        # but that's considered to be a non-issue (since this is mostly relevant for Cray systems,
+        # which are either using EnvironmentModulesC (3.2.10), EnvironmentModules (4.x) or Lmod...
+        if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl and self.modtool.__class__ != EnvironmentModulesTcl:
             test_mod_txt = "#%Module\nmodule swap GCC/7.3.0-2.30"
 
             test_mod_fn = 'test_single_arg_swap/1.2.3'

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -647,6 +647,21 @@ class ModuleGeneratorTest(EnhancedTestCase):
         self.assertEqual(expected, self.modgen.swap_module('foo', 'bar', guarded=True))
         self.assertEqual(expected, self.modgen.swap_module('foo', 'bar'))
 
+        # create tiny test Tcl module to make sure that tested modules tools support single-argument swap
+        # see https://github.com/easybuilders/easybuild-framework/issues/3396
+        if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
+            test_mod_txt = "#%Module\nmodule swap GCC/7.3.0-2.30"
+
+            test_mod_fn = 'test_single_arg_swap/1.2.3'
+            write_file(os.path.join(self.test_prefix, test_mod_fn), test_mod_txt)
+
+            self.modtool.load(['GCC/4.6.3'])
+            self.modtool.use(self.test_prefix)
+            self.modtool.load(['test_single_arg_swap/1.2.3'])
+
+            expected = ['GCC/7.3.0-2.30', 'test_single_arg_swap/1.2.3']
+            self.assertEqual(sorted([m['mod_name'] for m in self.modtool.list()]), expected)
+
     def test_append_paths(self):
         """Test generating append-paths statements."""
         # test append_paths


### PR DESCRIPTION
This should address #3396 by generating modulefiles which use `module swap` commands with the only argument being the module to load in. `module` is intelligent enough to know which module should be unloaded, and this doesn't result in conflicting modules (and so unusable modulefiles) which occurs with Modules 4.2.3 and newer.

edit: fixes #3396