### PR TITLE
Add cuda_cc_space_sep and cuda_cc_semicolon_sep templates

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -316,6 +316,8 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
     cuda_compute_capabilities = build_option('cuda_compute_capabilities') or config.get('cuda_compute_capabilities')
     if cuda_compute_capabilities:
         template_values['cuda_compute_capabilities'] = ','.join(cuda_compute_capabilities)
+        template_values['cuda_cc_space_sep'] = ' '.join(cuda_compute_capabilities)
+        template_values['cuda_cc_semc_sep'] = ';'.join(cuda_compute_capabilities)
         sm_values = ['sm_' + cc.replace('.', '') for cc in cuda_compute_capabilities]
         template_values['cuda_sm_comma_sep'] = ','.join(sm_values)
         template_values['cuda_sm_space_sep'] = ' '.join(sm_values)

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -317,7 +317,7 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
     if cuda_compute_capabilities:
         template_values['cuda_compute_capabilities'] = ','.join(cuda_compute_capabilities)
         template_values['cuda_cc_space_sep'] = ' '.join(cuda_compute_capabilities)
-        template_values['cuda_cc_semc_sep'] = ';'.join(cuda_compute_capabilities)
+        template_values['cuda_cc_semicolon_sep'] = ';'.join(cuda_compute_capabilities)
         sm_values = ['sm_' + cc.replace('.', '') for cc in cuda_compute_capabilities]
         template_values['cuda_sm_comma_sep'] = ','.join(sm_values)
         template_values['cuda_sm_space_sep'] = ' '.join(sm_values)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -4053,7 +4053,7 @@ class EasyConfigTest(EnhancedTestCase):
             "cuda_compute_capabilities = ['5.1', '7.0', '7.1']",
             "installopts = '%(cuda_compute_capabilities)s'",
             "preinstallopts = '%(cuda_cc_space_sep)s'",
-            "postinstallcmds = '%(cuda_cc_semicolon_sep)s'",
+            "prebuildopts = '%(cuda_cc_semicolon_sep)s'",
             "configopts = '%(cuda_sm_comma_sep)s'",
             "preconfigopts = '%(cuda_sm_space_sep)s'",
         ])
@@ -4062,7 +4062,7 @@ class EasyConfigTest(EnhancedTestCase):
         ec = EasyConfig(test_ec)
         self.assertEqual(ec['installopts'], '5.1,7.0,7.1')
         self.assertEqual(ec['preinstallopts'], '5.1 7.0 7.1')
-        self.assertEqual(ec['postinstallcmds'], '5.1;7.0;7.1')
+        self.assertEqual(ec['prebuildopts'], '5.1;7.0;7.1')
         self.assertEqual(ec['configopts'], 'sm_51,sm_70,sm_71')
         self.assertEqual(ec['preconfigopts'], 'sm_51 sm_70 sm_71')
 
@@ -4071,7 +4071,7 @@ class EasyConfigTest(EnhancedTestCase):
         ec = EasyConfig(test_ec)
         self.assertEqual(ec['installopts'], '4.2,6.3')
         self.assertEqual(ec['preinstallopts'], '4.2 6.3')
-        self.assertEqual(ec['postinstallcmds'], '4.2;6.3')
+        self.assertEqual(ec['prebuildopts'], '4.2;6.3')
         self.assertEqual(ec['configopts'], 'sm_42,sm_63')
         self.assertEqual(ec['preconfigopts'], 'sm_42 sm_63')
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -4053,7 +4053,7 @@ class EasyConfigTest(EnhancedTestCase):
             "cuda_compute_capabilities = ['5.1', '7.0', '7.1']",
             "installopts = '%(cuda_compute_capabilities)s'",
             "preinstallopts = '%(cuda_cc_space_sep)s'",
-            "postinstallcmds = '%(cuda_cc_semc_sep)s'",
+            "postinstallcmds = '%(cuda_cc_semicolon_sep)s'",
             "configopts = '%(cuda_sm_comma_sep)s'",
             "preconfigopts = '%(cuda_sm_space_sep)s'",
         ])

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -4052,6 +4052,8 @@ class EasyConfigTest(EnhancedTestCase):
             "toolchain = SYSTEM",
             "cuda_compute_capabilities = ['5.1', '7.0', '7.1']",
             "installopts = '%(cuda_compute_capabilities)s'",
+            "preinstallopts = '%(cuda_cc_space_sep)s'",
+            "postinstallcmds = '%(cuda_cc_semc_sep)s'",
             "configopts = '%(cuda_sm_comma_sep)s'",
             "preconfigopts = '%(cuda_sm_space_sep)s'",
         ])
@@ -4059,6 +4061,8 @@ class EasyConfigTest(EnhancedTestCase):
 
         ec = EasyConfig(test_ec)
         self.assertEqual(ec['installopts'], '5.1,7.0,7.1')
+        self.assertEqual(ec['preinstallopts'], '5.1 7.0 7.1')
+        self.assertEqual(ec['postinstallcmds'], '5.1;7.0;7.1')
         self.assertEqual(ec['configopts'], 'sm_51,sm_70,sm_71')
         self.assertEqual(ec['preconfigopts'], 'sm_51 sm_70 sm_71')
 
@@ -4066,6 +4070,8 @@ class EasyConfigTest(EnhancedTestCase):
         init_config(build_options={'cuda_compute_capabilities': ['4.2', '6.3']})
         ec = EasyConfig(test_ec)
         self.assertEqual(ec['installopts'], '4.2,6.3')
+        self.assertEqual(ec['preinstallopts'], '4.2 6.3')
+        self.assertEqual(ec['postinstallcmds'], '4.2;6.3')
         self.assertEqual(ec['configopts'], 'sm_42,sm_63')
         self.assertEqual(ec['preconfigopts'], 'sm_42 sm_63')
 


### PR DESCRIPTION
The latter is required for e.g. PyTorch and TorchVision which need a
CMake list, which is semicolon separated