### PR TITLE
Fix UTF-8 encoding errors when running EasyBuild with Python 3.0.x-3.6.x

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -169,6 +169,12 @@ jobs:
           PRINTED_MSG=$(egrep -v "${IGNORE_PATTERNS}" test_framework_suite.log | grep '\.\n*[A-Za-z]' || true)
           test "x$PRINTED_MSG" = "x" || (echo "ERROR: Found printed messages in output of test suite\n${PRINTED_MSG}" && exit 1)
 
+          # There may be encoding errors in Python 3 which are hidden when an UTF-8 encoding is set
+          # Hence run the tests again with LC_ALL=C
+          if [[ ${{matrix.python}} =~ "3." ]]; then
+            LC_ALL=C python -O -m test.framework.suite
+          fi
+
     - name: test bootstrap script
       run: |
           # (re)initialize environment for modules tool

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,6 +9,7 @@ jobs:
         python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
         modules_tool: [Lmod-7.8.22, Lmod-8.2.9, modules-tcl-1.147, modules-3.2.10, modules-4.1.4]
         module_syntax: [Lua, Tcl]
+        lc_all: [""]
         # exclude some configuration for non-Lmod modules tool:
         # - don't test with Lua module syntax (only supported in Lmod)
         # - exclude Python 3.x versions other than 3.6, to limit test configurations
@@ -51,6 +52,13 @@ jobs:
             python: 3.8
           - modules_tool: Lmod-7.8.22
             python: 3.9
+        # There may be encoding errors in Python 3 which are hidden when an UTF-8 encoding is set
+        # Hence run the tests (again) with LC_ALL=C and Python 3.6 (or any < 3.7)
+        include:
+          - python: 3.6
+            modules_tool: Lmod-8.2.9
+            module_syntax: Lua
+            lc_all: C
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
@@ -129,6 +137,7 @@ jobs:
         EB_VERBOSE: 1
         EASYBUILD_MODULE_SYNTAX: ${{matrix.module_syntax}}
         TEST_EASYBUILD_MODULE_SYNTAX: ${{matrix.module_syntax}}
+        LC_ALL: ${{matrix.lc_all}}
       run: |
           # run tests *outside* of checked out easybuild-framework directory,
           # to ensure we're testing installed version (see previous step)
@@ -168,12 +177,6 @@ jobs:
           # '|| true' is needed to avoid that Travis stops the job on non-zero exit of grep (i.e. when there are no matches)
           PRINTED_MSG=$(egrep -v "${IGNORE_PATTERNS}" test_framework_suite.log | grep '\.\n*[A-Za-z]' || true)
           test "x$PRINTED_MSG" = "x" || (echo "ERROR: Found printed messages in output of test suite\n${PRINTED_MSG}" && exit 1)
-
-          # There may be encoding errors in Python 3 which are hidden when an UTF-8 encoding is set
-          # Hence run the tests again with LC_ALL=C
-          if [[ ${{matrix.python}} =~ "3." ]]; then
-            LC_ALL=C python -O -m test.framework.suite
-          fi
 
     - name: test bootstrap script
       run: |

--- a/easybuild/base/fancylogger.py
+++ b/easybuild/base/fancylogger.py
@@ -580,6 +580,8 @@ def logToFile(filename, enable=True, filehandler=None, name=None, max_bytes=MAX_
         'maxBytes': max_bytes,
         'backupCount': backup_count,
     }
+    if sys.version_info[0] >= 3:
+        handleropts['encoding'] = 'utf-8'
     # logging to a file is going to create the file later on, so let's try to be helpful and create the path if needed
     directory = os.path.dirname(filename)
     if not os.path.exists(directory):

