### PR TITLE
Check for _VERSION and _PREFIX Cray environment variables with both software and module name

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1267,7 +1267,7 @@ class EasyConfig(object):
             (prefix_var_name % name, version_var_name % name)
             for name in [
                 soft_name_in_mod_name,
-                convert_name(mod_name.replace("-", "_"), upper=True),
+                convert_name(mod_name.split('/')[0].replace("-", "_"), upper=True),
             ]
             for prefix_var_name, version_var_name in var_name_pairs
         ]

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1251,9 +1251,9 @@ class EasyConfig(object):
                 soft_name = soft_name[len(cray_prefix):]
 
         # determine software name to use in names of environment variables (upper case, '-' becomes '_')
-        soft_name_in_mod_name = convert_name(soft_name.replace('-', '_'), upper=True)
+        soft_name_env_var_infix = convert_name(soft_name.replace('-', '_'), upper=True)
 
-        var_name_pairs = [
+        var_name_pairs_templates = [
             ('CRAY_%s_PREFIX', 'CRAY_%s_VERSION'),
             ('CRAY_%s_PREFIX_DIR', 'CRAY_%s_VERSION'),
             ('CRAY_%s_DIR', 'CRAY_%s_VERSION'),
@@ -1263,14 +1263,19 @@ class EasyConfig(object):
             ('%s_ROOT', '%s_VERSION'),
             ('%s_HOME', '%s_VERSION'),
         ]
-        var_name_pairs = [
-            (prefix_var_name % name, version_var_name % name)
-            for name in [
-                soft_name_in_mod_name,
-                convert_name(mod_name.split('/')[0].replace("-", "_"), upper=True),
-            ]
-            for prefix_var_name, version_var_name in var_name_pairs
-        ]
+
+        def mk_var_name_pair(var_name_pair, name):
+            """Complete variable name pair template using provided name."""
+            return (var_name_pair[0] % name, var_name_pair[1] % name)
+
+        var_name_pairs = [mk_var_name_pair(x, soft_name_env_var_infix) for x in var_name_pairs_templates]
+
+        # also consider name based on module name for environment variables to check
+        # for example, for the cray-netcdf-hdf5parallel module we should also check $CRAY_NETCDF_HDF5PARALLEL_VERSION
+        mod_name_env_var_infix = convert_name(mod_name.split('/')[0].replace('-', '_'), upper=True)
+
+        if mod_name_env_var_infix != soft_name_env_var_infix:
+            var_name_pairs.extend([mk_var_name_pair(x, mod_name_env_var_infix) for x in var_name_pairs_templates])
 
         for prefix_var_name, version_var_name in var_name_pairs:
             prefix = self.modules_tool.get_setenv_value_from_modulefile(mod_name, prefix_var_name)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1263,11 +1263,16 @@ class EasyConfig(object):
             ('%s_ROOT', '%s_VERSION'),
             ('%s_HOME', '%s_VERSION'),
         ]
+        var_name_pairs = [
+            (prefix_var_name % name, version_var_name % name)
+            for name in [
+                soft_name_in_mod_name,
+                convert_name(mod_name.replace("-", "_"), upper=True),
+            ]
+            for prefix_var_name, version_var_name in var_name_pairs
+        ]
 
         for prefix_var_name, version_var_name in var_name_pairs:
-            prefix_var_name = prefix_var_name % soft_name_in_mod_name
-            version_var_name = version_var_name % soft_name_in_mod_name
-
             prefix = self.modules_tool.get_setenv_value_from_modulefile(mod_name, prefix_var_name)
             version = self.modules_tool.get_setenv_value_from_modulefile(mod_name, version_var_name)
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1479,6 +1479,7 @@ class EasyConfigTest(EnhancedTestCase):
         ectxt += "  ('test/9.7.5', EXTERNAL_MODULE), "
         ectxt += "  ('pi/3.14', EXTERNAL_MODULE), "
         ectxt += "  ('hidden/.1.2.3', EXTERNAL_MODULE), "
+        ectxt += "  ('cray-netcdf-hdf5parallel/1.10.6', EXTERNAL_MODULE), "
         ectxt += "]"
         ectxt += "\nbuilddependencies = [('somebuilddep/0.1', EXTERNAL_MODULE)]"
         ectxt += "\ntoolchain = {'name': 'GCC', 'version': '6.4.0-2.28'}"
@@ -1493,13 +1494,13 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(builddeps[0]['external_module'], True)
 
         deps = ec.dependencies()
