### PR TITLE
don't inject -Wl,-rpath options when '-x c++-header' compiler option is used

### DIFF
--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -41,7 +41,7 @@ rpath_filter = sys.argv[2]
 rpath_include = sys.argv[3]
 args = sys.argv[4:]
 
-# wheter or not to use -Wl to pass options to the linker
+# determine whether or not to use -Wl to pass options to the linker based on name of command
 if cmd in ['ld', 'ld.gold', 'ld.bfd']:
     flag_prefix = ''
 else:
@@ -58,7 +58,7 @@ if rpath_include:
 else:
     rpath_include = []
 
-version_mode = False
+add_rpath_args = True
 cmd_args, cmd_args_rpath = [], []
 
 # process list of original command line arguments
@@ -69,7 +69,7 @@ while idx < len(args):
 
     # if command is run in 'version check' mode, make sure we don't include *any* -rpath arguments
     if arg in ['-v', '-V', '--version', '-dumpversion']:
-        version_mode = True
+        add_rpath_args = False
         cmd_args.append(arg)
 
     # FIXME: also consider $LIBRARY_PATH?
@@ -115,7 +115,7 @@ cmd_args = cmd_args_rpath + cmd_args
 
 cmd_args_rpath = [flag_prefix + '-rpath=%s' % inc for inc in rpath_include]
 
-if not version_mode:
+if add_rpath_args:
     cmd_args = cmd_args_rpath + [
         # try to make sure that RUNPATH is not used by always injecting --disable-new-dtags
         flag_prefix + '--disable-new-dtags',

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1925,10 +1925,11 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
         # verify that no -rpath arguments are injected when command is run in 'version check' mode
-        cmd = "%s g++ '' '%s' -v" % (script, rpath_inc)
-        out, ec = run_cmd(cmd, simple=False)
-        self.assertEqual(ec, 0)
-        self.assertEqual(out.strip(), "CMD_ARGS=('-v')")
+        for version_arg in ['-v', '-V', '--version', '-dumpversion']:
+            cmd = "%s g++ '' '%s' %s" % (script, rpath_inc, version_arg)
+            out, ec = run_cmd(cmd, simple=False)
+            self.assertEqual(ec, 0)
+            self.assertEqual(out.strip(), "CMD_ARGS=('%s')" % version_arg)
 
     def test_toolchain_prepare_rpath(self):
         """Test toolchain.prepare under --rpath"""


### PR DESCRIPTION
fixes #3371