### PR TITLE
Add toolchain deps to template resolution

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -80,6 +80,7 @@ TEMPLATE_NAMES_EASYBLOCK_RUN_STEP = [
 TEMPLATE_SOFTWARE_VERSIONS = [
     # software name, prefix for *ver and *shortver
     ('CUDA', 'cuda'),
+    ('CUDAcore', 'cuda'),
     ('Java', 'java'),
     ('Perl', 'perl'),
     ('Python', 'py'),
@@ -241,6 +242,10 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
                     deps += config.get('builddependencies', [])
             else:
                 deps += config.get('builddependencies', [])
+
+        # Include all toolchain deps (e.g. CUDAcore template in fosscuda)
+        if config.toolchain.tcdeps is not None:
+            deps += config.toolchain.tcdeps
 
         for dep in deps:
             if isinstance(dep, dict):

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -239,13 +239,13 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
             # only consider build dependencies when we're actually in iterative mode!
             if 'builddependencies' in config.iterate_options:
                 if config.iterating:
-                    deps += config.get('builddependencies', [])
+                    deps.extend(config.get('builddependencies', []))
             else:
-                deps += config.get('builddependencies', [])
+                deps.extend(config.get('builddependencies', []))
 
             # Include all toolchain deps (e.g. CUDAcore template in fosscuda)
             if config.toolchain.tcdeps is not None:
-                deps += config.toolchain.tcdeps
+                deps.extend(config.toolchain.tcdeps)
 
         for dep in deps:
             if isinstance(dep, dict):

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -243,9 +243,9 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
             else:
                 deps += config.get('builddependencies', [])
 
-        # Include all toolchain deps (e.g. CUDAcore template in fosscuda)
-        if config.toolchain.tcdeps is not None:
-            deps += config.toolchain.tcdeps
+            # Include all toolchain deps (e.g. CUDAcore template in fosscuda)
+            if config.toolchain.tcdeps is not None:
+                deps += config.toolchain.tcdeps
 
         for dep in deps:
             if isinstance(dep, dict):

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -436,7 +436,7 @@ class RobotTest(EnhancedTestCase):
             "   ('SQLite', '3.8.10.2'),",
             "]",
             # toolchain as list line, for easy modification later;
-            "toolchain = {'name': 'foss', 'version': '%(version_minor)s018a'}",
+            "toolchain = {'name': 'foss', 'version': '2018a'}",
         ]
         write_file(barec, '\n'.join(barec_lines))
         bar = process_easyconfig(barec)[0]


### PR DESCRIPTION
Adds the indirect toolchain dependencies to templates so that it works for system level CUDAcore packages.
Also includes CUDAcore -> cudaver. 

Cf. https://github.com/easybuilders/easybuild-easyconfigs/pull/11907