### PR TITLE
Deprecate adding a non-existing path to $MODULEPATH

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2155,7 +2155,7 @@ class EasyBlock(object):
         curr_modpaths = curr_module_paths()
         for init_modpath in init_modpaths:
             full_mod_path = os.path.join(self.installdir_mod, init_modpath)
-            if full_mod_path not in curr_modpaths:
+            if os.path.exists(full_mod_path) and full_mod_path not in curr_modpaths:
                 self.modules_tool.prepend_module_path(full_mod_path)
 
         # prepare toolchain: load toolchain module and dependencies, set up build environment

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -508,6 +508,24 @@ def det_common_path_prefix(paths):
         return None
 
 
+def normalize_path(path):
+    """Normalize path removing empty and dot components.
+
+    Similar to os.path.normpath but does not resolve '..' which may return a wrong path when symlinks are used
+    """
+    # In POSIX 3 or more leading slashes are equivalent to 1
+    if path.startswith(os.path.sep):
+        if path.startswith(os.path.sep * 2) and not path.startswith(os.path.sep * 3):
+            start_slashes = os.path.sep * 2
+        else:
+            start_slashes = os.path.sep
+    else:
+        start_slashes = ''
+
+    filtered_comps = (comp for comp in path.split(os.path.sep) if comp and comp != '.')
+    return start_slashes + os.path.sep.join(filtered_comps)
+
+
 def is_alt_pypi_url(url):
     """Determine whether specified URL is already an alternate PyPI URL, i.e. whether it contains a hash."""
     # example: .../packages/5b/03/e135b19fadeb9b1ccb45eac9f60ca2dc3afe72d099f6bd84e03cb131f9bf/easybuild-2.7.0.tar.gz

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -381,6 +381,7 @@ class ModulesTool(object):
         :param path: path to add to $MODULEPATH via 'use'
         :param set_mod_paths: (re)set self.mod_paths
         """
+        path = path.rstrip(os.path.sep)
         if path not in curr_module_paths():
             # add module path via 'module use' and make sure self.mod_paths is synced
             self.use(path)
@@ -395,6 +396,7 @@ class ModulesTool(object):
         :param set_mod_paths: (re)set self.mod_paths
         """
         # remove module path via 'module unuse' and make sure self.mod_paths is synced
+        path = path.rstrip(os.path.sep)
         if path in curr_module_paths():
             self.unuse(path)
 
@@ -1291,6 +1293,7 @@ class EnvironmentModulesTcl(EnvironmentModulesC):
         # remove module path via 'module use' and make sure self.mod_paths is synced
         # modulecmd.tcl keeps track of how often a path was added via 'module use',
         # so we need to check to make sure it's really removed
+        path = path.rstrip(os.path.sep)
         while path in curr_module_paths():
             self.unuse(path)
         if set_mod_paths:
@@ -1442,6 +1445,7 @@ class Lmod(ModulesTool):
             if os.environ.get('__LMOD_Priority_MODULEPATH'):
                 self.run_module(['use', path])
             else:
+                path = path.rstrip(os.path.sep)
                 cur_mod_path = os.environ.get('MODULEPATH')
                 if cur_mod_path is None:
                     new_mod_path = path
@@ -1462,6 +1466,7 @@ class Lmod(ModulesTool):
                 self.log.debug('Changing MODULEPATH from %s to <unset>' % cur_mod_path)
                 del os.environ['MODULEPATH']
             else:
+                path = path.rstrip(os.path.sep)
                 new_mod_path = ':'.join(p for p in cur_mod_path.split(':') if p != path)
                 if new_mod_path != cur_mod_path:
                     self.log.debug('Changing MODULEPATH from %s to %s' % (cur_mod_path, new_mod_path))

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -672,7 +672,8 @@ class ModulesTool(object):
         # extend $MODULEPATH if needed
         for mod_path in mod_paths:
             full_mod_path = os.path.join(install_path('mod'), build_option('suffix_modules_path'), mod_path)
-            self.prepend_module_path(full_mod_path)
+            if os.path.exists(full_mod_path):
+                self.prepend_module_path(full_mod_path)
 
         loaded_modules = self.loaded_modules()
         for mod in modules:

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -362,8 +362,12 @@ class ModulesTool(object):
             self.log.info("Ignoring specified priority '%s' when running 'module use %s' (Lmod-specific)",
                           priority, path)
 
-        # make sure path exists before we add it
-        mkdir(path, parents=True)
+        if not path:
+            raise EasyBuildError("Cannot add empty path to $MODULEPATH")
+        if not os.path.exists(path):
+            self.log.deprecated("Path '%s' for module.use should exist" % path, '5.0')
+            # make sure path exists before we add it
+            mkdir(path, parents=True)
         self.run_module(['use', path])
 
     def unuse(self, path):
@@ -431,6 +435,7 @@ class ModulesTool(object):
             eb_modpath = os.path.join(install_path(typ='modules'), build_option('suffix_modules_path'))
 
             # make sure EasyBuild module path is in 1st place
