### PR TITLE
Refactor the CI configuration to use inclusion instead of exclusion

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         python: [2.7, 3.6]
-        modules_tool: [Lmod-7.8.22, Lmod-8.2.9, modules-tcl-1.147, modules-3.2.10, modules-4.1.4]
+        modules_tool: [Lmod-7.8.22, Lmod-8.4.27, modules-tcl-1.147, modules-3.2.10, modules-4.1.4]
         module_syntax: [Lua, Tcl]
         lc_all: [""]
         # don't test with Lua module syntax (only supported in Lmod)
@@ -19,35 +19,35 @@ jobs:
           - modules_tool: modules-4.1.4
             module_syntax: Lua
         include:
-          # Test different python versions with latest Lmod
+          # Test different Python versions with Lmod 8.x (with both Lua and Tcl module syntax)
           - python: 3.5
-            modules_tool: Lmod-8.2.9
+            modules_tool: Lmod-8.4.27
             module_syntax: Lua
           - python: 3.5
-            modules_tool: Lmod-8.2.9
+            modules_tool: Lmod-8.4.27
             module_syntax: Tcl
           - python: 3.7
-            modules_tool: Lmod-8.2.9
+            modules_tool: Lmod-8.4.27
             module_syntax: Lua
           - python: 3.7
-            modules_tool: Lmod-8.2.9
+            modules_tool: Lmod-8.4.27
             module_syntax: Tcl
           - python: 3.8
-            modules_tool: Lmod-8.2.9
+            modules_tool: Lmod-8.4.27
             module_syntax: Lua
           - python: 3.8
-            modules_tool: Lmod-8.2.9
+            modules_tool: Lmod-8.4.27
             module_syntax: Tcl
           - python: 3.9
-            modules_tool: Lmod-8.2.9
+            modules_tool: Lmod-8.4.27
             module_syntax: Lua
           - python: 3.9
-            modules_tool: Lmod-8.2.9
+            modules_tool: Lmod-8.4.27
             module_syntax: Tcl
-        # There may be encoding errors in Python 3 which are hidden when an UTF-8 encoding is set
-        # Hence run the tests (again) with LC_ALL=C and Python 3.6 (or any < 3.7)
+          # There may be encoding errors in Python 3 which are hidden when an UTF-8 encoding is set
+          # Hence run the tests (again) with LC_ALL=C and Python 3.6 (or any < 3.7)
           - python: 3.6
-            modules_tool: Lmod-8.2.9
+            modules_tool: Lmod-8.4.27
             module_syntax: Lua
             lc_all: C
       fail-fast: false

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,52 +2,68 @@
 name: EasyBuild framework unit tests
 on: [push, pull_request]
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+        lmod7: Lmod-7.8.22
+        lmod8: Lmod-8.4.27
+        modulesTcl: modules-tcl-1.147
+        modules3: modules-3.2.10
+        modules4: modules-4.1.4
+    steps:
+      - run: "true"
   build:
+    needs: setup
     runs-on: ubuntu-18.04
     strategy:
       matrix:
         python: [2.7, 3.6]
-        modules_tool: [Lmod-7.8.22, Lmod-8.4.27, modules-tcl-1.147, modules-3.2.10, modules-4.1.4]
+        modules_tool:
+          - ${{needs.setup.outputs.lmod7}}
+          - ${{needs.setup.outputs.lmod8}}
+          - ${{needs.setup.outputs.modulesTcl}}
+          - ${{needs.setup.outputs.modules3}}
+          - ${{needs.setup.outputs.modules4}}
         module_syntax: [Lua, Tcl]
         lc_all: [""]
         # don't test with Lua module syntax (only supported in Lmod)
         exclude:
-          - modules_tool: modules-tcl-1.147
+          - modules_tool: ${{needs.setup.outputs.modulesTcl}}
             module_syntax: Lua
-          - modules_tool: modules-3.2.10
+          - modules_tool: ${{needs.setup.outputs.modules3}}
             module_syntax: Lua
-          - modules_tool: modules-4.1.4
+          - modules_tool: ${{needs.setup.outputs.modules4}}
             module_syntax: Lua
         include:
           # Test different Python versions with Lmod 8.x (with both Lua and Tcl module syntax)
           - python: 3.5
-            modules_tool: Lmod-8.4.27
+            modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Lua
           - python: 3.5
-            modules_tool: Lmod-8.4.27
+            modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Tcl
           - python: 3.7
-            modules_tool: Lmod-8.4.27
+            modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Lua
           - python: 3.7
-            modules_tool: Lmod-8.4.27
+            modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Tcl
           - python: 3.8
-            modules_tool: Lmod-8.4.27
+            modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Lua
           - python: 3.8
-            modules_tool: Lmod-8.4.27
+            modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Tcl
           - python: 3.9
-            modules_tool: Lmod-8.4.27
+            modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Lua
           - python: 3.9
-            modules_tool: Lmod-8.4.27
+            modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Tcl
           # There may be encoding errors in Python 3 which are hidden when an UTF-8 encoding is set
           # Hence run the tests (again) with LC_ALL=C and Python 3.6 (or any < 3.7)
           - python: 3.6