-        self.assertEqual(len(deps), 7)
+        self.assertEqual(len(deps), 8)
         correct_deps = ['somebuilddep/0.1', 'intel/2018a', 'GCC/6.4.0-2.28', 'foobar/1.2.3',
-                        'test/9.7.5', 'pi/3.14', 'hidden/.1.2.3']
+                        'test/9.7.5', 'pi/3.14', 'hidden/.1.2.3', 'cray-netcdf-hdf5parallel/1.10.6']
         self.assertEqual([d['short_mod_name'] for d in deps], correct_deps)
         self.assertEqual([d['full_mod_name'] for d in deps], correct_deps)
-        self.assertEqual([d['external_module'] for d in deps], [True, False, True, True, True, True, True])
-        self.assertEqual([d['hidden'] for d in deps], [False, False, False, False, False, False, True])
+        self.assertEqual([d['external_module'] for d in deps], [True, False, True, True, True, True, True, True])
+        self.assertEqual([d['hidden'] for d in deps], [False, False, False, False, False, False, True, False])
         # no metadata available for deps
         expected = [{}] * len(deps)
         self.assertEqual([d['external_module_metadata'] for d in deps], expected)
@@ -1517,6 +1518,13 @@ class EasyConfigTest(EnhancedTestCase):
         ])
         write_file(os.path.join(mod_dir, 'pi/3.14'), pi_mod_txt)
 
+        cray_netcdf_mod_txt = '\n'.join([
+            "#%Module",
+            "setenv CRAY_NETCDF_HDF5PARALLEL_PREFIX /software/cray-netcdf-hdf5parallel/1.10.6",
+            "setenv CRAY_NETCDF_HDF5PARALLEL_VERSION 1.10.6",
+        ])
+        write_file(os.path.join(mod_dir, 'cray-netcdf-hdf5parallel/1.10.6'), cray_netcdf_mod_txt)
+
         # foobar module with different version than the one used as an external dep;
         # will still be used for probing (as a fallback)
         foobar_mod_txt = '\n'.join([
@@ -1529,7 +1537,7 @@ class EasyConfigTest(EnhancedTestCase):
         ec = EasyConfig(toy_ec)
         deps = ec.dependencies()
 
-        self.assertEqual(len(deps), 7)
+        self.assertEqual(len(deps), 8)
 
         for idx in [0, 1, 2, 4, 6]:
             self.assertEqual(deps[idx]['external_module_metadata'], {})
@@ -1550,6 +1558,14 @@ class EasyConfigTest(EnhancedTestCase):
         }
         self.assertEqual(deps[5]['external_module_metadata'], pi_metadata)
 
+        self.assertEqual(deps[7]['full_mod_name'], 'cray-netcdf-hdf5parallel/1.10.6')
+        cray_netcdf_metadata = {
+            'name': ['netcdf-hdf5parallel'],
+            'prefix': '/software/cray-netcdf-hdf5parallel/1.10.6',
+            'version': ['1.10.6'],
+        }
+        self.assertEqual(deps[7]['external_module_metadata'], cray_netcdf_metadata)
+
         # provide file with partial metadata for some external modules;
         # metadata obtained from probing modules should be added to it...
         metadata = os.path.join(self.test_prefix, 'external_modules_metadata.cfg')
@@ -1563,6 +1579,9 @@ class EasyConfigTest(EnhancedTestCase):
             'version = 1.2.3',
             '[test]',
             'name = TEST',
+            '[cray-netcdf-hdf5parallel/1.10.6]',
+            'name = HDF5',
+            'version = 1.10.6',
         ])
         write_file(metadata, metadatatxt)
         build_options = {
@@ -1573,7 +1592,7 @@ class EasyConfigTest(EnhancedTestCase):
         ec = EasyConfig(toy_ec)
         deps = ec.dependencies()
 
-        self.assertEqual(len(deps), 7)
+        self.assertEqual(len(deps), 8)
 
         for idx in [0, 1, 2, 6]:
             self.assertEqual(deps[idx]['external_module_metadata'], {})
@@ -1600,6 +1619,14 @@ class EasyConfigTest(EnhancedTestCase):
         }
         self.assertEqual(deps[5]['external_module_metadata'], pi_metadata)
 
