### PR TITLE
use '--opt=val' for passing settings from config file to option parser to avoid error for values starting with '-' or '--'

### DIFF
--- a/easybuild/base/generaloption.py
+++ b/easybuild/base/generaloption.py
@@ -1376,8 +1376,7 @@ class GeneralOption(object):
                             configfile_values[opt_dest] = newval
                     else:
                         configfile_cmdline_dest.append(opt_dest)
-                        configfile_cmdline.append("--%s" % opt_name)
-                        configfile_cmdline.append(val)
+                        configfile_cmdline.append("--%s=%s" % (opt_name, val))
 
         # reparse
         self.log.debug('parseconfigfiles: going to parse options through cmdline %s' % configfile_cmdline)

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -244,6 +244,9 @@ class EasyBuildConfigTest(EnhancedTestCase):
         cfgtxt = '\n'.join([
             '[config]',
             'installpath = %s' % testpath2,
+            # special case: configuration option to a value starting with '--'
+            '[override]',
+            'optarch = --test',
         ])
         write_file(config_file, cfgtxt)
 
@@ -260,6 +263,8 @@ class EasyBuildConfigTest(EnhancedTestCase):
         self.assertEqual(source_paths(), [os.path.join(os.getenv('HOME'), '.local', 'easybuild', 'sources')])  # default
         self.assertEqual(install_path(), installpath_software)  # via cmdline arg
         self.assertEqual(install_path('mod'), os.path.join(testpath2, 'modules'))  # via config file
+
+        self.assertEqual(options.optarch, '--test')  # via config file
 
         # copy test easyconfigs to easybuild/easyconfigs subdirectory of temp directory
         # to check whether easyconfigs install path is auto-included in robot path


### PR DESCRIPTION
cfr. https://github.com/hpcugent/vsc-base/pull/308