### PR TITLE
Sort output of eb --search in natural order (respecting numbers)

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -60,7 +60,7 @@ from easybuild.tools import run
 from easybuild.tools.build_log import EasyBuildError, dry_run_msg, print_msg, print_warning
 from easybuild.tools.config import DEFAULT_WAIT_ON_LOCK_INTERVAL, GENERIC_EASYBLOCK_PKG, build_option, install_path
 from easybuild.tools.py2vs3 import HTMLParser, std_urllib, string_type
-from easybuild.tools.utilities import nub, remove_unwanted_chars
+from easybuild.tools.utilities import nub, remove_unwanted_chars, natural_keys
 
 try:
     import requests
@@ -1021,7 +1021,7 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filen
                 else:
                     path_hits.append(os.path.join(path, filepath))
 
-        path_hits = sorted(path_hits)
+        path_hits = sorted(path_hits, key=natural_keys)
 
         if path_hits:
             common_prefix = det_common_path_prefix(path_hits)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -60,7 +60,7 @@ from easybuild.tools import run
 from easybuild.tools.build_log import EasyBuildError, dry_run_msg, print_msg, print_warning
 from easybuild.tools.config import DEFAULT_WAIT_ON_LOCK_INTERVAL, GENERIC_EASYBLOCK_PKG, build_option, install_path
 from easybuild.tools.py2vs3 import HTMLParser, std_urllib, string_type
-from easybuild.tools.utilities import nub, remove_unwanted_chars, natural_keys
+from easybuild.tools.utilities import natural_keys, nub, remove_unwanted_chars
 
 try:
     import requests
@@ -1032,7 +1032,7 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filen
                 if common_prefix is not None and len(common_prefix) > len(var) * 2:
                     var_defs.append((var, common_prefix))
                     var_spec = '$' + var
-                    # Replace the common prefix by  var_spec
+                    # Replace the common prefix by var_spec
                     path_hits = (var_spec + fn[len(common_prefix):] for fn in path_hits)
             hits.extend(path_hits)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1027,12 +1027,14 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filen
         path_hits = sorted(path_hits, key=natural_keys)
 
         if path_hits:
-            common_prefix = det_common_path_prefix(path_hits)
-            if not terse and short and common_prefix is not None and len(common_prefix) > len(var) * 2:
-                var_defs.append((var, common_prefix))
-                hits.extend([os.path.join('$%s' % var, fn[len(common_prefix) + 1:]) for fn in path_hits])
-            else:
-                hits.extend(path_hits)
+            if not terse and short:
+                common_prefix = det_common_path_prefix(path_hits)
+                if common_prefix is not None and len(common_prefix) > len(var) * 2:
+                    var_defs.append((var, common_prefix))
+                    var_spec = '$' + var
+                    # Replace the common prefix by  var_spec
+                    path_hits = (var_spec + fn[len(common_prefix):] for fn in path_hits)
+            hits.extend(path_hits)
 
     return var_defs, hits
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1000,8 +1000,11 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filen
         if not terse:
             print_msg("Searching (case-insensitive) for '%s' in %s " % (query.pattern, path), log=_log, silent=silent)
 
-        path_index = load_index(path, ignore_dirs=ignore_dirs)
-        if path_index is None or build_option('ignore_index'):
+        if build_option('ignore_index'):
+            path_index = None
+        else:
+            path_index = load_index(path, ignore_dirs=ignore_dirs)
+        if path_index is None:
             if os.path.exists(path):
                 _log.info("No index found for %s, creating one...", path)
                 path_index = create_index(path, ignore_dirs=ignore_dirs)

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -316,3 +316,10 @@ def time2str(delta):
         res = '%d %s %d min %d sec' % (hours, hours_str, mins, secs)
 
     return res
+
+
+def natural_keys(key):
+    """Can be used as the sort key in list.sort(key=natural_keys) to sort in natural order (i.e. respecting numbers)"""
+    def try_to_int(key_part):
+        return int(key_part) if key_part.isdigit() else key_part
+    return [try_to_int(key_part) for key_part in re.split(r'(\d+)', key)]

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -34,7 +34,6 @@ import shutil
 import sys
 import tempfile
 from inspect import cleandoc
