### PR TITLE
make sure self.start_dir is set in ExtensionEasyBlock

### DIFF
--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -97,6 +97,17 @@ class ExtensionEasyBlock(EasyBlock, Extension):
 
         self.ext_dir = None  # dir where extension source was unpacked
 
+    def _set_start_dir(self):
+        # Don't change start_dir if it is already set and exists
+        # else if ext_dir (path to extracted source) is set and exists use that, similar to guess_start_dir
+        possible_dirs = (self.start_dir, self.ext_dir)
+        for possible_dir in possible_dirs:
+            if possible_dir and os.path.isdir(possible_dir):
+                self.cfg['start_dir'] = possible_dir
+                self.log.debug("Using start_dir: %s", self.start_dir)
+                return
+        self.log.debug("Unable to determine start_dir as none of these paths is set and exists: %s", possible_dirs)
+
     def run(self, unpack_src=False):
         """Common operations for extensions: unpacking sources, patching, ..."""
 
@@ -105,11 +116,11 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             targetdir = os.path.join(self.master.builddir, remove_unwanted_chars(self.name))
             self.ext_dir = extract_file(self.src, targetdir, extra_options=self.unpack_options,
                                         change_into_dir=False)
-            change_dir(self.ext_dir)
 
-            if self.start_dir and os.path.isdir(self.start_dir):
-                self.log.debug("Using start_dir: %s", self.start_dir)
-                change_dir(self.start_dir)
+            self._set_start_dir()
+            change_dir(self.start_dir)
+        else:
+            self._set_start_dir()
 
         # patch if needed
         EasyBlock.patch_step(self, beginpath=self.ext_dir)

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -98,8 +98,11 @@ class ExtensionEasyBlock(EasyBlock, Extension):
         self.ext_dir = None  # dir where extension source was unpacked
 
     def _set_start_dir(self):
-        # Don't change start_dir if it is already set and exists
-        # else if ext_dir (path to extracted source) is set and exists use that, similar to guess_start_dir
+        """Set value for self.start_dir
+
+        Uses existing value of self.start_dir if it is already set and exists
+        otherwise self.ext_dir (path to extracted source) if that is set and exists, similar to guess_start_dir
+        """
         possible_dirs = (self.start_dir, self.ext_dir)
         for possible_dir in possible_dirs:
             if possible_dir and os.path.isdir(possible_dir):


### PR DESCRIPTION
Currently it is confusing whether you should/can use `self.start_dir` in an EasyBlock (or EC) leading to subtile errors such as in https://github.com/easybuilders/easybuild-easyconfigs/pull/11109 where `start_dir` is `None` or workarounds such as `topdir = self.start_dir or self.ext_dir` which are repetitive and require comments to explain.

This solution maintains current behavior such that `ext_dir` is set to the extracted folder and the working directory is changed to start_dir or if that is not set to ext_dir iff `unpack_src=True`.
Additionally in any case `start_dir` is now set to either the current start_dir or ext_dir whichever is set and exists