### PR TITLE
Fix missing string template on Error for extension sources

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -555,7 +555,7 @@ class EasyBlock(object):
                             if len(sources) == 1:
                                 source = sources[0]
                             else:
-                                error_msg = "'sources' spec for %s in exts_list must be single element list"
+                                error_msg = "'sources' spec for %s in exts_list must be single element list. Is: %s"
                                 raise EasyBuildError(error_msg, ext_name, sources)
                         else:
                             source = sources


### PR DESCRIPTION
There are 2 values but only one `%s`

Bug introduced in https://github.com/easybuilders/easybuild-framework/commit/79aa779b07d9bfc9e25b3990f0b2527a4540208e by @boegel (you might want to have a look)