-from datetime import datetime
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
 
@@ -50,7 +49,6 @@ from easybuild.tools.filetools import change_dir, copy_dir, copy_file, mkdir, re
 from easybuild.tools.filetools import verify_checksum, write_file
 from easybuild.tools.module_generator import module_generator
 from easybuild.tools.modules import reset_module_caches
-from easybuild.tools.utilities import time2str
 from easybuild.tools.version import get_git_revision, this_is_easybuild
 from easybuild.tools.py2vs3 import string_type
 
@@ -2107,34 +2105,6 @@ class EasyBlockTest(EnhancedTestCase):
         hpl = easyblocks['easybuild.easyblocks.hpl']
         self.assertEqual(hpl['class'], 'EB_HPL')
         self.assertTrue(hpl['loc'].endswith('sandbox/easybuild/easyblocks/h/hpl.py'))
-
-    def test_time2str(self):
-        """Test time2str function."""
-
-        start = datetime(2019, 7, 30, 5, 14, 23)
-
-        test_cases = [
-            (start, "0 sec"),
-            (datetime(2019, 7, 30, 5, 14, 37), "14 sec"),
-            (datetime(2019, 7, 30, 5, 15, 22), "59 sec"),
-            (datetime(2019, 7, 30, 5, 15, 23), "1 min 0 sec"),
-            (datetime(2019, 7, 30, 5, 16, 22), "1 min 59 sec"),
-            (datetime(2019, 7, 30, 5, 37, 26), "23 min 3 sec"),
-            (datetime(2019, 7, 30, 6, 14, 22), "59 min 59 sec"),
-            (datetime(2019, 7, 30, 6, 14, 23), "1 hour 0 min 0 sec"),
-            (datetime(2019, 7, 30, 6, 49, 14), "1 hour 34 min 51 sec"),
-            (datetime(2019, 7, 30, 7, 14, 23), "2 hours 0 min 0 sec"),
-            (datetime(2019, 7, 30, 8, 35, 59), "3 hours 21 min 36 sec"),
-            (datetime(2019, 7, 30, 16, 29, 24), "11 hours 15 min 1 sec"),
-            (datetime(2019, 7, 31, 5, 14, 22), "23 hours 59 min 59 sec"),
-            (datetime(2019, 7, 31, 5, 14, 23), "24 hours 0 min 0 sec"),
-            (datetime(2019, 8, 5, 20, 39, 44), "159 hours 25 min 21 sec"),
-        ]
-        for end, expected in test_cases:
-            self.assertEqual(time2str(end - start), expected)
-
-        error_pattern = "Incorrect value type provided to time2str, should be datetime.timedelta: <.* 'int'>"
-        self.assertErrorRegex(EasyBuildError, error_pattern, time2str, 123)
 
     def test_sanity_check_paths_verification(self):
         """Test verification of sanity_check_paths w.r.t. keys & values."""

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2158,11 +2158,11 @@ class FileToolsTest(EnhancedTestCase):
         self.assertEqual(var_defs, [])
         self.assertEqual(len(hits), 5)
         self.assertTrue(all(os.path.exists(p) for p in hits))
