### PR TITLE
don't change directory in download_repo function

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -50,7 +50,7 @@ from easybuild.framework.easyconfig.easyconfig import process_easyconfig
 from easybuild.framework.easyconfig.parser import EasyConfigParser
 from easybuild.tools.build_log import EasyBuildError, print_msg, print_warning
 from easybuild.tools.config import build_option
-from easybuild.tools.filetools import apply_patch, change_dir, copy_dir, copy_easyblocks, copy_framework_files
+from easybuild.tools.filetools import apply_patch, copy_dir, copy_easyblocks, copy_framework_files
 from easybuild.tools.filetools import det_patched_files, download_file, extract_file
 from easybuild.tools.filetools import get_easyblock_class_name, mkdir, read_file, symlink, which, write_file
 from easybuild.tools.py2vs3 import HTTPError, URLError, ascii_letters, urlopen
@@ -364,7 +364,6 @@ def download_repo(repo=GITHUB_EASYCONFIGS_REPO, branch='master', account=GITHUB_
     _log.debug("%s downloaded to %s, extracting now" % (base_name, path))
 
     base_dir = extract_file(target_path, path, forced=True, change_into_dir=False)
-    change_dir(base_dir)
     extracted_path = os.path.join(base_dir, extracted_dir_name)
 
     # check if extracted_path exists

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -345,6 +345,8 @@ class GithubTest(EnhancedTestCase):
             print("Skipping test_download_repo, no GitHub token available?")
             return
 
+        cwd = os.getcwd()
+
         # default: download tarball for master branch of easybuilders/easybuild-easyconfigs repo
         path = gh.download_repo(path=self.test_prefix, github_user=GITHUB_TEST_ACCOUNT)
         repodir = os.path.join(self.test_prefix, 'easybuilders', 'easybuild-easyconfigs-master')
@@ -353,6 +355,9 @@ class GithubTest(EnhancedTestCase):
         shafile = os.path.join(repodir, 'latest-sha')
         self.assertTrue(re.match('^[0-9a-f]{40}$', read_file(shafile)))
         self.assertTrue(os.path.exists(os.path.join(repodir, 'easybuild', 'easyconfigs', 'f', 'foss', 'foss-2019b.eb')))
+
+        # current directory should not have changed after calling download_repo
+        self.assertTrue(os.path.samefile(cwd, os.getcwd()))
 
         # existing downloaded repo is not reperformed, except if SHA is different
         account, repo, branch = 'boegel', 'easybuild-easyblocks', 'develop'


### PR DESCRIPTION
fleshed out from #3482

The `change_dir` done by the `download_repo` function is a nasty side effect, and not actually needed at all for the implementation of it. In addition, none of the functions that call out to `download_repo` rely on this side effect, so it's a change that's safe to make as a bug fix.

fixes #3283