### PR TITLE
Don't skip sanity check for --module-only --rebuild

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3096,7 +3096,7 @@ class EasyBlock(object):
     def skip_step(self, step, skippable):
         """Dedice whether or not to skip the specified step."""
         module_only = build_option('module_only')
-        force = build_option('force') or build_option('rebuild')
+        force = build_option('force')
         skip = False
 
         # under --skip, sanity check is not skipped

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1583,16 +1583,11 @@ class ToyBuildTest(EnhancedTestCase):
 
         os.remove(toy_mod)
 
-        # --module-only --rebuild should be equivalent with --module-only --force
-        self.eb_main(args + ['--rebuild'], do_build=True, raise_error=True)
-        self.assertTrue(os.path.exists(toy_mod))
-
-        # make sure load statements for dependencies are included in additional module file generated with --module-only
-        modtxt = read_file(toy_mod)
-        self.assertTrue(re.search('load.*intel/2018a', modtxt), "load statement for intel/2018a found in module")
-        self.assertTrue(re.search('load.*GCC/6.4.0-2.28', modtxt), "load statement for GCC/6.4.0-2.28 found in module")
-
-        os.remove(toy_mod)
+        # --module-only --rebuild should run sanity check
+        rebuild_args = args + ['--rebuild']
+        err_msg = "Sanity check failed"
+        self.assertErrorRegex(EasyBuildError, err_msg, self.eb_main, rebuild_args, do_build=True, raise_error=True)
+        self.assertFalse(os.path.exists(toy_mod))
 
         # installing another module under a different naming scheme and using Lua module syntax works fine
 


### PR DESCRIPTION
The only difference to now us that the sanity check is run when `--rebuild` is used.
For "proper" use, i.e. regenerating a module, this does not cause any problems and might even show issues that user was not aware of.
For those that used it for something else, the sanity check can fail and those need to use `--force` instead.
So that is IMO very low impact.

I'd even say it is a bugfix as the comment states: "allow skipping sanity check too when only generating module and force is used"
