### PR TITLE
Add option to write file from file-like object and use in download_file

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -246,7 +246,7 @@ def write_file(path, data, append=False, forced=False, backup=False, always_over
     # cfr. https://docs.python.org/3/library/functions.html#open
     mode = 'a' if append else 'w'
 
-    data_is_file_obj = all(hasattr(data, x) for x in ('read', 'seek', 'tell', 'write'))
+    data_is_file_obj = hasattr(data, 'read')
 
     # special care must be taken with binary data in Python 3
     if sys.version_info[0] >= 3 and (isinstance(data, bytes) or data_is_file_obj):
@@ -258,7 +258,6 @@ def write_file(path, data, append=False, forced=False, backup=False, always_over
         with open_file(path, mode) as fh:
             if data_is_file_obj:
                 # if a file-like object was provided, use copyfileobj (which reads the file in chunks)
-                data.seek(0)
                 shutil.copyfileobj(data, fh)
             else:
                 fh.write(data)

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -705,14 +705,20 @@ class FileToolsTest(EnhancedTestCase):
         # test use of 'mode' in read_file
         self.assertEqual(ft.read_file(foo, mode='rb'), b'bar')
 
-    def test_write_file_like(self):
-        """Test writing from a file handle directly"""
+    def test_write_file_obj(self):
+        """Test writing from a file-like object directly"""
         # Write a text file
         fp = os.path.join(self.test_prefix, 'test.txt')
         fp_out = os.path.join(self.test_prefix, 'test_out.txt')
         ft.write_file(fp, b'Hyphen: \xe2\x80\x93\nEuro sign: \xe2\x82\xac\na with dots: \xc3\xa4')
 
         with ft.open_file(fp, 'rb') as fh:
+            ft.write_file(fp_out, fh)
+        self.assertEqual(ft.read_file(fp_out), ft.read_file(fp))
+
+        # works fine even if same data was already read through the provided file handle
+        with ft.open_file(fp, 'rb') as fh:
+            fh.read(4)
             ft.write_file(fp_out, fh)
         self.assertEqual(ft.read_file(fp_out), ft.read_file(fp))
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -716,12 +716,6 @@ class FileToolsTest(EnhancedTestCase):
             ft.write_file(fp_out, fh)
         self.assertEqual(ft.read_file(fp_out), ft.read_file(fp))
 
-        # works fine even if same data was already read through the provided file handle
-        with ft.open_file(fp, 'rb') as fh:
-            fh.read(4)
-            ft.write_file(fp_out, fh)
-        self.assertEqual(ft.read_file(fp_out), ft.read_file(fp))
-
         # Write a binary file
         fp = os.path.join(self.test_prefix, 'test.bin')
         fp_out = os.path.join(self.test_prefix, 'test_out.bin')

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -705,6 +705,26 @@ class FileToolsTest(EnhancedTestCase):
         # test use of 'mode' in read_file
         self.assertEqual(ft.read_file(foo, mode='rb'), b'bar')
 
+    def test_write_file_like(self):
+        """Test writing from a file handle directly"""
+        # Write a text file
+        fp = os.path.join(self.test_prefix, 'test.txt')
+        fp_out = os.path.join(self.test_prefix, 'test_out.txt')
+        ft.write_file(fp, b'Hyphen: \xe2\x80\x93\nEuro sign: \xe2\x82\xac\na with dots: \xc3\xa4')
+
+        with ft.open_file(fp, 'rb') as fh:
+            ft.write_file(fp_out, fh)
+        self.assertEqual(ft.read_file(fp_out), ft.read_file(fp))
+
+        # Write a binary file
+        fp = os.path.join(self.test_prefix, 'test.bin')
+        fp_out = os.path.join(self.test_prefix, 'test_out.bin')
+        ft.write_file(fp, b'\x00\x01'+os.urandom(42)+b'\x02\x03')
+
+        with ft.open_file(fp, 'rb') as fh:
+            ft.write_file(fp_out, fh)
+        self.assertEqual(ft.read_file(fp_out, mode='rb'), ft.read_file(fp, mode='rb'))
+
     def test_is_binary(self):
         """Test is_binary function."""
 


### PR DESCRIPTION
Fixes downloads of large files where the size exceeds the maximum integer size
Fixes #3455