### PR TITLE
Avoid no-op changes to $LD_* environment variables in ModulesTool

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -793,9 +793,12 @@ class ModulesTool(object):
         # restore selected original environment variables before running module command
         environ = os.environ.copy()
         for key in LD_ENV_VAR_KEYS:
-            environ[key] = ORIG_OS_ENVIRON.get(key, '')
-            self.log.debug("Changing %s from '%s' to '%s' in environment for module command",
-                           key, os.environ.get(key, ''), environ[key])
+            old_value = environ.get(key, '')
+            new_value = ORIG_OS_ENVIRON.get(key, '')
+            if old_value != new_value:
+                environ[key] = new_value
+                self.log.debug("Changing %s from '%s' to '%s' in environment for module command",
+                               key, old_value, new_value)
 
         cmd_list = self.compose_cmd_list(args)
         full_cmd = ' '.join(cmd_list)
@@ -842,11 +845,13 @@ class ModulesTool(object):
             # correct values of selected environment variables as yielded by the adjustments made
             # make sure we get the order right (reverse lists with [::-1])
             for key in LD_ENV_VAR_KEYS:
-                curr_ld_val = os.environ.get(key, '').split(os.pathsep)
+                curr_ld_val = os.environ.get(key, '')
+                curr_ld_val = curr_ld_val.split(os.pathsep) if curr_ld_val else []  # Take care of empty/unset values
                 new_ld_val = [x for x in nub(prev_ld_values[key] + curr_ld_val[::-1]) if x][::-1]
 
-                self.log.debug("Correcting paths in $%s from %s to %s" % (key, curr_ld_val, new_ld_val))
-                self.set_path_env_var(key, new_ld_val)
+                if new_ld_val != curr_ld_val:
+                    self.log.debug("Correcting paths in $%s from %s to %s" % (key, curr_ld_val, new_ld_val))
+                    self.set_path_env_var(key, new_ld_val)
 
             # Process stderr
             result = []


### PR DESCRIPTION
LD_ENV_VAR_KEYS variables are set and restore prior and after running any module command. Often they don't have any change leading to many messages like:
> INFO Environment variable LD_LIBRARY_PATH set to <long value> (previous value: '<same value>')

This just clutters the log without any benefit.
This change skips such messages and changes