### PR TITLE
exclude test configuration with Lmod 7 and Python 3, except for Python 3.6

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -43,6 +43,14 @@ jobs:
             python: 3.8
           - modules_tool: modules-4.1.4
             python: 3.9
+          - modules_tool: Lmod-7.8.22
+            python: 3.5
+          - modules_tool: Lmod-7.8.22
+            python: 3.7
+          - modules_tool: Lmod-7.8.22
+            python: 3.8
+          - modules_tool: Lmod-7.8.22
+            python: 3.9
       fail-fast: false
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
I think we're overdoing it a bit with test configuration, especially after also testing with Python 3.9 (see #3465).

So I propose we trim the configurations a bit, by excluding the tests with Lmod 7 and Python 3, except for Python 3.6