### PR TITLE
Correct cryptography comment in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ requests
 
 archspec; python_version >= '2.7'
 
-# cryptography 3.0 deprecates Python 2.7 (but v3.2.1 still works with Python 2.7);
 # cryptography is not needed at all for Python 2.6
+# cryptography 3.4.0 no longer supports Python 2.7
 cryptography==3.3.2; python_version == '2.7'
 cryptography; python_version >= '3.5'


### PR DESCRIPTION
This makes the comment consistent with that for the other packages above and that means that we no longer have the mismatch between the version being installed and the comment (which #3643 introduced).