### PR TITLE
don't include file/ldd/readelf commands run during RPATH sanity check in --trace output

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2460,7 +2460,7 @@ class EasyBlock(object):
                 for path in [os.path.join(dirpath, x) for x in os.listdir(dirpath)]:
                     self.log.debug("Sanity checking RPATH for %s", path)
 
-                    out, ec = run_cmd("file %s" % path, simple=False)
+                    out, ec = run_cmd("file %s" % path, simple=False, trace=False)
                     if ec:
                         fails.append("Failed to run 'file %s': %s" % (path, out))
 
@@ -2470,7 +2470,7 @@ class EasyBlock(object):
                     # ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, not stripped
                     if "dynamically linked" in out:
                         # check whether all required libraries are found via 'ldd'
-                        out, ec = run_cmd("ldd %s" % path, simple=False)
+                        out, ec = run_cmd("ldd %s" % path, simple=False, trace=False)
                         if ec:
                             fail_msg = "Failed to run 'ldd %s': %s" % (path, out)
                             self.log.warning(fail_msg)
@@ -2483,7 +2483,7 @@ class EasyBlock(object):
                             self.log.debug("Output of 'ldd %s' checked, looks OK", path)
 
                         # check whether RPATH section in 'readelf -d' output is there
-                        out, ec = run_cmd("readelf -d %s" % path, simple=False)
+                        out, ec = run_cmd("readelf -d %s" % path, simple=False, trace=False)
                         if ec:
                             fail_msg = "Failed to run 'readelf %s': %s" % (path, out)
                             self.log.warning(fail_msg)


### PR DESCRIPTION
The RPATH-specific part of the sanity check step is currently overly verbose when using `eb --rpath --trace`:

```
== sanity checking...
  >> running command:
        [started at: 2020-11-28 16:33:52]
        [working dir: /home/centos/EasyBuild/EasyBuild-4.3.1/build/binutils/2.31.1/system-system/binutils-2.31.1]
        [output logged in /tmp/eb-nplkyey8/easybuild-run_cmd-sxcm8f0k.log]
        file /home/centos/EasyBuild/EasyBuild-4.3.1/software/binutils/2.31.1/bin/addr2line
  >> command completed: exit 0, ran in < 1s
  >> running command:
        [started at: 2020-11-28 16:33:52]
        [working dir: /home/centos/EasyBuild/EasyBuild-4.3.1/build/binutils/2.31.1/system-system/binutils-2.31.1]
        [output logged in /tmp/eb-nplkyey8/easybuild-run_cmd-fqacpwfs.log]
        ldd /home/centos/EasyBuild/EasyBuild-4.3.1/software/binutils/2.31.1/bin/addr2line
  >> command completed: exit 0, ran in < 1s
...
```

The changes in this PR avoid including the `file`, `ldd` and `readelf` commands in the `--trace` output.