### PR TITLE
add create_unused_dir function to create a directory which does not yet exist

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2485,14 +2485,11 @@ def create_unused_dir(parent_folder, name):
         parent_folder = os.path.abspath(parent_folder)
 
     start_path = os.path.join(parent_folder, name)
-    number = None
-    while True:
-        if number is None:
+    for number in range(-1, 10000):  # Start with no suffix and limit the number of attempts
+        if number < 0:
             path = start_path
-            number = 0
         else:
             path = start_path + '_' + str(number)
-            number += 1
         try:
             os.mkdir(path)
             break

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2473,3 +2473,43 @@ def copy_framework_files(paths, target_dir):
             raise EasyBuildError("Couldn't find parent folder of updated file: %s", path)
 
     return file_info
+
+
+def create_unused_dir(parent_folder, name):
+    """
+    Create a new folder in parent_folder using name as the name.
+    When a folder of that name already exists, '_0' is appended which is retried for increasing numbers until
+    an unused name was found
+    """
+    if not os.path.isabs(parent_folder):
+        parent_folder = os.path.abspath(parent_folder)
+
+    start_path = os.path.join(parent_folder, name)
+    number = None
+    while True:
+        if number is None:
+            path = start_path
+            number = 0
+        else:
+            path = start_path + '_' + str(number)
+            number += 1
+        try:
+            os.mkdir(path)
+            break
+        except OSError as err:
+            # Distinguish between error due to existing folder and anything else
+            if not os.path.exists(path):
+                raise EasyBuildError("Failed to create directory %s: %s", path, err)
+
+    # set group ID and sticky bits, if desired
+    bits = 0
+    if build_option('set_gid_bit'):
+        bits |= stat.S_ISGID
+    if build_option('sticky_bit'):
+        bits |= stat.S_ISVTX
+    if bits:
+        try:
+            adjust_permissions(path, bits, add=True, relative=True, recursive=True, onlydirs=True)
+        except OSError as err:
+            raise EasyBuildError("Failed to set group ID/sticky bit: %s", err)
+    return path

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2888,6 +2888,24 @@ class FileToolsTest(EnhancedTestCase):
         error_pattern = r"One or more files not found: 2\.txt \(search paths: \)"
         self.assertErrorRegex(EasyBuildError, error_pattern, ft.locate_files, ['2.txt'], [])
 
+    def test_create_unused_dir(self):
+        path = ft.create_unused_dir(self.test_prefix, 'folder')
+        self.assertEqual(path, os.path.join(self.test_prefix, 'folder'))
+        self.assertTrue(os.path.exists(path))
+        # Repeat with existing folder(s) should create new ones
+        for i in range(10):
+            path = ft.create_unused_dir(self.test_prefix, 'folder')
+            self.assertEqual(path, os.path.join(self.test_prefix, 'folder_%s' % i))
+            self.assertTrue(os.path.exists(path))
+        # Not influenced by similar folder
+        path = ft.create_unused_dir(self.test_prefix, 'folder2')
+        self.assertEqual(path, os.path.join(self.test_prefix, 'folder2'))
+        self.assertTrue(os.path.exists(path))
+        for i in range(10):
+            path = ft.create_unused_dir(self.test_prefix, 'folder2')
+            self.assertEqual(path, os.path.join(self.test_prefix, 'folder2_%s' % i))
+            self.assertTrue(os.path.exists(path))
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2889,6 +2889,7 @@ class FileToolsTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, error_pattern, ft.locate_files, ['2.txt'], [])
 
     def test_create_unused_dir(self):
+        """Test create_unused_dir function."""
         path = ft.create_unused_dir(self.test_prefix, 'folder')
         self.assertEqual(path, os.path.join(self.test_prefix, 'folder'))
         self.assertTrue(os.path.exists(path))
@@ -2905,6 +2906,21 @@ class FileToolsTest(EnhancedTestCase):
             path = ft.create_unused_dir(self.test_prefix, 'folder2')
             self.assertEqual(path, os.path.join(self.test_prefix, 'folder2_%s' % i))
             self.assertTrue(os.path.exists(path))
