### PR TITLE
fix copying of (non-existing) file with apply_patch

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1203,9 +1203,6 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
     elif fn and not os.path.isfile(fn):
         raise EasyBuildError("Can't patch file %s: no such file", fn)
 
-    elif not os.path.isdir(dest):
-        raise EasyBuildError("Can't patch directory %s: no such directory", dest)
-
     # copy missing files
     if copy:
         if build_option('extended_dry_run'):
@@ -1213,8 +1210,12 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
         else:
             copy_file(patch_file, dest)
             _log.debug("Copied patch %s to dir %s" % (patch_file, dest))
-            # early exit, work is done after copying
-            return True
+
+        # early exit, work is done after copying
+        return True
+
+    elif not os.path.isdir(dest):
+        raise EasyBuildError("Can't patch directory %s: no such directory", dest)
 
     # use absolute paths
     apatch = os.path.abspath(patch_file)

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1380,6 +1380,29 @@ class FileToolsTest(EnhancedTestCase):
         # trying the patch again should fail
         self.assertErrorRegex(EasyBuildError, "Couldn't apply patch file", ft.apply_patch, toy_patch, path)
 
+        # test copying of files, both to an existing directory and a non-existing location
+        test_file = os.path.join(self.test_prefix, 'foo.txt')
+        ft.write_file(test_file, '123')
+        target_dir = os.path.join(self.test_prefix, 'target_dir')
+        ft.mkdir(target_dir)
+
+        # copy to existing dir
+        ft.apply_patch(test_file, target_dir, copy=True)
+        self.assertEqual(ft.read_file(os.path.join(target_dir, 'foo.txt')), '123')
+
+        # copy to existing file
+        ft.write_file(os.path.join(target_dir, 'foo.txt'), '')
+        ft.apply_patch(test_file, target_dir, copy=True)
+        self.assertEqual(ft.read_file(os.path.join(target_dir, 'foo.txt')), '123')
+
+        # copy to new file in existing dir
+        ft.apply_patch(test_file, os.path.join(target_dir, 'target.txt'), copy=True)
+        self.assertEqual(ft.read_file(os.path.join(target_dir, 'target.txt')), '123')
+
+        # copy to non-existing subdir
+        ft.apply_patch(test_file, os.path.join(target_dir, 'subdir', 'target.txt'), copy=True)
+        self.assertEqual(ft.read_file(os.path.join(target_dir, 'subdir', 'target.txt')), '123')
+
     def test_copy_file(self):
         """Test copy_file function."""
         testdir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Copying a file through patches was failing if the target location is a non-existing file. Example:

```python
patches = [('foo.txt', 'src/bar.txt')]
```

resulting error:

```
Can't patch directory /tmp/example/1.2.3/intel-2020a-Python-3.8.2/example-1.2.3/src/bar.txt: no such directory
```

The fix is basically to postpone the directory check until after copying of files (when `copy` is `True`) is dealt with.