### PR TITLE
Allow amending easyconfig parameters which are not the default

### DIFF
--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -230,3 +230,8 @@ def get_easyconfig_parameter_default(param):
     else:
         _log.debug("Returning default value for easyconfig parameter %s: %s" % (param, DEFAULT_CONFIG[param][0]))
         return DEFAULT_CONFIG[param][0]
+
+
+def is_easyconfig_parameter_default_value(param, value):
+    """Return True if the parameters is one of the default ones and the value equals its default value"""
+    return param in DEFAULT_CONFIG and get_easyconfig_parameter_default(param) == value

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -331,14 +331,20 @@ def tweak_one(orig_ec, tweaked_ec, tweaks, targetdir=None):
 
     # add parameters or replace existing ones
     special_values = {
-        'True': True, "'True'": 'True', '"True"': 'True',
-        'False': False, "'False'": 'False', '"False"': 'False',
-        'None': None, "'None'": 'None', '"None"': 'None',
+        # if the value is True/False/None then take that
+        'True': True,
+        'False': False,
+        'None': None,
+        # if e.g. (literal) True is wanted, then it can be passed as "True"/'True'
+        "'True'": 'True',
+        '"True"': 'True',
+        "'False'": 'False',
+        '"False"': 'False',
+        "'None'": 'None',
+        '"None"': 'None',
     }
     for (key, val) in tweaks.items():
-        # if the value is True/False/None then take that
-        # if e.g. (literal) True is wanted, then it can be passed as "True"/'True'
-        if val in special_values:
+        if isinstance(val, string_type) and val in special_values:
             str_val = val
             val = special_values[val]
         else:

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -330,17 +330,17 @@ def tweak_one(orig_ec, tweaked_ec, tweaks, targetdir=None):
             tweaks.pop(key)
 
     # add parameters or replace existing ones
-    special_values = ('True', 'False', 'None')
-    quoted_special_values = ['"%s"' % val for val in special_values] + ["'%s'" % val for val in special_values]
+    special_values = {
+        'True': True, "'True'": 'True', '"True"': 'True',
+        'False': False, "'False'": 'False', '"False"': 'False',
+        'None': None, "'None'": 'None', '"None"': 'None',
+    }
     for (key, val) in tweaks.items():
         # if the value is True/False/None then take that
         # if e.g. (literal) True is wanted, then it can be passed as "True"/'True'
         if val in special_values:
             str_val = val
-            val = eval(val)
-        elif val in quoted_special_values:
-            str_val = val
-            val = val.strip('"\'')
+            val = special_values[val]
         else:
             str_val = quote_str(val)
 

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -45,7 +45,7 @@ from distutils.version import LooseVersion
 
 from easybuild.base import fancylogger
 from easybuild.framework.easyconfig.constants import EASYCONFIG_CONSTANTS
-from easybuild.framework.easyconfig.default import get_easyconfig_parameter_default
+from easybuild.framework.easyconfig.default import is_easyconfig_parameter_default_value
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, create_paths, process_easyconfig
 from easybuild.framework.easyconfig.easyconfig import get_toolchain_hierarchy
 from easybuild.framework.easyconfig.format.one import EB_FORMAT_EXTENSION
@@ -324,7 +324,7 @@ def tweak_one(orig_ec, tweaked_ec, tweaks, targetdir=None):
                     _log.debug("Overwriting %s with %s" % (key, fval))
                 ectxt = regexp.sub("%s = %s" % (res.group('key'), newval), ectxt)
                 _log.info("Tweaked %s list to '%s'" % (key, newval))
-            elif get_easyconfig_parameter_default(key) != val:
+            elif not is_easyconfig_parameter_default_value(key, val):
                 additions.append("%s = %s" % (key, val))
 
             tweaks.pop(key)
@@ -350,7 +350,7 @@ def tweak_one(orig_ec, tweaked_ec, tweaks, targetdir=None):
             if diff:
                 ectxt = regexp.sub("%s = %s" % (res.group('key'), quote_str(val)), ectxt)
                 _log.info("Tweaked '%s' to '%s'" % (key, quote_str(val)))
-        elif get_easyconfig_parameter_default(key) != val:
+        elif not is_easyconfig_parameter_default_value(key, val):
             additions.append("%s = %s" % (key, quote_str(val)))
 
     if additions:

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -631,6 +631,8 @@ class EasyConfigTest(EnhancedTestCase):
             'version = "3.14"',
             'toolchain = {"name": "GCC", "version": "4.6.3"}',
             'patches = %s',
+            'parallel = 1',
+            'keepsymlinks = True',
         ]) % str(patches)
         self.prep()
 
@@ -647,7 +649,17 @@ class EasyConfigTest(EnhancedTestCase):
             'versionprefix': verpref,
             'versionsuffix': versuff,
             'toolchain_version': tcver,
-            'patches': new_patches
+            'patches': new_patches,
+            'keepsymlinks': 'True',  # Don't change this
+            # It should be possible to overwrite values with True/False/None as they often have special meaning
+            'runtest': 'False',
+            'hidden': 'True',
+            'parallel': 'None',  # Good example: parallel=None means "Auto detect"
+            # Adding new options (added only by easyblock) should also be possible
+            # and in case the string "True/False/None" is really wanted it is possible to quote it first
+            'test_none': '"False"',
+            'test_bool': '"True"',
+            'test_123': '"None"',
         }
         tweak_one(self.eb_file, tweaked_fn, tweaks)
 
@@ -657,6 +669,12 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(eb['versionsuffix'], versuff)
         self.assertEqual(eb['toolchain']['version'], tcver)
         self.assertEqual(eb['patches'], new_patches)
+        self.assertTrue(eb['runtest'] is False)
+        self.assertTrue(eb['hidden'] is True)
+        self.assertTrue(eb['parallel'] is None)
+        self.assertEqual(eb['test_none'], 'False')
+        self.assertEqual(eb['test_bool'], 'True')
+        self.assertEqual(eb['test_123'], 'None')
 
         remove_file(tweaked_fn)
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -857,13 +857,6 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(ec['start_dir'], specs['start_dir'])
         remove_file(res[1])
 
-        specs.update({
-            'foo': 'bar123'
-        })
-        self.assertErrorRegex(EasyBuildError, "Unknown easyconfig parameter: foo",
-                              obtain_ec_for, specs, [self.test_prefix], None)
-        del specs['foo']
-
         # should pick correct version, i.e. not newer than what's specified, if a choice needs to be made
         ver = '3.14'
         specs.update({'version': ver})


### PR DESCRIPTION
Overwriting parameters which are not in the EC and not one of a few standard ones is currently impossible.
However it is useful when e.g. EasyBlocks introduce new params where the user wants to overwrite the default value without changing the EC manually.
This change allows this by simply appending the new parameter when it is not in the default list.