### PR TITLE
don't clean up imported modules after verifying imports of included Python modules

### DIFF
--- a/easybuild/tools/include.py
+++ b/easybuild/tools/include.py
@@ -125,10 +125,16 @@ def set_up_eb_package(parent_path, eb_pkg_name, subpkgs=None, pkg_init_body=None
 
 def verify_imports(pymods, pypkg, from_path):
     """Verify that import of specified modules from specified package and expected location works."""
-    saved_modules = sys.modules.copy()
 
     for pymod in pymods:
         pymod_spec = '%s.%s' % (pypkg, pymod)
+
+        # force re-import if the specified modules was already imported;
+        # this is required to ensure that an easyblock that is included via --include-easyblocks-from-pr
+        # gets preference over one that is included via --include-easyblocks
+        if pymod_spec in sys.modules:
+            del sys.modules[pymod_spec]
+
         try:
             pymod = __import__(pymod_spec, fromlist=[pypkg])
         # different types of exceptions may be thrown, not only ImportErrors
@@ -141,10 +147,6 @@ def verify_imports(pymods, pypkg, from_path):
                                  pymod_spec, from_path, pymod.__file__)
 
         _log.debug("Import of %s from %s verified", pymod_spec, from_path)
-
-    # restore sys.modules to its original state (not only verified modules but also their dependencies)
-    sys.modules.clear()
-    sys.modules.update(saved_modules)
 
 
 def is_software_specific_easyblock(module):
@@ -279,7 +281,7 @@ def include_toolchains(tmpdir, paths):
         sys.modules[tcpkg].__path__.insert(0, os.path.join(toolchains_path, 'easybuild', 'toolchains', subpkg))
 
     # sanity check: verify that included toolchain modules can be imported (from expected location)
-    verify_imports([os.path.splitext(mns)[0] for mns in included_toolchains], 'easybuild.toolchains', tcs_dir)
+    verify_imports([os.path.splitext(tc)[0] for tc in included_toolchains], 'easybuild.toolchains', tcs_dir)
     for subpkg in toolchain_subpkgs:
         pkg = '.'.join(['easybuild', 'toolchains', subpkg])
         loc = os.path.join(tcs_dir, subpkg)

--- a/test/framework/include.py
+++ b/test/framework/include.py
@@ -156,8 +156,8 @@ class IncludeTest(EnhancedTestCase):
         self.assertFalse(os.path.samefile(os.path.dirname(os.path.dirname(foo_pyc_path)), test_easyblocks))
         self.assertTrue(os.path.samefile(foo_real_py_path, os.path.join(myeasyblocks, 'foo.py')))
 
-        # check that the included easyblock is not loaded
-        self.assertFalse('easybuild.easyblocks.foo' in sys.modules)
+        # 'undo' import of foo easyblock
+        del sys.modules['easybuild.easyblocks.foo']
 
     def test_include_mns(self):
         """Test include_module_naming_schemes()."""

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3047,6 +3047,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             return
 
         orig_local_sys_path = sys.path[:]
+        orig_sys_modules = sys.modules.copy()
+
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 
@@ -3091,14 +3093,10 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertTrue(issubclass(klass, EasyBlock), "%s is an EasyBlock derivative class" % klass)
 
         # 'undo' import of easyblocks
-        del sys.modules['easybuild.easyblocks.foo']
-        del sys.modules['easybuild.easyblocks.generic.cmakemake']
+        sys.modules.clear()
+        sys.modules.update(orig_sys_modules)
         os.remove(os.path.join(self.test_prefix, 'foo.py'))
         sys.path = orig_local_sys_path
-        import easybuild.easyblocks
-        reload(easybuild.easyblocks)
-        import easybuild.easyblocks.generic
-        reload(easybuild.easyblocks.generic)
 
         # include test cmakemake easyblock
         cmm_txt = '\n'.join([

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3047,7 +3047,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
             return
 
         orig_local_sys_path = sys.path[:]
-        orig_sys_modules = sys.modules.copy()
 
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
@@ -3093,8 +3092,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertTrue(issubclass(klass, EasyBlock), "%s is an EasyBlock derivative class" % klass)
 
         # 'undo' import of easyblocks
-        sys.modules.clear()
-        sys.modules.update(orig_sys_modules)
+        del sys.modules['easybuild.easyblocks.foo']
+        del sys.modules['easybuild.easyblocks.generic.cmakemake']
         os.remove(os.path.join(self.test_prefix, 'foo.py'))
         sys.path = orig_local_sys_path
 


### PR DESCRIPTION
fixes #3542