### PR TITLE
avoid initializing Toolchain instance when taking into account toolchain dependencies for templates

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -233,7 +233,6 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
         #  a cyclic import...);
         # we need to know to determine whether we're iterating over a list of build dependencies
         is_easyconfig = hasattr(config, 'iterating') and hasattr(config, 'iterate_options')
-
         if is_easyconfig:
             # if we're iterating over different lists of build dependencies,
             # only consider build dependencies when we're actually in iterative mode!
@@ -243,9 +242,11 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
             else:
                 deps.extend(config.get('builddependencies', []))
 
-            # Include all toolchain deps (e.g. CUDAcore template in fosscuda)
-            if config.toolchain.tcdeps is not None:
-                deps.extend(config.toolchain.tcdeps)
+            # include all toolchain deps (e.g. CUDAcore component in fosscuda);
+            # access Toolchain instance via _toolchain to avoid triggering initialization of the toolchain!
+            if config._toolchain is not None:
+                if config._toolchain.tcdeps is not None:
+                    deps.extend(config._toolchain.tcdeps)
 
         for dep in deps:
             if isinstance(dep, dict):

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1050,6 +1050,51 @@ class EasyConfigTest(EnhancedTestCase):
         ec = EasyConfig(test_ec)
         self.assertEqual(ec['sanity_check_commands'], ['mpiexec -np 1 -- toy'])
 
+    def test_templating_cuda_toolchain(self):
+        """Test templates via toolchain component, like setting %(cudaver)s with fosscuda toolchain."""
+
+        build_options = {'robot_path': [self.test_prefix]}
+        init_config(build_options=build_options)
+
+        # create fake easyconfig files, good enough to test with
+        cuda_ec = os.path.join(self.test_prefix, 'CUDA-10.1.243')
+        cuda_ec_txt = '\n'.join([
+            "easyblock = 'Toolchain'",
+            "name = 'CUDA'",
+            "version = '10.1.243'",
+            "homepage = 'https://example.com'",
+            "description = 'CUDA'",
+            "toolchain = SYSTEM",
+        ])
+        write_file(cuda_ec, cuda_ec_txt)
+
+        fosscuda_ec = os.path.join(self.test_prefix, 'fosscuda-2021.02.eb')
+        fosscuda_ec_txt = '\n'.join([
+            "easyblock = 'Toolchain'",
+            "name = 'fosscuda'",
+            "version = '2021.02'",
+            "homepage = 'https://example.com'",
+            "description = 'fosscuda toolchain'",
+            "toolchain = SYSTEM",
+            "dependencies = [('CUDA', '10.1.243')]",
+        ])
+        write_file(fosscuda_ec, fosscuda_ec_txt)
+
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        test_ec_txt = '\n'.join([
+            "easyblock = 'Toolchain'",
+            "name = 'test'",
+            "version = '1.0'",
+            "homepage = 'https://example.com'",
+            "description = 'just a test'",
+            "toolchain = {'name': 'fosscuda', 'version': '2021.02'}",
+        ])
+        write_file(test_ec, test_ec_txt)
+        ec = EasyConfig(test_ec)
+        self.assertEqual(ec.template_values['cudaver'], '10.1.243')
+        self.assertEqual(ec.template_values['cudamajver'], '10')
+        self.assertEqual(ec.template_values['cudashortver'], '10.1')
+
     def test_java_wrapper_templating(self):
         """test templating when the Java wrapper is a dep"""
         self.contents = '\n'.join([

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -436,7 +436,7 @@ class RobotTest(EnhancedTestCase):
             "   ('SQLite', '3.8.10.2'),",
             "]",
             # toolchain as list line, for easy modification later;
-            "toolchain = {'name': 'foss', 'version': '2018a'}",
+            "toolchain = {'name': 'foss', 'version': '%(version_minor)s018a'}",
         ]
         write_file(barec, '\n'.join(barec_lines))
         bar = process_easyconfig(barec)[0]


### PR DESCRIPTION
This was missing in #3541.

The test fails without the changes in #3541...