-        self.assertTrue(hits[0].endswith('/hwloc-1.11.8-GCC-4.6.4.eb'))
-        self.assertTrue(hits[1].endswith('/hwloc-1.11.8-GCC-6.4.0-2.28.eb'))
-        self.assertTrue(hits[2].endswith('/hwloc-1.11.8-GCC-7.3.0-2.30.eb'))
-        self.assertTrue(hits[3].endswith('/hwloc-1.6.2-GCC-4.9.3-2.26.eb'))
-        self.assertTrue(hits[4].endswith('/hwloc-1.8-gcccuda-2018a.eb'))
+        self.assertTrue(hits[0].endswith('/hwloc-1.6.2-GCC-4.9.3-2.26.eb'))
+        self.assertTrue(hits[1].endswith('/hwloc-1.8-gcccuda-2018a.eb'))
+        self.assertTrue(hits[2].endswith('/hwloc-1.11.8-GCC-4.6.4.eb'))
+        self.assertTrue(hits[3].endswith('/hwloc-1.11.8-GCC-6.4.0-2.28.eb'))
+        self.assertTrue(hits[4].endswith('/hwloc-1.11.8-GCC-7.3.0-2.30.eb'))
 
         # also test case-sensitive searching
         var_defs, hits_bis = ft.search_file([test_ecs], 'HWLOC', silent=True, case_sensitive=True)
@@ -2176,9 +2176,12 @@ class FileToolsTest(EnhancedTestCase):
         # check filename-only mode
         var_defs, hits = ft.search_file([test_ecs], 'HWLOC', silent=True, filename_only=True)
         self.assertEqual(var_defs, [])
-        self.assertEqual(hits, ['hwloc-1.11.8-GCC-4.6.4.eb', 'hwloc-1.11.8-GCC-6.4.0-2.28.eb',
-                                'hwloc-1.11.8-GCC-7.3.0-2.30.eb', 'hwloc-1.6.2-GCC-4.9.3-2.26.eb',
-                                'hwloc-1.8-gcccuda-2018a.eb'])
+        self.assertEqual(hits, ['hwloc-1.6.2-GCC-4.9.3-2.26.eb',
+                                'hwloc-1.8-gcccuda-2018a.eb',
+                                'hwloc-1.11.8-GCC-4.6.4.eb',
+                                'hwloc-1.11.8-GCC-6.4.0-2.28.eb',
+                                'hwloc-1.11.8-GCC-7.3.0-2.30.eb',
+                                ])
 
         # check specifying of ignored dirs
         var_defs, hits = ft.search_file([test_ecs], 'HWLOC', silent=True, ignore_dirs=['hwloc'])
@@ -2187,28 +2190,34 @@ class FileToolsTest(EnhancedTestCase):
         # check short mode
         var_defs, hits = ft.search_file([test_ecs], 'HWLOC', silent=True, short=True)
         self.assertEqual(var_defs, [('CFGS1', os.path.join(test_ecs, 'h', 'hwloc'))])
-        self.assertEqual(hits, ['$CFGS1/hwloc-1.11.8-GCC-4.6.4.eb', '$CFGS1/hwloc-1.11.8-GCC-6.4.0-2.28.eb',
-                                '$CFGS1/hwloc-1.11.8-GCC-7.3.0-2.30.eb', '$CFGS1/hwloc-1.6.2-GCC-4.9.3-2.26.eb',
-                                '$CFGS1/hwloc-1.8-gcccuda-2018a.eb'])
+        self.assertEqual(hits, ['$CFGS1/hwloc-1.6.2-GCC-4.9.3-2.26.eb',
+                                '$CFGS1/hwloc-1.8-gcccuda-2018a.eb',
+                                '$CFGS1/hwloc-1.11.8-GCC-4.6.4.eb',
+                                '$CFGS1/hwloc-1.11.8-GCC-6.4.0-2.28.eb',
+                                '$CFGS1/hwloc-1.11.8-GCC-7.3.0-2.30.eb'
+                                ])
 
         # check terse mode (implies 'silent', overrides 'short')
         var_defs, hits = ft.search_file([test_ecs], 'HWLOC', terse=True, short=True)
         self.assertEqual(var_defs, [])
         expected = [
+            os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.6.2-GCC-4.9.3-2.26.eb'),
+            os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.8-gcccuda-2018a.eb'),
             os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.11.8-GCC-4.6.4.eb'),
             os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.11.8-GCC-6.4.0-2.28.eb'),
             os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.11.8-GCC-7.3.0-2.30.eb'),
-            os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.6.2-GCC-4.9.3-2.26.eb'),
-            os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.8-gcccuda-2018a.eb'),
         ]
         self.assertEqual(hits, expected)
 
         # check combo of terse and filename-only
         var_defs, hits = ft.search_file([test_ecs], 'HWLOC', terse=True, filename_only=True)
         self.assertEqual(var_defs, [])
