### PR TITLE
fix failing GitHub tests due to trivial change in output of 'eb' command

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -100,12 +100,17 @@ jobs:
         # see https://github.com/<username>/easybuild-framework/settings/secrets
         GITHUB_TOKEN: ${{secrets.TEST_GITHUB_TOKEN}}
       run: |
-        if [ ! -z $GITHUB_TOKEN ]; then
-          if [ "x${{matrix.python}}" == 'x2.6' ];
+        # don't install GitHub token when testing with Lmod 7.x or non-Lmod module tools,
+        # to avoid hitting GitHub rate limit;
+        # tests that require a GitHub token are skipped automatically when no GitHub token is available
+        if [[ ! "${{matrix.modules_tool}}" =~ 'Lmod-7' ]] && [[ ! "${{matrix.modules_tool}}" =~ 'modules-' ]]; then
+          if [ ! -z $GITHUB_TOKEN ]; then
+            if [ "x${{matrix.python}}" == 'x2.6' ];
               then SET_KEYRING="keyring.set_keyring(keyring.backends.file.PlaintextKeyring())";
               else SET_KEYRING="import keyrings; keyring.set_keyring(keyrings.alt.file.PlaintextKeyring())";
-          fi;
-          python -c "import keyring; $SET_KEYRING; keyring.set_password('github_token', 'easybuild_test', '$GITHUB_TOKEN')";
+            fi;
+            python -c "import keyring; $SET_KEYRING; keyring.set_password('github_token', 'easybuild_test', '$GITHUB_TOKEN')";
+          fi
         fi
 
     - name: install modules tool

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -111,6 +111,9 @@ jobs:
             fi;
             python -c "import keyring; $SET_KEYRING; keyring.set_password('github_token', 'easybuild_test', '$GITHUB_TOKEN')";
           fi
+          echo "GitHub token installed!"
+        else
+          echo "Installation of GitHub token skipped!"
         fi
 
     - name: install modules tool

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -4184,7 +4184,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         github_path = r"boegel/easybuild-easyconfigs\.git"
         pattern = '\n'.join([
-            r"== temporary log file in case of crash .*",
+            r"== Temporary log file in case of crash .*",
             r"== Determined branch name corresponding to easybuilders/easybuild-easyconfigs PR #9150: develop",
             r"== fetching branch 'develop' from https://github\.com/%s\.\.\." % github_path,
             r"== pulling latest version of 'develop' branch from easybuilders/easybuild-easyconfigs\.\.\.",
@@ -4215,7 +4215,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         github_path = r"boegel/easybuild-easyconfigs\.git"
         pattern = '\n'.join([
-            r"== temporary log file in case of crash .*",
+            r"== Temporary log file in case of crash .*",
             r"== fetching branch '%s' from https://github\.com/%s\.\.\." % (test_branch, github_path),
             r"== pulling latest version of 'develop' branch from easybuilders/easybuild-easyconfigs\.\.\.",
             r"== merging 'develop' branch into PR branch '%s'\.\.\." % test_branch,


### PR DESCRIPTION
Two of the GitHub tests starting failing due to a trivial change in #3472, where the `eb` command now prints "`Temporary log file in case of crash`" rather then "`temporary log file in case of crash`" (capital `T`).

This went undetected in the PR tests because the GitHub-related tests are skipped for PRs, because the GitHub token is not available then (to avoid that it can be leaked by a malicious PR), but they are still run when the PR is merged to `develop`.

I'm also limiting the use of the GitHub token a bit here, to avoid hitting the GitHub rate limit now that we're running additional test configurations (cfr. #3565). There's little point in running the GitHub tests with different module tools...