### PR TITLE
avoid appending lib stubs pattern to RPATH filter over and over again

### DIFF
--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -953,7 +953,9 @@ class Toolchain(object):
 
         # always include filter for 'stubs' library directory,
         # cfr. https://github.com/easybuilders/easybuild-framework/issues/2683
-        rpath_filter_dirs.append('.*/lib(64)?/stubs/?')
+        lib_stubs_pattern = '.*/lib(64)?/stubs/?'
+        if lib_stubs_pattern not in rpath_filter_dirs:
+            rpath_filter_dirs.append(lib_stubs_pattern)
 
         # directory where all wrappers will be placed
         wrappers_dir = os.path.join(tempfile.mkdtemp(), RPATH_WRAPPERS_SUBDIR)


### PR DESCRIPTION
Requires to avoid that this pattern is added again for every extension that is being installed, since `EasyBlock.rpath_filter_dirs` is passed down to `Toolchain.prepare` every time, which leads to:

```
== 2020-09-28 09:03:43,588 toolchain.py:973 DEBUG Combined RPATH filter: '/lib.*,/usr.*,/tmp/eb-fx9yc8f8.*,
/tmp/easybuild/build/RbundleBioconductor/3.11/foss-2020a-R-4.0.0.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,
.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,
.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.
*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,
.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,
.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,
.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,
.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,
.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*,.*/lib(64)?/stubs/?.*'
```

reported by @terjekv