### PR TITLE
Create the lib64 symlink as a relative symlink

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2405,6 +2405,8 @@ class EasyBlock(object):
             lib_dir = os.path.join(self.installdir, 'lib')
             lib64_dir = os.path.join(self.installdir, 'lib64')
             if os.path.exists(lib_dir) and not os.path.exists(lib64_dir):
+                # create *relative* 'lib64' symlink to 'lib';
+                # see https://github.com/easybuilders/easybuild-framework/issues/3564
                 symlink('lib', lib64_dir, use_abspath_source=False)
 
     def sanity_check_step(self, *args, **kwargs):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2405,7 +2405,7 @@ class EasyBlock(object):
             lib_dir = os.path.join(self.installdir, 'lib')
             lib64_dir = os.path.join(self.installdir, 'lib64')
             if os.path.exists(lib_dir) and not os.path.exists(lib64_dir):
-                symlink(lib_dir, lib64_dir)
+                symlink('lib', lib64_dir, use_abspath_source=False)
 
     def sanity_check_step(self, *args, **kwargs):
         """

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3151,6 +3151,8 @@ class ToyBuildTest(EnhancedTestCase):
         self.assertFalse(os.path.islink(lib_path))
         self.assertTrue(os.path.islink(lib64_path))
         self.assertTrue(os.path.samefile(lib_path, lib64_path))
+        # Need relative path: https://github.com/easybuilders/easybuild-framework/issues/3564
+        self.assertFalse(os.path.isabs(os.readlink(lib64_path)))
 
         # cleanup and try again with --disable-lib64-lib-symlink
         remove_dir(self.test_installpath)


### PR DESCRIPTION
This makes moving the install tree easier.

Closes #3564