-        self.assertEqual(hits, ['hwloc-1.11.8-GCC-4.6.4.eb', 'hwloc-1.11.8-GCC-6.4.0-2.28.eb',
-                                'hwloc-1.11.8-GCC-7.3.0-2.30.eb', 'hwloc-1.6.2-GCC-4.9.3-2.26.eb',
-                                'hwloc-1.8-gcccuda-2018a.eb'])
+        self.assertEqual(hits, ['hwloc-1.6.2-GCC-4.9.3-2.26.eb',
+                                'hwloc-1.8-gcccuda-2018a.eb',
+                                'hwloc-1.11.8-GCC-4.6.4.eb',
+                                'hwloc-1.11.8-GCC-6.4.0-2.28.eb',
+                                'hwloc-1.11.8-GCC-7.3.0-2.30.eb',
+                                ])
 
         # patterns that include special characters + (or ++) shouldn't cause trouble
         # cfr. https://github.com/easybuilders/easybuild-framework/issues/2966

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -1513,10 +1513,10 @@ class RobotTest(EnhancedTestCase):
 
         paths = search_easyconfigs('8-gcc', consider_extra_paths=False, print_result=False)
         ref_paths = [
+            os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.8-gcccuda-2018a.eb'),
             os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.11.8-GCC-4.6.4.eb'),
             os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.11.8-GCC-6.4.0-2.28.eb'),
             os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.11.8-GCC-7.3.0-2.30.eb'),
-            os.path.join(test_ecs, 'h', 'hwloc', 'hwloc-1.8-gcccuda-2018a.eb'),
             os.path.join(test_ecs, 'o', 'OpenBLAS', 'OpenBLAS-0.2.8-GCC-4.8.2-LAPACK-3.4.2.eb')
         ]
         self.assertEqual(paths, ref_paths)

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -77,6 +77,7 @@ import test.framework.toolchainvariables as tcv
 import test.framework.toy_build as t
 import test.framework.type_checking as et
 import test.framework.tweak as tw
+import test.framework.utilities_test as u
 import test.framework.variables as v
 import test.framework.yeb as y
 
@@ -118,7 +119,7 @@ log = fancylogger.getLogger()
 # call suite() for each module and then run them all
 # note: make sure the options unit tests run first, to avoid running some of them with a readily initialized config
 tests = [gen, bl, o, r, ef, ev, ebco, ep, e, mg, m, mt, f, run, a, robot, b, v, g, tcv, tc, t, c, s, lic, f_c,
-         tw, p, i, pkg, d, env, et, y, st, h, ct, lib]
+         tw, p, i, pkg, d, env, et, y, st, h, ct, lib, u]
 
 SUITE = unittest.TestSuite([x.suite() for x in tests])
 res = unittest.TextTestRunner().run(SUITE)

