### PR TITLE
fix 'eb --help=rst' when running with Python 3

### DIFF
--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -258,6 +258,10 @@ def mk_rst_table(titles, columns):
     """
     Returns an rst table with given titles and columns (a nested list of string columns for each column)
     """
+    # take into account that passed values may be iterators produced via 'map'
+    titles = list(titles)
+    columns = list(columns)
+
     title_cnt, col_cnt = len(titles), len(columns)
     if title_cnt != col_cnt:
         msg = "Number of titles/columns should be equal, found %d titles and %d columns" % (title_cnt, col_cnt)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -174,6 +174,26 @@ class CommandLineOptionsTest(EnhancedTestCase):
         regex = re.compile("default: True; disable with --disable-cleanup-builddir", re.M)
         self.assertTrue(regex.search(outtxt), "Pattern '%s' found in: %s" % (regex.pattern, outtxt))
 
+    def test_help_rst(self):
+        """Test generating --help in RST output format."""
+
+        self.mock_stderr(True)
+        self.mock_stdout(True)
+        self.eb_main(['--help=rst'], raise_error=True)
+        stderr, stdout = self.get_stderr(), self.get_stdout()
+        self.mock_stderr(False)
+        self.mock_stdout(False)
+
+        self.assertFalse(stderr)
+
+        patterns = [
+            r"^Basic options\n-------------",
+            r"^``--fetch``[ ]*Allow downloading sources",
+        ]
+        for pattern in patterns:
+            regex = re.compile(pattern, re.M)
+            self.assertTrue(regex.search(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
+
     def test_no_args(self):
         """Test using no arguments."""
 


### PR DESCRIPTION
Fixes hard crash when running `eb --help=rst` on top of Python 3 (used to re-generate EasyBuild docs):

```
$ eb --help=rst
Traceback (most recent call last):
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/options.py", line 1356, in parse_options
    eb_go = EasyBuildOptions(usage=usage, description=description, prog='eb', envvar_prefix=CONFIG_ENV_VAR_PREFIX,
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/options.py", line 242, in __init__
    super(EasyBuildOptions, self).__init__(*args, **kwargs)
  File "/Users/kehoste/work/easybuild-framework/easybuild/base/generaloption.py", line 915, in __init__
    self.parseoptions(options_list=go_args)
  File "/Users/kehoste/work/easybuild-framework/easybuild/base/generaloption.py", line 1189, in parseoptions
    (self.options, self.args) = self.parser.parse_args(options_list)
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/optparse.py", line 1387, in parse_args
    stop = self._process_args(largs, rargs, values)
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/optparse.py", line 1427, in _process_args
    self._process_long_opt(rargs, values)
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/optparse.py", line 1501, in _process_long_opt
    option.process(opt, value, values, self)
  File "/Users/kehoste/work/easybuild-framework/easybuild/base/generaloption.py", line 238, in process
    return Option.process(self, opt, value, values, parser)
  File "/usr/local/Cellar/python@3.9/3.9.0_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/optparse.py", line 784, in process
    return self.take_action(
  File "/Users/kehoste/work/easybuild-framework/easybuild/base/generaloption.py", line 251, in take_action
    fn()
  File "/Users/kehoste/work/easybuild-framework/easybuild/base/generaloption.py", line 633, in print_rsthelp
    result.append(self.format_option_rsthelp())
  File "/Users/kehoste/work/easybuild-framework/easybuild/base/generaloption.py", line 658, in format_option_rsthelp
    res.extend(mk_rst_table(titles, map(list, zip(*values))))
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/utilities.py", line 261, in mk_rst_table
    title_cnt, col_cnt = len(titles), len(columns)
TypeError: object of type 'map' has no len()
```