### PR TITLE
fix issues with applying PR patch in --from-pr

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2029,8 +2029,7 @@ class EasyBlock(object):
             src = os.path.abspath(weld_paths(beginpath, srcpathsuffix))
             self.log.debug("Applying patch %s in path %s", patch, src)
 
-            if not apply_patch(patch['path'], src, copy=copy_patch, level=level):
-                raise EasyBuildError("Applying patch %s failed", patch['name'])
+            apply_patch(patch['path'], src, copy=copy_patch, level=level)
 
     def prepare_step(self, start_dir=True, load_tc_deps_modules=True):
         """

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1186,7 +1186,7 @@ def guess_patch_level(patched_files, parent_dir):
     return patch_level
 
 
-def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=False):
+def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git=False):
     """
     Apply a patch to source code in directory dest
     - assume unified diff created with "diff -ru old new"
@@ -1237,8 +1237,8 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
             change_dir(apatch_dir)
             apatch = os.path.join(apatch_dir, apatch_name)
 
-    if use_git_am:
-        patch_cmd = "git am patch %s" % apatch
+    if use_git:
+        patch_cmd = "git apply %s" % apatch
     else:
         if level is None and build_option('extended_dry_run'):
             level = '<derived>'

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1228,19 +1228,19 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
     abs_dest = os.path.abspath(dest)
 
     # Attempt extracting the patch if it ends in .patch.gz, .patch.bz2, .patch.xz
-    # split in name + extension
-    patch_filestem, patch_extension = os.path.splitext(os.path.split(abs_patch_file)[1])
+    # split in stem (filename w/o extension) + extension
+    patch_stem, patch_extension = os.path.splitext(os.path.split(abs_patch_file)[1])
     # Supports only bz2, gz and xz. zip can be archives which are not supported.
     if patch_extension in ['.gz', '.bz2', '.xz']:
         # split again to get the second extension
-        patch_subextension = os.path.splitext(patch_filestem)[1]
+        patch_subextension = os.path.splitext(patch_stem)[1]
         if patch_subextension == ".patch":
             workdir = tempfile.mkdtemp(prefix='eb-patch-')
             _log.debug("Extracting the patch to: %s", workdir)
             # extracting the patch
             extracted_dir = extract_file(abs_patch_file, workdir, change_into_dir=False)
             change_dir(extracted_dir)
-            abs_patch_file = os.path.join(extracted_dir, patch_filestem)
+            abs_patch_file = os.path.join(extracted_dir, patch_stem)
 
     if use_git:
         verbose = '--verbose ' if build_option('debug') else ''

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1239,7 +1239,6 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
             _log.debug("Extracting the patch to: %s", workdir)
             # extracting the patch
             extracted_dir = extract_file(abs_patch_file, workdir, change_into_dir=False)
-            change_dir(extracted_dir)
             abs_patch_file = os.path.join(extracted_dir, patch_stem)
 
     if use_git:

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1224,27 +1224,26 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
         raise EasyBuildError("Can't patch directory %s: no such directory", dest)
 
     # use absolute paths
-    apatch = os.path.abspath(patch_file)
-    adest = os.path.abspath(dest)
+    abs_patch_file = os.path.abspath(patch_file)
+    abs_dest = os.path.abspath(dest)
 
     # Attempt extracting the patch if it ends in .patch.gz, .patch.bz2, .patch.xz
     # split in name + extension
-    apatch_root, apatch_file = os.path.split(apatch)
-    apatch_name, apatch_extension = os.path.splitext(apatch_file)
+    patch_filestem, patch_extension = os.path.splitext(os.path.split(abs_patch_file)[1])
     # Supports only bz2, gz and xz. zip can be archives which are not supported.
-    if apatch_extension in ['.gz', '.bz2', '.xz']:
+    if patch_extension in ['.gz', '.bz2', '.xz']:
         # split again to get the second extension
-        apatch_subname, apatch_subextension = os.path.splitext(apatch_name)
-        if apatch_subextension == ".patch":
+        patch_subextension = os.path.splitext(patch_filestem)[1]
+        if patch_subextension == ".patch":
             workdir = tempfile.mkdtemp(prefix='eb-patch-')
             _log.debug("Extracting the patch to: %s", workdir)
             # extracting the patch
-            apatch_dir = extract_file(apatch, workdir, change_into_dir=False)
-            change_dir(apatch_dir)
-            apatch = os.path.join(apatch_dir, apatch_name)
+            extracted_dir = extract_file(abs_patch_file, workdir, change_into_dir=False)
+            change_dir(extracted_dir)
+            abs_patch_file = os.path.join(extracted_dir, patch_filestem)
 
     if use_git:
