### PR TITLE
consider $EB_INSTALLPYTHON to specify 'python' command to use for running EasyBuild

### DIFF
--- a/eb
+++ b/eb
@@ -43,7 +43,7 @@ function verbose() {
 }
 
 PYTHON=
-for python_cmd in ${EB_PYTHON} 'python' 'python3' 'python2'; do
+for python_cmd in ${EB_PYTHON} ${EB_INSTALLPYTHON} 'python' 'python3' 'python2'; do
 
     verbose "Considering '$python_cmd'..."
 

--- a/eb
+++ b/eb
@@ -42,7 +42,6 @@ function verbose() {
     if [ ! -z ${EB_VERBOSE} ]; then echo ">> $1"; fi
 }
 
-
 PYTHON=
 # When selecting the PYTHON command to use, we need to first take environment variable settings into account
 # - EB_PYTHON is a variable set by the user that takes precedence over everything else

--- a/eb
+++ b/eb
@@ -42,7 +42,13 @@ function verbose() {
     if [ ! -z ${EB_VERBOSE} ]; then echo ">> $1"; fi
 }
 
+
 PYTHON=
+# When selecting the PYTHON command to use, we need to first take environment variable settings into account
+# - EB_PYTHON is a variable set by the user that takes precedence over everything else
+# - EB_INSTALLPYTHON is set when EasyBuild is installed as a module (by EasyBuild). It is set to the PYTHON
+#   used during that installation (for example, you could override PYTHON using EB_PYTHON at installation
+#   time, this variable preserves that choice).
 for python_cmd in ${EB_PYTHON} ${EB_INSTALLPYTHON} 'python' 'python3' 'python2'; do
 
     verbose "Considering '$python_cmd'..."


### PR DESCRIPTION
Replaces #3394 (which was created on a branch in the easybuilders repo by accident)

This replaces the use of the `EB_PYTHON` in an EasyBuild module (generated by EasyBuild). `EB_PYTHON` still takes precedence