### PR TITLE
Further GCC toolchain fixes for aarch64.

### DIFF
--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -69,12 +69,12 @@ class Gcc(Compiler):
         DEFAULT_OPT_LEVEL: ['O2', 'ftree-vectorize'],
     }
 
-    # aarch64 does not support -mno-recip for precision. Based on
-    # https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html the following options are used instead
+    # gcc on aarch64 does not support -mno-recip, -mieee-fp, -mfno-math-errno...
+    # https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html
     if systemtools.get_cpu_architecture() == systemtools.AARCH64:
-        COMPILER_UNIQUE_OPTION_MAP['precise'] = ['mno-low-precision-recip-sqrt',
-                                                 'mno-low-precision-sqrt',
-                                                 'mno-low-precision-div']
+        no_recip_alternative = ['mno-low-precision-recip-sqrt', 'mno-low-precision-sqrt', 'mno-low-precision-div']
+        COMPILER_UNIQUE_OPTION_MAP['strict'] = no_recip_alternative
+        COMPILER_UNIQUE_OPTION_MAP['precise'] = no_recip_alternative
 
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {


### PR DESCRIPTION
  - Both strict and precise use no-recip.
  - strict wants -mieee-fp. :-(