-        patch_cmd = "git apply %s" % apatch
+        patch_cmd = "git apply %s" % abs_patch_file
     else:
         if level is None and build_option('extended_dry_run'):
             level = '<derived>'
@@ -1254,25 +1253,26 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
             # - based on +++ lines
             # - first +++ line that matches an existing file determines guessed level
             # - we will try to match that level from current directory
-            patched_files = det_patched_files(path=apatch)
+            patched_files = det_patched_files(path=abs_patch_file)
 
             if not patched_files:
-                raise EasyBuildError("Can't guess patchlevel from patch %s: no testfile line found in patch", apatch)
+                raise EasyBuildError("Can't guess patchlevel from patch %s: no testfile line found in patch",
+                                     abs_patch_file)
 
-            level = guess_patch_level(patched_files, adest)
+            level = guess_patch_level(patched_files, abs_dest)
 
             if level is None:  # level can also be 0 (zero), so don't use "not level"
                 # no match
-                raise EasyBuildError("Can't determine patch level for patch %s from directory %s", patch_file, adest)
+                raise EasyBuildError("Can't determine patch level for patch %s from directory %s", patch_file, abs_dest)
             else:
                 _log.debug("Guessed patch level %d for patch %s" % (level, patch_file))
 
         else:
             _log.debug("Using specified patch level %d for patch %s" % (level, patch_file))
 
-        patch_cmd = "patch -b -p%s -i %s" % (level, apatch)
+        patch_cmd = "patch -b -p%s -i %s" % (level, abs_patch_file)
 
-    out, ec = run.run_cmd(patch_cmd, simple=False, path=adest, log_ok=False, trace=False)
+    out, ec = run.run_cmd(patch_cmd, simple=False, path=abs_dest, log_ok=False, trace=False)
 
     if ec:
         raise EasyBuildError("Couldn't apply patch file %s. Process exited with code %s: %s", patch_file, ec, out)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1190,6 +1190,8 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
     """
     Apply a patch to source code in directory dest
     - assume unified diff created with "diff -ru old new"
+
+    Raises EasyBuildError on any error and returns True on success
     """
 
     if use_git_am:
@@ -1256,7 +1258,6 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
 
             if not patched_files:
                 raise EasyBuildError("Can't guess patchlevel from patch %s: no testfile line found in patch", apatch)
-                return
 
             level = guess_patch_level(patched_files, adest)
 
@@ -1275,7 +1276,7 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
 
     if ec:
         raise EasyBuildError("Couldn't apply patch file %s. Process exited with code %s: %s", patch_file, ec, out)
-    return ec == 0
+    return True
 
 
 def apply_regex_substitutions(path, regex_subs, backup='.orig.eb'):

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1195,7 +1195,7 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
     """
 
     if use_git_am:
-        _log.deprecated('5.0', "'use_git_am' named argument in apply_patch function has been renamed to 'use_git'")
+        _log.deprecated("'use_git_am' named argument in apply_patch function has been renamed to 'use_git'", '5.0')
         use_git = True
 
     if build_option('extended_dry_run'):

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1237,41 +1237,40 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
             change_dir(apatch_dir)
             apatch = os.path.join(apatch_dir, apatch_name)
 
-    if level is None and build_option('extended_dry_run'):
-        level = '<derived>'
-
-    elif level is None:
-        # guess value for -p (patch level)
-        # - based on +++ lines
-        # - first +++ line that matches an existing file determines guessed level
-        # - we will try to match that level from current directory
-        patched_files = det_patched_files(path=apatch)
-
-        if not patched_files:
-            raise EasyBuildError("Can't guess patchlevel from patch %s: no testfile line found in patch", apatch)
-            return
-
-        level = guess_patch_level(patched_files, adest)
-
-        if level is None:  # level can also be 0 (zero), so don't use "not level"
-            # no match
-            raise EasyBuildError("Can't determine patch level for patch %s from directory %s", patch_file, adest)
-        else:
-            _log.debug("Guessed patch level %d for patch %s" % (level, patch_file))
-
-    else:
-        _log.debug("Using specified patch level %d for patch %s" % (level, patch_file))
-
     if use_git_am:
         patch_cmd = "git am patch %s" % apatch
     else:
+        if level is None and build_option('extended_dry_run'):
+            level = '<derived>'
+
+        elif level is None:
+            # guess value for -p (patch level)
+            # - based on +++ lines
+            # - first +++ line that matches an existing file determines guessed level
+            # - we will try to match that level from current directory
+            patched_files = det_patched_files(path=apatch)
+
+            if not patched_files:
+                raise EasyBuildError("Can't guess patchlevel from patch %s: no testfile line found in patch", apatch)
+                return
+
+            level = guess_patch_level(patched_files, adest)
+
+            if level is None:  # level can also be 0 (zero), so don't use "not level"
+                # no match
+                raise EasyBuildError("Can't determine patch level for patch %s from directory %s", patch_file, adest)
+            else:
+                _log.debug("Guessed patch level %d for patch %s" % (level, patch_file))
+
+        else:
+            _log.debug("Using specified patch level %d for patch %s" % (level, patch_file))
+
         patch_cmd = "patch -b -p%s -i %s" % (level, apatch)
 
     out, ec = run.run_cmd(patch_cmd, simple=False, path=adest, log_ok=False, trace=False)
 
     if ec:
         raise EasyBuildError("Couldn't apply patch file %s. Process exited with code %s: %s", patch_file, ec, out)
-
     return ec == 0
 
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1195,7 +1195,7 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
     """
 
     if use_git_am:
-        _log.deprecated('5.0', "'use_git_am' named argument has been renamed to 'use_git'")
+        _log.deprecated('5.0', "'use_git_am' named argument in apply_patch function has been renamed to 'use_git'")
         use_git = True
 
     if build_option('extended_dry_run'):

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1186,11 +1186,15 @@ def guess_patch_level(patched_files, parent_dir):
     return patch_level
 
 
-def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git=False):
+def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=False, use_git=False):
     """
     Apply a patch to source code in directory dest
     - assume unified diff created with "diff -ru old new"
     """
+
+    if use_git_am:
+        _log.deprecated('5.0', "'use_git_am' named argument has been renamed to 'use_git'")
+        use_git = True
 
     if build_option('extended_dry_run'):
         # skip checking of files in dry run mode

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1243,7 +1243,8 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
             abs_patch_file = os.path.join(extracted_dir, patch_filestem)
 
     if use_git:
-        patch_cmd = "git apply %s" % abs_patch_file
+        verbose = '--verbose ' if build_option('debug') else ''
+        patch_cmd = "git apply %s%s" % (verbose, abs_patch_file)
     else:
         if level is None and build_option('extended_dry_run'):
             level = '<derived>'

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -454,7 +454,7 @@ def fetch_files_from_pr(pr, path=None, github_user=None, github_repo=None):
     elif not pr_closed:
         try:
             _log.debug("Trying to apply PR patch %s to %s...", diff_filepath, repo_target_branch)
-            apply_patch(diff_filepath, repo_target_branch, use_git_am=True)
+            apply_patch(diff_filepath, repo_target_branch, use_git=True)
             _log.info("Using %s which included PR patch to test PR #%s", repo_target_branch, pr)
             final_path = repo_target_branch
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1856,7 +1856,7 @@ class EasyBlockTest(EnhancedTestCase):
         # single SHA256 checksum per source/patch: OK
         eb.cfg['checksums'] = [
             '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # toy-0.0.tar.gz
-            '45b5e3f9f495366830e1869bb2b8f4e7c28022739ce48d9f9ebb159b439823c5',  # toy-*.patch
+            '81a3accc894592152f81814fbf133d39afad52885ab52c25018722c7bda92487',  # toy-*.patch
             '4196b56771140d8e2468fb77f0240bc48ddbf5dabafe0713d612df7fafb1e458',  # toy-extra.txt]
         ]
         # no checksum issues
@@ -1865,7 +1865,7 @@ class EasyBlockTest(EnhancedTestCase):
         # SHA256 checksum with type specifier: OK
         eb.cfg['checksums'] = [
             ('sha256', '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc'),  # toy-0.0.tar.gz
-            '45b5e3f9f495366830e1869bb2b8f4e7c28022739ce48d9f9ebb159b439823c5',  # toy-*.patch
+            '81a3accc894592152f81814fbf133d39afad52885ab52c25018722c7bda92487',  # toy-*.patch
             ('sha256', '4196b56771140d8e2468fb77f0240bc48ddbf5dabafe0713d612df7fafb1e458'),  # toy-extra.txt]
         ]
         # no checksum issues
@@ -1878,7 +1878,7 @@ class EasyBlockTest(EnhancedTestCase):
                 'a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd',
                 '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',
             ),
