### PR TITLE
enhance 'eb' command to ensure that easybuild.main can be imported before settling on python* command to use

### DIFF
--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -1,0 +1,88 @@
+# documentation: https://help.github.com/en/articles/workflow-syntax-for-github-actions
+name: Tests for the 'eb' command
+on: [push, pull_request]
+jobs:
+  test-eb:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{matrix.python}}
+        architecture: x64
+
+    - name: install OS & Python packages
+      run: |
+        # check Python version
+        python -V
+        # update to latest pip, check version
+        pip install --upgrade pip
+        pip --version
+        # install packages required for modules tool
+        sudo apt-get install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
+        # fix for lua-posix packaging issue, see https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082
+        # needed for Ubuntu 18.04, but not for Ubuntu 20.04, so skipping symlinking if posix.so already exists
+        if [ ! -e /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so ] ; then
+            sudo ln -s /usr/lib/x86_64-linux-gnu/lua/5.2/posix_c.so /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so
+        fi
+
+    - name: install modules tool
+      run: |
+          # avoid downloading modules tool sources into easybuild-framework dir
+          cd $HOME
+          export INSTALL_DEP=$GITHUB_WORKSPACE/easybuild/scripts/install_eb_dep.sh
+          # install Lmod
+          source $INSTALL_DEP Lmod-8.4.26 $HOME
+          # changes in environment are not passed to other steps, so need to create files...
+          echo $MOD_INIT > mod_init
+          echo $PATH > path
+          if [ ! -z $MODULESHOME ]; then echo $MODULESHOME > moduleshome; fi
+
+    - name: install EasyBuild framework
+      run: |
+          # install from source distribution tarball, to test release as published on PyPI
+          python setup.py sdist
+          ls dist
+          export PREFIX=/tmp/$USER/$GITHUB_SHA
+          pip install --prefix $PREFIX dist/easybuild-framework*tar.gz
+
+    - name: run tests for 'eb' command
+      env:
+        EB_VERBOSE: 1
+      run: |
+          # run tests *outside* of checked out easybuild-framework directory,
+          # to ensure we're testing installed version (see previous step)
+          cd $HOME
+          # initialize environment for modules tool
+          if [ -f $HOME/moduleshome ]; then export MODULESHOME=$(cat $HOME/moduleshome); fi
+          source $(cat $HOME/mod_init); type module
+          # make sure 'eb' is available via $PATH, and that $PYTHONPATH is set (some tests expect that);
+          # also pick up changes to $PATH set by sourcing $MOD_INIT
+          export PREFIX=/tmp/$USER/$GITHUB_SHA
+          export PATH=$PREFIX/bin:$(cat $HOME/path)
+          export PYTHONPATH=$PREFIX/lib/python${{matrix.python}}/site-packages:$PYTHONPATH
+          # run --version, capture (verbose) output
+          eb --version | tee eb_version.out 2>&1
+          # determine active Python version
+          pymajver=$(python -c 'import sys; print(sys.version_info[0])')
+          pymajminver=$(python -c 'import sys; print(".".join(str(x) for x in sys.version_info[:2]))')
+          # check patterns in verbose output
+          for pattern in "^>> Considering .python.\.\.\." "^>> .python. version: ${pymajminver}\.[0-9]\+, which matches Python ${pymajver} version requirement" "^>> Selected Python command: python \(.*/bin/python\)" "^This is EasyBuild 4\.[0-9.]\+"; do
+              echo "Looking for pattern \"${pattern}\" in eb_version.out..."
+              grep "$pattern" eb_version.out
+          done
+          # also check when specifying Python command via $EB_PYTHON
+          for eb_python in "python${pymajver}" "python${pymajminver}"; do
+              export EB_PYTHON="${eb_python}"
+              eb --version | tee eb_version.out 2>&1
+              for pattern in "^>> Considering .${eb_python}.\.\.\." "^>> .${eb_python}. version: ${pymajminver}\.[0-9]\+, which matches Python ${pymajver} version requirement" "^>> Selected Python command: ${eb_python} \(.*/bin/${eb_python}\)" "^This is EasyBuild 4\.[0-9.]\+"; do
+                  echo "Looking for pattern \"${pattern}\" in eb_version.out..."
+                  grep "$pattern" eb_version.out
+              done
+          done

--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -73,7 +73,7 @@ jobs:
           pymajver=$(python -c 'import sys; print(sys.version_info[0])')
           pymajminver=$(python -c 'import sys; print(".".join(str(x) for x in sys.version_info[:2]))')
           # check patterns in verbose output
