### PR TITLE
limit Travis to only test with Python 2.6 + Lomod 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,10 @@
 language: python
-python: 2.7
-dist: xenial
+python: 2.6
+dist: trusty
 env:
-  matrix:
-    - LMOD_VERSION=7.8.22
-    - LMOD_VERSION=7.8.22 TEST_EASYBUILD_MODULE_SYNTAX=Tcl
-    - ENV_MOD_VERSION=3.2.10 TEST_EASYBUILD_MODULES_TOOL=EnvironmentModulesC TEST_EASYBUILD_MODULE_SYNTAX=Tcl
-    - ENV_MOD_TCL_VERSION=1.147 TEST_EASYBUILD_MODULES_TOOL=EnvironmentModulesTcl TEST_EASYBUILD_MODULE_SYNTAX=Tcl
-    - ENV_MOD_VERSION=4.1.4 TEST_EASYBUILD_MODULE_SYNTAX=Tcl TEST_EASYBUILD_MODULES_TOOL=EnvironmentModules  # Tmod 4.1.4 is used in RHEL8
+    - LMOD_VERSION=7.8.22 TEST_EASYBUILD_SILENCE_DEPRECATION_WARNINGS=Python26
 cache:
   pip: true
-matrix:
-  # mark build as finished as soon as job has failed
-  fast_finish: true
-  include:
-    # also test default configuration with Python 2.6
-    - python: 2.6
-      env: LMOD_VERSION=7.8.22 TEST_EASYBUILD_SILENCE_DEPRECATION_WARNINGS=Python26
-      dist: trusty
-    # single configuration to test with Lmod 6 and Python 2.7
-    - python: 2.7
-      env: LMOD_VERSION=6.5.1 TEST_EASYBUILD_SILENCE_DEPRECATION_WARNINGS=Lmod6
-    # also test with Python 3.6
-    - python: 3.6
-      env: LMOD_VERSION=7.8.22
 addons:
   apt:
     packages:


### PR DESCRIPTION
All other combination of python/Tmod/Lmod are covered by github
workflows.