+        # Fail cleanly if passed a readonly folder
+        readonly_dir = os.path.join(self.test_prefix, 'ro_folder')
+        os.mkdir(readonly_dir)
+        old_perms = os.lstat(readonly_dir)[stat.ST_MODE]
+        os.chmod(readonly_dir, stat.S_IREAD | stat.S_IEXEC)
+        try:
+            self.assertErrorRegex(EasyBuildError, 'Failed to create directory',
+                                  ft.create_unused_dir, readonly_dir, 'new_folder')
+        finally:
+            os.chmod(readonly_dir, old_perms)
+        # Ignore files same as folders. So first just create a file with no contents
+        open(os.path.join(self.test_prefix, 'file'), 'w').close()
+        path = ft.create_unused_dir(self.test_prefix, 'file')
+        self.assertEqual(path, os.path.join(self.test_prefix, 'file_0'))
+        self.assertTrue(os.path.exists(path))
 
 
 def suite():

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2947,16 +2947,84 @@ class FileToolsTest(EnhancedTestCase):
         error_pattern = r"One or more files not found: 2\.txt \(search paths: \)"
         self.assertErrorRegex(EasyBuildError, error_pattern, ft.locate_files, ['2.txt'], [])
 
+    def test_set_gid_sticky_bits(self):
+        """Test for set_gid_sticky_bits function."""
+        test_dir = os.path.join(self.test_prefix, 'test_dir')
+        test_subdir = os.path.join(test_dir, 'subdir')
+
+        ft.mkdir(test_subdir, parents=True)
+        dir_perms = os.lstat(test_dir)[stat.ST_MODE]
+        self.assertEqual(dir_perms & stat.S_ISGID, 0)
+        self.assertEqual(dir_perms & stat.S_ISVTX, 0)
+        dir_perms = os.lstat(test_subdir)[stat.ST_MODE]
+        self.assertEqual(dir_perms & stat.S_ISGID, 0)
+        self.assertEqual(dir_perms & stat.S_ISVTX, 0)
+
+        # by default, GID & sticky bits are not set
+        ft.set_gid_sticky_bits(test_dir)
+        dir_perms = os.lstat(test_dir)[stat.ST_MODE]
+        self.assertEqual(dir_perms & stat.S_ISGID, 0)
+        self.assertEqual(dir_perms & stat.S_ISVTX, 0)
+
+        ft.set_gid_sticky_bits(test_dir, set_gid=True)
+        dir_perms = os.lstat(test_dir)[stat.ST_MODE]
+        self.assertEqual(dir_perms & stat.S_ISGID, stat.S_ISGID)
+        self.assertEqual(dir_perms & stat.S_ISVTX, 0)
+        ft.remove_dir(test_dir)
+        ft.mkdir(test_subdir, parents=True)
+
+        ft.set_gid_sticky_bits(test_dir, sticky=True)
+        dir_perms = os.lstat(test_dir)[stat.ST_MODE]
+        self.assertEqual(dir_perms & stat.S_ISGID, 0)
+        self.assertEqual(dir_perms & stat.S_ISVTX, stat.S_ISVTX)
+        ft.remove_dir(test_dir)
+        ft.mkdir(test_subdir, parents=True)
+
+        ft.set_gid_sticky_bits(test_dir, set_gid=True, sticky=True)
+        dir_perms = os.lstat(test_dir)[stat.ST_MODE]
+        self.assertEqual(dir_perms & stat.S_ISGID, stat.S_ISGID)
+        self.assertEqual(dir_perms & stat.S_ISVTX, stat.S_ISVTX)
+        # no recursion by default
+        dir_perms = os.lstat(test_subdir)[stat.ST_MODE]
+        self.assertEqual(dir_perms & stat.S_ISGID, 0)
+        self.assertEqual(dir_perms & stat.S_ISVTX, 0)
+
+        ft.remove_dir(test_dir)
+        ft.mkdir(test_subdir, parents=True)
+
+        ft.set_gid_sticky_bits(test_dir, set_gid=True, sticky=True, recursive=True)
+        dir_perms = os.lstat(test_dir)[stat.ST_MODE]
+        self.assertEqual(dir_perms & stat.S_ISGID, stat.S_ISGID)
+        self.assertEqual(dir_perms & stat.S_ISVTX, stat.S_ISVTX)
+        dir_perms = os.lstat(test_subdir)[stat.ST_MODE]
+        self.assertEqual(dir_perms & stat.S_ISGID, stat.S_ISGID)
+        self.assertEqual(dir_perms & stat.S_ISVTX, stat.S_ISVTX)
+
+        ft.remove_dir(test_dir)
+        ft.mkdir(test_subdir, parents=True)
+
+        # set_gid_sticky_bits honors relevant build options
+        init_config(build_options={'set_gid_bit': True, 'sticky_bit': True})
+        ft.set_gid_sticky_bits(test_dir, recursive=True)
+        dir_perms = os.lstat(test_dir)[stat.ST_MODE]
+        self.assertEqual(dir_perms & stat.S_ISGID, stat.S_ISGID)
+        self.assertEqual(dir_perms & stat.S_ISVTX, stat.S_ISVTX)
+        dir_perms = os.lstat(test_subdir)[stat.ST_MODE]
+        self.assertEqual(dir_perms & stat.S_ISGID, stat.S_ISGID)
+        self.assertEqual(dir_perms & stat.S_ISVTX, stat.S_ISVTX)
+
     def test_create_unused_dir(self):
         """Test create_unused_dir function."""
         path = ft.create_unused_dir(self.test_prefix, 'folder')
         self.assertEqual(path, os.path.join(self.test_prefix, 'folder'))
         self.assertTrue(os.path.exists(path))
