### PR TITLE
set up a minimal build environment when using system compiler

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -83,6 +83,7 @@ DEFAULT_INDEX_MAX_AGE = 7 * 24 * 60 * 60  # 1 week (in seconds)
 DEFAULT_JOB_BACKEND = 'GC3Pie'
 DEFAULT_LOGFILE_FORMAT = ("easybuild", "easybuild-%(name)s-%(version)s-%(date)s.%(time)s.log")
 DEFAULT_MAX_FAIL_RATIO_PERMS = 0.5
+DEFAULT_MINIMAL_BUILD_ENV = 'CC:gcc,CXX:g++'
 DEFAULT_MNS = 'EasyBuildMNS'
 DEFAULT_MODULE_SYNTAX = 'Lua'
 DEFAULT_MODULES_TOOL = 'Lmod'
@@ -289,6 +290,9 @@ BUILD_OPTIONS_CMDLINE = {
     ],
     DEFAULT_MAX_FAIL_RATIO_PERMS: [
         'max_fail_ratio_adjust_permissions',
+    ],
+    DEFAULT_MINIMAL_BUILD_ENV: [
+        'minimal_build_env',
     ],
     DEFAULT_PKG_RELEASE: [
         'package_release',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -62,12 +62,13 @@ from easybuild.tools.build_log import init_logging, log_start, print_warning, ra
 from easybuild.tools.config import CONT_IMAGE_FORMATS, CONT_TYPES, DEFAULT_CONT_TYPE, DEFAULT_ALLOW_LOADED_MODULES
 from easybuild.tools.config import DEFAULT_BRANCH, DEFAULT_FORCE_DOWNLOAD, DEFAULT_INDEX_MAX_AGE
 from easybuild.tools.config import DEFAULT_JOB_BACKEND, DEFAULT_LOGFILE_FORMAT, DEFAULT_MAX_FAIL_RATIO_PERMS
-from easybuild.tools.config import DEFAULT_MNS, DEFAULT_MODULE_SYNTAX, DEFAULT_MODULES_TOOL, DEFAULT_MODULECLASSES
-from easybuild.tools.config import DEFAULT_PATH_SUBDIRS, DEFAULT_PKG_RELEASE, DEFAULT_PKG_TOOL, DEFAULT_PKG_TYPE
-from easybuild.tools.config import DEFAULT_PNS, DEFAULT_PREFIX, DEFAULT_REPOSITORY, DEFAULT_WAIT_ON_LOCK_INTERVAL
-from easybuild.tools.config import DEFAULT_WAIT_ON_LOCK_LIMIT, EBROOT_ENV_VAR_ACTIONS, ERROR, FORCE_DOWNLOAD_CHOICES
-from easybuild.tools.config import GENERAL_CLASS, IGNORE, JOB_DEPS_TYPE_ABORT_ON_ERROR, JOB_DEPS_TYPE_ALWAYS_RUN
-from easybuild.tools.config import LOADED_MODULES_ACTIONS, LOCAL_VAR_NAMING_CHECK_WARN, LOCAL_VAR_NAMING_CHECKS, WARN
+from easybuild.tools.config import DEFAULT_MINIMAL_BUILD_ENV, DEFAULT_MNS, DEFAULT_MODULE_SYNTAX, DEFAULT_MODULES_TOOL
+from easybuild.tools.config import DEFAULT_MODULECLASSES, DEFAULT_PATH_SUBDIRS, DEFAULT_PKG_RELEASE, DEFAULT_PKG_TOOL
+from easybuild.tools.config import DEFAULT_PKG_TYPE, DEFAULT_PNS, DEFAULT_PREFIX, DEFAULT_REPOSITORY
+from easybuild.tools.config import DEFAULT_WAIT_ON_LOCK_INTERVAL, DEFAULT_WAIT_ON_LOCK_LIMIT, EBROOT_ENV_VAR_ACTIONS
+from easybuild.tools.config import ERROR, FORCE_DOWNLOAD_CHOICES, GENERAL_CLASS, IGNORE, JOB_DEPS_TYPE_ABORT_ON_ERROR
+from easybuild.tools.config import JOB_DEPS_TYPE_ALWAYS_RUN, LOADED_MODULES_ACTIONS, LOCAL_VAR_NAMING_CHECK_WARN
+from easybuild.tools.config import LOCAL_VAR_NAMING_CHECKS, WARN
 from easybuild.tools.config import get_pretend_installpath, init, init_build_options, mk_full_default_path
 from easybuild.tools.configobj import ConfigObj, ConfigObjError
 from easybuild.tools.docs import FORMAT_TXT, FORMAT_RST
@@ -402,6 +403,10 @@ class EasyBuildOptions(GeneralOption):
                                             None, 'store_true', True),
             'max-fail-ratio-adjust-permissions': ("Maximum ratio for failures to allow when adjusting permissions",
                                                   'float', 'store', DEFAULT_MAX_FAIL_RATIO_PERMS),
