### PR TITLE
 More tuning of GCC options for aarch64.

### DIFF
--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -72,10 +72,9 @@ class Gcc(Compiler):
     # gcc on aarch64 does not support -mno-recip, -mieee-fp, -mfno-math-errno...
     # https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html
     if systemtools.get_cpu_architecture() == systemtools.AARCH64:
-        COMPILER_UNIQUE_OPTION_MAP = {
-            'strict': ['mno-low-precision-recip-sqrt', 'mno-low-precision-sqrt', 'mno-low-precision-div'],
-            'precise': ['mno-low-precision-recip-sqrt', 'mno-low-precision-sqrt', 'mno-low-precision-div'],
-        }
+        no_recip_alternative = ['mno-low-precision-recip-sqrt', 'mno-low-precision-sqrt', 'mno-low-precision-div']
+        COMPILER_UNIQUE_OPTION_MAP['strict'] = no_recip_alternative
+        COMPILER_UNIQUE_OPTION_MAP['precise'] = no_recip_alternative
 
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {

--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -69,12 +69,13 @@ class Gcc(Compiler):
         DEFAULT_OPT_LEVEL: ['O2', 'ftree-vectorize'],
     }
 
-    # aarch64 does not support -mno-recip for precision. Based on
-    # https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html the following options are used instead
+    # gcc on aarch64 does not support -mno-recip, -mieee-fp, -mfno-math-errno...
+    # https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html
     if systemtools.get_cpu_architecture() == systemtools.AARCH64:
-        COMPILER_UNIQUE_OPTION_MAP['precise'] = ['mno-low-precision-recip-sqrt',
-                                                 'mno-low-precision-sqrt',
-                                                 'mno-low-precision-div']
+        COMPILER_UNIQUE_OPTION_MAP = {
+            'strict': ['mno-low-precision-recip-sqrt', 'mno-low-precision-sqrt', 'mno-low-precision-div'],
+            'precise': ['mno-low-precision-recip-sqrt', 'mno-low-precision-sqrt', 'mno-low-precision-div'],
+        }
 
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {


### PR DESCRIPTION
There are plenty more things missing from gcc on aarch64...

  - '-mno-recip', '-mieee-fp', and '-mfno-math-errno' are all gone.
  - A full pass over all the options needs to be done.   