### PR TITLE
also remove empty checksums list specified in easyconfig file when using --inject-checksums

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3657,11 +3657,11 @@ def inject_checksums(ecs, checksum_type):
 
         checksums_txt = '\n'.join(checksum_lines)
 
-        # if any checksums were provided before, get rid of them
-        if app.cfg['checksums']:
+        # if 'checksums' is specified in easyconfig file, get rid of it (even if it's just an empty list)
+        checksums_regex = re.compile(r'^checksums(?:.|\n)+?\]\s*$', re.M)
+        if checksums_regex.search(ectxt):
             _log.debug("Removing existing 'checksums' easyconfig parameter definition...")
-            regex = re.compile(r'^checksums(?:.|\n)+?\]\s*$', re.M)
-            ectxt = regex.sub('', ectxt)
+            ectxt = checksums_regex.sub('', ectxt)
 
         # it is possible no sources (and hence patches) are listed, e.g. for 'bundle' easyconfigs
         if app.src:

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5128,6 +5128,32 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         self.assertEqual(ec['checksums'], checksums)
 
+        # check whether empty list of checksums is stripped out by --inject-checksums
+        toy_ec_txt = read_file(toy_ec)
+
+        regex = re.compile(r'^checksums(?:.|\n)*?\]\s*$', re.M)
+        toy_ec_txt = regex.sub('', toy_ec_txt)
+
+        toy_ec_txt += "\nchecksums = []"
+
+        write_file(test_ec, toy_ec_txt)
+        args = [test_ec, '--inject-checksums', '--force']
+        self._run_mock_eb(args, raise_error=True, strip=True)
+
+        ec_txt = read_file(test_ec)
+        regex = re.compile(r"^checksums = \[\]", re.M)
+        self.assertFalse(regex.search(ec_txt), "Pattern '%s' should not be found in: %s" % (regex.pattern, ec_txt))
+
+        ec = EasyConfigParser(test_ec).get_config_dict()
+        expected_checksums = [
+            '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',
+            '81a3accc894592152f81814fbf133d39afad52885ab52c25018722c7bda92487',
+            '4196b56771140d8e2468fb77f0240bc48ddbf5dabafe0713d612df7fafb1e458'
+        ]
+        self.assertEqual(ec['checksums'], expected_checksums)
+
+        # passing easyconfig filename as argument to --inject-checksums results in error being reported,
+        # because it's not a valid type of checksum
         args = ['--inject-checksums', test_ec]
         self.mock_stdout(True)
         self.mock_stderr(True)


### PR DESCRIPTION
fixes #3459