### PR TITLE
use --dry-run in test_easystack_basic to avoid downloading of binutils sources

### DIFF
--- a/easybuild/framework/easystack.py
+++ b/easybuild/framework/easystack.py
@@ -225,7 +225,7 @@ def parse_easystack(filepath):
 
     general_options = easystack.get_general_options()
 
-    _log.debug("EasyStack parsed. Proceeding to install these Easyconfigs: %s" % ", ".join(easyconfig_names))
+    _log.debug("EasyStack parsed. Proceeding to install these Easyconfigs: %s" % ', '.join(sorted(easyconfig_names)))
     if len(general_options) != 0:
         _log.debug("General options for installation are: \n%s" % str(general_options))
     else:

--- a/easybuild/framework/easystack.py
+++ b/easybuild/framework/easystack.py
@@ -225,7 +225,7 @@ def parse_easystack(filepath):
 
     general_options = easystack.get_general_options()
 
-    _log.debug("EasyStack parsed. Proceeding to install these Easyconfigs: \n'%s'" % "',\n'".join(easyconfig_names))
+    _log.debug("EasyStack parsed. Proceeding to install these Easyconfigs: %s" % ", ".join(easyconfig_names))
     if len(general_options) != 0:
         _log.debug("General options for installation are: \n%s" % str(general_options))
     else:

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5620,20 +5620,19 @@ class CommandLineOptionsTest(EnhancedTestCase):
         topdir = os.path.dirname(os.path.abspath(__file__))
         toy_easystack = os.path.join(topdir, 'easystacks', 'test_easystack_basic.yaml')
 
-        args = ['--easystack', toy_easystack, '--stop', '--debug', '--experimental']
+        args = ['--easystack', toy_easystack, '--debug', '--experimental', '--dry-run']
         stdout = self.eb_main(args, do_build=True, raise_error=True)
         patterns = [
             r"[\S\s]*INFO Building from easystack:[\S\s]*",
-            r"[\S\s]*DEBUG EasyStack parsed\. Proceeding to install these Easyconfigs:.*?[\n]"
-            r"[\S\s]*INFO building and installing binutils/2\.25-GCCcore-4\.9\.3[\S\s]*",
-            r"[\S\s]*INFO building and installing binutils/2\.26-GCCcore-4\.9\.3[\S\s]*",
-            r"[\S\s]*INFO building and installing toy/0\.0-gompi-2018a-test[\S\s]*",
-            r"[\S\s]*INFO COMPLETED: Installation STOPPED successfully[\S\s]*",
-            r"[\S\s]*INFO Build succeeded for 3 out of 3[\S\s]*"
+            r"[\S\s]*DEBUG EasyStack parsed\. Proceeding to install these Easyconfigs: "
+            r"binutils-2.25-GCCcore-4.9.3.eb, binutils-2.26-GCCcore-4.9.3.eb, toy-0.0-gompi-2018a-test.eb",
+            r"\* \[ \] .*/test_ecs/b/binutils/binutils-2.25-GCCcore-4.9.3.eb \(module: binutils/2.25-GCCcore-4.9.3\)",
+            r"\* \[ \] .*/test_ecs/b/binutils/binutils-2.26-GCCcore-4.9.3.eb \(module: binutils/2.26-GCCcore-4.9.3\)",
+            r"\* \[ \] .*/test_ecs/t/toy/toy-0.0-gompi-2018a-test.eb \(module: toy/0.0-gompi-2018a-test\)",
         ]
         for pattern in patterns:
             regex = re.compile(pattern)
-            self.assertTrue(regex.match(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
+            self.assertTrue(regex.search(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
 
     def test_easystack_wrong_structure(self):
         """Test for --easystack <easystack.yaml> when yaml easystack has wrong structure"""


### PR DESCRIPTION
This is mainly to avoid downloading of binutils sources in the test, which is sometimes failing due to problems with the GNU mirrors:

```
Unexpected error occurred when trying to download https://ftpmirror.gnu.org/gnu/binutils/binutils-2.25.tar.gz 
```