### PR TITLE
add support for using oneAPI versions of 'intel' toolchain components

### DIFF
--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -57,15 +57,16 @@ class IntelFFTW(Fftw):
         bitsuff = '_lp64'
         if self.options.get('i8', None):
             bitsuff = '_ilp64'
-        compsuff = '_intel'
-        if get_software_root('icc') is None:
-            if get_software_root('PGI'):
-                compsuff = '_pgi'
-            elif get_software_root('GCC'):
-                compsuff = '_gnu'
-            else:
-                error_msg = "Not using Intel compilers, PGI nor GCC, don't know compiler suffix for FFTW libraries."
-                raise EasyBuildError(error_msg)
+
+        if get_software_root('icc') or get_software_root('intel-compilers'):
+            compsuff = '_intel'
+        elif get_software_root('PGI'):
+            compsuff = '_pgi'
+        elif get_software_root('GCC'):
+            compsuff = '_gnu'
+        else:
+            error_msg = "Not using Intel compilers, PGI nor GCC, don't know compiler suffix for FFTW libraries."
+            raise EasyBuildError(error_msg)
 
         interface_lib = "fftw3xc%s%s" % (compsuff, picsuff)
         fftw_libs = [interface_lib]

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -28,6 +28,7 @@ Support for Intel MKL as toolchain linear algebra library.
 :author: Stijn De Weirdt (Ghent University)
 :author: Kenneth Hoste (Ghent University)
 """
+import os
 from distutils.version import LooseVersion
 
 from easybuild.toolchains.compiler.gcc import TC_CONSTANT_GCC
@@ -152,13 +153,18 @@ class IntelMKL(LinAlg):
                 raise EasyBuildError("_set_blas_variables: 32-bit libraries not supported yet for IMKL v%s (> v10.3)",
                                      found_version)
             else:
-                self.BLAS_LIB_DIR = ['mkl/lib/intel64']
-                if ver >= LooseVersion('10.3.4') and ver < LooseVersion('11.1'):
-                    self.BLAS_LIB_DIR.append('compiler/lib/intel64')
+                if ver >= LooseVersion('2021'):
+                    basedir = os.path.join('mkl', found_version)
                 else:
-                    self.BLAS_LIB_DIR.append('lib/intel64')
+                    basedir = 'mkl'
 
-            self.BLAS_INCLUDE_DIR = ['mkl/include']
+                self.BLAS_LIB_DIR = [os.path.join(basedir, 'lib', 'intel64')]
+                if ver >= LooseVersion('10.3.4') and ver < LooseVersion('11.1'):
+                    self.BLAS_LIB_DIR.append(os.path.join('compiler', 'lib', 'intel64'))
+                elif ver < LooseVersion('2021'):
+                    self.BLAS_LIB_DIR.append(os.path.join('lib', 'intel64'))
+
+            self.BLAS_INCLUDE_DIR = [os.path.join(basedir, 'include')]
 
         super(IntelMKL, self)._set_blas_variables()
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3337,6 +3337,12 @@ class EasyConfigTest(EnhancedTestCase):
                     for subtoolchain_name in subtoolchains[current_tc['name']]]
         self.assertEqual(versions, ['4.9.3', ''])
 
+        # test det_subtoolchain_version when two alternatives for subtoolchain are specified
+        current_tc = {'name': 'gompi', 'version': '2018b'}
+        cands = [{'name': 'GCC', 'version': '7.3.0-2.30'}]
+        subtc_version = det_subtoolchain_version(current_tc, ('GCCcore', 'GCC'), optional_toolchains, cands)
+        self.assertEqual(subtc_version, '7.3.0-2.30')
+
     def test_verify_easyconfig_filename(self):
         """Test verify_easyconfig_filename function"""
         test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')


### PR DESCRIPTION
The `iimpi` toolchain definition had to be enhanced to discriminate between the oneAPI generation (`iimpi` version 2020.12 and newer), and the "classic" generation. No changes are needed for the `intel` toolchain itself (since that just derives from `iimpi` and adds MKL).

The `det_subtoolchain_version` function was enhanced to accept alternative subtoolchain names, since we don't know whether `intel-compilers` (for the oneAPI generation) or `iccifort` is the actual subtoolchain for `iimpi` until we can check the version, which we can't until there's an actual *instance* of the `Toochain` class...

Other toolchains that use the Intel compilers will need to be tweaked in a similar way, but `iimpi` is the more important one in the short term (for `intel/2021a`).