### PR TITLE
use http://sources/easybuild.io as fallback source URL

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -97,6 +97,8 @@ from easybuild.tools.utilities import remove_unwanted_chars, time2str, trace_msg
 from easybuild.tools.version import this_is_easybuild, VERBOSE_VERSION, VERSION
 
 
+EASYBUILD_SOURCES_URL = 'http://sources.easybuild.io'
+
 MODULE_ONLY_STEPS = [MODULE_STEP, PREPARE_STEP, READY_STEP, POSTITER_STEP, SANITYCHECK_STEP]
 
 # string part of URL for Python packages on PyPI that indicates needs to be rewritten (see derive_alt_pypi_url)
@@ -756,7 +758,8 @@ class EasyBlock(object):
 
                     break  # no need to try other source paths
 
-            targetdir = os.path.join(srcpaths[0], self.name.lower()[0], self.name)
+            name_letter = self.name.lower()[0]
+            targetdir = os.path.join(srcpaths[0], name_letter, self.name)
 
             if foundfile:
                 if self.dry_run:
@@ -771,6 +774,9 @@ class EasyBlock(object):
                 else:
                     source_urls = []
                 source_urls.extend(self.cfg['source_urls'])
+
+                # add sources.easybuild.io as fallback source URL
+                source_urls.append(EASYBUILD_SOURCES_URL + '/' + os.path.join(name_letter, self.name))
 
                 mkdir(targetdir, parents=True)
 


### PR DESCRIPTION
As discussed recently, it's useful to bake in a fallback source URL, so we can easily and quickly fix disappearing upstream source tarballs (assuming we're allowed to redistribute them of course), see for example https://github.com/easybuilders/easybuild-easyconfigs/pull/12156 .

For now, only UDUNITS source tarballs are available at http://sources/easybuild.io (which is a VPS hosted by [fosshost](https://fosshost.org/)).