### PR TITLE
take into account slightly different error with Python 2.6 in test_easystack_wrong_structure

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5642,8 +5642,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         toy_easystack = os.path.join(topdir, 'easystacks', 'test_easystack_wrong_structure.yaml')
 
         expected_err = r"[\S\s]*An error occurred when interpreting the data for software Bioconductor:"
-        expected_err += r" 'float' object is not subscriptable[\S\s]*"
-        expected_err += r"| 'float' object has no attribute '__getitem__'[\S\s]*"
+        expected_err += r"( 'float' object is not subscriptable[\S\s]*"
+        expected_err += r"| 'float' object is unsubscriptable"
+        expected_err += r"| 'float' object has no attribute '__getitem__'[\S\s]*)"
         self.assertErrorRegex(EasyBuildError, expected_err, parse_easystack, toy_easystack)
 
     def test_easystack_asterisk(self):


### PR DESCRIPTION
Fix for failing test in Travis with Python 2.6:

```
FAIL: Test for --easystack <easystack.yaml> when yaml easystack has wrong structure

----------------------------------------------------------------------

Traceback (most recent call last):

  File "/tmp/455093316/lib/python2.6/site-packages/easybuild_framework-4.3.2.dev0-py2.6.egg/test/framework/options.py", line 5647, in test_easystack_wrong_structure

    self.assertErrorRegex(EasyBuildError, expected_err, parse_easystack, toy_easystack)

  File "/tmp/455093316/lib/python2.6/site-packages/easybuild_framework-4.3.2.dev0-py2.6.egg/easybuild/base/testing.py", line 162, in assertErrorRegex

    self.assertTrue(regex.search(msg), "Pattern '%s' is found in '%s'" % (regex.pattern, msg))

AssertionError: Pattern '[\S\s]*An error occurred when interpreting the data for software Bioconductor: 'float' object is not subscriptable[\S\s]*| 'float' object has no attribute '__getitem__'[\S\s]*' is found in 'An error occurred when interpreting the data for software Bioconductor: 'float' object is unsubscriptable'
```