### PR TITLE
move disable_templating function into the EasyConfig class

### DIFF
--- a/contrib/hooks/hpc2n_hooks.py
+++ b/contrib/hooks/hpc2n_hooks.py
@@ -162,21 +162,19 @@ def pre_module_hook(self, *args, **kwargs):
         self.log.info("[pre-module hook] Set I_MPI_PMI_LIBRARY in impi module")
         # Must be done this way, updating self.cfg['modextravars']
         # directly doesn't work due to templating.
-        en_templ = self.cfg.enable_templating
-        self.cfg.enable_templating = False
-        shlib_ext = get_shared_lib_ext()
-        pmix_root = get_software_root('PMIx')
-        if pmix_root:
-            mpi_type = 'pmix_v3'
-            self.cfg['modextravars'].update({
-                'I_MPI_PMI_LIBRARY': os.path.join(pmix_root, "lib", "libpmi." + shlib_ext)
-            })
-            self.cfg['modextravars'].update({'SLURM_MPI_TYPE': mpi_type})
-            # Unfortunately UCX doesn't yet work for unknown reasons. Make sure it is off.
-            self.cfg['modextravars'].update({'SLURM_PMIX_DIRECT_CONN_UCX': 'false'})
-        else:
-            self.cfg['modextravars'].update({'I_MPI_PMI_LIBRARY': "/lap/slurm/lib/libpmi.so"})
-        self.cfg.enable_templating = en_templ
+        with self.cfg.disable_templating():
+            shlib_ext = get_shared_lib_ext()
+            pmix_root = get_software_root('PMIx')
+            if pmix_root:
+                mpi_type = 'pmix_v3'
+                self.cfg['modextravars'].update({
+                    'I_MPI_PMI_LIBRARY': os.path.join(pmix_root, "lib", "libpmi." + shlib_ext)
+                })
+                self.cfg['modextravars'].update({'SLURM_MPI_TYPE': mpi_type})
+                # Unfortunately UCX doesn't yet work for unknown reasons. Make sure it is off.
+                self.cfg['modextravars'].update({'SLURM_PMIX_DIRECT_CONN_UCX': 'false'})
+            else:
+                self.cfg['modextravars'].update({'I_MPI_PMI_LIBRARY': "/lap/slurm/lib/libpmi.so"})
 
     if self.name == 'OpenBLAS':
         self.log.info("[pre-module hook] Set OMP_NUM_THREADS=1 in OpenBLAS module")
@@ -197,18 +195,14 @@ def pre_module_hook(self, *args, **kwargs):
         self.log.info("[pre-module hook] Set SLURM_MPI_TYPE=%s in OpenMPI module" % mpi_type)
         # Must be done this way, updating self.cfg['modextravars']
         # directly doesn't work due to templating.
-        en_templ = self.cfg.enable_templating
-        self.cfg.enable_templating = False
-        self.cfg['modextravars'].update({'SLURM_MPI_TYPE': mpi_type})
-        # Unfortunately UCX doesn't yet work for unknown reasons. Make sure it is off.
-        self.cfg['modextravars'].update({'SLURM_PMIX_DIRECT_CONN_UCX': 'false'})
-        self.cfg.enable_templating = en_templ
+        with self.cfg.disable_templating():
+            self.cfg['modextravars'].update({'SLURM_MPI_TYPE': mpi_type})
+            # Unfortunately UCX doesn't yet work for unknown reasons. Make sure it is off.
+            self.cfg['modextravars'].update({'SLURM_PMIX_DIRECT_CONN_UCX': 'false'})
 
     if self.name == 'PMIx':
         # This is a, hopefully, temporary workaround for https://github.com/pmix/pmix/issues/1114
         if LooseVersion(self.version) > LooseVersion('2') and LooseVersion(self.version) < LooseVersion('3'):
             self.log.info("[pre-module hook] Set PMIX_MCA_gds=^ds21 in PMIx module")
-            en_templ = self.cfg.enable_templating
-            self.cfg.enable_templating = False
-            self.cfg['modextravars'].update({'PMIX_MCA_gds': '^ds21'})
-            self.cfg.enable_templating = en_templ
+            with self.cfg.disable_templating():
+                self.cfg['modextravars'].update({'PMIX_MCA_gds': '^ds21'})

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1682,11 +1682,10 @@ class EasyBlockTest(EnhancedTestCase):
 
         # purposely inject failing custom extension filter for last extension
         toy_ec = EasyConfig(toy_ec_fn)
-        toy_ec.enable_templating = False
-        exts_list = toy_ec['exts_list']
-        exts_list[-1][2]['exts_filter'] = ("thisshouldfail", '')
-        toy_ec['exts_list'] = exts_list
-        toy_ec.enable_templating = True
+        with toy_ec.disable_templating():
+            exts_list = toy_ec['exts_list']
+            exts_list[-1][2]['exts_filter'] = ("thisshouldfail", '')
+            toy_ec['exts_list'] = exts_list
 
         eb = EB_toy(toy_ec)
         eb.silent = True

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -662,10 +662,9 @@ class EasyConfigTest(EnhancedTestCase):
 
         eb = EasyConfig(self.eb_file)
         # eb['toolchain']['version'] = tcver does not work as expected with templating enabled
-        eb.enable_templating = False
-        eb['version'] = ver
-        eb['toolchain']['version'] = tcver
-        eb.enable_templating = True
+        with eb.disable_templating():
+            eb['version'] = ver
+            eb['toolchain']['version'] = tcver
         eb.dump(self.eb_file)
 
         tweaks = {
@@ -1070,12 +1069,9 @@ class EasyConfigTest(EnhancedTestCase):
         eb.validate()
 
         # temporarily disable templating, just so we can check later whether it's *still* disabled
-        eb.enable_templating = False
-
-        eb.generate_template_values()
-
-        self.assertFalse(eb.enable_templating)
-        eb.enable_templating = True
+        with eb.disable_templating():
+            eb.generate_template_values()
+            self.assertFalse(eb.enable_templating)
 
         self.assertEqual(eb['description'], "test easyconfig PI")
         self.assertEqual(eb['sources'][0], 'PI-3.04.tar.gz')


### PR DESCRIPTION
Allows easier use from outside as e.g. a few tests and easyblocks use it
The free function now just redirects to the member function

This also changes all uses if `ec.enable_templating = False` to use the context manager which avoids "forgetting" to reset it on error