### PR TITLE
exclude local variables from typo check in easyconfig files

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -661,18 +661,18 @@ class EasyConfig(object):
 
         self.log.info("Parsing easyconfig file %s with rawcontent: %s", self.path, self.rawtxt)
         self.parser.set_specifications(arg_specs)
-        local_vars = self.parser.get_config_dict()
-        self.log.debug("Parsed easyconfig as a dictionary: %s" % local_vars)
+        ec_vars = self.parser.get_config_dict()
+        self.log.debug("Parsed easyconfig as a dictionary: %s" % ec_vars)
 
         # make sure all mandatory parameters are defined
         # this includes both generic mandatory parameters and software-specific parameters defined via extra_options
-        missing_mandatory_keys = [key for key in self.mandatory if key not in local_vars]
+        missing_mandatory_keys = [key for key in self.mandatory if key not in ec_vars]
         if missing_mandatory_keys:
             raise EasyBuildError("mandatory parameters not provided in %s: %s", self.path, missing_mandatory_keys)
 
-        # provide suggestions for typos
+        # provide suggestions for typos. Local variable names are excluded from this check
         possible_typos = [(key, difflib.get_close_matches(key.lower(), self._config.keys(), 1, 0.85))
-                          for key in local_vars if key not in self]
+                          for key in ec_vars if not is_local_var_name(key) and key not in self]
 
         typos = [(key, guesses[0]) for (key, guesses) in possible_typos if len(guesses) == 1]
         if typos:
@@ -680,7 +680,7 @@ class EasyConfig(object):
                                  ', '.join(["%s -> %s" % typo for typo in typos]))
 
         # set keys in current EasyConfig instance based on dict obtained by parsing easyconfig file
-        known_ec_params, self.unknown_keys = triage_easyconfig_params(local_vars, self._config)
+        known_ec_params, self.unknown_keys = triage_easyconfig_params(ec_vars, self._config)
 
         self.set_keys(known_ec_params)
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -530,6 +530,24 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, "source_URLs -> source_urls", EasyConfig, self.eb_file)
         self.assertErrorRegex(EasyBuildError, "sourceURLs -> source_urls", EasyConfig, self.eb_file)
 
+        # No error for known params prefixed by "local_"
+        self.contents = '\n'.join([
+            'easyblock = "ConfigureMake"',
+            'name = "pi"',
+            'version = "3.14"',
+            'homepage = "http://example.com"',
+            'description = "test easyconfig"',
+            'toolchain = {"name":"GCC", "version": "4.6.3"}',
+            'local_source_urls = "https://example.com"',
+            'source_urls = [local_source_urls]',
+            'local_cuda_compute_capabilities = ["3.3"]',  # This is known that it triggered the typo detection before
+            'cuda_compute_capabilities = local_cuda_compute_capabilities',
+        ])
+        self.prep()
+        # Should not raise any error, sanity check that something was done below
+        ec = EasyConfig(self.eb_file)
+        self.assertEqual(ec['version'], '3.14')
+
     def test_tweaking(self):
         """test tweaking ability of easyconfigs"""
 


### PR DESCRIPTION
Avoids misdetection of e.g. `local_cuda_compute_capabilities`

example:
```
Failed to process easyconfig /tmp/RELION-2.1-fosscuda-2017b.eb:
You may have some typos in your easyconfig file: local_cuda_compute_capabilities -> cuda_compute_capabilities
```