### PR TITLE
avoid running expensive 'module use' command when using Lmod as modules tool, update $MODULEPATH directly instead

### DIFF
--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -1142,8 +1142,8 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(mod.MODULE_AVAIL_CACHE, {})
         self.assertEqual(mod.MODULE_SHOW_CACHE, {})
 
-    def test_module_use(self):
-        """Test 'module use'."""
+    def test_module_use_unuse(self):
+        """Test 'module use' and 'module unuse'."""
         test_dir1 = os.path.join(self.test_prefix, 'one')
         test_dir2 = os.path.join(self.test_prefix, 'two')
         test_dir3 = os.path.join(self.test_prefix, 'three')
@@ -1151,6 +1151,16 @@ class ModulesTest(EnhancedTestCase):
         self.assertFalse(test_dir1 in os.environ.get('MODULEPATH', ''))
         self.modtool.use(test_dir1)
         self.assertTrue(os.environ.get('MODULEPATH', '').startswith('%s:' % test_dir1))
+        self.modtool.use(test_dir2)
+        self.assertTrue(os.environ.get('MODULEPATH', '').startswith('%s:' % test_dir2))
+        self.modtool.use(test_dir3)
+        self.assertTrue(os.environ.get('MODULEPATH', '').startswith('%s:' % test_dir3))
+        self.modtool.unuse(test_dir3)
+        self.assertFalse(test_dir3 in os.environ.get('MODULEPATH', ''))
+        self.modtool.unuse(test_dir2)
+        self.assertFalse(test_dir2 in os.environ.get('MODULEPATH', ''))
+        self.modtool.unuse(test_dir1)
+        self.assertFalse(test_dir1 in os.environ.get('MODULEPATH', ''))
 
         # also test use with high priority
         self.modtool.use(test_dir2, priority=10000)
@@ -1158,8 +1168,9 @@ class ModulesTest(EnhancedTestCase):
 
         # check whether prepend with priority actually works (only for Lmod)
         if isinstance(self.modtool, Lmod):
+            self.modtool.use(test_dir1, priority=100)
             self.modtool.use(test_dir3)
-            self.assertTrue(os.environ['MODULEPATH'].startswith('%s:%s:' % (test_dir2, test_dir3)))
+            self.assertTrue(os.environ['MODULEPATH'].startswith('%s:%s:%s:' % (test_dir2, test_dir1, test_dir3)))
 
     def test_module_use_bash(self):
         """Test whether effect of 'module use' is preserved when a new bash session is started."""


### PR DESCRIPTION
I discovered an issue: The priority.
There are 2 problems:
- module use foo won't put foo to the front if any other path has a (big) priority
- We have a function `prepend_module_path` with an optional priority. Hence if we don't pass a priority then this function will not "prepend" the path

@boegel 
> First bullet is not a problem, that's just how module use works?
> Second one: yeah, if we really want to be sure, we should give it a (very) high priority, or at least detect that we need to do so.

It is a problem if I replace module use by setting MODULEPATH because that would yield a different behavior. I currently check if any priority is in use and fallback to module use instead
We use the priority in `load_fake_module`, but I guess we should not. The problem is: It doesn't tell what is intended. In `prepend_module_path` we could (hard, but possible) check current priorities and choose a higher one. Who knows that the 10000 we currently use isn't in use already or a user used 10001?
hence I'd deprecate the priority argument