### PR TITLE
Replace log_error parameter of which() by on_error

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -181,7 +181,7 @@ class ModulesTool(object):
             self.set_mod_paths(mod_paths)
 
         if env_cmd_path:
-            cmd_path = which(self.cmd, log_ok=False, log_error=False)
+            cmd_path = which(self.cmd, log_ok=False, on_error=IGNORE)
             # only use command path in environment variable if command in not available in $PATH
             if cmd_path is None:
                 self.cmd = env_cmd_path

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -45,6 +45,7 @@ from unittest import TextTestRunner
 
 import easybuild.tools.filetools as ft
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import IGNORE, ERROR
 from easybuild.tools.multidiff import multidiff
 from easybuild.tools.py2vs3 import std_urllib
 
@@ -213,8 +214,13 @@ class FileToolsTest(EnhancedTestCase):
         python = ft.which('python')
         self.assertTrue(python and os.path.exists(python) and os.path.isabs(python))
 
-        path = ft.which('i_really_do_not_expect_a_command_with_a_name_like_this_to_be_available')
+        invalid_cmd = 'i_really_do_not_expect_a_command_with_a_name_like_this_to_be_available'
+        path = ft.which(invalid_cmd)
         self.assertTrue(path is None)
+        path = ft.which(invalid_cmd, on_error=IGNORE)
+        self.assertTrue(path is None)
+        error_msg = "Could not find command '%s'" % invalid_cmd
+        self.assertErrorRegex(EasyBuildError, error_msg, ft.which, invalid_cmd, on_error=ERROR)
 
         os.environ['PATH'] = '%s:%s' % (self.test_prefix, os.environ['PATH'])
         # put a directory 'foo' in place (should be ignored by 'which')


### PR DESCRIPTION
This allows to additionally make the warning an error instead of only being able to ignore it.
This is useful if the command must be found.