### PR TITLE
Making symlinking of posix_c.so to posix.so in test suite configuration conditional

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -69,7 +69,10 @@ jobs:
         # for modules tool
         sudo apt-get install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
         # fix for lua-posix packaging issue, see https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082
-        sudo ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so
+        # needed for Ubuntu 18.04, but not for Ubuntu 20.04, so skipping symlinking if posix.so already exists
+        if [ ! -e /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so ] ; then
+            sudo ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so
+        fi
         # for GitPython, python-hglib
         sudo apt-get install git mercurial
         # dep for GC3Pie


### PR DESCRIPTION
The missing lua posix.so symlink has been fixed in Ubuntu 2.04.1 so
the creating of it breaks testing.  I added a conditional that will
only create it if the posix.so file does not exist as either a file
or a symlink.