### PR TITLE
add support for --accept-eula configuration option + 'accept_eula' easyconfig parameter

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1636,6 +1636,28 @@ class EasyBlock(object):
         change_dir(self.start_dir)
         self.log.debug("Changed to real build directory %s (start_dir)", self.start_dir)
 
+    def check_accepted_eula(self, more_info=None):
+        """Check whether EULA for this software is accepted in current EasyBuild configuration."""
+
+        accepted_eulas = build_option('accept_eula') or []
+        if self.cfg['accept_eula'] or self.name in accepted_eulas:
+            self.log.info("EULA for %s is accepted", self.name)
+        else:
+            error_lines = [
+                "The End User License Argreement (EULA) for %(name)s is currently not accepted!",
+            ]
+            if more_info:
+                error_lines.append("(see %s for more information)" % more_info)
+
+            error_lines.extend([
+                "You should either:",
+                "- add --accept-eula-for=%(name)s to the 'eb' command;",
+                "- update your EasyBuild configuration to always accept the EULA for %(name)s;",
+                "- add 'accept_eula = True' to the easyconfig file you are using;",
+                '',
+            ])
+            raise EasyBuildError('\n'.join(error_lines) % {'name': self.name})
+
     def handle_iterate_opts(self):
         """Handle options relevant during iterated part of build/install procedure."""
 

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -158,6 +158,7 @@ DEFAULT_CONFIG = {
     'moddependpaths': [None, "Absolute path(s) to prepend to MODULEPATH before loading dependencies", DEPENDENCIES],
 
     # LICENSE easyconfig parameters
+    'accept_eula': [False, "Accepted End User License Agreement (EULA) for this software", LICENSE],
     'group': [None, "Name of the user group for which the software should be available; "
                     "format: string or 2-tuple with group name + custom error for users outside group", LICENSE],
     'key': [None, 'Key for installing software', LICENSE],

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -161,6 +161,7 @@ def mk_full_default_path(name, prefix=DEFAULT_PREFIX):
 # build options that have a perfectly matching command line option, listed by default value
 BUILD_OPTIONS_CMDLINE = {
     None: [
+        'accept_eula',
         'aggregate_regtest',
         'backup_modules',
         'container_config',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -333,6 +333,7 @@ class EasyBuildOptions(GeneralOption):
         descr = ("Override options", "Override default EasyBuild behavior.")
 
         opts = OrderedDict({
+            'accept-eula': ("Accept EULA for specified software", 'strlist', 'store', []),
             'add-dummy-to-minimal-toolchains': ("Include dummy toolchain in minimal toolchain searches "
                                                 "[DEPRECATED, use --add-system-to-minimal-toolchains instead!)",
                                                 None, 'store_true', False),

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -49,7 +49,7 @@ from easybuild.framework.easyconfig.easyconfig import EasyConfig, get_easyblock_
 from easybuild.framework.easyconfig.parser import EasyConfigParser
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import DEFAULT_MODULECLASSES
-from easybuild.tools.config import find_last_log, get_build_log_path, get_module_syntax, module_classes
+from easybuild.tools.config import build_option, find_last_log, get_build_log_path, get_module_syntax, module_classes
 from easybuild.tools.environment import modify_env
 from easybuild.tools.filetools import change_dir, copy_dir, copy_file, download_file, is_patch_file, mkdir
 from easybuild.tools.filetools import read_file, remove_dir, remove_file, which, write_file
@@ -5657,6 +5657,41 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         os.environ['EASYBUILD_SYSROOT'] = doesnotexist
         self.assertErrorRegex(EasyBuildError, error_pattern, self._run_mock_eb, ['--show-config'], raise_error=True)
+
+    def test_accept_eula_for(self):
+        """Test --accept-eula configuration option."""
+
+        # use toy-0.0.eb easyconfig file that comes with the tests
+        topdir = os.path.abspath(os.path.dirname(__file__))
+        toy_ec = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        test_ec_txt = '\n'.join([
+            "easyblock = 'EB_toy_eula'",
+            '',
+            read_file(toy_ec),
+        ])
+        write_file(test_ec, test_ec_txt)
+
+        # by default, no EULAs are accepted at all
+        args = [test_ec, '--force']
+        error_pattern = "EULA not accepted for toy!"
+        self.assertErrorRegex(EasyBuildError, error_pattern, self.eb_main, args, do_build=True, raise_error=True)
+
+        # installation proceeds if EasyBuild is configured to accept EULA for specified software
+        self.eb_main(args + ['--accept-eula=foo,toy,bar'], do_build=True, raise_error=True)
+
+        toy_modfile = os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0')
+        if get_module_syntax() == 'Lua':
+            toy_modfile += '.lua'
+        self.assertTrue(os.path.exists(toy_modfile))
+
+        remove_dir(self.test_installpath)
+        self.assertFalse(os.path.exists(toy_modfile))
+
+        # installation proceeds if EasyBuild is configured to accept EULA for specified software
+        os.environ['EASYBUILD_ACCEPT_EULA'] = 'toy'
+        self.eb_main(args, do_build=True, raise_error=True)
+        self.assertTrue(os.path.exists(toy_modfile))
 
     # end-to-end testing of unknown filename
     def test_easystack_wrong_read(self):

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -765,6 +765,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                 r'\|-- ExtensionEasyBlock',
                 r'\|   \|-- DummyExtension',
                 r'\|   \|-- EB_toy',
+                r'\|   \|   \|-- EB_toy_eula',
                 r'\|   \|   \|-- EB_toytoy',
                 r'\|   \|-- Toy_Extension',
                 r'\|-- ModuleRC',
@@ -773,6 +774,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                 r'\|-- ExtensionEasyBlock',
                 r'\|   \|-- DummyExtension',
                 r'\|   \|-- EB_toy',
+                r'\|   \|   \|-- EB_toy_eula',
                 r'\|   \|   \|-- EB_toytoy',
                 r'\|   \|-- Toy_Extension',
             ])

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy_eula.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy_eula.py
@@ -1,0 +1,44 @@
+##
+# Copyright 2020-2020 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for building and installing toy with EULA, implemented as an easyblock
+
+@author: Kenneth Hoste (Ghent University)
+"""
+from easybuild.easyblocks.toy import EB_toy
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import build_option
+
+
+class EB_toy_eula(EB_toy):
+    """Support for building/installing toy."""
+
+    def prepare_step(self, *args, **kwargs):
+        """Constructor"""
+        super(EB_toy_eula, self).prepare_step(*args, **kwargs)
+
+        accept_eula_for = build_option('accept_eula') or []
+        if 'toy' not in accept_eula_for:
+            raise EasyBuildError("EULA not accepted for toy!")

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy_eula.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy_eula.py
@@ -28,8 +28,6 @@ EasyBuild support for building and installing toy with EULA, implemented as an e
 @author: Kenneth Hoste (Ghent University)
 """
 from easybuild.easyblocks.toy import EB_toy
-from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import build_option
 
 
 class EB_toy_eula(EB_toy):
@@ -39,6 +37,6 @@ class EB_toy_eula(EB_toy):
         """Constructor"""
         super(EB_toy_eula, self).prepare_step(*args, **kwargs)
 
-        accept_eula_for = build_option('accept_eula') or []
-        if 'toy' not in accept_eula_for:
-            raise EasyBuildError("EULA not accepted for toy!")
+        # EULA for toy must be accepted via --accept-eula EasyBuild configuration option,
+        # or via 'accept_eula = True' in easyconfig file
+        self.check_accepted_eula(more_info='https://example.com/toy_eula.txt')


### PR DESCRIPTION
This will come in useful for software like [AOCC](https://github.com/easybuilders/easybuild-easyconfigs/pull/11868) and Intel's oneAPI that require accepting an End User License Agreement (EULA) on installation...