--- a/test/framework/utilities_test.py
+++ b/test/framework/utilities_test.py
@@ -1,0 +1,89 @@
+##
+# Copyright 2012-2021 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+Unit tests for utilities.py
+
+@author: Jens Timmerman (Ghent University)
+@author: Kenneth Hoste (Ghent University)
+@author: Alexander Grund (TU Dresden)
+"""
+import os
+import sys
+import tempfile
+from datetime import datetime
+from unittest import TextTestRunner
+
+from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.utilities import time2str
+
+
+class UtilitiesTest(EnhancedTestCase):
+    """Class for utilities testcases """
+
+    def setUp(self):
+        """ setup """
+        super(UtilitiesTest, self).setUp()
+
+        self.test_tmp_logdir = tempfile.mkdtemp()
+        os.environ['EASYBUILD_TMP_LOGDIR'] = self.test_tmp_logdir
+
+    def test_time2str(self):
+        """Test time2str function."""
+
+        start = datetime(2019, 7, 30, 5, 14, 23)
+
+        test_cases = [
+            (start, "0 sec"),
+            (datetime(2019, 7, 30, 5, 14, 37), "14 sec"),
+            (datetime(2019, 7, 30, 5, 15, 22), "59 sec"),
+            (datetime(2019, 7, 30, 5, 15, 23), "1 min 0 sec"),
+            (datetime(2019, 7, 30, 5, 16, 22), "1 min 59 sec"),
+            (datetime(2019, 7, 30, 5, 37, 26), "23 min 3 sec"),
+            (datetime(2019, 7, 30, 6, 14, 22), "59 min 59 sec"),
+            (datetime(2019, 7, 30, 6, 14, 23), "1 hour 0 min 0 sec"),
+            (datetime(2019, 7, 30, 6, 49, 14), "1 hour 34 min 51 sec"),
+            (datetime(2019, 7, 30, 7, 14, 23), "2 hours 0 min 0 sec"),
+            (datetime(2019, 7, 30, 8, 35, 59), "3 hours 21 min 36 sec"),
+            (datetime(2019, 7, 30, 16, 29, 24), "11 hours 15 min 1 sec"),
+            (datetime(2019, 7, 31, 5, 14, 22), "23 hours 59 min 59 sec"),
+            (datetime(2019, 7, 31, 5, 14, 23), "24 hours 0 min 0 sec"),
+            (datetime(2019, 8, 5, 20, 39, 44), "159 hours 25 min 21 sec"),
+        ]
+        for end, expected in test_cases:
+            self.assertEqual(time2str(end - start), expected)
+
+        error_pattern = "Incorrect value type provided to time2str, should be datetime.timedelta: <.* 'int'>"
+        self.assertErrorRegex(EasyBuildError, error_pattern, time2str, 123)
+
+
+def suite():
+    """ return all the tests in this file """
+    return TestLoaderFiltered().loadTestsFromTestCase(UtilitiesTest, sys.argv[1:])
+
+
+if __name__ == '__main__':
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/utilities_test.py
+++ b/test/framework/utilities_test.py
@@ -30,6 +30,7 @@ Unit tests for utilities.py
 @author: Alexander Grund (TU Dresden)
 """
 import os
+import random
 import sys
 import tempfile
 from datetime import datetime
@@ -37,7 +38,7 @@ from unittest import TextTestRunner
 
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.utilities import time2str
+from easybuild.tools.utilities import time2str, natural_keys
 
 
 class UtilitiesTest(EnhancedTestCase):
@@ -77,6 +78,25 @@ class UtilitiesTest(EnhancedTestCase):
 
         error_pattern = "Incorrect value type provided to time2str, should be datetime.timedelta: <.* 'int'>"
         self.assertErrorRegex(EasyBuildError, error_pattern, time2str, 123)
+
+    def test_natural_keys(self):
+        """Test the natural_keys function"""
+        sorted_items = [
+            'ACoolSw-1.0',
+            'ACoolSw-2.1',
+            'ACoolSw-11.0',
+            'ACoolSw-23.0',
+            'ACoolSw-30.0',
+            'ACoolSw-30.1',
+            'BigNumber-1234567890',
+            'BigNumber-1234567891',
+            'NoNumbers',
+            'VeryLastEntry-10'
+        ]
+        shuffled_items = sorted_items[:]
+        random.shuffle(shuffled_items)
+        shuffled_items.sort(key=natural_keys)
+        self.assertEqual(shuffled_items, sorted_items)
 
 
 def suite():


### PR DESCRIPTION
This makes the output of `eb --search` more approachable by sorting versions in natural order. I.e. Foo-10.1 comes **after* Foo-9.2

Had to create and move a test file to add a test for natural_keys

Code is based on https://stackoverflow.com/a/5967539/1930508 which is based on http://nedbatchelder.com/blog/200712/human_sorting.html