-            '45b5e3f9f495366830e1869bb2b8f4e7c28022739ce48d9f9ebb159b439823c5',  # toy-*.patch
+            '81a3accc894592152f81814fbf133d39afad52885ab52c25018722c7bda92487',  # toy-*.patch
             '4196b56771140d8e2468fb77f0240bc48ddbf5dabafe0713d612df7fafb1e458',  # toy-extra.txt
         ]
         # no checksum issues

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-multiple.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-multiple.eb
@@ -12,7 +12,7 @@ sources = [SOURCE_TAR_GZ]
 patches = ['toy-0.0_fix-silly-typo-in-printf-statement.patch']
 checksums = [
     ('adler32', '0x998410035'),
-    'e6785e1a721fc8bf79892e3ef41557c0',
+    'a99f2a72cee1689a2f7e3ace0356efb1',
 ]
 
 moduleclass = 'tools'

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1359,9 +1359,8 @@ class FileToolsTest(EnhancedTestCase):
     def test_apply_patch(self):
         """ Test apply_patch """
         testdir = os.path.dirname(os.path.abspath(__file__))
-        tmpdir = self.test_prefix
         toy_tar_gz = os.path.join(testdir, 'sandbox', 'sources', 'toy', 'toy-0.0.tar.gz')
-        path = ft.extract_file(toy_tar_gz, tmpdir, change_into_dir=False)
+        path = ft.extract_file(toy_tar_gz, self.test_prefix, change_into_dir=False)
         toy_patch_fn = 'toy-0.0_fix-silly-typo-in-printf-statement.patch'
         toy_patch = os.path.join(testdir, 'sandbox', 'sources', 'toy', toy_patch_fn)
 
@@ -1402,6 +1401,49 @@ class FileToolsTest(EnhancedTestCase):
         # copy to non-existing subdir
         ft.apply_patch(test_file, os.path.join(target_dir, 'subdir', 'target.txt'), copy=True)
         self.assertEqual(ft.read_file(os.path.join(target_dir, 'subdir', 'target.txt')), '123')
+
+        # cleanup and re-extract toy source tarball
+        ft.remove_dir(self.test_prefix)
+        ft.mkdir(self.test_prefix)
+        ft.change_dir(self.test_prefix)
+        path = ft.extract_file(toy_tar_gz, self.test_prefix, change_into_dir=False)
+
+        # test applying of patch with git
+        toy_source_path = os.path.join(self.test_prefix, 'toy-0.0', 'toy.source')
+        self.assertFalse("I'm a toy, and very proud of it" in ft.read_file(toy_source_path))
+
+        ft.apply_patch(toy_patch, self.test_prefix, use_git=True)
+        self.assertTrue("I'm a toy, and very proud of it" in ft.read_file(toy_source_path))
+
+        # construct patch that only adds a new file,
+        # this shouldn't break applying a patch with git even when no level is specified
+        new_file_patch = os.path.join(self.test_prefix, 'toy_new_file.patch')
+        new_file_patch_txt = '\n'.join([
+            "new file mode 100755",
+            "--- /dev/null\t1970-01-01 01:00:00.000000000 +0100",
+            "+++ b/toy-0.0/new_file.txt\t2020-08-18 12:31:57.000000000 +0200",
+            "@@ -0,0 +1 @@",
+            "+This is a new file\n",
+        ])
+        ft.write_file(new_file_patch, new_file_patch_txt)
+        ft.apply_patch(new_file_patch, self.test_prefix, use_git=True)
+        new_file_path = os.path.join(self.test_prefix, 'toy-0.0', 'new_file.txt')
+        self.assertEqual(ft.read_file(new_file_path), "This is a new file\n")
+
+        # cleanup & restore
+        ft.remove_dir(path)
+        path = ft.extract_file(toy_tar_gz, self.test_prefix, change_into_dir=False)
+
+        self.assertFalse("I'm a toy, and very proud of it" in ft.read_file(toy_source_path))
+
+        # mock stderr to catch deprecation warning caused by setting 'use_git_am'
+        self.allow_deprecated_behaviour()
+        self.mock_stderr(True)
+        ft.apply_patch(toy_patch, self.test_prefix, use_git_am=True)
+        stderr = self.get_stderr()
+        self.mock_stderr(False)
+        self.assertTrue("I'm a toy, and very proud of it" in ft.read_file(toy_source_path))
+        self.assertTrue("'use_git_am' named argument in apply_patch function has been renamed to 'use_git'" in stderr)
 
     def test_copy_file(self):
         """Test copy_file function."""

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -4717,7 +4717,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             'checksums = [',
             "    None,  # toy-0.0.tar.gz",
             "    # toy-0.0_fix-silly-typo-in-printf-statement.patch",