-            modules_tool: Lmod-8.4.27
+            modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Lua
             lc_all: C
       fail-fast: false

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,6 +19,8 @@ jobs:
       matrix:
         python: [2.7, 3.6]
         modules_tool:
+          # use variables defined by 'setup' job above, see also
+          # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#needs-context
           - ${{needs.setup.outputs.lmod7}}
           - ${{needs.setup.outputs.lmod8}}
           - ${{needs.setup.outputs.modulesTcl}}
@@ -35,7 +37,7 @@ jobs:
           - modules_tool: ${{needs.setup.outputs.modules4}}
             module_syntax: Lua
         include:
-          # Test different Python versions with Lmod 8.x (with both Lua and Tcl module syntax)
+          # Test different Python 3 versions with Lmod 8.x (with both Lua and Tcl module syntax)
           - python: 3.5
             modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Lua

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,13 +6,11 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python: [2.7, 3.6]
         modules_tool: [Lmod-7.8.22, Lmod-8.2.9, modules-tcl-1.147, modules-3.2.10, modules-4.1.4]
         module_syntax: [Lua, Tcl]
         lc_all: [""]
-        # exclude some configuration for non-Lmod modules tool:
-        # - don't test with Lua module syntax (only supported in Lmod)
-        # - exclude Python 3.x versions other than 3.6, to limit test configurations
+        # don't test with Lua module syntax (only supported in Lmod)
         exclude:
           - modules_tool: modules-tcl-1.147
             module_syntax: Lua
@@ -20,41 +18,34 @@ jobs:
             module_syntax: Lua
           - modules_tool: modules-4.1.4
             module_syntax: Lua
-          - modules_tool: modules-tcl-1.147
-            python: 3.5
-          - modules_tool: modules-tcl-1.147
-            python: 3.7
-          - modules_tool: modules-tcl-1.147
-            python: 3.8
-          - modules_tool: modules-tcl-1.147
-            python: 3.9
-          - modules_tool: modules-3.2.10
-            python: 3.5
-          - modules_tool: modules-3.2.10
-            python: 3.7
-          - modules_tool: modules-3.2.10
-            python: 3.8
-          - modules_tool: modules-3.2.10
-            python: 3.9
-          - modules_tool: modules-4.1.4
-            python: 3.5
-          - modules_tool: modules-4.1.4
-            python: 3.7
-          - modules_tool: modules-4.1.4
-            python: 3.8
-          - modules_tool: modules-4.1.4
-            python: 3.9
-          - modules_tool: Lmod-7.8.22
-            python: 3.5
-          - modules_tool: Lmod-7.8.22
-            python: 3.7
-          - modules_tool: Lmod-7.8.22
-            python: 3.8
-          - modules_tool: Lmod-7.8.22
-            python: 3.9
+        include:
+          # Test different python versions with latest Lmod
+          - python: 3.5
+            modules_tool: Lmod-8.2.9
+            module_syntax: Lua
+          - python: 3.5
+            modules_tool: Lmod-8.2.9
+            module_syntax: Tcl
+          - python: 3.7
+            modules_tool: Lmod-8.2.9
+            module_syntax: Lua
+          - python: 3.7
+            modules_tool: Lmod-8.2.9
+            module_syntax: Tcl
+          - python: 3.8
+            modules_tool: Lmod-8.2.9
+            module_syntax: Lua
+          - python: 3.8
+            modules_tool: Lmod-8.2.9
+            module_syntax: Tcl
+          - python: 3.9
+            modules_tool: Lmod-8.2.9
+            module_syntax: Lua
+          - python: 3.9
+            modules_tool: Lmod-8.2.9
+            module_syntax: Tcl
         # There may be encoding errors in Python 3 which are hidden when an UTF-8 encoding is set
         # Hence run the tests (again) with LC_ALL=C and Python 3.6 (or any < 3.7)
-        include:
           - python: 3.6
             modules_tool: Lmod-8.2.9
             module_syntax: Lua


### PR DESCRIPTION
This provides more clarity on what exactly is run

The jobs have not changed, the following configurations are tested before (and after):
```
build (2.7, Lmod-7.8.22, Lua)
build (2.7, Lmod-7.8.22, Tcl)
build (2.7, Lmod-8.2.9, Lua)
build (2.7, Lmod-8.2.9, Tcl)
build (2.7, modules-tcl-1.147, Tcl)
build (2.7, modules-3.2.10, Tcl)
build (2.7, modules-4.1.4, Tcl)

build (3.6, Lmod-7.8.22, Lua)
build (3.6, Lmod-7.8.22, Tcl)
build (3.6, Lmod-8.2.9, Lua)
build (3.6, Lmod-8.2.9, Tcl)
build (3.6, modules-tcl-1.147, Tcl)
build (3.6, modules-3.2.10, Tcl)
build (3.6, modules-4.1.4, Tcl)

build (3.5, Lmod-8.2.9, Lua)
build (3.5, Lmod-8.2.9, Tcl)

build (3.7, Lmod-8.2.9, Lua)
build (3.7, Lmod-8.2.9, Tcl)

build (3.8, Lmod-8.2.9, Lua)
build (3.8, Lmod-8.2.9, Tcl)

build (3.9, Lmod-8.2.9, Lua)
build (3.9, Lmod-8.2.9, Tcl)

build (3.6, Lmod-8.2.9, Lua, C)
```