+        self.assertEqual(deps[7]['full_mod_name'], 'cray-netcdf-hdf5parallel/1.10.6')
+        cray_netcdf_metadata = {
+            'name': ['HDF5'],
+            'prefix': '/software/cray-netcdf-hdf5parallel/1.10.6',
+            'version': ['1.10.6'],
+        }
+        self.assertEqual(deps[7]['external_module_metadata'], cray_netcdf_metadata)
+
         # provide file with full metadata for external modules;
         # this data wins over probed metadata from modules (for backwards compatibility)
         metadatatxt = '\n'.join([
@@ -1615,6 +1642,10 @@ class EasyConfigTest(EnhancedTestCase):
             'name = foo,bar',
             'version = 1.2.3, 3.2.1',
             'prefix = /foo/bar',
+            '[cray-netcdf-hdf5parallel/1.10.6]',
+            'name = HDF5',
+            'version = 1.10.6-1',
+            'prefix = /netcdf-par/1.10.6',
         ])
         write_file(metadata, metadatatxt)
         build_options = {
@@ -1623,32 +1654,42 @@ class EasyConfigTest(EnhancedTestCase):
         }
         init_config(build_options=build_options)
         ec = EasyConfig(toy_ec)
-        self.assertEqual(ec.dependencies()[3]['short_mod_name'], 'foobar/1.2.3')
-        self.assertEqual(ec.dependencies()[3]['external_module'], True)
+        deps = ec.dependencies()
+
+        self.assertEqual(deps[3]['short_mod_name'], 'foobar/1.2.3')
+        self.assertEqual(deps[3]['external_module'], True)
         metadata = {
             'name': ['foo', 'bar'],
             'version': ['1.2.3', '3.2.1'],
             'prefix': '/foo/bar',
         }
-        self.assertEqual(ec.dependencies()[3]['external_module_metadata'], metadata)
+        self.assertEqual(deps[3]['external_module_metadata'], metadata)
 
-        self.assertEqual(ec.dependencies()[4]['short_mod_name'], 'test/9.7.5')
-        self.assertEqual(ec.dependencies()[4]['external_module'], True)
+        self.assertEqual(deps[4]['short_mod_name'], 'test/9.7.5')
+        self.assertEqual(deps[4]['external_module'], True)
         metadata = {
             'name': ['test'],
             'version': ['9.7.5'],
             'prefix': 'TEST_INC/..',
         }
-        self.assertEqual(ec.dependencies()[4]['external_module_metadata'], metadata)
+        self.assertEqual(deps[4]['external_module_metadata'], metadata)
 
-        self.assertEqual(ec.dependencies()[5]['short_mod_name'], 'pi/3.14')
-        self.assertEqual(ec.dependencies()[5]['external_module'], True)
+        self.assertEqual(deps[5]['short_mod_name'], 'pi/3.14')
+        self.assertEqual(deps[5]['external_module'], True)
         metadata = {
             'name': ['PI'],
             'version': ['3.14'],
             'prefix': 'PI_PREFIX',
         }
-        self.assertEqual(ec.dependencies()[5]['external_module_metadata'], metadata)
+        self.assertEqual(deps[5]['external_module_metadata'], metadata)
+
+        self.assertEqual(deps[7]['full_mod_name'], 'cray-netcdf-hdf5parallel/1.10.6')
+        cray_netcdf_metadata = {
+            'name': ['HDF5'],
+            'prefix': '/netcdf-par/1.10.6',
+            'version': ['1.10.6-1'],
+        }
+        self.assertEqual(deps[7]['external_module_metadata'], cray_netcdf_metadata)
 
         # get rid of modules first
         self.modtool.unuse(mod_dir)
@@ -1663,11 +1704,13 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(os.environ.get('EBROOTBAR'), '/foo/bar')
         self.assertEqual(os.environ.get('EBROOTFOO'), '/foo/bar')
         self.assertEqual(os.environ.get('EBROOTHIDDEN'), None)
+        self.assertEqual(os.environ.get('EBROOTHDF5'), '/netcdf-par/1.10.6')
         self.assertEqual(os.environ.get('EBROOTPI'), '/test/prefix/PI')
         self.assertEqual(os.environ.get('EBROOTTEST'), '/test/prefix/test/include/../')
         self.assertEqual(os.environ.get('EBVERSIONBAR'), '3.2.1')
         self.assertEqual(os.environ.get('EBVERSIONFOO'), '1.2.3')
         self.assertEqual(os.environ.get('EBVERSIONHIDDEN'), None)
+        self.assertEqual(os.environ.get('EBVERSIONHDF5'), '1.10.6-1')
         self.assertEqual(os.environ.get('EBVERSIONPI'), '3.14')
         self.assertEqual(os.environ.get('EBVERSIONTEST'), '9.7.5')
 


### PR DESCRIPTION
Cray should include the variables `<MODULE_NAME>_VERSION` and `<MODULE_NAME>_PREFIX` in the module. The module name is sometimes different than the software name, so EasyBuild should check for both cases.