### PR TITLE
take into account multiple easyblock PRs when uploading test reports

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1454,11 +1454,11 @@ def set_up_configuration(args=None, logfile=None, testing=False, silent=False):
     init_build_options(build_options=build_options, cmdline_options=options)
 
     # done here instead of in _postprocess_include because github integration requires build_options to be initialized
-    try:
-        easyblock_prs = map(int, eb_go.options.include_easyblocks_from_pr)
-    except ValueError:
-        raise EasyBuildError("Argument to --include-easyblocks-from-pr must be a comma separated list of PR numbers.")
-    if easyblock_prs:
+    if eb_go.options.include_easyblocks_from_pr:
+        try:
+            easyblock_prs = map(int, eb_go.options.include_easyblocks_from_pr)
+        except ValueError:
+            raise EasyBuildError("Argument to --include-easyblocks-from-pr must be a comma separated list of PR #s.")
 
         if eb_go.options.include_easyblocks:
             # check if you are including the same easyblock twice


### PR DESCRIPTION
follow-up to #3480

when used with --from-pr, it simply lists the multiple easyblocks in the comment (e.g. https://github.com/easybuilders/easybuild-easyconfigs/pull/11489#issuecomment-716089715)

when used without --from-pr and with multiple easyblock PRs, this leads to some duplication (e.g. https://github.com/easybuilders/easybuild-easyblocks/pull/2191#issuecomment-716087172, https://github.com/easybuilders/easybuild-easyblocks/pull/2205#issuecomment-716087176), these comments should probably only list the easyconfigs related to the easyblocks in each PR...