+            mkdir(eb_modpath, parents=True)
             self.prepend_module_path(eb_modpath)
             self.log.info("Prepended list of module paths with path used by EasyBuild: %s" % eb_modpath)
 
@@ -1422,8 +1427,12 @@ class Lmod(ModulesTool):
         :param path: path to add to $MODULEPATH
         :param priority: priority for this path in $MODULEPATH (Lmod-specific)
         """
-        # make sure path exists before we add it
-        mkdir(path, parents=True)
+        if not path:
+            raise EasyBuildError("Cannot add empty path to $MODULEPATH")
+        if not os.path.exists(path):
+            self.log.deprecated("Path '%s' for module.use should exist" % path, '5.0')
+            # make sure path exists before we add it
+            mkdir(path, parents=True)
 
         if priority:
             self.run_module(['use', '--priority', str(priority), path])

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -634,7 +634,9 @@ class Toolchain(object):
             if self.init_modpaths:
                 mod_path_suffix = build_option('suffix_modules_path')
                 for modpath in self.init_modpaths:
-                    self.modules_tool.prepend_module_path(os.path.join(install_path('mod'), mod_path_suffix, modpath))
+                    modpath = os.path.join(install_path('mod'), mod_path_suffix, modpath)
+                    if os.path.exists(modpath):
+                        self.modules_tool.prepend_module_path(modpath)
 
             # load modules for all dependencies
             self.log.debug("Loading module for toolchain: %s", tc_mod)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1655,7 +1655,6 @@ class EasyConfigTest(EnhancedTestCase):
         # by adding a couple of matching module files with some useful data in them
         # (use Tcl syntax, so it works with all varieties of module tools)
         mod_dir = os.path.join(self.test_prefix, 'modules')
-        self.modtool.use(mod_dir)
 
         pi_mod_txt = '\n'.join([
             "#%Module",
@@ -1679,6 +1678,8 @@ class EasyConfigTest(EnhancedTestCase):
             "setenv CRAY_FOOBAR_VERSION 2.3.4",
         ])
         write_file(os.path.join(mod_dir, 'foobar/2.3.4'), foobar_mod_txt)
+
+        self.modtool.use(mod_dir)
 
         ec = EasyConfig(toy_ec)
         deps = ec.dependencies()

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -351,6 +351,21 @@ class FileToolsTest(EnhancedTestCase):
         self.assertEqual(ft.det_common_path_prefix(['foo']), None)
         self.assertEqual(ft.det_common_path_prefix([]), None)
 
+    def test_normalize_path(self):
+        """Test normalize_path"""
+        self.assertEqual(ft.normalize_path(''), '')
+        self.assertEqual(ft.normalize_path('/'), '/')
+        self.assertEqual(ft.normalize_path('//'), '//')
+        self.assertEqual(ft.normalize_path('///'), '/')
+        self.assertEqual(ft.normalize_path('/foo/bar/baz'), '/foo/bar/baz')
+        self.assertEqual(ft.normalize_path('/foo//bar/././baz/'), '/foo/bar/baz')
+        self.assertEqual(ft.normalize_path('foo//bar/././baz/'), 'foo/bar/baz')
+        self.assertEqual(ft.normalize_path('//foo//bar/././baz/'), '//foo/bar/baz')
+        self.assertEqual(ft.normalize_path('///foo//bar/././baz/'), '/foo/bar/baz')
+        self.assertEqual(ft.normalize_path('////foo//bar/././baz/'), '/foo/bar/baz')
+        self.assertEqual(ft.normalize_path('/././foo//bar/././baz/'), '/foo/bar/baz')
+        self.assertEqual(ft.normalize_path('//././foo//bar/././baz/'), '//foo/bar/baz')
+
     def test_download_file(self):
         """Test download_file function."""
         fn = 'toy-0.0.tar.gz'

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -1089,7 +1089,7 @@ class ModulesTest(EnhancedTestCase):
         """Test module caches and invalidate_module_caches_for function."""
         self.assertEqual(mod.MODULE_AVAIL_CACHE, {})
 
-        # purposely extending $MODULEPATH with non-existing path, should be handled fine
+        # purposely extending $MODULEPATH with an empty path, should be handled fine
         nonpath = os.path.join(self.test_prefix, 'nosuchfileordirectory')
         mkdir(nonpath)
         self.modtool.use(nonpath)

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -1091,6 +1091,7 @@ class ModulesTest(EnhancedTestCase):
 
         # purposely extending $MODULEPATH with non-existing path, should be handled fine
         nonpath = os.path.join(self.test_prefix, 'nosuchfileordirectory')
+        mkdir(nonpath)
         self.modtool.use(nonpath)
         modulepaths = [p for p in os.environ.get('MODULEPATH', '').split(os.pathsep) if p]
         self.assertTrue(any([os.path.samefile(nonpath, mp) for mp in modulepaths]))
@@ -1163,6 +1164,11 @@ class ModulesTest(EnhancedTestCase):
         self.modtool.use(test_dir3)
         self.assertTrue(os.environ['MODULEPATH'].startswith('%s:' % test_dir3))
 
+        # Adding an empty modulepath is not possible
+        modulepath = os.environ.get('MODULEPATH', '')
+        self.assertErrorRegex(EasyBuildError, "Cannot add empty path", self.modtool.use, '')
+        self.assertEqual(os.environ.get('MODULEPATH', ''), modulepath)
+
         # make sure the right test module is loaded
         self.modtool.load(['test'])
         self.assertEqual(os.getenv('TEST123'), 'three')
@@ -1220,18 +1226,6 @@ class ModulesTest(EnhancedTestCase):
             self.modtool.use(test_dir1)
             self.assertEqual(os.environ['MODULEPATH'], test_dir1)
             self.modtool.unuse(test_dir1)
-            self.assertFalse('MODULEPATH' in os.environ)
-            os.environ['MODULEPATH'] = old_module_path  # Restore
-
-            # Using an empty path still works (technically) (Lmod only, ignored by Tcl)
-            old_module_path = os.environ['MODULEPATH']
-            self.modtool.use('')
-            self.assertEqual(os.environ['MODULEPATH'], ':' + old_module_path)
-            self.modtool.unuse('')
-            self.assertEqual(os.environ['MODULEPATH'], old_module_path)
-            # Even works when the whole path is empty
-            os.environ['MODULEPATH'] = ''
-            self.modtool.unuse('')
             self.assertFalse('MODULEPATH' in os.environ)
             os.environ['MODULEPATH'] = old_module_path  # Restore
 

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -1259,6 +1259,27 @@ class ModulesTest(EnhancedTestCase):
         self.modtool.remove_module_path(os.path.join(test_dir1, ''))
         self.assertEqual(os.environ.get('MODULEPATH', ''), '')
 
+        # And with some more trickery
+        test_dir1_relative = os.path.join(test_dir1, '..', os.path.basename(test_dir1))
+        test_dir2_dot = os.path.join(os.path.dirname(test_dir2), '.', os.path.basename(test_dir2))
+        self.modtool.add_module_path(test_dir1_relative)
+        self.assertEqual(os.environ['MODULEPATH'], test_dir1_relative)
+        self.modtool.add_module_path(test_dir1)
+        self.assertEqual(os.environ['MODULEPATH'], test_dir1 + ':' + test_dir1_relative)
+        self.modtool.remove_module_path(test_dir1)
+        self.assertEqual(os.environ['MODULEPATH'], test_dir1_relative)
+        self.modtool.add_module_path(test_dir2_dot)
+        self.assertEqual(os.environ['MODULEPATH'], test_dir2 + ':' + test_dir1_relative)
+        self.modtool.remove_module_path(test_dir2_dot)
+        self.assertEqual(os.environ['MODULEPATH'], test_dir1_relative)
+        # Force adding such a dot path which can be removed with either variant
+        os.environ['MODULEPATH'] = test_dir2_dot + ':' + test_dir1_relative
+        self.modtool.remove_module_path(test_dir2_dot)
+        self.assertEqual(os.environ['MODULEPATH'], test_dir1_relative)
+        os.environ['MODULEPATH'] = test_dir2_dot + ':' + test_dir1_relative
+        self.modtool.remove_module_path(test_dir2)
+        self.assertEqual(os.environ['MODULEPATH'], test_dir1_relative)
+
         os.environ['MODULEPATH'] = old_module_path  # Restore
 
     def test_module_use_bash(self):


### PR DESCRIPTION
The `module.use` function is not actually supposed to create a directory, but we require that the directories of `$MODULEPATH` exist in `curr_module_paths`

Hence deprecate adding a path which does not exist

As a side effect we need to explicitly disallow the empty path `''`, as that also does not exist. EnvironmentModules ignores such paths, LMod does create an empty entry in `$MODULEPATH` but doesn't really use it. We also filter it in  `curr_module_paths` so it makes sense to fully disallow adding it.

During the tests on CI another bug was discovered: The module tools (at least Lmod) strip trailing slashes before adding a path to $MODULEPATH. However we sometimes do `add_module_path(os.path.join(some_prefix, modpath))` where `modpath` could be empty which leads to a trailing slash and `add_module_path` (and `remove_module_path`) not finding the path in `curr_module_paths` (which do not contain the trailing slashes) This means that paths wrongly were retained in $MODULEPATH or unnecessarily added again.

I added a test to catch this issue and fixed it.

I also had to add checks before adding Hierarchical MNS paths, such as `Core` if they exist (already). Not adding non-existing ones is fine as far as I can tell and even leads to more speed by avoiding module calls, cache invalidation and work for the modules tool (repeatably checking a non-existing folder)