--- a/easybuild/base/optcomplete.py
+++ b/easybuild/base/optcomplete.py
@@ -594,8 +594,8 @@ def autocomplete(parser, arg_completer=None, opt_completer=None, subcmd_complete
         if isinstance(debugfn, logging.Logger):
             debugfn.debug(txt)
         else:
-            with open(debugfn, 'a') as f:
-                f.write(txt)
+            with open(debugfn, 'a') as fh:
+                fh.write(txt)
 
     # Exit with error code (we do not let the caller continue on purpose, this
     # is a run for completions only.)

--- a/easybuild/base/optcomplete.py
+++ b/easybuild/base/optcomplete.py
@@ -594,9 +594,8 @@ def autocomplete(parser, arg_completer=None, opt_completer=None, subcmd_complete
         if isinstance(debugfn, logging.Logger):
             debugfn.debug(txt)
         else:
-            f = open(debugfn, 'a')
-            f.write(txt)
-            f.close()
+            with open(debugfn, 'a') as f:
+                f.write(txt)
 
     # Exit with error code (we do not let the caller continue on purpose, this
     # is a run for completions only.)

--- a/easybuild/scripts/fix_docs.py
+++ b/easybuild/scripts/fix_docs.py
@@ -57,13 +57,12 @@ for tmp in py_files:
         continue
     with open(tmp) as f:
         temp = "tmp_file.py"
-        out = open(temp, 'w')
-        for line in f:
-            if "@author" in line:
-                out.write(re.sub(r"@author: (.*)", r":author: \1", line))
-            elif "@param" in line:
-                out.write(re.sub(r"@param ([^:]*):", r":param \1:", line))
-            else:
-                out.write(line)
-        out.close()
+        with open(temp, 'w') as out:
+            for line in f:
+                if "@author" in line:
+                    out.write(re.sub(r"@author: (.*)", r":author: \1", line))
+                elif "@param" in line:
+                    out.write(re.sub(r"@param ([^:]*):", r":param \1:", line))
+                else:
+                    out.write(line)
         os.rename(temp, tmp)

--- a/easybuild/scripts/fix_docs.py
+++ b/easybuild/scripts/fix_docs.py
@@ -55,10 +55,10 @@ for tmp in py_files:
     # exclude self
     if os.path.basename(tmp) == os.path.basename(__file__):
         continue
-    with open(tmp) as f:
+    with open(tmp) as fh:
         temp = "tmp_file.py"
         with open(temp, 'w') as out:
-            for line in f:
+            for line in fh:
                 if "@author" in line:
                     out.write(re.sub(r"@author: (.*)", r":author: \1", line))
                 elif "@param" in line:

--- a/easybuild/scripts/mk_tmpl_easyblock_for.py
+++ b/easybuild/scripts/mk_tmpl_easyblock_for.py
@@ -225,8 +225,8 @@ try:
     dirpath = os.path.dirname(easyblock_path)
     if not os.path.exists(dirpath):
         os.makedirs(dirpath)
-    with open(easyblock_path, "w") as f:
-        f.write(txt)
+    with open(easyblock_path, "w") as fh:
+        fh.write(txt)
 except (IOError, OSError) as err:
     sys.stderr.write("ERROR! Writing template easyblock for %s to %s failed: %s" % (name, easyblock_path, err))
     sys.exit(1)

--- a/easybuild/scripts/mk_tmpl_easyblock_for.py
+++ b/easybuild/scripts/mk_tmpl_easyblock_for.py
@@ -225,9 +225,8 @@ try:
     dirpath = os.path.dirname(easyblock_path)
     if not os.path.exists(dirpath):
         os.makedirs(dirpath)
-    f = open(easyblock_path, "w")
-    f.write(txt)
-    f.close()
+    with open(easyblock_path, "w") as f:
+        f.write(txt)
 except (IOError, OSError) as err:
     sys.stderr.write("ERROR! Writing template easyblock for %s to %s failed: %s" % (name, easyblock_path, err))
     sys.exit(1)

--- a/easybuild/tools/configobj.py
+++ b/easybuild/tools/configobj.py
@@ -1213,9 +1213,8 @@ class ConfigObj(Section):
         if isinstance(infile, string_type):
             self.filename = infile
             if os.path.isfile(infile):
-                h = open(infile, 'r')
-                infile = h.read() or []
-                h.close()
+                with open(infile, 'r') as h:
+                    infile = h.read() or []
             elif self.file_error:
                 # raise an error if the file doesn't exist
                 raise IOError('Config file not found: "%s".' % self.filename)
@@ -1224,9 +1223,8 @@ class ConfigObj(Section):
                 if self.create_empty:
                     # this is a good test that the filename specified
                     # isn't impossible - like on a non-existent device
-                    h = open(infile, 'w')
-                    h.write('')
-                    h.close()
+                    with open(infile, 'w') as h:
+                        h.write('')
                 infile = []
 
         elif isinstance(infile, (list, tuple)):
@@ -2052,9 +2050,8 @@ class ConfigObj(Section):
         if outfile is not None:
             outfile.write(output)
         else:
-            h = open(self.filename, 'wb')
-            h.write(output)
-            h.close()
+            with open(self.filename, 'wb') as h:
+                h.write(output)
 
     def validate(self, validator, preserve_errors=False, copy=False,
                  section=None):

--- a/easybuild/tools/configobj.py
+++ b/easybuild/tools/configobj.py
@@ -1213,8 +1213,8 @@ class ConfigObj(Section):
         if isinstance(infile, string_type):
             self.filename = infile
             if os.path.isfile(infile):
-                with open(infile, 'r') as h:
-                    infile = h.read() or []
+                with open(infile, 'r') as fh:
+                    infile = fh.read() or []
             elif self.file_error:
                 # raise an error if the file doesn't exist
                 raise IOError('Config file not found: "%s".' % self.filename)
@@ -1223,8 +1223,8 @@ class ConfigObj(Section):
                 if self.create_empty:
                     # this is a good test that the filename specified
                     # isn't impossible - like on a non-existent device
-                    with open(infile, 'w') as h:
-                        h.write('')
+                    with open(infile, 'w') as fh:
+                        fh.write('')
                 infile = []
 
         elif isinstance(infile, (list, tuple)):
@@ -2050,8 +2050,8 @@ class ConfigObj(Section):
         if outfile is not None:
             outfile.write(output)
         else:
-            with open(self.filename, 'wb') as h:
-                h.write(output)
+            with open(self.filename, 'wb') as fh:
+                fh.write(output)
 
     def validate(self, validator, preserve_errors=False, copy=False,
                  section=None):

--- a/easybuild/tools/environment.py
+++ b/easybuild/tools/environment.py
@@ -50,17 +50,11 @@ def write_changes(filename):
     """
     Write current changes to filename and reset environment afterwards
     """
-    script = None
     try:
-        script = open(filename, 'w')
-
-        for key in _changes:
-            script.write('export %s=%s\n' % (key, shell_quote(_changes[key])))
-
-        script.close()
+        with open(filename, 'w') as script:
+            for key in _changes:
+                script.write('export %s=%s\n' % (key, shell_quote(_changes[key])))
     except IOError as err:
-        if script is not None:
-            script.close()
         raise EasyBuildError("Failed to write to %s: %s", filename, err)
     reset_changes()
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -189,7 +189,7 @@ def is_readable(path):
 
 
 def _open(path, mode):
-    """Open a file. If mode is not binary, then utf-8 encoding will be selected for Python3"""
+    """Open a file. If mode is not binary, then utf-8 encoding will be used for Python 3.x"""
     if sys.version_info[0] >= 3 and 'b' not in mode:
         return open(path, mode, encoding='utf-8')
     else:
@@ -1018,8 +1018,8 @@ def calc_block_checksum(path, algorithm):
     _log.debug("Using blocksize %s for calculating the checksum" % blocksize)
 
     try:
-        with open(path, 'rb') as f:
-            for block in iter(lambda: f.read(blocksize), b''):
+        with open(path, 'rb') as fh:
+            for block in iter(lambda: fh.read(blocksize), b''):
                 algorithm.update(block)
     except IOError as err:
         raise EasyBuildError("Failed to read %s: %s", path, err)
@@ -2049,6 +2049,7 @@ def find_flexlm_license(custom_env_vars=None, lic_specs=None):
             if lic_files:
                 for lic_file in lic_files:
                     try:
+                        # just try to open file for reading, no need to actually read it
                         open(lic_file, 'r').close()
                         valid_lic_specs.append(lic_file)
                     except IOError as err:

--- a/easybuild/tools/jenkins.py
+++ b/easybuild/tools/jenkins.py
@@ -105,9 +105,8 @@ def write_to_xml(succes, failed, filename):
         root.firstChild.appendChild(el)
 
     try:
-        output_file = open(filename, "w")
-        root.writexml(output_file)
-        output_file.close()
+        with open(filename, "w") as output_file:
+            root.writexml(output_file)
     except IOError as err:
         raise EasyBuildError("Failed to write out XML file %s: %s", filename, err)
 
@@ -162,9 +161,8 @@ def aggregate_xml_in_dirs(base_dir, output_filename):
     comment = root.createComment("%s out of %s builds succeeded" % (succes, total))
     root.firstChild.insertBefore(comment, properties)
     try:
-        output_file = open(output_filename, "w")
-        root.writexml(output_file, addindent="\t", newl="\n")
-        output_file.close()
+        with open(output_filename, "w") as output_file:
+            root.writexml(output_file, addindent="\t", newl="\n")
     except IOError as err:
         raise EasyBuildError("Failed to write out XML file %s: %s", output_filename, err)
 

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1409,9 +1409,8 @@ class Lmod(ModulesTool):
                     cache_dir = os.path.dirname(cache_fp)
                     if not os.path.exists(cache_dir):
                         mkdir(cache_dir, parents=True)
-                    cache_file = open(cache_fp, 'w')
-                    cache_file.write(stdout)
-                    cache_file.close()
+                    with open(cache_fp, 'w') as cache_file:
+                        cache_file.write(stdout)
                 except (IOError, OSError) as err:
                     raise EasyBuildError("Failed to update Lmod spider cache %s: %s", cache_fp, err)
 

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -46,7 +46,7 @@ from easybuild.tools.config import ERROR, IGNORE, PURGE, UNLOAD, UNSET
 from easybuild.tools.config import EBROOT_ENV_VAR_ACTIONS, LOADED_MODULES_ACTIONS
 from easybuild.tools.config import build_option, get_modules_tool, install_path
 from easybuild.tools.environment import ORIG_OS_ENVIRON, restore_env, setvar, unset_env_vars
-from easybuild.tools.filetools import convert_name, mkdir, path_matches, read_file, which
+from easybuild.tools.filetools import convert_name, mkdir, path_matches, read_file, which, write_file
 from easybuild.tools.module_naming_scheme.mns import DEVEL_MODULE_SUFFIX
 from easybuild.tools.py2vs3 import subprocess_popen_text
 from easybuild.tools.run import run_cmd
@@ -1403,16 +1403,12 @@ class Lmod(ModulesTool):
                 # don't actually update local cache when testing, just return the cache contents
                 return stdout
             else:
-                try:
-                    cache_fp = os.path.join(self.USER_CACHE_DIR, 'moduleT.lua')
-                    self.log.debug("Updating Lmod spider cache %s with output from '%s'" % (cache_fp, ' '.join(cmd)))
-                    cache_dir = os.path.dirname(cache_fp)
-                    if not os.path.exists(cache_dir):
-                        mkdir(cache_dir, parents=True)
-                    with open(cache_fp, 'w') as cache_file:
-                        cache_file.write(stdout)
-                except (IOError, OSError) as err:
-                    raise EasyBuildError("Failed to update Lmod spider cache %s: %s", cache_fp, err)
+                cache_fp = os.path.join(self.USER_CACHE_DIR, 'moduleT.lua')
+                self.log.debug("Updating Lmod spider cache %s with output from '%s'" % (cache_fp, ' '.join(cmd)))
+                cache_dir = os.path.dirname(cache_fp)
+                if not os.path.exists(cache_dir):
+                    mkdir(cache_dir, parents=True)
+                write_file(cache_fp, stdout)
 
     def use(self, path, priority=None):
         """

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -70,7 +70,7 @@ class BuildLogTest(EnhancedTestCase):
         logToFile(tmplog, enable=False)
 
         log_re = re.compile(r"^fancyroot ::.* BOOM \(at .*:[0-9]+ in [a-z_]+\)$", re.M)
-        logtxt = open(tmplog, 'r').read()
+        logtxt = read_file(tmplog, 'r')
         self.assertTrue(log_re.match(logtxt), "%s matches %s" % (log_re.pattern, logtxt))
 
         # test formatting of message

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -317,8 +317,8 @@ class EasyBlockTest(EnhancedTestCase):
 
         # create fake directories and files that should be guessed
         os.makedirs(eb.installdir)
-        open(os.path.join(eb.installdir, 'foo.jar'), 'w').write('foo.jar')
-        open(os.path.join(eb.installdir, 'bla.jar'), 'w').write('bla.jar')
+        write_file(os.path.join(eb.installdir, 'foo.jar'), 'foo.jar')
+        write_file(os.path.join(eb.installdir, 'bla.jar'), 'bla.jar')
         for path in ('bin', ('bin', 'testdir'), 'sbin', 'share', ('share', 'man'), 'lib', 'lib64'):
             if isinstance(path, string_type):
                 path = (path, )
@@ -352,7 +352,7 @@ class EasyBlockTest(EnhancedTestCase):
             self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
 
         # check that bin is only added to PATH if there are files in there
-        open(os.path.join(eb.installdir, 'bin', 'test'), 'w').write('test')
+        write_file(os.path.join(eb.installdir, 'bin', 'test'), 'test')
         guess = eb.make_module_req()
         if get_module_syntax() == 'Tcl':
             self.assertTrue(re.search(r"^prepend-path\s+PATH\s+\$root/bin$", guess, re.M))
@@ -371,14 +371,14 @@ class EasyBlockTest(EnhancedTestCase):
         elif get_module_syntax() == 'Lua':
             self.assertFalse('prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib64"))' in guess)
         # -- With files
-        open(os.path.join(eb.installdir, 'lib64', 'libfoo.so'), 'w').write('test')
+        write_file(os.path.join(eb.installdir, 'lib64', 'libfoo.so'), 'test')
         guess = eb.make_module_req()
         if get_module_syntax() == 'Tcl':
             self.assertTrue(re.search(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib64$", guess, re.M))
         elif get_module_syntax() == 'Lua':
             self.assertTrue('prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib64"))' in guess)
         # -- With files in lib and lib64 symlinks to lib
-        open(os.path.join(eb.installdir, 'lib', 'libfoo.so'), 'w').write('test')
+        write_file(os.path.join(eb.installdir, 'lib', 'libfoo.so'), 'test')
         shutil.rmtree(os.path.join(eb.installdir, 'lib64'))
         os.symlink('lib', os.path.join(eb.installdir, 'lib64'))
         guess = eb.make_module_req()
@@ -425,7 +425,7 @@ class EasyBlockTest(EnhancedTestCase):
         eb.make_module_req_guess = lambda: {'LD_LIBRARY_PATH': ['lib/pathC', 'lib/pathA', 'lib/pathB', 'lib/pathA']}
         for path in ['pathA', 'pathB', 'pathC']:
             os.mkdir(os.path.join(eb.installdir, 'lib', path))
-            open(os.path.join(eb.installdir, 'lib', path, 'libfoo.so'), 'w').write('test')
+            write_file(os.path.join(eb.installdir, 'lib', path, 'libfoo.so'), 'test')
         txt = eb.make_module_req()
         if get_module_syntax() == 'Tcl':
             self.assertTrue(re.search(r"\nprepend-path\s+LD_LIBRARY_PATH\s+\$root/lib/pathC\n" +
@@ -1388,7 +1388,7 @@ class EasyBlockTest(EnhancedTestCase):
                 loc = os.path.join(tmpdir, 't', 'toy', fn)
                 self.assertEqual(res, loc)
                 self.assertTrue(os.path.exists(loc), "%s file is found at %s" % (fn, loc))
-                txt = open(loc, 'r').read()
+                txt = read_file(loc)
                 eb_regex = re.compile("EasyBuild: building software with ease")
                 self.assertTrue(eb_regex.search(txt), "Pattern '%s' found in: %s" % (eb_regex.pattern, txt))
             else:
@@ -1430,9 +1430,7 @@ class EasyBlockTest(EnhancedTestCase):
         tmpdir = tempfile.mkdtemp()
         shutil.copy2(ec_path, tmpdir)
         ec_path = os.path.join(tmpdir, ec_file)
-        f = open(ec_path, 'a')
-        f.write("\ndependencies += [('nosuchsoftware', '1.2.3')]\n")
-        f.close()
+        write_file(ec_path, "\ndependencies += [('nosuchsoftware', '1.2.3')]\n", append=True)
         ec = EasyConfig(ec_path)
         eb = EasyBlock(ec)
         try:

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -737,9 +737,7 @@ class FileToolsTest(EnhancedTestCase):
     def test_guess_patch_level(self):
         "Test guess_patch_level."""
         # create dummy toy.source file so guess_patch_level can work
-        f = open(os.path.join(self.test_buildpath, 'toy.source'), 'w')
-        f.write("This is toy.source")
-        f.close()
+        ft.write_file(os.path.join(self.test_buildpath, 'toy.source'), "This is toy.source")
 
         for patched_file, correct_patch_level in [
             ('toy.source', 0),

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -603,11 +603,34 @@ class FileToolsTest(EnhancedTestCase):
     def test_read_write_file(self):
         """Test reading/writing files."""
 
+        # Test different "encodings"
+        ascii_file = os.path.join(self.test_prefix, 'ascii.txt')
+        txt = 'Hello World\nFoo bar'
+        ft.write_file(ascii_file, txt)
+        self.assertEqual(ft.read_file(ascii_file), txt)
+
+        binary_file = os.path.join(self.test_prefix, 'binary.txt')
+        txt = b'Hello World\x12\x00\x01\x02\x03\nFoo bar'
+        ft.write_file(binary_file, txt)
+        self.assertEqual(ft.read_file(binary_file, mode='rb'), txt)
+
+        utf8_file = os.path.join(self.test_prefix, 'utf8.txt')
+        txt = b'Hyphen: \xe2\x80\x93\nEuro sign: \xe2\x82\xac\na with dots: \xc3\xa4'
+        if sys.version_info[0] == 3:
+            txt_decoded = txt.decode('utf-8')
+        else:
+            txt_decoded = txt
+        # Must work as binary and string
+        ft.write_file(utf8_file, txt)
+        self.assertEqual(ft.read_file(utf8_file), txt_decoded)
+        ft.write_file(utf8_file, txt_decoded)
+        self.assertEqual(ft.read_file(utf8_file), txt_decoded)
+
+        # Test append
         fp = os.path.join(self.test_prefix, 'test.txt')
         txt = "test123"
         ft.write_file(fp, txt)
         self.assertEqual(ft.read_file(fp), txt)
-
         txt2 = '\n'.join(['test', '123'])
         ft.write_file(fp, txt2, append=True)
         self.assertEqual(ft.read_file(fp), txt + txt2)
@@ -1211,6 +1234,15 @@ class FileToolsTest(EnhancedTestCase):
         error_pat = "Failed to patch .*/nosuchfile.txt: .*No such file or directory"
         path = os.path.join(self.test_prefix, 'nosuchfile.txt')
         self.assertErrorRegex(EasyBuildError, error_pat, ft.apply_regex_substitutions, path, regex_subs)
+
+        # make sure apply_regex_substitutions can patch files that include UTF-8 characters
+        testtxt = b"foo \xe2\x80\x93 bar"  # This is an UTF-8 "-"
+        ft.write_file(testfile, testtxt)
+        ft.apply_regex_substitutions(testfile, [('foo', 'FOO')])
+        txt = ft.read_file(testfile)
+        if sys.version_info[0] == 3:
+            testtxt = testtxt.decode('utf-8')
+        self.assertEqual(txt, testtxt.replace('foo', 'FOO'))
 
         # make sure apply_regex_substitutions can patch files that include non-UTF-8 characters
         testtxt = b"foo \xe2 bar"

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -115,7 +115,7 @@ class GithubTest(EnhancedTestCase):
 
         try:
             fp = self.ghfs.read("a_directory/a_file.txt", api=False)
-            self.assertEqual(open(fp, 'r').read().strip(), "this is a line of text")
+            self.assertEqual(read_file(fp).strip(), "this is a line of text")
             os.remove(fp)
         except (IOError, OSError):
             pass

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -678,7 +678,7 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(get_software_libdir(name, only_one=False), ['lib', 'lib64'])
 
         # only directories containing files in specified list should be retained
-        open(os.path.join(root, 'lib64', 'foo'), 'w').write('foo')
+        write_file(os.path.join(root, 'lib64', 'foo'), 'foo')
         self.assertEqual(get_software_libdir(name, fs=['foo']), 'lib64')
 
         # duplicate paths due to symlink get filtered

--- a/test/framework/modulestool.py
+++ b/test/framework/modulestool.py
@@ -39,7 +39,7 @@ from distutils.version import StrictVersion
 from easybuild.base import fancylogger
 from easybuild.tools import modules
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import which, write_file, read_file
+from easybuild.tools.filetools import read_file, which, write_file
 from easybuild.tools.modules import Lmod
 from test.framework.utilities import init_config
 

--- a/test/framework/modulestool.py
+++ b/test/framework/modulestool.py
@@ -39,7 +39,7 @@ from distutils.version import StrictVersion
 from easybuild.base import fancylogger
 from easybuild.tools import modules
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import which, write_file
+from easybuild.tools.filetools import which, write_file, read_file
 from easybuild.tools.modules import Lmod
 from test.framework.utilities import init_config
 
@@ -123,9 +123,7 @@ class ModulesToolTest(EnhancedTestCase):
         fancylogger.logToFile(self.logfile)
 
         mt = MockModulesTool(testing=True)
-        f = open(self.logfile, 'r')
-        logtxt = f.read()
-        f.close()
+        logtxt = read_file(self.logfile)
         warn_regex = re.compile("WARNING .*pattern .* not found in defined 'module' function")
         self.assertTrue(warn_regex.search(logtxt), "Found pattern '%s' in: %s" % (warn_regex.pattern, logtxt))
 
@@ -137,9 +135,7 @@ class ModulesToolTest(EnhancedTestCase):
         # a warning should be logged if the 'module' function is undefined
         del os.environ['module']
         mt = MockModulesTool(testing=True)
-        f = open(self.logfile, 'r')
-        logtxt = f.read()
-        f.close()
+        logtxt = read_file(self.logfile)
         warn_regex = re.compile("WARNING No 'module' function defined, can't check if it matches .*")
         self.assertTrue(warn_regex.search(logtxt), "Pattern %s found in %s" % (warn_regex.pattern, logtxt))
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1341,7 +1341,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         robot_decoy = os.path.join(self.test_prefix, 'robot_decoy')
         mkdir(robot_decoy)
         for dry_run_arg in ['-D', '--dry-run-short']:
-            open(self.logfile, 'w').write('')
+            write_file(self.logfile, '')
             args = [
                 os.path.join(tmpdir, 'easybuild', 'easyconfigs', 'g', 'gzip', 'gzip-1.4-GCC-4.6.3.eb'),
                 dry_run_arg,
@@ -2160,9 +2160,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ecs_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         tweaked_toy_ec = os.path.join(self.test_buildpath, 'toy-0.0-tweaked.eb')
         copy_file(os.path.join(ecs_path, 't', 'toy', 'toy-0.0.eb'), tweaked_toy_ec)
-        f = open(tweaked_toy_ec, 'a')
-        f.write("easyblock = 'ConfigureMake'")
-        f.close()
+        write_file(tweaked_toy_ec, "easyblock = 'ConfigureMake'", append=True)
 
         args = [
             tweaked_toy_ec,
@@ -2223,9 +2221,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ecs_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         tweaked_toy_ec = os.path.join(self.test_buildpath, 'toy-0.0-tweaked.eb')
         copy_file(os.path.join(ecs_path, 't', 'toy', 'toy-0.0.eb'), tweaked_toy_ec)
-        f = open(tweaked_toy_ec, 'a')
-        f.write("easyblock = 'ConfigureMake'")
-        f.close()
+        write_file(tweaked_toy_ec, "easyblock = 'ConfigureMake'", append=True)
 
         args = [
             tweaked_toy_ec,
@@ -2292,9 +2288,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ecs_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         tweaked_toy_ec = os.path.join(self.test_buildpath, 'toy-0.0-tweaked.eb')
         copy_file(os.path.join(ecs_path, 't', 'toy', 'toy-0.0.eb'), tweaked_toy_ec)
-        f = open(tweaked_toy_ec, 'a')
-        f.write("dependencies = [('gzip', '1.4')]\n")  # add fictious dependency
-        f.close()
+        write_file(tweaked_toy_ec, "dependencies = [('gzip', '1.4')]\n", append=True)  # add fictious dependency
 
         sourcepath = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'sandbox', 'sources')
         args = [
@@ -2348,9 +2342,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                 self.assertTrue(mod_regex.search(outtxt), "Pattern %s found in %s" % (mod_regex.pattern, outtxt))
 
         # clear fictitious dependency
-        f = open(tweaked_toy_ec, 'a')
-        f.write("dependencies = []\n")
-        f.close()
+        write_file(tweaked_toy_ec, "dependencies = []\n", append=True)
 
         # no recursive try if --disable-map-toolchains is involved
         for extra_args in [['--try-software-version=1.2.3'], ['--software-version=1.2.3']]:
@@ -2410,7 +2402,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertFalse(re.search('module: zlib', outtxt))
 
         # clear log file
-        open(self.logfile, 'w').write('')
+        write_file(self.logfile, '')
 
         # filter deps (including a non-existing dep, i.e. zlib)
         args.extend(['--filter-deps', 'FFTW,ScaLAPACK,zlib'])
@@ -2419,7 +2411,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertFalse(re.search('module: ScaLAPACK/2.0.2-gompi', outtxt))
         self.assertFalse(re.search('module: zlib', outtxt))
 
-        open(self.logfile, 'w').write('')
+        write_file(self.logfile, '')
 
         # filter specific version of deps
         args[-1] = 'FFTW=3.2.3,zlib,ScaLAPACK=2.0.2'
@@ -2428,7 +2420,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertFalse(re.search('module: ScaLAPACK', outtxt))
         self.assertFalse(re.search('module: zlib', outtxt))
 
-        open(self.logfile, 'w').write('')
+        write_file(self.logfile, '')
 
         args[-1] = 'zlib,FFTW=3.3.7,ScaLAPACK=2.0.1'
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
@@ -2436,7 +2428,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertTrue(re.search('module: ScaLAPACK/2.0.2-gompi', outtxt))
         self.assertFalse(re.search('module: zlib', outtxt))
 
-        open(self.logfile, 'w').write('')
+        write_file(self.logfile, '')
 
         # filter deps with version range: only filter FFTW 3.x, ScaLAPACK 1.x
         args[-1] = 'zlib,ScaLAPACK=]1.0:2.0[,FFTW=[3.0:4.0['
@@ -2445,7 +2437,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertTrue(re.search('module: ScaLAPACK/2.0.2-gompi', outtxt))
         self.assertFalse(re.search('module: zlib', outtxt))
 
-        open(self.logfile, 'w').write('')
+        write_file(self.logfile, '')
 
         # also test open ended ranges
         args[-1] = 'zlib,ScaLAPACK=[1.0:,FFTW=:4.0['
@@ -2454,7 +2446,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertFalse(re.search('module: ScaLAPACK', outtxt))
         self.assertFalse(re.search('module: zlib', outtxt))
 
-        open(self.logfile, 'w').write('')
+        write_file(self.logfile, '')
 
         args[-1] = 'zlib,ScaLAPACK=[2.1:,FFTW=:3.0['
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
@@ -2469,7 +2461,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertFalse(re.search('module: ScaLAPACK', outtxt))
         self.assertFalse(re.search('module: zlib', outtxt))
 
-        open(self.logfile, 'w').write('')
+        write_file(self.logfile, '')
 
         # FFTW & ScaLAPACK versions are not included in range, so no filtering
         args[-1] = 'FFTW=]3.3.7:4.0],zlib,ScaLAPACK=[1.0:2.0.2['
@@ -2478,7 +2470,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertTrue(re.search('module: ScaLAPACK/2.0.2-gompi', outtxt))
         self.assertFalse(re.search('module: zlib', outtxt))
 
-        open(self.logfile, 'w').write('')
+        write_file(self.logfile, '')
 
         # also test mix of ranges & specific versions
         args[-1] = 'FFTW=3.3.7,zlib,ScaLAPACK=[1.0:2.0.2['
@@ -2487,7 +2479,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertTrue(re.search('module: ScaLAPACK/2.0.2-gompi', outtxt))
         self.assertFalse(re.search('module: zlib', outtxt))
 
-        open(self.logfile, 'w').write('')
+        write_file(self.logfile, '')
         args[-1] = 'FFTW=]3.3.7:4.0],zlib,ScaLAPACK=2.0.2'
         outtxt = self.eb_main(args, do_build=True, verbose=True, raise_error=True)
         self.assertTrue(re.search('module: FFTW/3.3.7-gompi', outtxt))
@@ -2496,7 +2488,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         # This easyconfig contains a dependency of CMake for which no easyconfig exists. It should still
         # succeed when called with --filter-deps=CMake=:2.8.10]
-        open(self.logfile, 'w').write('')
+        write_file(self.logfile, '')
         ec_file = os.path.join(test_dir, 'easyconfigs', 'test_ecs', 'f', 'foss', 'foss-2018a-broken.eb')
         args[0] = ec_file
         args[-1] = 'FFTW=3.3.7,CMake=:2.8.10],zlib'
@@ -2506,7 +2498,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertTrue(re.search(regexp, outtxt))
 
         # The test below fails without PR 2983
-        open(self.logfile, 'w').write('')
+        write_file(self.logfile, '')
         ec_file = os.path.join(test_dir, 'easyconfigs', 'test_ecs', 'f', 'foss', 'foss-2018a-broken.eb')
         args[0] = ec_file
         args[-1] = 'FFTW=3.3.7,CMake=:2.8.10],zlib'
@@ -2535,7 +2527,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertFalse(re.search('module: zlib', outtxt))
 
         # clear log file
-        open(self.logfile, 'w').write('')
+        write_file(self.logfile, '')
 
         # hide deps (including a non-existing dep, i.e. zlib)
         args.append('--hide-deps=FFTW,ScaLAPACK,zlib')
@@ -2583,9 +2575,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
             software_path = os.path.join(self.test_installpath, 'software', 'toy', '0.0')
             test_report_path_pattern = os.path.join(software_path, 'easybuild', 'easybuild-toy-0.0*test_report.md')
-            f = open(glob.glob(test_report_path_pattern)[0], 'r')
-            test_report_txt = f.read()
-            f.close()
+            test_report_txt = read_file(glob.glob(test_report_path_pattern)[0])
             return test_report_txt
 
         # define environment variables that should (not) show up in the test report

--- a/test/framework/package.py
+++ b/test/framework/package.py
@@ -49,9 +49,8 @@ MOCKED_FPM = """#!/usr/bin/env python
 import os, sys
 
 def verbose(msg):
-    fp = open('%(fpm_output_file)s', 'a')
-    fp.write(msg + '\\n')
-    fp.close()
+    with open('%(fpm_output_file)s', 'a') as fp:
+        fp.write(msg + '\\n')
 
 description, iteration, name, source, target, url, version, workdir = '', '', '', '', '', '', '', ''
 excludes = []
@@ -112,29 +111,26 @@ while idx < len(sys.argv):
 
 pkgfile = os.path.join(workdir, name + '-' + version + '.' + iteration + '.' + target)
 
-fp = open(pkgfile, 'w')
+with open(pkgfile, 'w') as fp:
+    fp.write('thisisan' + target + '\\n')
+    fp.write(' '.join(sys.argv[1:]) + '\\n')
+    fp.write("STARTCONTENTS of installdir " + installdir + ':\\n')
 
-fp.write('thisisan' + target + '\\n')
-fp.write(' '.join(sys.argv[1:]) + '\\n')
-fp.write("STARTCONTENTS of installdir " + installdir + ':\\n')
+    find_cmd = 'find ' + installdir + '  ' + ''.join([" -not -path /" + x + ' ' for x in excludes])
+    verbose("trying: " + find_cmd)
+    fp.write(find_cmd + '\\n')
 
-find_cmd = 'find ' + installdir + '  ' + ''.join([" -not -path /" + x + ' ' for x in excludes])
-verbose("trying: " + find_cmd)
-fp.write(find_cmd + '\\n')
+    fp.write('ENDCONTENTS\\n')
 
-fp.write('ENDCONTENTS\\n')
-
-fp.write("Contents of module file " + modulefile + ':')
+    fp.write("Contents of module file " + modulefile + ':')
 
 
-fp.write('modulefile: ' + modulefile + '\\n')
-#modtxt = open(modulefile).read()
-#fp.write(modtxt + '\\n')
+    fp.write('modulefile: ' + modulefile + '\\n')
+    #modtxt = open(modulefile).read()
+    #fp.write(modtxt + '\\n')
 
-fp.write("I found excludes " + ' '.join(excludes) + '\\n')
-fp.write("DESCRIPTION: " + description + '\\n')
-
-fp.close()
+    fp.write("I found excludes " + ' '.join(excludes) + '\\n')
+    fp.write("DESCRIPTION: " + description + '\\n')
 """
 
 

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -36,7 +36,7 @@ from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.environment import setvar
-from easybuild.tools.filetools import mkdir
+from easybuild.tools.filetools import mkdir, write_file
 from easybuild.tools.modules import get_software_root, get_software_version
 from easybuild.tools.run import run_cmd
 
@@ -116,9 +116,7 @@ class EB_toy(ExtensionEasyBlock):
         # also install a dummy libtoy.a, to make the default sanity check happy
         libdir = os.path.join(self.installdir, 'lib')
         mkdir(libdir, parents=True)
-        f = open(os.path.join(libdir, 'lib%s.a' % name), 'w')
-        f.write(name.upper())
-        f.close()
+        write_file(os.path.join(libdir, 'lib%s.a' % name), name.upper())
 
     def run(self):
         """Install toy as extension."""

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -264,9 +264,8 @@ class EnhancedTestCase(TestCase):
             logfile = self.logfile
         # clear log file
         if logfile:
-            f = open(logfile, 'w')
-            f.write('')
-            f.close()
+            with open(logfile, 'w') as f:
+                f.write('')
 
         env_before = copy.deepcopy(os.environ)
 

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -264,8 +264,8 @@ class EnhancedTestCase(TestCase):
             logfile = self.logfile
         # clear log file
         if logfile:
-            with open(logfile, 'w') as f:
-                f.write('')
+            with open(logfile, 'w') as fh:
+                fh.write('')
 
         env_before = copy.deepcopy(os.environ)
 


### PR DESCRIPTION
When the system encoding is not UTF-8 Python 3 will try to decode files as ASCII which fails
This adds a test to CI with LC_ALL=C to enforce this situation and test cases reproducing failures in read_file, write_file and apply_regex_substitutions as seen in the wild

Example: https://github.com/easybuilders/easybuild-easyblocks/issues/2279 the failing text is valid UTF-8 (likely)

It seems only Python 3 < 3.7 is affected because in 3.7 a "UTF-8" mode was introduced which opens files as UTF-8 by default: https://www.python.org/dev/peps/pep-0540/

Fixes https://github.com/easybuilders/easybuild-easyblocks/issues/2279
fixed https://github.com/easybuilders/easybuild-easyblocks/issues/2329

This change makes sure files are opened with utf-8 encoding in Python 3 (Python 2 doesn't really care). This applies to read_file/write_file and friends as well as the logger which also opens files and if no encoding is specified it will run into the same situation: It uses the default encoding which may be ASCII and then fail to log UTF-8 encoded strings. Example: Dumping an EC with an UTF-8 char in the description