### PR TITLE
fix compatibility with Python 3.9 by renaming fancy root logger

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
         modules_tool: [Lmod-7.8.22, Lmod-8.2.9, modules-tcl-1.147, modules-3.2.10, modules-4.1.4]
         module_syntax: [Lua, Tcl]
         # exclude some configuration for non-Lmod modules tool:
@@ -25,24 +25,30 @@ jobs:
             python: 3.7
           - modules_tool: modules-tcl-1.147
             python: 3.8
+          - modules_tool: modules-tcl-1.147
+            python: 3.9
           - modules_tool: modules-3.2.10
             python: 3.5
           - modules_tool: modules-3.2.10
             python: 3.7
           - modules_tool: modules-3.2.10
             python: 3.8
+          - modules_tool: modules-3.2.10
+            python: 3.9
           - modules_tool: modules-4.1.4
             python: 3.5
           - modules_tool: modules-4.1.4
             python: 3.7
           - modules_tool: modules-4.1.4
             python: 3.8
+          - modules_tool: modules-4.1.4
+            python: 3.9
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
 
     - name: set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -167,6 +167,14 @@ jobs:
           if [ -f $HOME/moduleshome ]; then export MODULESHOME=$(cat $HOME/moduleshome); fi
           source $(cat $HOME/mod_init); type module
 