+            'minimal-build-env': ("Minimal build environment to define when using system toolchain, "
+                                  "specified as a comma-separated list that defines a mapping between name of "
+                                  "environment variable and its value separated by a colon (':')",
+                                  None, 'store', DEFAULT_MINIMAL_BUILD_ENV),
             'minimal-toolchains': ("Use minimal toolchain when resolving dependencies", None, 'store_true', False),
             'module-only': ("Only generate module file(s); skip all steps except for %s" % ', '.join(MODULE_ONLY_STEPS),
                             None, 'store_true', False),

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -239,7 +239,7 @@ class Toolchain(object):
         return is_system_toolchain(self.name)
 
     def set_minimal_build_env(self):
-        """Set up a minimal build environment, by setting $CC, $CXX, $FC environment variables."""
+        """Set up a minimal build environment, by setting (only) the $CC and $CXX environment variables."""
 
         # this is only relevant when using a system toolchain,
         # for proper toolchains these variables will get set via the call to set_variables()

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -953,10 +953,11 @@ class Toolchain(object):
                 }
                 write_file(cmd_wrapper, cmd_wrapper_txt)
                 adjust_permissions(cmd_wrapper, stat.S_IXUSR)
-                self.log.info("Wrapper script for %s: %s (log: %s)", orig_cmd, which(cmd), rpath_wrapper_log)
 
                 # prepend location to this wrapper to $PATH
                 setvar('PATH', '%s:%s' % (wrapper_dir, os.getenv('PATH')))
+
+                self.log.info("RPATH wrapper script for %s: %s (log: %s)", orig_cmd, which(cmd), rpath_wrapper_log)
             else:
                 self.log.debug("Not installing RPATH wrapper for non-existing command '%s'", cmd)
 

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -238,6 +238,21 @@ class Toolchain(object):
         """Return boolean to indicate whether this toolchain is a system(/dummy) toolchain."""
         return is_system_toolchain(self.name)
 
+    def set_minimal_build_env(self):
+        """Set up a minimal build environment, by setting $CC, $CXX, $FC environment variables."""
+
+        # this is only relevant when using a system toolchain,
+        # for proper toolchains these variables will get set via the call to set_variables()
+        env_vars = {
+            'CC': 'gcc',
+            'CXX': 'g++',
+            'F77': 'gfortran',
+            'F90': 'gfortran',
+            'FC': 'gfortran',
+        }
+        for name, value in env_vars.items():
+            setvar(name, value)
+
     def base_init(self):
         """Initialise missing class attributes (log, options, variables)."""
         if not hasattr(self, 'log'):
@@ -780,8 +795,14 @@ class Toolchain(object):
         if loadmod:
             self._load_modules(silent=silent)
 
-        if not self.is_system_toolchain():
+        if self.is_system_toolchain():
 
+            # define minimal build environment when using system toolchain;
+            # this is mostly done to try controlling which compiler commands are being used,
+            # cfr. https://github.com/easybuilders/easybuild-framework/issues/3398
+            self.set_minimal_build_env()
+
+        else:
             trace_msg("defining build environment for %s/%s toolchain" % (self.name, self.version))
 
             if not self.dry_run:

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -260,8 +260,12 @@ class Toolchain(object):
                 warning_msg = "%s command not found, not setting $%s in minimal build environment" % (cmd, env_var)
                 print_warning(warning_msg, log=self.log)
 
-        for key, value in env_vars.items():
-            setvar(key, value)
+        for key, new_value in env_vars.items():
+            curr_value = os.getenv(key)
+            if curr_value and curr_value != new_value:
+                print_warning("$%s was defined as '%s', but is now set to '%s' in minimal build environment",
+                              key, curr_value, new_value)
+            setvar(key, new_value)
 
     def base_init(self):
         """Initialise missing class attributes (log, options, variables)."""

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -335,7 +335,11 @@ class ToolchainTest(EnhancedTestCase):
         # and the specs in --minimal-build-env are ignored
         tc = self.get_toolchain('foss', version='2018a')
         tc.set_options({})
+
+        # catch potential warning about too long $TMPDIR value that causes trouble for Open MPI (irrelevant here)
+        self.mock_stderr(True)
         tc.prepare()
+        self.mock_stderr(False)
 
         self.assertEqual(os.getenv('CC'), 'gcc')
         self.assertEqual(os.getenv('CXX'), 'g++')

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -191,11 +191,12 @@ class ToolchainTest(EnhancedTestCase):
         tc.set_options({})
         tc.prepare()
 
+        # only $CC and $CXX are set, no point is setting environment variables for Fortran
+        # since gfortran is often not installed on the system
         self.assertEqual(os.getenv('CC'), 'gcc')
         self.assertEqual(os.getenv('CXX'), 'g++')
-        self.assertEqual(os.getenv('F77'), 'gfortran')
-        self.assertEqual(os.getenv('F90'), 'gfortran')
-        self.assertEqual(os.getenv('FC'), 'gfortran')
+        for key in ['F77', 'F90', 'FC']:
+            self.assertEqual(os.getenv(key), None)
 
         # env vars for compiler flags and MPI compiler commands are not set for system toolchain
         flags_keys = ['CFLAGS', 'CXXFLAGS', 'F90FLAGS', 'FCFLAGS', 'FFLAGS']


### PR DESCRIPTION
It should be safe to define `$CC` & co to the standard GCC compiler commands when using the `system` toolchain.

Not only will this fix the problem discussed in #3398, it also ensures that values for `$CC` & co that were defined outside of EasyBuild don't mess things up...

(fixes #3398)