### PR TITLE
use https for sources.easybuild.io fallback URL

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -97,7 +97,7 @@ from easybuild.tools.utilities import remove_unwanted_chars, time2str, trace_msg
 from easybuild.tools.version import this_is_easybuild, VERBOSE_VERSION, VERSION
 
 
-EASYBUILD_SOURCES_URL = 'http://sources.easybuild.io'
+EASYBUILD_SOURCES_URL = 'https://sources.easybuild.io'
 
 MODULE_ONLY_STEPS = [MODULE_STEP, PREPARE_STEP, READY_STEP, POSTITER_STEP, SANITYCHECK_STEP]
 
@@ -775,7 +775,7 @@ class EasyBlock(object):
                     source_urls = []
                 source_urls.extend(self.cfg['source_urls'])
 
-                # add sources.easybuild.io as fallback source URL
+                # add https://sources.easybuild.io as fallback source URL
                 source_urls.append(EASYBUILD_SOURCES_URL + '/' + os.path.join(name_letter, self.name))
 
                 mkdir(targetdir, parents=True)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1398,7 +1398,7 @@ class EasyBlockTest(EnhancedTestCase):
         shutil.rmtree(tmpdir)
 
     def test_fallback_source_url(self):
-        """Check whether downloading from fallback source URL http://sources.easybuild.io works."""
+        """Check whether downloading from fallback source URL https://sources.easybuild.io works."""
         # cfr. https://github.com/easybuilders/easybuild-easyconfigs/issues/11951
 
         init_config(args=["--sourcepath=%s" % self.test_prefix])


### PR DESCRIPTION
follow-up to #3572, SSL certificate is now in place for https://sources.easybuild.io