### PR TITLE
switch to status badge based on tests run in GitHub Actions CI in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+.. image:: https://github.com/easybuilders/easybuild-framework/workflows/EasyBuild%20framework%20unit%20tests/badge.svg?branch=develop
+
 .. image:: https://easybuilders.github.io/easybuild/images/easybuild_logo_small.png
    :align: center
 
@@ -31,16 +33,3 @@ Related Python packages:
     with the latest compatible versions of the easybuild-framework and easybuild-easyblocks packages
   * GitHub repository: https://github.com/easybuilders/easybuild-easyconfigs
   * PyPi: https://pypi.python.org/pypi/easybuild-easyconfigs
-
-
-*Build status overview:*
-
-* **master** branch:
-
-  .. image:: https://travis-ci.org/easybuilders/easybuild-framework.svg?branch=master
-      :target: https://travis-ci.org/easybuilders/easybuild-framework/branches
-
-* **develop** branch:
-
-  .. image:: https://travis-ci.org/easybuilders/easybuild-framework.svg?branch=develop
-      :target: https://travis-ci.org/easybuilders/easybuild-framework/branches


### PR DESCRIPTION
The tests in GitHub Actions are a better representation of the test suite nowadays (and Travis CI is still too flake)

see https://github.com/boegel/easybuild-framework/blob/README_status_badge/README.rst for result