### PR TITLE
Allow module-only on existing installations (without write permissions)

### DIFF
--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1645,7 +1645,6 @@ class ToyBuildTest(EnhancedTestCase):
         os.remove(toy_core_mod)
         os.remove(toy_mod)
 
-
         # test installing (only) additional module in Lua syntax (if Lmod is available)
         lmod_abspath = os.environ.get('LMOD_CMD') or which('lmod')
         if lmod_abspath is not None:

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -36,6 +36,7 @@ import os
 import re
 import shutil
 import signal
+import subprocess
 import stat
 import sys
 import tempfile
@@ -1625,8 +1626,25 @@ class ToyBuildTest(EnhancedTestCase):
         modtxt = read_file(toy_core_mod)
         self.assertTrue(re.search('load.*intel/2018a', modtxt), "load statement for intel/2018a found in module")
 
-        os.remove(toy_mod)
+        # Test we can create a module even for an installation where we don't have write permissions
         os.remove(toy_core_mod)
+        subprocess.call(['chmod', '-R', '-w', prefix])
+        self.assertFalse(os.path.exists(toy_core_mod))
+        self.eb_main(args, do_build=True, raise_error=True)
+        self.assertTrue(os.path.exists(toy_core_mod))
+        # existing install is reused
+        modtxt2 = read_file(toy_core_mod)
+        self.assertTrue(re.search("set root %s" % prefix, modtxt2))
+        self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software'))), 3)
+        self.assertEqual(len(os.listdir(os.path.join(self.test_installpath, 'software', 'toy'))), 1)
+
+        # make sure load statements for dependencies are included
+        modtxt = read_file(toy_core_mod)
+        self.assertTrue(re.search('load.*intel/2018a', modtxt), "load statement for intel/2018a found in module")
+
+        os.remove(toy_core_mod)
+        os.remove(toy_mod)
+
 
         # test installing (only) additional module in Lua syntax (if Lmod is available)
         lmod_abspath = os.environ.get('LMOD_CMD') or which('lmod')

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1627,7 +1627,8 @@ class ToyBuildTest(EnhancedTestCase):
 
         # Test we can create a module even for an installation where we don't have write permissions
         os.remove(toy_core_mod)
-        adjust_permissions(prefix,  stat.S_IRUSR)
+        # remove the write permissions on the installation
+        adjust_permissions(prefix, stat.S_IRUSR | stat.S_IXUSR, relative=False)
         self.assertFalse(os.path.exists(toy_core_mod))
         self.eb_main(args, do_build=True, raise_error=True)
         self.assertTrue(os.path.exists(toy_core_mod))

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -36,7 +36,6 @@ import os
 import re
 import shutil
 import signal
-import subprocess
 import stat
 import sys
 import tempfile
@@ -1628,7 +1627,7 @@ class ToyBuildTest(EnhancedTestCase):
 
         # Test we can create a module even for an installation where we don't have write permissions
         os.remove(toy_core_mod)
-        subprocess.call(['chmod', '-R', '-w', prefix])
+        adjust_permissions(prefix,  stat.S_IRUSR)
         self.assertFalse(os.path.exists(toy_core_mod))
         self.eb_main(args, do_build=True, raise_error=True)
         self.assertTrue(os.path.exists(toy_core_mod))


### PR DESCRIPTION
While attempting to rebuild a module tree from EESSI, I realised there are a couple of barriers in the code right now that don't permit this. As things currently stand `--module-only` requires write permissions on the existing installation (for log files and other goodies), this PR fixes this.