### PR TITLE
add path to pkg-config files in sysroot to $PKG_CONFIG_PATH when --sysroot is specified

### DIFF
--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -1039,7 +1039,7 @@ class Toolchain(object):
             # update $PKG_CONFIG_PATH to include sysroot location to pkg-config files (*.pc)
             sysroot_pc_paths = [os.path.join(sysroot, 'usr', libdir, 'pkgconfig') for libdir in ['lib', 'lib64']]
 
-            pkg_config_path = [p for p in os.getenv('PKG_CONFIG_PATH', '').split(':') if p]
+            pkg_config_path = [p for p in os.getenv('PKG_CONFIG_PATH', '').split(os.pathsep) if p]
 
             for sysroot_pc_path in sysroot_pc_paths:
                 if os.path.exists(sysroot_pc_path):
@@ -1048,7 +1048,7 @@ class Toolchain(object):
                         pkg_config_path.append(sysroot_pc_path)
 
             if pkg_config_path:
-                setvar('PKG_CONFIG_PATH', ':'.join(pkg_config_path))
+                setvar('PKG_CONFIG_PATH', os.pathsep.join(pkg_config_path))
 
     def _add_dependency_variables(self, names=None, cpp=None, ld=None):
         """ Add LDFLAGS and CPPFLAGS to the self.variables based on the dependencies

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -821,6 +821,9 @@ class Toolchain(object):
         :param rpath_include_dirs: extra directories to include in RPATH
         """
 
+        # take into account --sysroot configuration setting
+        self.handle_sysroot()
+
         # do all dependencies have a toolchain version?
         if deps is None:
             deps = []
@@ -1024,6 +1027,28 @@ class Toolchain(object):
                 self.log.info("RPATH wrapper script for %s: %s (log: %s)", orig_cmd, which(cmd), rpath_wrapper_log)
             else:
                 self.log.debug("Not installing RPATH wrapper for non-existing command '%s'", cmd)
+
+    def handle_sysroot(self):
+        """
+        Extra stuff to be done when alternate system root is specified via --sysroot EasyBuild configuration option.
+
+        * Update $PKG_CONFIG_PATH to include sysroot location to pkg-config files (*.pc).
+        """
+        sysroot = build_option('sysroot')
+        if sysroot:
+            # update $PKG_CONFIG_PATH to include sysroot location to pkg-config files (*.pc)
+            sysroot_pc_paths = [os.path.join(sysroot, 'usr', libdir, 'pkgconfig') for libdir in ['lib', 'lib64']]
+
+            pkg_config_path = [p for p in os.getenv('PKG_CONFIG_PATH', '').split(':') if p]
+
+            for sysroot_pc_path in sysroot_pc_paths:
+                if os.path.exists(sysroot_pc_path):
+                    # avoid adding duplicate paths
+                    if not any(os.path.exists(x) and os.path.samefile(x, sysroot_pc_path) for x in pkg_config_path):
+                        pkg_config_path.append(sysroot_pc_path)
+
+            if pkg_config_path:
+                setvar('PKG_CONFIG_PATH', ':'.join(pkg_config_path))
 
     def _add_dependency_variables(self, names=None, cpp=None, ld=None):
         """ Add LDFLAGS and CPPFLAGS to the self.variables based on the dependencies

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -196,13 +196,13 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(os.getenv('PKG_CONFIG_PATH'), sysroot_pkgconfig)
 
         # existing $PKG_CONFIG_PATH value is retained
-        test_pkg_config_path = ':'.join([self.test_prefix, '/foo/bar'])
+        test_pkg_config_path = os.pathsep.join([self.test_prefix, '/foo/bar'])
         os.environ['PKG_CONFIG_PATH'] = test_pkg_config_path
         tc.prepare()
-        self.assertEqual(os.getenv('PKG_CONFIG_PATH'), test_pkg_config_path + ':' + sysroot_pkgconfig)
+        self.assertEqual(os.getenv('PKG_CONFIG_PATH'), test_pkg_config_path + os.pathsep + sysroot_pkgconfig)
 
         # no duplicate paths are added
-        test_pkg_config_path = ':'.join([self.test_prefix, sysroot_pkgconfig, '/foo/bar'])
+        test_pkg_config_path = os.pathsep.join([self.test_prefix, sysroot_pkgconfig, '/foo/bar'])
         os.environ['PKG_CONFIG_PATH'] = test_pkg_config_path
         tc.prepare()
         self.assertEqual(os.getenv('PKG_CONFIG_PATH'), test_pkg_config_path)


### PR DESCRIPTION
Setting `$PKG_CONFIG_PATH` to include the alternate sysroot location fixes problems with `pkg-config` not finding libraries like `zlib` in case they are available in the alternate sysroot and have been filtered out as proper EasyBuild dependency via `--filter-deps`.