+          # define $EASYBUILD_MODULES_TOOL only for oldest module tools
+          # (for Lmod and EnvironmentModules 4.x the bootstrap script should correctly auto-detect the modules tool)
+          if [[ ${{matrix.modules_tool}} =~ ^modules-tcl- ]]; then
+            export EASYBUILD_MODULES_TOOL=EnvironmentModulesTcl
+          elif [[ ${{matrix.modules_tool}} =~ ^modules-3 ]]; then
+            export EASYBUILD_MODULES_TOOL=EnvironmentModulesC
+          fi
+
           # version and SHA256 checksum are hardcoded below to avoid forgetting to update the version in the script along with contents
           EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
           EB_BOOTSTRAP_SHA256SUM=$(sha256sum easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -163,6 +163,10 @@ jobs:
       # until an EasyBuild release that is compatible with Python 3.9 is available
       if: ${{ matrix.python != 3.9 }}
       run: |
+          # (re)initialize environment for modules tool
+          if [ -f $HOME/moduleshome ]; then export MODULESHOME=$(cat $HOME/moduleshome); fi
+          source $(cat $HOME/mod_init); type module
+
           # version and SHA256 checksum are hardcoded below to avoid forgetting to update the version in the script along with contents
           EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
           EB_BOOTSTRAP_SHA256SUM=$(sha256sum easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -166,6 +166,8 @@ jobs:
           # (re)initialize environment for modules tool
           if [ -f $HOME/moduleshome ]; then export MODULESHOME=$(cat $HOME/moduleshome); fi
           source $(cat $HOME/mod_init); type module
+          # also pick up changes to $PATH set by sourcing $HOME/mod_init
+          export PATH=$(cat $HOME/path)
 
           # define $EASYBUILD_MODULES_TOOL only for oldest module tools
           # (for Lmod and EnvironmentModules 4.x the bootstrap script should correctly auto-detect the modules tool)

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -116,7 +116,7 @@ jobs:
           export PREFIX=/tmp/$USER/$GITHUB_SHA
           pip install --prefix $PREFIX dist/easybuild-framework*tar.gz
 
-    - name: run test suite & test bootstrap script
+    - name: run test suite
       env:
         EB_VERBOSE: 1
         EASYBUILD_MODULE_SYNTAX: ${{matrix.module_syntax}}
@@ -158,6 +158,11 @@ jobs:
           PRINTED_MSG=$(egrep -v "${IGNORE_PATTERNS}" test_framework_suite.log | grep '\.\n*[A-Za-z]' || true)
           test "x$PRINTED_MSG" = "x" || (echo "ERROR: Found printed messages in output of test suite\n${PRINTED_MSG}" && exit 1)
 
+    - name: test bootstrap script
+      # skip testing of bootstrap script with Python 3.9,
+      # until an EasyBuild release that is compatible with Python 3.9 is available
+      if: ${{ matrix.python != 3.9 }}
+      run: |
           # version and SHA256 checksum are hardcoded below to avoid forgetting to update the version in the script along with contents
           EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
           EB_BOOTSTRAP_SHA256SUM=$(sha256sum easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')

--- a/easybuild/base/fancylogger.py
+++ b/easybuild/base/fancylogger.py
@@ -456,7 +456,7 @@ def getLogger(name=None, fname=False, clsname=False, fancyrecord=None):
     if not is_fancyroot():
         # deliberately not calling getRootLoggerName function to determine actual root logger name,
         # because it is prohibitively expensive in some texts (even when using 'python -O')
-        nameparts.append('root')
+        nameparts.append('fancyroot')
 
     if fancyrecord is None:
         # Altough we could set it as default value in the function definition

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -69,7 +69,7 @@ class BuildLogTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, 'BOOM', raise_easybuilderror, 'BOOM')
         logToFile(tmplog, enable=False)
 
-        log_re = re.compile(r"^root ::.* BOOM \(at .*:[0-9]+ in [a-z_]+\)$", re.M)
+        log_re = re.compile(r"^fancyroot ::.* BOOM \(at .*:[0-9]+ in [a-z_]+\)$", re.M)
         logtxt = open(tmplog, 'r').read()
         self.assertTrue(log_re.match(logtxt), "%s matches %s" % (log_re.pattern, logtxt))
 
@@ -132,16 +132,16 @@ class BuildLogTest(EnhancedTestCase):
         logtxt = read_file(tmplog)
 
         expected_logtxt = '\n'.join([
-            r"root.test_easybuildlog \[DEBUG\] :: 123 debug",
-            r"root.test_easybuildlog \[INFO\] :: foobar info",
-            r"root.test_easybuildlog \[WARNING\] :: justawarning",
-            r"root.test_easybuildlog \[WARNING\] :: Deprecated functionality.*anotherwarning.*",
-            r"root.test_easybuildlog \[WARNING\] :: Deprecated functionality.*onemorewarning.*",
-            r"root.test_easybuildlog \[WARNING\] :: Deprecated functionality.*lastwarning.*",
-            r"root.test_easybuildlog \[WARNING\] :: Deprecated functionality.*thisisnotprinted.*",
-            r"root.test_easybuildlog \[ERROR\] :: EasyBuild crashed with an error \(at .* in .*\): kaput",
-            r"root.test_easybuildlog \[ERROR\] :: EasyBuild crashed with an error \(at .* in .*\): err: msg: %s",
-            r"root.test_easybuildlog \[ERROR\] :: .*EasyBuild encountered an exception \(at .* in .*\): oops",
+            r"fancyroot.test_easybuildlog \[DEBUG\] :: 123 debug",
+            r"fancyroot.test_easybuildlog \[INFO\] :: foobar info",
+            r"fancyroot.test_easybuildlog \[WARNING\] :: justawarning",
+            r"fancyroot.test_easybuildlog \[WARNING\] :: Deprecated functionality.*anotherwarning.*",
+            r"fancyroot.test_easybuildlog \[WARNING\] :: Deprecated functionality.*onemorewarning.*",
+            r"fancyroot.test_easybuildlog \[WARNING\] :: Deprecated functionality.*lastwarning.*",
+            r"fancyroot.test_easybuildlog \[WARNING\] :: Deprecated functionality.*thisisnotprinted.*",
+            r"fancyroot.test_easybuildlog \[ERROR\] :: EasyBuild crashed with an error \(at .* in .*\): kaput",
+            r"fancyroot.test_easybuildlog \[ERROR\] :: EasyBuild crashed with an error \(at .* in .*\): err: msg: %s",
+            r"fancyroot.test_easybuildlog \[ERROR\] :: .*EasyBuild encountered an exception \(at .* in .*\): oops",
             '',
         ])
         logtxt_regex = re.compile(r'^%s' % expected_logtxt, re.M)
@@ -165,10 +165,10 @@ class BuildLogTest(EnhancedTestCase):
         logToFile(tmplog, enable=False)
         logtxt = read_file(tmplog)
         expected_logtxt = '\n'.join([
-            r"root.test_easybuildlog \[WARNING\] :: bleh",
-            r"root.test_easybuildlog \[INFO\] :: 4\+2 = 42",
-            r"root.test_easybuildlog \[DEBUG\] :: this is just a test",
-            r"root.test_easybuildlog \[ERROR\] :: EasyBuild crashed with an error \(at .* in .*\): foo baz baz",
+            r"fancyroot.test_easybuildlog \[WARNING\] :: bleh",
+            r"fancyroot.test_easybuildlog \[INFO\] :: 4\+2 = 42",
+            r"fancyroot.test_easybuildlog \[DEBUG\] :: this is just a test",
+            r"fancyroot.test_easybuildlog \[ERROR\] :: EasyBuild crashed with an error \(at .* in .*\): foo baz baz",
             '',
         ])
         logtxt_regex = re.compile(r'^%s' % expected_logtxt, re.M)
@@ -217,7 +217,7 @@ class BuildLogTest(EnhancedTestCase):
         logToFile(tmplog, enable=False)
         logtxt = read_file(tmplog)
 
-        prefix = 'root.test_easybuildlog'
+        prefix = 'fancyroot.test_easybuildlog'
         devel_msg = r"%s \[DEVEL\] :: tmi" % prefix
         debug_msg = r"%s \[DEBUG\] :: gdb" % prefix
         info_msg = r"%s \[INFO\] :: fyi" % prefix


### PR DESCRIPTION
Requires because of changed behavior in Python's `getLogger` function, see https://github.com/python/cpython/pull/15077

Fix for:

```
 >> python -m easybuild.main --version
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.0/x64/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/hostedtoolcache/Python/3.9.0/x64/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/runner/work/easybuild-framework/easybuild-framework/easybuild/main.py", line 46, in <module>
    from easybuild.tools.build_log import EasyBuildError, print_error, print_msg, stop_logging
  File "/home/runner/work/easybuild-framework/easybuild-framework/easybuild/tools/build_log.py", line 191, in <module>
    del _init_fancylog.manager.loggerDict[_init_fancylog.name]
KeyError: 'root'
```