### PR TITLE
add --init and --recursive options to 'git submodule update' command that is used when creating source tarball for specific commit

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2287,7 +2287,7 @@ def get_source_tarball_from_git(filename, targetdir, git_config):
     if commit:
         checkout_cmd = ['git', 'checkout', commit]
         if recursive:
-            checkout_cmd.extend(['&&', 'git', 'submodule', 'update'])
+            checkout_cmd.extend(['&&', 'git', 'submodule', 'update', '--init', '--recursive'])
 
         run.run_cmd(' '.join(checkout_cmd), log_all=True, log_ok=False, simple=False, regexp=False, path=repo_name)
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2475,7 +2475,7 @@ class FileToolsTest(EnhancedTestCase):
         expected = '\n'.join([
             r'  running command "git clone --recursive git@github.com:easybuilders/testrepository.git"',
             r"  \(in .*/tmp.*\)",
-            r'  running command "git checkout 8456f86 && git submodule update"',
+            r'  running command "git checkout 8456f86 && git submodule update --init --recursive"',
             r"  \(in testrepository\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
             r"  \(in .*/tmp.*\)",


### PR DESCRIPTION
cfr. https://github.com/easybuilders/easybuild-easyconfigs/pull/8667/files#r550523877