### PR TITLE
Allow use of alternate envvar(s) to $HOME for user modules

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -66,6 +66,7 @@ from easybuild.tools import config, run
 from easybuild.tools.build_details import get_build_stats
 from easybuild.tools.build_log import EasyBuildError, dry_run_msg, dry_run_warning, dry_run_set_dirs
 from easybuild.tools.build_log import print_error, print_msg, print_warning
+from easybuild.tools.config import DEFAULT_ENVVAR_USERS_MODULES
 from easybuild.tools.config import FORCE_DOWNLOAD_ALL, FORCE_DOWNLOAD_PATCHES, FORCE_DOWNLOAD_SOURCES
 from easybuild.tools.config import build_option, build_path, get_log_filename, get_repository, get_repositorypath
 from easybuild.tools.config import install_path, log_path, package_path, source_paths
@@ -1351,7 +1352,7 @@ class EasyBlock(object):
             # add user-specific module path; use statement will be guarded so no need to create the directories
             user_modpath = build_option('subdir_user_modules')
             if user_modpath:
-                user_envvars = build_option('envvars_user_modules') or ['HOME']
+                user_envvars = build_option('envvars_user_modules') or [DEFAULT_ENVVAR_USERS_MODULES]
                 user_modpath_exts = ActiveMNS().det_user_modpath_extensions(self.cfg)
                 self.log.debug("Including user module path extensions returned by naming scheme: %s", user_modpath_exts)
                 for user_envvar in user_envvars:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1356,9 +1356,8 @@ class EasyBlock(object):
                 user_modpath_exts = ActiveMNS().det_user_modpath_extensions(self.cfg)
                 self.log.debug("Including user module path extensions returned by naming scheme: %s", user_modpath_exts)
                 for user_envvar in user_envvars:
-                    if not os.getenv(user_envvar):
-                        self.log.warning("Requested environment variable $%s as an additional branch for user "
-                                         "modules does not exist in current environment", user_envvar)
+                    self.log.debug("Requested environment variable $%s to host additional branch for modules",
+                                   user_envvar)
                     default_value = user_envvar + "_NOT_DEFINED"
                     txt += self.module_generator.use(user_modpath_exts,
                                                      prefix=self.module_generator.getenv_cmd(user_envvar,

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1359,9 +1359,8 @@ class EasyBlock(object):
                     self.log.debug("Requested environment variable $%s to host additional branch for modules",
                                    user_envvar)
                     default_value = user_envvar + "_NOT_DEFINED"
-                    txt += self.module_generator.use(user_modpath_exts,
-                                                     prefix=self.module_generator.getenv_cmd(user_envvar,
-                                                                                             default=default_value),
+                    getenv_txt = self.module_generator.getenv_cmd(user_envvar, default=default_value)
+                    txt += self.module_generator.use(user_modpath_exts, prefix=getenv_txt,
                                                      guarded=True, user_modpath=user_modpath)
         else:
             self.log.debug("Not including module path extensions, as specified.")

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1357,8 +1357,8 @@ class EasyBlock(object):
                 self.log.debug("Including user module path extensions returned by naming scheme: %s", user_modpath_exts)
                 for user_envvar in user_envvars:
                     if not os.getenv(user_envvar):
-                        raise EasyBuildError("Requested environment variable $%s as an additional branch for user "
-                                             "modules does not exist in current environment", user_envvar)
+                        self.log.warning("Requested environment variable $%s as an additional branch for user "
+                                         "modules does not exist in current environment", user_envvar)
                     txt += self.module_generator.use(user_modpath_exts,
                                                      prefix=self.module_generator.getenv_cmd(user_envvar), guarded=True,
                                                      user_modpath=user_modpath)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1360,8 +1360,8 @@ class EasyBlock(object):
                         self.log.warning("Requested environment variable $%s as an additional branch for user "
                                          "modules does not exist in current environment", user_envvar)
                     txt += self.module_generator.use(user_modpath_exts,
-                                                     prefix=self.module_generator.getenv_cmd(user_envvar), guarded=True,
-                                                     user_modpath=user_modpath)
+                                                     prefix=self.module_generator.getenv_cmd(user_envvar, safe=True),
+                                                     guarded=True, user_modpath=user_modpath)
         else:
             self.log.debug("Not including module path extensions, as specified.")
         return txt

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1345,12 +1345,16 @@ class EasyBlock(object):
             # add user-specific module path; use statement will be guarded so no need to create the directories
             user_modpath = build_option('subdir_user_modules')
             if user_modpath:
-                user_envvar = build_option('envvar_user_modules')
+                user_envvars = build_option('envvars_user_modules') or ['HOME']
                 user_modpath_exts = ActiveMNS().det_user_modpath_extensions(self.cfg)
                 self.log.debug("Including user module path extensions returned by naming scheme: %s", user_modpath_exts)
-                txt += self.module_generator.use(user_modpath_exts,
-                                                 prefix=self.module_generator.getenv_cmd(user_envvar), guarded=True,
-                                                 user_modpath=user_modpath)
+                for user_envvar in user_envvars:
+                    if not os.getenv(user_envvar):
+                        raise EasyBuildError("Requested environment variable %s as an additional branch for user"
+                                             "modules does not exist in current environment", user_envvar)
+                    txt += self.module_generator.use(user_modpath_exts,
+                                                     prefix=self.module_generator.getenv_cmd(user_envvar), guarded=True,
+                                                     user_modpath=user_modpath)
         else:
             self.log.debug("Not including module path extensions, as specified.")
         return txt

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1345,10 +1345,12 @@ class EasyBlock(object):
             # add user-specific module path; use statement will be guarded so no need to create the directories
             user_modpath = build_option('subdir_user_modules')
             if user_modpath:
+                user_envvar = build_option('envvar_user_modules')
                 user_modpath_exts = ActiveMNS().det_user_modpath_extensions(self.cfg)
                 self.log.debug("Including user module path extensions returned by naming scheme: %s", user_modpath_exts)
-                txt += self.module_generator.use(user_modpath_exts, prefix=self.module_generator.getenv_cmd('HOME'),
-                                                 guarded=True, user_modpath=user_modpath)
+                txt += self.module_generator.use(user_modpath_exts,
+                                                 prefix=self.module_generator.getenv_cmd(user_envvar), guarded=True,
+                                                 user_modpath=user_modpath)
         else:
             self.log.debug("Not including module path extensions, as specified.")
         return txt

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1359,8 +1359,10 @@ class EasyBlock(object):
                     if not os.getenv(user_envvar):
                         self.log.warning("Requested environment variable $%s as an additional branch for user "
                                          "modules does not exist in current environment", user_envvar)
+                    default_value = user_envvar + "_NOT_DEFINED"
                     txt += self.module_generator.use(user_modpath_exts,
-                                                     prefix=self.module_generator.getenv_cmd(user_envvar, safe=True),
+                                                     prefix=self.module_generator.getenv_cmd(user_envvar,
+                                                                                             default=default_value),
                                                      guarded=True, user_modpath=user_modpath)
         else:
             self.log.debug("Not including module path extensions, as specified.")

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -79,6 +79,7 @@ CONT_TYPES = [CONT_TYPE_DOCKER, CONT_TYPE_SINGULARITY]
 DEFAULT_CONT_TYPE = CONT_TYPE_SINGULARITY
 
 DEFAULT_BRANCH = 'develop'
+DEFAULT_ENVVAR_USER_MODULES = 'HOME'
 DEFAULT_INDEX_MAX_AGE = 7 * 24 * 60 * 60  # 1 week (in seconds)
 DEFAULT_JOB_BACKEND = 'GC3Pie'
 DEFAULT_LOGFILE_FORMAT = ("easybuild", "easybuild-%(name)s-%(version)s-%(date)s.%(time)s.log")
@@ -290,6 +291,9 @@ BUILD_OPTIONS_CMDLINE = {
     ],
     DEFAULT_BRANCH: [
         'pr_target_branch',
+    ],
+    DEFAULT_ENVVAR_USER_MODULES: [
+        'envvar_user_modules',
     ],
     DEFAULT_INDEX_MAX_AGE: [
         'index_max_age',

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -79,7 +79,7 @@ CONT_TYPES = [CONT_TYPE_DOCKER, CONT_TYPE_SINGULARITY]
 DEFAULT_CONT_TYPE = CONT_TYPE_SINGULARITY
 
 DEFAULT_BRANCH = 'develop'
-DEFAULT_ENVVAR_USER_MODULES = 'HOME'
+DEFAULT_ENVVAR_USERS_MODULES = 'HOME'
 DEFAULT_INDEX_MAX_AGE = 7 * 24 * 60 * 60  # 1 week (in seconds)
 DEFAULT_JOB_BACKEND = 'GC3Pie'
 DEFAULT_LOGFILE_FORMAT = ("easybuild", "easybuild-%(name)s-%(version)s-%(date)s.%(time)s.log")
@@ -174,6 +174,7 @@ BUILD_OPTIONS_CMDLINE = {
         'download_timeout',
         'dump_test_report',
         'easyblock',
+        'envvars_user_modules',
         'extra_modules',
         'filter_deps',
         'filter_env_vars',
@@ -291,9 +292,6 @@ BUILD_OPTIONS_CMDLINE = {
     ],
     DEFAULT_BRANCH: [
         'pr_target_branch',
-    ],
-    DEFAULT_ENVVAR_USER_MODULES: [
-        'envvar_user_modules',
     ],
     DEFAULT_INDEX_MAX_AGE: [
         'index_max_age',

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -780,7 +780,7 @@ class ModuleGeneratorTcl(ModuleGenerator):
         """
         Return module-syntax specific code to get value of specific environment variable.
         """
-        return '$::env(%s)' % envvar
+        return '[if { [info exists ::env(%s)] } { concat $::env(%s) } ]' % (envvar, envvar)
 
     def load_module(self, mod_name, recursive_unload=False, depends_on=False, unload_modules=None, multi_dep_mods=None):
         """
@@ -1200,7 +1200,7 @@ class ModuleGeneratorLua(ModuleGenerator):
         """
         Return module-syntax specific code to get value of specific environment variable.
         """
-        return 'os.getenv("%s")' % envvar
+        return 'os.getenv("%s") or ""' % envvar
 
     def load_module(self, mod_name, recursive_unload=False, depends_on=False, unload_modules=None, multi_dep_mods=None):
         """

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -394,7 +394,7 @@ class ModuleGenerator(object):
         """
         raise NotImplementedError
 
-    def getenv_cmd(self, envvar, safe=False):
+    def getenv_cmd(self, envvar, default=None):
         """
         Return module-syntax specific code to get value of specific environment variable.
         """
@@ -776,12 +776,13 @@ class ModuleGeneratorTcl(ModuleGenerator):
 
         return txt
 
-    def getenv_cmd(self, envvar, safe=False):
+    def getenv_cmd(self, envvar, default=None):
         """
         Return module-syntax specific code to get value of specific environment variable.
         """
-        if safe:
-            cmd = '[if { [info exists ::env(%s)] } { concat $::env(%s) } ]' % (envvar, envvar)
+        if default is not None:
+            cmd = '[if { [info exists ::env(%s)] } { concat $::env(%s) } else { concat "%s" } ]' % (envvar, envvar,
+                                                                                                  default)
         else:
             cmd = '$::env(%s)' % envvar
         return cmd
@@ -1200,12 +1201,12 @@ class ModuleGeneratorLua(ModuleGenerator):
 
         return txt
 
-    def getenv_cmd(self, envvar, safe=False):
+    def getenv_cmd(self, envvar, default=None):
         """
         Return module-syntax specific code to get value of specific environment variable.
         """
-        if safe:
-            cmd = 'os.getenv("%s") or ""' % envvar
+        if default is not None:
+            cmd = 'os.getenv("%s") or "%s"' % (envvar, default)
         else:
             cmd = 'os.getenv("%s")' % envvar
         return cmd

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -782,7 +782,7 @@ class ModuleGeneratorTcl(ModuleGenerator):
         """
         if default is not None:
             cmd = '[if { [info exists ::env(%s)] } { concat $::env(%s) } else { concat "%s" } ]' % (envvar, envvar,
-                                                                                                  default)
+                                                                                                    default)
         else:
             cmd = '$::env(%s)' % envvar
         return cmd

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -780,11 +780,14 @@ class ModuleGeneratorTcl(ModuleGenerator):
         """
         Return module-syntax specific code to get value of specific environment variable.
         """
-        if default is not None:
-            cmd = '[if { [info exists ::env(%s)] } { concat $::env(%s) } else { concat "%s" } ]' % (envvar, envvar,
-                                                                                                    default)
-        else:
+        if default is None:
             cmd = '$::env(%s)' % envvar
+        else:
+            values = {
+                'default': default,
+                'envvar': '::env(%s)' % envvar,
+            }
+            cmd = '[if { [info exists %(envvar)s] } { concat $%(envvar)s } else { concat "%(default)s" } ]' % values
         return cmd
 
     def load_module(self, mod_name, recursive_unload=False, depends_on=False, unload_modules=None, multi_dep_mods=None):
@@ -1205,10 +1208,10 @@ class ModuleGeneratorLua(ModuleGenerator):
         """
         Return module-syntax specific code to get value of specific environment variable.
         """
-        if default is not None:
-            cmd = 'os.getenv("%s") or "%s"' % (envvar, default)
-        else:
+        if default is None:
             cmd = 'os.getenv("%s")' % envvar
+        else:
+            cmd = 'os.getenv("%s") or "%s"' % (envvar, default)
         return cmd
 
     def load_module(self, mod_name, recursive_unload=False, depends_on=False, unload_modules=None, multi_dep_mods=None):

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -394,7 +394,7 @@ class ModuleGenerator(object):
         """
         raise NotImplementedError
 
-    def getenv_cmd(self, envvar):
+    def getenv_cmd(self, envvar, safe=False):
         """
         Return module-syntax specific code to get value of specific environment variable.
         """
@@ -776,11 +776,15 @@ class ModuleGeneratorTcl(ModuleGenerator):
 
         return txt
 
-    def getenv_cmd(self, envvar):
+    def getenv_cmd(self, envvar, safe=False):
         """
         Return module-syntax specific code to get value of specific environment variable.
         """
-        return '[if { [info exists ::env(%s)] } { concat $::env(%s) } ]' % (envvar, envvar)
+        if safe:
+            cmd = '[if { [info exists ::env(%s)] } { concat $::env(%s) } ]' % (envvar, envvar)
+        else:
+            cmd = '$::env(%s)' % envvar
+        return cmd
 
     def load_module(self, mod_name, recursive_unload=False, depends_on=False, unload_modules=None, multi_dep_mods=None):
         """
@@ -1196,11 +1200,15 @@ class ModuleGeneratorLua(ModuleGenerator):
 
         return txt
 
-    def getenv_cmd(self, envvar):
+    def getenv_cmd(self, envvar, safe=False):
         """
         Return module-syntax specific code to get value of specific environment variable.
         """
-        return 'os.getenv("%s") or ""' % envvar
+        if safe:
+            cmd = 'os.getenv("%s") or ""' % envvar
+        else:
+            cmd = 'os.getenv("%s")' % envvar
+        return cmd
 
     def load_module(self, mod_name, recursive_unload=False, depends_on=False, unload_modules=None, multi_dep_mods=None):
         """

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -60,7 +60,8 @@ from easybuild.tools import build_log, run  # build_log should always stay there
 from easybuild.tools.build_log import DEVEL_LOG_LEVEL, EasyBuildError
 from easybuild.tools.build_log import init_logging, log_start, print_msg, print_warning, raise_easybuilderror
 from easybuild.tools.config import CONT_IMAGE_FORMATS, CONT_TYPES, DEFAULT_CONT_TYPE, DEFAULT_ALLOW_LOADED_MODULES
-from easybuild.tools.config import DEFAULT_BRANCH, DEFAULT_FORCE_DOWNLOAD, DEFAULT_INDEX_MAX_AGE
+from easybuild.tools.config import DEFAULT_BRANCH, DEFAULT_ENVVAR_USER_MODULES
+from easybuild.tools.config import DEFAULT_FORCE_DOWNLOAD, DEFAULT_INDEX_MAX_AGE
 from easybuild.tools.config import DEFAULT_JOB_BACKEND, DEFAULT_LOGFILE_FORMAT, DEFAULT_MAX_FAIL_RATIO_PERMS
 from easybuild.tools.config import DEFAULT_MINIMAL_BUILD_ENV, DEFAULT_MNS, DEFAULT_MODULE_SYNTAX, DEFAULT_MODULES_TOOL
 from easybuild.tools.config import DEFAULT_MODULECLASSES, DEFAULT_PATH_SUBDIRS, DEFAULT_PKG_RELEASE, DEFAULT_PKG_TOOL
@@ -489,6 +490,9 @@ class EasyBuildOptions(GeneralOption):
             'buildpath': ("Temporary build path", None, 'store', mk_full_default_path('buildpath')),
             'containerpath': ("Location where container recipe & image will be stored", None, 'store',
                               mk_full_default_path('containerpath')),
+            'envvar-user-modules': ("Environment variable that holds the base path for which user-specific modules are "
+                                    "installed relative to (defaults to 'HOME')", None, 'store',
+                                    DEFAULT_ENVVAR_USER_MODULES),
             'external-modules-metadata': ("List of (glob patterns for) paths to files specifying metadata "
                                           "for external modules (INI format)", 'strlist', 'store', None),
             'hooks': ("Location of Python module with hook implementations", 'str', 'store', None),
@@ -547,7 +551,8 @@ class EasyBuildOptions(GeneralOption):
             'subdir-modules': ("Installpath subdir for modules", None, 'store', DEFAULT_PATH_SUBDIRS['subdir_modules']),
             'subdir-software': ("Installpath subdir for software",
                                 None, 'store', DEFAULT_PATH_SUBDIRS['subdir_software']),
-            'subdir-user-modules': ("Base path of user-specific modules relative to their $HOME", None, 'store', None),
+            'subdir-user-modules': ("Base path of user-specific modules relative to --envvar-user-modules (which "
+                                    "defaults to $HOME)", None, 'store', None),
             'suffix-modules-path': ("Suffix for module files install path", None, 'store', GENERAL_CLASS),
             # this one is sort of an exception, it's something jobscripts can set,
             # has no real meaning for regular eb usage

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -60,8 +60,7 @@ from easybuild.tools import build_log, run  # build_log should always stay there
 from easybuild.tools.build_log import DEVEL_LOG_LEVEL, EasyBuildError
 from easybuild.tools.build_log import init_logging, log_start, print_msg, print_warning, raise_easybuilderror
 from easybuild.tools.config import CONT_IMAGE_FORMATS, CONT_TYPES, DEFAULT_CONT_TYPE, DEFAULT_ALLOW_LOADED_MODULES
-from easybuild.tools.config import DEFAULT_BRANCH, DEFAULT_ENVVAR_USER_MODULES
-from easybuild.tools.config import DEFAULT_FORCE_DOWNLOAD, DEFAULT_INDEX_MAX_AGE
+from easybuild.tools.config import DEFAULT_BRANCH, DEFAULT_FORCE_DOWNLOAD, DEFAULT_INDEX_MAX_AGE
 from easybuild.tools.config import DEFAULT_JOB_BACKEND, DEFAULT_LOGFILE_FORMAT, DEFAULT_MAX_FAIL_RATIO_PERMS
 from easybuild.tools.config import DEFAULT_MINIMAL_BUILD_ENV, DEFAULT_MNS, DEFAULT_MODULE_SYNTAX, DEFAULT_MODULES_TOOL
 from easybuild.tools.config import DEFAULT_MODULECLASSES, DEFAULT_PATH_SUBDIRS, DEFAULT_PKG_RELEASE, DEFAULT_PKG_TOOL
@@ -490,9 +489,9 @@ class EasyBuildOptions(GeneralOption):
             'buildpath': ("Temporary build path", None, 'store', mk_full_default_path('buildpath')),
             'containerpath': ("Location where container recipe & image will be stored", None, 'store',
                               mk_full_default_path('containerpath')),
-            'envvar-user-modules': ("Environment variable that holds the base path for which user-specific modules are "
-                                    "installed relative to (defaults to 'HOME')", None, 'store',
-                                    DEFAULT_ENVVAR_USER_MODULES),
+            'envvars-user-modules': ("List of environment variables that hold the base paths for which user-specific "
+                                     "modules will be installed relative to", 'strlist', 'store',
+                                     ['HOME']),
             'external-modules-metadata': ("List of (glob patterns for) paths to files specifying metadata "
                                           "for external modules (INI format)", 'strlist', 'store', None),
             'hooks': ("Location of Python module with hook implementations", 'str', 'store', None),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -60,7 +60,8 @@ from easybuild.tools import build_log, run  # build_log should always stay there
 from easybuild.tools.build_log import DEVEL_LOG_LEVEL, EasyBuildError
 from easybuild.tools.build_log import init_logging, log_start, print_msg, print_warning, raise_easybuilderror
 from easybuild.tools.config import CONT_IMAGE_FORMATS, CONT_TYPES, DEFAULT_CONT_TYPE, DEFAULT_ALLOW_LOADED_MODULES
-from easybuild.tools.config import DEFAULT_BRANCH, DEFAULT_FORCE_DOWNLOAD, DEFAULT_INDEX_MAX_AGE
+from easybuild.tools.config import DEFAULT_BRANCH, DEFAULT_ENVVAR_USERS_MODULES, DEFAULT_FORCE_DOWNLOAD
+from easybuild.tools.config import DEFAULT_INDEX_MAX_AGE
 from easybuild.tools.config import DEFAULT_JOB_BACKEND, DEFAULT_LOGFILE_FORMAT, DEFAULT_MAX_FAIL_RATIO_PERMS
 from easybuild.tools.config import DEFAULT_MINIMAL_BUILD_ENV, DEFAULT_MNS, DEFAULT_MODULE_SYNTAX, DEFAULT_MODULES_TOOL
 from easybuild.tools.config import DEFAULT_MODULECLASSES, DEFAULT_PATH_SUBDIRS, DEFAULT_PKG_RELEASE, DEFAULT_PKG_TOOL
@@ -491,7 +492,7 @@ class EasyBuildOptions(GeneralOption):
                               mk_full_default_path('containerpath')),
             'envvars-user-modules': ("List of environment variables that hold the base paths for which user-specific "
                                      "modules will be installed relative to", 'strlist', 'store',
-                                     ['HOME']),
+                                     [DEFAULT_ENVVAR_USERS_MODULES]),
             'external-modules-metadata': ("List of (glob patterns for) paths to files specifying metadata "
                                           "for external modules (INI format)", 'strlist', 'store', None),
             'hooks': ("Location of Python module with hook implementations", 'str', 'store', None),
@@ -550,8 +551,8 @@ class EasyBuildOptions(GeneralOption):
             'subdir-modules': ("Installpath subdir for modules", None, 'store', DEFAULT_PATH_SUBDIRS['subdir_modules']),
             'subdir-software': ("Installpath subdir for software",
                                 None, 'store', DEFAULT_PATH_SUBDIRS['subdir_software']),
-            'subdir-user-modules': ("Base path of user-specific modules relative to --envvar-user-modules (which "
-                                    "defaults to $HOME)", None, 'store', None),
+            'subdir-user-modules': ("Base path of user-specific modules relative to --envvar-user-modules",
+                                    None, 'store', None),
             'suffix-modules-path': ("Suffix for module files install path", None, 'store', GENERAL_CLASS),
             # this one is sort of an exception, it's something jobscripts can set,
             # has no real meaning for regular eb usage

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -307,8 +307,6 @@ class EasyBlockTest(EnhancedTestCase):
         list_of_envvars = ['SITE_INSTALLS', 'USER_INSTALLS']
         site_install_path = os.path.join(config.install_path(), 'site')
         user_install_path = os.path.join(config.install_path(), 'user')
-        os.environ['SITE_INSTALLS'] = site_install_path
-        os.environ['USER_INSTALLS'] = user_install_path
 
         build_options = {
             'envvars_user_modules': list_of_envvars,
@@ -373,7 +371,7 @@ class EasyBlockTest(EnhancedTestCase):
         os.environ['MODULEPATH'] = temp_module_file_dir
 
         # Let's switch to a dir where the paths we will use exist to make sure they can
-        # not be accidentally picked up is the variable is not defined but the paths exist
+        # not be accidentally picked up if the variable is not defined but the paths exist
         # relative to the current directory
         cwd = os.getcwd()
         os.makedirs(os.path.join(config.install_path(), "existing_dir", usermodsdir, "funky", "Compiler/pi/3.14"))
@@ -382,6 +380,10 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertFalse(os.path.join(usermodsdir, "funky") in os.environ['MODULEPATH'])
         self.modtool.run_module('unload', 'mytest')
         change_dir(cwd)
+
+        # Now define our environment variables
+        os.environ['SITE_INSTALLS'] = site_install_path
+        os.environ['USER_INSTALLS'] = user_install_path
 
         # Check MODULEPATH when neither directories exist
         self.modtool.run_module('load', 'mytest')

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -368,8 +368,20 @@ class EasyBlockTest(EnhancedTestCase):
         handle = open(module_file, "w")
         handle.write(module_txt)
         handle.close()
+
         # Set MODULEPATH and check the effect of `module load`
         os.environ['MODULEPATH'] = temp_module_file_dir
+
+        # Let's switch to a dir where the paths we will use exist to make sure they can
+        # not be accidentally picked up is the variable is not defined but the paths exist
+        # relative to the current directory
+        cwd = os.getcwd()
+        os.makedirs(os.path.join(config.install_path(), "existing_dir", "my/own/modules", "funky", "Compiler/pi/3.14"))
+        change_dir(os.path.join(config.install_path(), "existing_dir"))
+        self.modtool.run_module('load', 'mytest')
+        self.assertFalse("existing_dir" in os.environ['MODULEPATH'])
+        self.modtool.run_module('unload', 'mytest')
+        change_dir(cwd)
 
         # Check MODULEPATH when neither directories exist
         self.modtool.run_module('load', 'mytest')

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -304,8 +304,8 @@ class EasyBlockTest(EnhancedTestCase):
 
         # Repeat this but using an alternate envvars (instead of $HOME)
         list_of_envvars = ['SITE_INSTALLS', 'USER_INSTALLS']
-        site_install_path = os.path.join('path','to','site','installs')
-        user_install_path = os.path.join('path','to','user','installs')
+        site_install_path = os.path.join('path', 'to', 'site', 'installs')
+        user_install_path = os.path.join('path', 'to', 'user', 'installs')
         os.environ['SITE_INSTALLS'] = site_install_path
         os.environ['USER_INSTALLS'] = user_install_path
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -329,7 +329,8 @@ class EasyBlockTest(EnhancedTestCase):
                     r'^\s+module use \[ file join %s \[ %s \] \]$' % (home, fj_usermodsdir),
                 ])
             elif get_module_syntax() == 'Lua':
-                regexs = [r'^prepend_path\("MODULEPATH", ".*/modules/funky/Compiler/pi/3.14/%s"\)$' % c for c in modclasses]
+                regexs = [r'^prepend_path\("MODULEPATH", ".*/modules/funky/Compiler/pi/3.14/%s"\)$' % c
+                          for c in modclasses]
                 home = r'os.getenv\("%s"\)' % envvar
                 pj_usermodsdir = r'pathJoin\("%s", "funky", "Compiler/pi/3.14"\)' % usermodsdir
                 regexs.extend([

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -351,8 +351,9 @@ class EasyBlockTest(EnhancedTestCase):
             os.unsetenv(envvar)
 
         # Check behaviour when directories do and do not exist
-        site_modules = os.path.join(site_install_path, usermodsdir, "funky", "Compiler/pi/3.14")
-        user_modules = os.path.join(user_install_path, usermodsdir, "funky", "Compiler/pi/3.14")
+        usermodsdir_extension = os.path.join(usermodsdir, "funky", "Compiler/pi/3.14")
+        site_modules = os.path.join(site_install_path, usermodsdir_extension)
+        user_modules = os.path.join(user_install_path, usermodsdir_extension)
         # make a modules directory so that we can create our module files
         temp_module_file_dir = os.path.join(site_install_path, usermodsdir, "temp_module_files")
         os.makedirs(temp_module_file_dir)
@@ -374,10 +375,10 @@ class EasyBlockTest(EnhancedTestCase):
         # not be accidentally picked up if the variable is not defined but the paths exist
         # relative to the current directory
         cwd = os.getcwd()
-        os.makedirs(os.path.join(config.install_path(), "existing_dir", usermodsdir, "funky", "Compiler/pi/3.14"))
+        os.makedirs(os.path.join(config.install_path(), "existing_dir", usermodsdir_extension))
         change_dir(os.path.join(config.install_path(), "existing_dir"))
         self.modtool.run_module('load', 'mytest')
-        self.assertFalse(os.path.join(usermodsdir, "funky") in os.environ['MODULEPATH'])
+        self.assertFalse(usermodsdir_extension in os.environ['MODULEPATH'])
         self.modtool.run_module('unload', 'mytest')
         change_dir(cwd)
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -263,7 +263,7 @@ class EasyBlockTest(EnhancedTestCase):
 
         # no $MODULEPATH extensions for default module naming scheme (EasyBuildMNS)
         self.assertEqual(eb.make_module_extend_modpath(), '')
-        usermodsdir = 'my/own/modules'
+        usermodsdir = 'my_own_modules'
         modclasses = ['compiler', 'tools']
         os.environ['EASYBUILD_MODULE_NAMING_SCHEME'] = 'CategorizedHMNS'
         build_options = {
@@ -353,10 +353,10 @@ class EasyBlockTest(EnhancedTestCase):
             os.unsetenv(envvar)
 
         # Check behaviour when directories do and do not exist
-        site_modules = os.path.join(site_install_path, "my/own/modules", "funky", "Compiler/pi/3.14")
-        user_modules = os.path.join(user_install_path, "my/own/modules", "funky", "Compiler/pi/3.14")
+        site_modules = os.path.join(site_install_path, usermodsdir, "funky", "Compiler/pi/3.14")
+        user_modules = os.path.join(user_install_path, usermodsdir, "funky", "Compiler/pi/3.14")
         # make a modules directory so that we can create our module files
-        temp_module_file_dir = os.path.join(site_install_path, "my/own/modules", "temp_module_files")
+        temp_module_file_dir = os.path.join(site_install_path, usermodsdir, "temp_module_files")
         os.makedirs(temp_module_file_dir)
         # write out a module file
         if get_module_syntax() == 'Tcl':
@@ -376,10 +376,10 @@ class EasyBlockTest(EnhancedTestCase):
         # not be accidentally picked up is the variable is not defined but the paths exist
         # relative to the current directory
         cwd = os.getcwd()
-        os.makedirs(os.path.join(config.install_path(), "existing_dir", "my/own/modules", "funky", "Compiler/pi/3.14"))
+        os.makedirs(os.path.join(config.install_path(), "existing_dir", usermodsdir, "funky", "Compiler/pi/3.14"))
         change_dir(os.path.join(config.install_path(), "existing_dir"))
         self.modtool.run_module('load', 'mytest')
-        self.assertFalse("existing_dir" in os.environ['MODULEPATH'])
+        self.assertFalse(os.path.join(usermodsdir, "funky") in os.environ['MODULEPATH'])
         self.modtool.run_module('unload', 'mytest')
         change_dir(cwd)
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -278,7 +278,7 @@ class EasyBlockTest(EnhancedTestCase):
         txt = eb.make_module_extend_modpath()
         if get_module_syntax() == 'Tcl':
             regexs = [r'^module use ".*/modules/funky/Compiler/pi/3.14/%s"$' % c for c in modclasses]
-            home = r'\$::env\(HOME\)'
+            home = r'\[if \{ \[info exists ::env\(%s\)\] \} \{ concat \$::env\(%s\) \} \]' % ("HOME", "HOME")
             fj_usermodsdir = 'file join "%s" "funky" "Compiler/pi/3.14"' % usermodsdir
             regexs.extend([
                 # extension for user modules is guarded
@@ -288,7 +288,7 @@ class EasyBlockTest(EnhancedTestCase):
             ])
         elif get_module_syntax() == 'Lua':
             regexs = [r'^prepend_path\("MODULEPATH", ".*/modules/funky/Compiler/pi/3.14/%s"\)$' % c for c in modclasses]
-            home = r'os.getenv\("HOME"\)'
+            home = r'os.getenv\("HOME"\) or ""'
             pj_usermodsdir = r'pathJoin\("%s", "funky", "Compiler/pi/3.14"\)' % usermodsdir
             regexs.extend([
                 # extension for user modules is guarded
@@ -323,7 +323,8 @@ class EasyBlockTest(EnhancedTestCase):
         for envvar in list_of_envvars:
             if get_module_syntax() == 'Tcl':
                 regexs = [r'^module use ".*/modules/funky/Compiler/pi/3.14/%s"$' % c for c in modclasses]
-                module_envvar = r'\$::env\(%s\)' % envvar
+                module_envvar = r'\[if \{ \[info exists ::env\(%s\)\] \} \{ concat \$::env\(%s\) \} \]' % (envvar,
+                                                                                                           envvar)
                 fj_usermodsdir = 'file join "%s" "funky" "Compiler/pi/3.14"' % usermodsdir
                 regexs.extend([
                     # extension for user modules is guarded
@@ -334,7 +335,7 @@ class EasyBlockTest(EnhancedTestCase):
             elif get_module_syntax() == 'Lua':
                 regexs = [r'^prepend_path\("MODULEPATH", ".*/modules/funky/Compiler/pi/3.14/%s"\)$' % c
                           for c in modclasses]
-                module_envvar = r'os.getenv\("%s"\)' % envvar
+                module_envvar = r'os.getenv\("%s"\) or ""' % envvar
                 pj_usermodsdir = r'pathJoin\("%s", "funky", "Compiler/pi/3.14"\)' % usermodsdir
                 regexs.extend([
                     # extension for user modules is guarded

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -362,11 +362,9 @@ class EasyBlockTest(EnhancedTestCase):
         if get_module_syntax() == 'Tcl':
             module_file = os.path.join(temp_module_file_dir, "mytest")
             module_txt = "#%Module\n" + txt
-            print(module_txt)
         elif get_module_syntax() == 'Lua':
             module_file = os.path.join(temp_module_file_dir, "mytest.lua")
             module_txt = txt
-            print(module_txt)
         handle = open(module_file, "w")
         handle.write(module_txt)
         handle.close()

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -278,7 +278,8 @@ class EasyBlockTest(EnhancedTestCase):
         txt = eb.make_module_extend_modpath()
         if get_module_syntax() == 'Tcl':
             regexs = [r'^module use ".*/modules/funky/Compiler/pi/3.14/%s"$' % c for c in modclasses]
-            home = r'\[if \{ \[info exists ::env\(%s\)\] \} \{ concat \$::env\(%s\) \} \]' % ("HOME", "HOME")
+            home = r'\[if { \[info exists ::env\(%s\)\] } { concat \$::env\(%s\) } else { concat "%s" } \]'\
+                   % ("HOME", "HOME", "HOME_NOT_DEFINED")
             fj_usermodsdir = 'file join "%s" "funky" "Compiler/pi/3.14"' % usermodsdir
             regexs.extend([
                 # extension for user modules is guarded
@@ -288,7 +289,7 @@ class EasyBlockTest(EnhancedTestCase):
             ])
         elif get_module_syntax() == 'Lua':
             regexs = [r'^prepend_path\("MODULEPATH", ".*/modules/funky/Compiler/pi/3.14/%s"\)$' % c for c in modclasses]
-            home = r'os.getenv\("HOME"\) or ""'
+            home = r'os.getenv\("HOME"\) or "HOME_NOT_DEFINED"'
             pj_usermodsdir = r'pathJoin\("%s", "funky", "Compiler/pi/3.14"\)' % usermodsdir
             regexs.extend([
                 # extension for user modules is guarded
@@ -323,8 +324,9 @@ class EasyBlockTest(EnhancedTestCase):
         for envvar in list_of_envvars:
             if get_module_syntax() == 'Tcl':
                 regexs = [r'^module use ".*/modules/funky/Compiler/pi/3.14/%s"$' % c for c in modclasses]
-                module_envvar = r'\[if \{ \[info exists ::env\(%s\)\] \} \{ concat \$::env\(%s\) \} \]' % (envvar,
-                                                                                                           envvar)
+                module_envvar =\
+                    r'\[if \{ \[info exists ::env\(%s\)\] \} \{ concat \$::env\(%s\) \} else { concat "%s" } \]'\
+                    % (envvar, envvar, envvar + "_NOT_DEFINED")
                 fj_usermodsdir = 'file join "%s" "funky" "Compiler/pi/3.14"' % usermodsdir
                 regexs.extend([
                     # extension for user modules is guarded
@@ -335,7 +337,7 @@ class EasyBlockTest(EnhancedTestCase):
             elif get_module_syntax() == 'Lua':
                 regexs = [r'^prepend_path\("MODULEPATH", ".*/modules/funky/Compiler/pi/3.14/%s"\)$' % c
                           for c in modclasses]
-                module_envvar = r'os.getenv\("%s"\) or ""' % envvar
+                module_envvar = r'os.getenv\("%s"\) or "%s"' % (envvar, envvar + "_NOT_DEFINED")
                 pj_usermodsdir = r'pathJoin\("%s", "funky", "Compiler/pi/3.14"\)' % usermodsdir
                 regexs.extend([
                     # extension for user modules is guarded
@@ -360,9 +362,11 @@ class EasyBlockTest(EnhancedTestCase):
         if get_module_syntax() == 'Tcl':
             module_file = os.path.join(temp_module_file_dir, "mytest")
             module_txt = "#%Module\n" + txt
+            print(module_txt)
         elif get_module_syntax() == 'Lua':
             module_file = os.path.join(temp_module_file_dir, "mytest.lua")
             module_txt = txt
+            print(module_txt)
         handle = open(module_file, "w")
         handle.write(module_txt)
         handle.close()

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -303,9 +303,11 @@ class EasyBlockTest(EnhancedTestCase):
             self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
 
         # Repeat this but using an alternate envvars (instead of $HOME)
-        list_of_envvars = ['TURKEY', 'HAM']
-        os.environ['TURKEY'] = "1"
-        os.environ['HAM'] = "1"
+        list_of_envvars = ['SITE_INSTALLS', 'USER_INSTALLS']
+        site_install_path = os.path.join('path','to','site','installs')
+        user_install_path = os.path.join('path','to','user','installs')
+        os.environ['SITE_INSTALLS'] = site_install_path
+        os.environ['USER_INSTALLS'] = user_install_path
 
         build_options = {
             'envvars_user_modules': list_of_envvars,
@@ -321,24 +323,24 @@ class EasyBlockTest(EnhancedTestCase):
         for envvar in list_of_envvars:
             if get_module_syntax() == 'Tcl':
                 regexs = [r'^module use ".*/modules/funky/Compiler/pi/3.14/%s"$' % c for c in modclasses]
-                home = r'\$::env\(%s\)' % envvar
+                module_envvar = r'\$::env\(%s\)' % envvar
                 fj_usermodsdir = 'file join "%s" "funky" "Compiler/pi/3.14"' % usermodsdir
                 regexs.extend([
                     # extension for user modules is guarded
-                    r'if { \[ file isdirectory \[ file join %s \[ %s \] \] \] } {$' % (home, fj_usermodsdir),
+                    r'if { \[ file isdirectory \[ file join %s \[ %s \] \] \] } {$' % (module_envvar, fj_usermodsdir),
                     # no per-moduleclass extension for user modules
-                    r'^\s+module use \[ file join %s \[ %s \] \]$' % (home, fj_usermodsdir),
+                    r'^\s+module use \[ file join %s \[ %s \] \]$' % (module_envvar, fj_usermodsdir),
                 ])
             elif get_module_syntax() == 'Lua':
                 regexs = [r'^prepend_path\("MODULEPATH", ".*/modules/funky/Compiler/pi/3.14/%s"\)$' % c
                           for c in modclasses]
-                home = r'os.getenv\("%s"\)' % envvar
+                module_envvar = r'os.getenv\("%s"\)' % envvar
                 pj_usermodsdir = r'pathJoin\("%s", "funky", "Compiler/pi/3.14"\)' % usermodsdir
                 regexs.extend([
                     # extension for user modules is guarded
-                    r'if isDir\(pathJoin\(%s, %s\)\) then' % (home, pj_usermodsdir),
+                    r'if isDir\(pathJoin\(%s, %s\)\) then' % (module_envvar, pj_usermodsdir),
                     # no per-moduleclass extension for user modules
-                    r'\s+prepend_path\("MODULEPATH", pathJoin\(%s, %s\)\)' % (home, pj_usermodsdir),
+                    r'\s+prepend_path\("MODULEPATH", pathJoin\(%s, %s\)\)' % (module_envvar, pj_usermodsdir),
                 ])
             else:
                 self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -301,9 +301,13 @@ class EasyBlockTest(EnhancedTestCase):
             regex = re.compile(regex, re.M)
             self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
 
-        # Repeat this but using an alternate envvar (instead of $HOME)
+        # Repeat this but using an alternate envvars (instead of $HOME)
+        list_of_envvars = ['TURKEY', 'HAM']
+        os.environ['TURKEY'] = "1"
+        os.environ['HAM'] = "1"
+
         build_options = {
-            'envvar_user_modules': 'TURKEY',
+            'envvars_user_modules': list_of_envvars,
             'subdir_user_modules': usermodsdir,
             'valid_module_classes': modclasses,
             'suffix_modules_path': 'funky',
@@ -313,31 +317,33 @@ class EasyBlockTest(EnhancedTestCase):
         eb.installdir = config.install_path()
 
         txt = eb.make_module_extend_modpath()
-        if get_module_syntax() == 'Tcl':
-            regexs = [r'^module use ".*/modules/funky/Compiler/pi/3.14/%s"$' % c for c in modclasses]
-            home = r'\$::env\(TURKEY\)'
-            fj_usermodsdir = 'file join "%s" "funky" "Compiler/pi/3.14"' % usermodsdir
-            regexs.extend([
-                # extension for user modules is guarded
-                r'if { \[ file isdirectory \[ file join %s \[ %s \] \] \] } {$' % (home, fj_usermodsdir),
-                # no per-moduleclass extension for user modules
-                r'^\s+module use \[ file join %s \[ %s \] \]$' % (home, fj_usermodsdir),
-            ])
-        elif get_module_syntax() == 'Lua':
-            regexs = [r'^prepend_path\("MODULEPATH", ".*/modules/funky/Compiler/pi/3.14/%s"\)$' % c for c in modclasses]
-            home = r'os.getenv\("TURKEY"\)'
-            pj_usermodsdir = r'pathJoin\("%s", "funky", "Compiler/pi/3.14"\)' % usermodsdir
-            regexs.extend([
-                # extension for user modules is guarded
-                r'if isDir\(pathJoin\(%s, %s\)\) then' % (home, pj_usermodsdir),
-                # no per-moduleclass extension for user modules
-                r'\s+prepend_path\("MODULEPATH", pathJoin\(%s, %s\)\)' % (home, pj_usermodsdir),
-            ])
-        else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
-        for regex in regexs:
-            regex = re.compile(regex, re.M)
-            self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
+        for envvar in list_of_envvars:
+            if get_module_syntax() == 'Tcl':
+                regexs = [r'^module use ".*/modules/funky/Compiler/pi/3.14/%s"$' % c for c in modclasses]
+                home = r'\$::env\(%s\)' % envvar
+                fj_usermodsdir = 'file join "%s" "funky" "Compiler/pi/3.14"' % usermodsdir
+                regexs.extend([
+                    # extension for user modules is guarded
+                    r'if { \[ file isdirectory \[ file join %s \[ %s \] \] \] } {$' % (home, fj_usermodsdir),
+                    # no per-moduleclass extension for user modules
+                    r'^\s+module use \[ file join %s \[ %s \] \]$' % (home, fj_usermodsdir),
+                ])
+            elif get_module_syntax() == 'Lua':
+                regexs = [r'^prepend_path\("MODULEPATH", ".*/modules/funky/Compiler/pi/3.14/%s"\)$' % c for c in modclasses]
+                home = r'os.getenv\("%s"\)' % envvar
+                pj_usermodsdir = r'pathJoin\("%s", "funky", "Compiler/pi/3.14"\)' % usermodsdir
+                regexs.extend([
+                    # extension for user modules is guarded
+                    r'if isDir\(pathJoin\(%s, %s\)\) then' % (home, pj_usermodsdir),
+                    # no per-moduleclass extension for user modules
+                    r'\s+prepend_path\("MODULEPATH", pathJoin\(%s, %s\)\)' % (home, pj_usermodsdir),
+                ])
+            else:
+                self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            for regex in regexs:
+                regex = re.compile(regex, re.M)
+                self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
+            os.unsetenv(envvar)
 
     def test_make_module_req(self):
         """Testcase for make_module_req"""


### PR DESCRIPTION
The use of `$HOME` for user modules is quite restrictive, it makes it very difficult to share user space installations. Even if we use a symlink to an accessible space it is still problematic as the `root` directory is still placed into the module (with $HOME expanded).

The nice thing about `$HOME` is that it is guaranteed to exist and right now that is required by module file that we create. Nevertheless, if a site is willing to take on using another (configurable) variable instead (with a sensible default value, such as `$HOME`), it would make user space installations with a module hierarchy a lot more flexible.