-          for pattern in "^>> Considering .python.\.\.\." "^>> .python. version: ${pymajminver}\.[0-9]\+, which matches Python ${pymajver} version requirement" "^>> Selected Python command: python \(.*/bin/python\)" "^This is EasyBuild 4\.[0-9.]\+"; do
+          for pattern in "^>> Considering .python.\.\.\." "^>> .python. version: ${pymajminver}\.[0-9]\+, which matches Python ${pymajver} version requirement" "^>> 'python' is able to import 'easybuild.main', so retaining it" "^>> Selected Python command: python \(.*/bin/python\)" "^This is EasyBuild 4\.[0-9.]\+"; do
               echo "Looking for pattern \"${pattern}\" in eb_version.out..."
               grep "$pattern" eb_version.out
           done
@@ -81,7 +81,7 @@ jobs:
           for eb_python in "python${pymajver}" "python${pymajminver}"; do
               export EB_PYTHON="${eb_python}"
               eb --version | tee eb_version.out 2>&1
-              for pattern in "^>> Considering .${eb_python}.\.\.\." "^>> .${eb_python}. version: ${pymajminver}\.[0-9]\+, which matches Python ${pymajver} version requirement" "^>> Selected Python command: ${eb_python} \(.*/bin/${eb_python}\)" "^This is EasyBuild 4\.[0-9.]\+"; do
+              for pattern in "^>> Considering .${eb_python}.\.\.\." "^>> .${eb_python}. version: ${pymajminver}\.[0-9]\+, which matches Python ${pymajver} version requirement" "^>> '${eb_python}' is able to import 'easybuild.main', so retaining it" "^>> Selected Python command: ${eb_python} \(.*/bin/${eb_python}\)" "^This is EasyBuild 4\.[0-9.]\+"; do
                   echo "Looking for pattern \"${pattern}\" in eb_version.out..."
                   grep "$pattern" eb_version.out
               done

--- a/eb
+++ b/eb
@@ -37,6 +37,7 @@
 REQ_MIN_PY2VER=6
 REQ_MIN_PY3VER=5
 
+EASYBUILD_MAIN='easybuild.main'
 
 function verbose() {
     if [ ! -z ${EB_VERBOSE} ]; then echo ">> $1"; fi
@@ -52,6 +53,8 @@ for python_cmd in ${EB_PYTHON} ${EB_INSTALLPYTHON} 'python' 'python3' 'python2';
 
     verbose "Considering '$python_cmd'..."
 
+    # check whether python* command being considered is available
+    # (using 'command -v', since 'which' implies an extra dependency)
     command -v $python_cmd &> /dev/null
     if [ $? -eq 0 ]; then
 
@@ -63,10 +66,25 @@ for python_cmd in ${EB_PYTHON} ${EB_INSTALLPYTHON} 'python' 'python3' 'python2';
         if [ $pyver_maj -eq 2 ] && [ $pyver_min -ge $REQ_MIN_PY2VER ]; then
             verbose "'$python_cmd' version: $pyver, which matches Python 2 version requirement (>= 2.$REQ_MIN_PY2VER)"
             PYTHON=$python_cmd
-            break
         elif [ $pyver_maj -eq 3 ] && [ $pyver_min -ge $REQ_MIN_PY3VER ]; then
             verbose "'$python_cmd' version: $pyver, which matches Python 3 version requirement (>= 3.$REQ_MIN_PY3VER)"
             PYTHON=$python_cmd
+        fi
+
+        if [ ! -z $PYTHON ]; then
+            # check whether easybuild.main is available for selected python command
+            $PYTHON -c "import $EASYBUILD_MAIN" 2> /dev/null
+            if [ $? -eq 0 ]; then
+                verbose "'$python_cmd' is able to import '$EASYBUILD_MAIN', so retaining it"
+            else
+                # if easybuild.main is not available, don't use this python command, keep searching...
+                verbose "'$python_cmd' is NOT able to import '$EASYBUILD_MAIN', so NOT retaining it"
+                unset PYTHON
+            fi
+        fi
+
+        # break out of for loop if we've found a valid python command
+        if [ ! -z $PYTHON ]; then
             break
         fi
     else
@@ -97,5 +115,5 @@ fi
 
 export EB_SCRIPT_PATH=$0
 
-verbose "$PYTHON -m easybuild.main `echo \"$@\"`"
-$PYTHON -m easybuild.main "$@"
+verbose "$PYTHON -m $EASYBUILD_MAIN `echo \"$@\"`"
+$PYTHON -m $EASYBUILD_MAIN "$@"


### PR DESCRIPTION
This is a small enhancement for the `eb` command: only accepted the `python*` command if it's able to import `easybuild.main`.

This fixes the following strange/confusing situation, which occurs currently because `eb` considers `python` before `python3` (unless `$EB_PYTHON` is set):

```
# default Python command is Python 2
$ python -V
Python 2.7.18

# use pip3 to install EasyBuild, with the intention to run it via 'python3'
$ pip3 install easybuild

# try running 'eb' fails because default 'python' command is not Python 3
$ eb --version
/usr/bin/python: No module named easybuild
```