-            "    '45b5e3f9f495366830e1869bb2b8f4e7c28022739ce48d9f9ebb159b439823c5',",
+            "    '81a3accc894592152f81814fbf133d39afad52885ab52c25018722c7bda92487',",
             "    '4196b56771140d8e2468fb77f0240bc48ddbf5dabafe0713d612df7fafb1e458',  # toy-extra.txt",
             ']\n',
         ])
@@ -4921,7 +4921,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         stdout, stderr = self._run_mock_eb(args, raise_error=True, strip=True)
 
         toy_source_sha256 = '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc'
-        toy_patch_sha256 = '45b5e3f9f495366830e1869bb2b8f4e7c28022739ce48d9f9ebb159b439823c5'
+        toy_patch_sha256 = '81a3accc894592152f81814fbf133d39afad52885ab52c25018722c7bda92487'
         bar_tar_gz_sha256 = 'f3676716b610545a4e8035087f5be0a0248adee0abb3930d3edb76d498ae91e7'
         bar_patch = 'bar-0.0_fix-silly-typo-in-printf-statement.patch'
         bar_patch_sha256 = '84db53592e882b5af077976257f9c7537ed971cb2059003fd4faa05d02cae0ab'
@@ -5056,7 +5056,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             "^== backup of easyconfig file saved to .*/test\.eb\.bak_[0-9]+_[0-9]+\.\.\.$",
             "^== injecting md5 checksums for sources & patches in test\.eb\.\.\.$",
             "^== \* toy-0.0\.tar\.gz: be662daa971a640e40be5c804d9d7d10$",
-            "^== \* toy-0\.0_fix-silly-typo-in-printf-statement\.patch: e6785e1a721fc8bf79892e3ef41557c0$",
+            "^== \* toy-0\.0_fix-silly-typo-in-printf-statement\.patch: a99f2a72cee1689a2f7e3ace0356efb1$",
             "^== \* toy-extra\.txt: 3b0787b3bf36603ae1398c4a49097893$",
         ]
         for pattern in patterns:
@@ -5074,7 +5074,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ec = EasyConfigParser(test_ec).get_config_dict()
         checksums = [
             'be662daa971a640e40be5c804d9d7d10',
-            'e6785e1a721fc8bf79892e3ef41557c0',
+            'a99f2a72cee1689a2f7e3ace0356efb1',
             '3b0787b3bf36603ae1398c4a49097893',
         ]
         self.assertEqual(ec['checksums'], checksums)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5056,7 +5056,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             "^== backup of easyconfig file saved to .*/test\.eb\.bak_[0-9]+_[0-9]+\.\.\.$",
             "^== injecting md5 checksums for sources & patches in test\.eb\.\.\.$",
             "^== \* toy-0.0\.tar\.gz: be662daa971a640e40be5c804d9d7d10$",
-            "^== \* toy-0\.0_fix-silly-typo-in-printf-statement\.patch: a99f2a72cee1689a2f7e3ace0356efb1$",
+            r"^== \* toy-0\.0_fix-silly-typo-in-printf-statement\.patch: a99f2a72cee1689a2f7e3ace0356efb1$",
             "^== \* toy-extra\.txt: 3b0787b3bf36603ae1398c4a49097893$",
         ]
         for pattern in patterns:

--- a/test/framework/sandbox/sources/toy/toy-0.0_fix-silly-typo-in-printf-statement.patch
+++ b/test/framework/sandbox/sources/toy/toy-0.0_fix-silly-typo-in-printf-statement.patch
@@ -1,8 +1,8 @@
---- a/toy-0.0/toy.source.orig	2013-11-30 14:43:48.000000000 +0100
-+++ b/toy-0.0/toy.source	2013-11-30 14:43:58.000000000 +0100
+--- a/toy-0.0.orig/toy.source	2014-03-06 18:48:16.000000000 +0100
++++ b/toy-0.0/toy.source	2020-08-18 12:19:35.000000000 +0200
 @@ -2,6 +2,6 @@
  
- int main(int argc, char* *argv[]){
+ int main(int argc, char* argv[]){
  
 -    printf("I'm a toy, and proud of it.\n");
 +    printf("I'm a toy, and very proud of it.\n");


### PR DESCRIPTION
When PRs introduce only new files determining the patch level fails which makes it skip the whole `git am` part even though the level is not even required. Hence as a first part of the fix the level determination is skipped when using git to apply the patch.

Secondly `git am` requires an active git repo but we download the base branch via the archive, not a clone. Also the parameter `patch` is likely wrong as I can't find it in the docu. Hence replace that with `git apply` which does work for regular folders too.

Fixes #3411