### PR TITLE
avoid TypeError being raised by list_toolchains

### DIFF
--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -726,20 +726,16 @@ def list_software_txt(software, detailed=False):
 def list_toolchains(output_format=FORMAT_TXT):
     """Show list of known toolchains."""
     _, all_tcs = search_toolchain('')
+
+    # filter deprecated 'dummy' toolchain
+    all_tcs = [x for x in all_tcs if x.NAME != DUMMY_TOOLCHAIN_NAME]
     all_tcs_names = [x.NAME for x in all_tcs]
 
     # start with dict that maps toolchain name to corresponding subclass of Toolchain
     tcs = dict(zip(all_tcs_names, all_tcs))
 
-    for tcname in sorted(tcs.keys()):
-
+    for tcname in sorted(tcs):
         tcc = tcs[tcname]
-
-        # filter deprecated 'dummy' toolchain
-        if tcname == DUMMY_TOOLCHAIN_NAME:
-            del tcs[tcname]
-            continue
-
         tc = tcc(version='1.2.3')  # version doesn't matter here, but something needs to be there
         tcs[tcname] = tc.definition()
 

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -727,13 +727,17 @@ def list_toolchains(output_format=FORMAT_TXT):
     """Show list of known toolchains."""
     _, all_tcs = search_toolchain('')
     all_tcs_names = [x.NAME for x in all_tcs]
-    tclist = sorted(zip(all_tcs_names, all_tcs))
 
-    tcs = dict()
-    for (tcname, tcc) in tclist:
+    # start with dict that maps toolchain name to corresponding subclass of Toolchain
+    tcs = dict(zip(all_tcs_names, all_tcs))
+
+    for tcname in sorted(tcs.keys()):
+
+        tcc = tcs[tcname]
 
         # filter deprecated 'dummy' toolchain
         if tcname == DUMMY_TOOLCHAIN_NAME:
+            del tcs[tcname]
             continue
 
         tc = tcc(version='1.2.3')  # version doesn't matter here, but something needs to be there


### PR DESCRIPTION
This fixes a `TypeError` that is (sometimes) raised when running `--list-toolchains`:

```
Traceback (most recent call last):
  File "/home/runner/work/easybuild-framework/easybuild-framework/easybuild/tools/options.py", line 1353, in parse_options
    eb_go = EasyBuildOptions(usage=usage, description=description, prog=\'eb\', envvar_prefix=CONFIG_ENV_VAR_PREFIX,
  File "/home/runner/work/easybuild-framework/easybuild-framework/easybuild/tools/options.py", line 242, in __init__
    super(EasyBuildOptions, self).__init__(*args, **kwargs)
  File "/home/runner/work/easybuild-framework/easybuild-framework/easybuild/base/generaloption.py", line 924, in __init__
    self.postprocess()
  File "/home/runner/work/easybuild-framework/easybuild-framework/easybuild/tools/options.py", line 856, in postprocess
    self._postprocess_list_avail()
  File "/home/runner/work/easybuild-framework/easybuild-framework/easybuild/tools/options.py", line 1099, in _postprocess_list_avail
    msg += list_toolchains(self.options.output_format)
  File "/home/runner/work/easybuild-framework/easybuild-framework/easybuild/tools/docs.py", line 730, in list_toolchains
    tclist = sorted(zip(all_tcs_names, all_tcs))
TypeError: \'<\' not supported between instances of \'type\' and \'type\'
```

fixes #3469