### PR TITLE
also inject -rpath options for all entries in $LIBRARY_PATH in RPATH wrappers

### DIFF
--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -81,7 +81,6 @@ while idx < len(args):
             add_rpath_args = False
         cmd_args.append(arg)
 
-    # FIXME: also consider $LIBRARY_PATH?
     # FIXME: support to hard inject additional library paths?
     # FIXME: support to specify list of path prefixes that should not be RPATH'ed into account?
     # FIXME skip paths in /tmp, build dir, etc.?
@@ -118,6 +117,14 @@ while idx < len(args):
         cmd_args.append(arg)
 
     idx += 1
+
+# also inject -rpath options for all entries in $LIBRARY_PATH,
+# unless they are there already
+for lib_path in os.getenv('LIBRARY_PATH', '').split(os.pathsep):
+    if lib_path and (rpath_filter is None or not rpath_filter.match(lib_path)):
+        rpath_arg = flag_prefix + '-rpath=%s' % lib_path
+        if rpath_arg not in cmd_args_rpath:
+            cmd_args_rpath.append(rpath_arg)
 
 if add_rpath_args:
     # try to make sure that RUNPATH is not used by always injecting --disable-new-dtags

--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -95,14 +95,15 @@ while idx < len(args):
         else:
             lib_path = arg[2:]
 
-        if os.path.isabs(lib_path) and (rpath_filter is None or not rpath_filter.match(lib_path)):
+        if lib_path and os.path.isabs(lib_path) and (rpath_filter is None or not rpath_filter.match(lib_path)):
             # inject -rpath flag in front for every -L with an absolute path,
             # also retain the -L flag (without reordering!)
             cmd_args_rpath.append(flag_prefix + '-rpath=%s' % lib_path)
             cmd_args.append('-L%s' % lib_path)
         else:
-            # don't RPATH in relative paths;
-            # it doesn't make much sense, and it can also break the build because it may result in reordering lib paths
+            # don't RPATH in empty or relative paths, or paths that are filtered out;
+            # linking relative paths via RPATH doesn't make much sense,
+            # and it can also break the build because it may result in reordering lib paths
             cmd_args.append('-L%s' % lib_path)
 
     # replace --enable-new-dtags with --disable-new-dtags if it's used;
@@ -121,7 +122,7 @@ while idx < len(args):
 # also inject -rpath options for all entries in $LIBRARY_PATH,
 # unless they are there already
 for lib_path in os.getenv('LIBRARY_PATH', '').split(os.pathsep):
-    if lib_path and (rpath_filter is None or not rpath_filter.match(lib_path)):
+    if lib_path and os.path.isabs(lib_path) and (rpath_filter is None or not rpath_filter.match(lib_path)):
         rpath_arg = flag_prefix + '-rpath=%s' % lib_path
         if rpath_arg not in cmd_args_rpath:
             cmd_args_rpath.append(rpath_arg)

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1729,6 +1729,11 @@ class ToolchainTest(EnhancedTestCase):
 
     def test_rpath_args_script(self):
         """Test rpath_args.py script"""
+
+        # $LIBRARY_PATH affects result of rpath_args.py, so make sure it's not set
+        if 'LIBRARY_PATH' in os.environ:
+            del os.environ['LIBRARY_PATH']
+
         script = find_eb_script('rpath_args.py')
 
         rpath_inc = ','.join([
@@ -2011,6 +2016,63 @@ class ToolchainTest(EnhancedTestCase):
             out, ec = run_cmd(cmd, simple=False)
             self.assertEqual(ec, 0)
             cmd_args = ["'foo.c'", "'-O2'"] + ["'%s'" % x for x in extra_args.split(' ')]
+            self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
+
+        # check whether $LIBRARY_PATH is taken into account
+        test_cmd_gcc = "%s gcc '' '%s' -c foo.c" % (script, rpath_inc)
+        pre_cmd_args_gcc = [
+            "'-Wl,-rpath=%s/lib'" % self.test_prefix,
+            "'-Wl,-rpath=%s/lib64'" % self.test_prefix,
+            "'-Wl,-rpath=$ORIGIN'",
+            "'-Wl,-rpath=$ORIGIN/../lib'",
+            "'-Wl,-rpath=$ORIGIN/../lib64'",
+            "'-Wl,--disable-new-dtags'",
+        ]
+        post_cmd_args_gcc = [
+            "'-c'",
+            "'foo.c'",
+        ]
+
+        test_cmd_ld = "%s ld '' '%s' -L/foo foo.o -L/lib64 -lfoo -lbar -L/usr/lib -L/bar" % (script, rpath_inc)
+        pre_cmd_args_ld = [
+            "'-rpath=%s/lib'" % self.test_prefix,
+            "'-rpath=%s/lib64'" % self.test_prefix,
+            "'-rpath=$ORIGIN'",
+            "'-rpath=$ORIGIN/../lib'",
+            "'-rpath=$ORIGIN/../lib64'",
+            "'--disable-new-dtags'",
+            "'-rpath=/foo'",
+            "'-rpath=/lib64'",
+            "'-rpath=/usr/lib'",
+            "'-rpath=/bar'",
+        ]
+        post_cmd_args_ld = [
+            "'-L/foo'",
+            "'foo.o'",
+            "'-L/lib64'",
+            "'-lfoo'",
+            "'-lbar'",
+            "'-L/usr/lib'",
+            "'-L/bar'",
+        ]
+
+        library_paths = [
+            ('',),  # special case: empty value
+            ('/path/to/lib',),
+            ('/path/to/lib', '/another/path/to/lib64'),
+            ('/path/to/lib', '/another/path/to/lib64', '/yet-another/path/to/libraries'),
+        ]
+        for library_path in library_paths:
+            os.environ['LIBRARY_PATH'] = ':'.join(library_path)
+
+            out, ec = run_cmd(test_cmd_gcc, simple=False)
+            self.assertEqual(ec, 0)
+            cmd_args = pre_cmd_args_gcc + ["'-Wl,-rpath=%s'" % x for x in library_path if x] + post_cmd_args_gcc
+            self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
+
+            out, ec = run_cmd(test_cmd_ld, simple=False)
+            self.assertEqual(ec, 0)
+            cmd_args = pre_cmd_args_ld + ["'-rpath=%s'" % x for x in library_path if x] + post_cmd_args_ld
             self.assertEqual(out.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
     def test_toolchain_prepare_rpath(self):


### PR DESCRIPTION
This is required to make a TensorFlow installation work when using `eb --rpath --filter-env-vars=LD_LIBRARY_PATH` (at least in combination with https://github.com/easybuilders/easybuild-easyblocks/pull/2218)