### PR TITLE
Exclude protobuf and pybind11 in createSubmoduleDeps

### DIFF
--- a/easybuild/scripts/createSubmoduleDeps.sh
+++ b/easybuild/scripts/createSubmoduleDeps.sh
@@ -20,13 +20,11 @@ if [[ "$(basename "$git_repo")" == "pytorch" ]]; then
     # Variable in EC containing the name of the thirdparty_dir
     thirdparty_var="local_pytorchthirdpartydir"
     # Repo names for dependencies that should be ignored
-    repo_ignore=(zstd nccl six enum34 ios-cmake ARM_NEON_2_x86_SSE clang-cindex-python3)
+    repo_ignore=(zstd nccl six enum34 ios-cmake ARM_NEON_2_x86_SSE clang-cindex-python3 protobuf pybind11)
     # Subdir of git_repo to ignore
     subdir_ignore=(
         onnx/third_party/pybind11
         onnx-tensorrt/third_party/onnx
-        protobuf/third_party/benchmark
-        protobuf/third_party/googletest
         tensorpipe/third_party/pybind11
     )
 fi


### PR DESCRIPTION
With the new EasyBlock those can be installed with EasyBuild and hence are no longer required to download