### PR TITLE
detect 'SYSTEM' toolchain as special case in easystack files

### DIFF
--- a/easybuild/framework/easystack.py
+++ b/easybuild/framework/easystack.py
@@ -110,14 +110,18 @@ class EasyStackParser(object):
                 raise EasyBuildError("Toolchains for software '%s' are not defined in %s", name, filepath)
             for toolchain in toolchains:
                 toolchain = str(toolchain)
-                toolchain_parts = toolchain.split('-', 1)
-                if len(toolchain_parts) == 2:
-                    toolchain_name, toolchain_version = toolchain_parts
-                elif len(toolchain_parts) == 1:
-                    toolchain_name, toolchain_version = toolchain, ''
+
+                if toolchain == 'SYSTEM':
+                    toolchain_name, toolchain_version = 'system', ''
                 else:
-                    raise EasyBuildError("Incorrect toolchain specification for '%s' in %s, too many parts: %s",
-                                         name, filepath, toolchain_parts)
+                    toolchain_parts = toolchain.split('-', 1)
+                    if len(toolchain_parts) == 2:
+                        toolchain_name, toolchain_version = toolchain_parts
+                    elif len(toolchain_parts) == 1:
+                        toolchain_name, toolchain_version = toolchain, ''
+                    else:
+                        raise EasyBuildError("Incorrect toolchain specification for '%s' in %s, too many parts: %s",
+                                             name, filepath, toolchain_parts)
 
                 try:
                     # if version string containts asterisk or labels, raise error (asterisks not supported)

--- a/test/framework/easystacks/test_easystack_basic.yaml
+++ b/test/framework/easystacks/test_easystack_basic.yaml
@@ -5,6 +5,10 @@ software:
         versions:
           2.25:
           2.26:
+  foss:
+    toolchains:
+      SYSTEM:
+        versions: [2018a]
   toy:
     toolchains:
       gompi-2018a:

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5725,10 +5725,12 @@ class CommandLineOptionsTest(EnhancedTestCase):
         patterns = [
             r"[\S\s]*INFO Building from easystack:[\S\s]*",
             r"[\S\s]*DEBUG EasyStack parsed\. Proceeding to install these Easyconfigs: "
-            r"binutils-2.25-GCCcore-4.9.3.eb, binutils-2.26-GCCcore-4.9.3.eb, toy-0.0-gompi-2018a-test.eb",
+            r"binutils-2.25-GCCcore-4.9.3.eb, binutils-2.26-GCCcore-4.9.3.eb, "
+            r"foss-2018a.eb, toy-0.0-gompi-2018a-test.eb",
             r"\* \[ \] .*/test_ecs/b/binutils/binutils-2.25-GCCcore-4.9.3.eb \(module: binutils/2.25-GCCcore-4.9.3\)",
             r"\* \[ \] .*/test_ecs/b/binutils/binutils-2.26-GCCcore-4.9.3.eb \(module: binutils/2.26-GCCcore-4.9.3\)",
             r"\* \[ \] .*/test_ecs/t/toy/toy-0.0-gompi-2018a-test.eb \(module: toy/0.0-gompi-2018a-test\)",
+            r"\* \[x\] .*/test_ecs/f/foss/foss-2018a.eb \(module: foss/2018a\)",
         ]
         for pattern in patterns:
             regex = re.compile(pattern)


### PR DESCRIPTION
This adds support for more easily specifying software that is installed with a system toolchain in an easystack file, for example:

```yaml
software:
  EasyBuild:
    toolchains:
      SYSTEM:
        versions: [4.3.2]
```