+
         # Repeat with existing folder(s) should create new ones
         for i in range(10):
             path = ft.create_unused_dir(self.test_prefix, 'folder')
             self.assertEqual(path, os.path.join(self.test_prefix, 'folder_%s' % i))
             self.assertTrue(os.path.exists(path))
+
         # Not influenced by similar folder
         path = ft.create_unused_dir(self.test_prefix, 'folder2')
         self.assertEqual(path, os.path.join(self.test_prefix, 'folder2'))
@@ -2965,18 +3033,20 @@ class FileToolsTest(EnhancedTestCase):
             path = ft.create_unused_dir(self.test_prefix, 'folder2')
             self.assertEqual(path, os.path.join(self.test_prefix, 'folder2_%s' % i))
             self.assertTrue(os.path.exists(path))
+
         # Fail cleanly if passed a readonly folder
         readonly_dir = os.path.join(self.test_prefix, 'ro_folder')
-        os.mkdir(readonly_dir)
+        ft.mkdir(readonly_dir)
         old_perms = os.lstat(readonly_dir)[stat.ST_MODE]
-        os.chmod(readonly_dir, stat.S_IREAD | stat.S_IEXEC)
+        ft.adjust_permissions(readonly_dir, stat.S_IREAD | stat.S_IEXEC, relative=False)
         try:
             self.assertErrorRegex(EasyBuildError, 'Failed to create directory',
                                   ft.create_unused_dir, readonly_dir, 'new_folder')
         finally:
-            os.chmod(readonly_dir, old_perms)
+            ft.adjust_permissions(readonly_dir, old_perms, relative=False)
+
         # Ignore files same as folders. So first just create a file with no contents
-        open(os.path.join(self.test_prefix, 'file'), 'w').close()
+        ft.write_file(os.path.join(self.test_prefix, 'file'), '')
         path = ft.create_unused_dir(self.test_prefix, 'file')
         self.assertEqual(path, os.path.join(self.test_prefix, 'file_0'))
         self.assertTrue(os.path.exists(path))


### PR DESCRIPTION
This will append _%d until a new folder could be created.
If the base folder name does not exists, it is used directly, so the simple, most common case is the cleanest

Note that I didn't use our `mkdir` function to reduce the possibility of a race condition where the folder gets created between the check and the `os.mkdir` call. This solution pushes the burden to Python, which at least reduces the window for such an issue.