### PR TITLE
Add Support for BLIS+libFLAME toolchain

### DIFF
--- a/easybuild/toolchains/gobff.py
+++ b/easybuild/toolchains/gobff.py
@@ -23,36 +23,19 @@
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 ##
 """
-Support for BLIS as toolchain linear algebra library.
+EasyBuild support for gobff compiler toolchain (includes GCC, OpenMPI, BLIS, libFLAME, ScaLAPACK and FFTW).
 
-:author: Kenneth Hoste (Ghent University)
-:author: Bart Oldeman (McGill University, Calcul Quebec, Compute Canada)
 :author: Sebastian Achilles (Forschungszentrum Juelich GmbH)
 """
-from distutils.version import LooseVersion
 
-from easybuild.tools.toolchain.linalg import LinAlg
+from easybuild.toolchains.gompi import Gompi
+from easybuild.toolchains.linalg.blis import Blis
+from easybuild.toolchains.linalg.flame import Flame
+from easybuild.toolchains.linalg.scalapack import ScaLAPACK
+from easybuild.toolchains.fft.fftw import Fftw
 
 
-TC_CONSTANT_BLIS = 'BLIS'
-
-
-class Blis(LinAlg):
-    """
-    Trivial class, provides BLIS support.
-    """
-    BLAS_MODULE_NAME = ['BLIS']
-    BLAS_LIB = ['blis']
-    BLAS_FAMILY = TC_CONSTANT_BLIS
-    
-    def _set_blas_variables(self):
-        """AMD's fork with version number > 2.1 names the MT library blis-mt, while vanilla BLIS doesn't."""
-        
-        # This assumes that AMD's BLIS has ver > 2.1 and vanilla BLIS < 2.1
-        
-        found_version = self.get_software_version(self.BLAS_MODULE_NAME)[0]
-        ver = LooseVersion(found_version)
-        if ver > LooseVersion('2.1'):
-            self.BLAS_LIB_MT = ['blis-mt']
-    
-        super(Blis, self)._set_blas_variables()
+class Gobff(Gompi, Blis, Flame, ScaLAPACK, Fftw):
+    """Compiler toolchain with GCC, OpenMPI, BLIS, libFLAME, ScaLAPACK and FFTW."""
+    NAME = 'gobff'
+    SUBTOOLCHAIN = Gompi.NAME

--- a/easybuild/toolchains/linalg/blis.py
+++ b/easybuild/toolchains/linalg/blis.py
@@ -51,8 +51,7 @@ class Blis(LinAlg):
         # This assumes that AMD's BLIS has ver > 2.1 and vanilla BLIS < 2.1
 
         found_version = self.get_software_version(self.BLAS_MODULE_NAME)[0]
-        ver = LooseVersion(found_version)
-        if ver > LooseVersion('2.1'):
+        if LooseVersion(found_version) > LooseVersion('2.1'):
             self.BLAS_LIB_MT = ['blis-mt']
 
         super(Blis, self)._set_blas_variables()

--- a/easybuild/toolchains/linalg/blis.py
+++ b/easybuild/toolchains/linalg/blis.py
@@ -44,15 +44,15 @@ class Blis(LinAlg):
     BLAS_MODULE_NAME = ['BLIS']
     BLAS_LIB = ['blis']
     BLAS_FAMILY = TC_CONSTANT_BLIS
-    
+
     def _set_blas_variables(self):
         """AMD's fork with version number > 2.1 names the MT library blis-mt, while vanilla BLIS doesn't."""
-        
+
         # This assumes that AMD's BLIS has ver > 2.1 and vanilla BLIS < 2.1
-        
+
         found_version = self.get_software_version(self.BLAS_MODULE_NAME)[0]
         ver = LooseVersion(found_version)
         if ver > LooseVersion('2.1'):
             self.BLAS_LIB_MT = ['blis-mt']
-    
+
         super(Blis, self)._set_blas_variables()

--- a/easybuild/toolchains/linalg/flame.py
+++ b/easybuild/toolchains/linalg/flame.py
@@ -38,6 +38,6 @@ TC_CONSTANT_FLAME = 'FLAME'
 
 class Flame(Lapack):
     """Less trivial module, provides FLAME support."""
-    LAPACK_MODULE_NAME = ['libFLAME'] # + Lapack.LAPACK_MODULE_NAME  # no super()
-    LAPACK_LIB = ['flame'] # + Lapack.LAPACK_LIB  # no super()
+    LAPACK_MODULE_NAME = ['libFLAME']  # + Lapack.LAPACK_MODULE_NAME  # no super()
+    LAPACK_LIB = ['flame']  # + Lapack.LAPACK_LIB  # no super()
     LAPACK_FAMILY = TC_CONSTANT_FLAME

--- a/easybuild/toolchains/linalg/flame.py
+++ b/easybuild/toolchains/linalg/flame.py
@@ -27,6 +27,7 @@ Support for FLAME as toolchain linear algebra library.
 
 :author: Stijn De Weirdt (Ghent University)
 :author: Kenneth Hoste (Ghent University)
+:author: Sebastian Achilles (Forschungszentrum Juelich GmbH)
 """
 
 from easybuild.toolchains.linalg.lapack import Lapack
@@ -37,6 +38,6 @@ TC_CONSTANT_FLAME = 'FLAME'
 
 class Flame(Lapack):
     """Less trivial module, provides FLAME support."""
-    LAPACK_MODULE_NAME = ['FLAME'] + Lapack.LAPACK_MODULE_NAME  # no super()
-    LAPACK_LIB = ['lapack2flame', 'flame'] + Lapack.LAPACK_LIB  # no super()
+    LAPACK_MODULE_NAME = ['libFLAME'] # + Lapack.LAPACK_MODULE_NAME  # no super()
+    LAPACK_LIB = ['flame'] # + Lapack.LAPACK_LIB  # no super()
     LAPACK_FAMILY = TC_CONSTANT_FLAME


### PR DESCRIPTION
This pull request adds support for a toolchain using GNU with OpenMPI, BLIS, libFLAME, ScaLAPACK and FFTW.

I am not sure if the name `gobff` is the best. I tried to be in line with the other naming of toolchains, like `goblf`.