### PR TITLE
honor keyboard interrupt in 'eb' command

### DIFF
--- a/eb
+++ b/eb
@@ -33,6 +33,13 @@
 # @author: Pieter De Baets (Ghent University)
 # @author: Jens Timmerman (Ghent University)
 
+keyboard_interrupt() {
+    echo "Keyboard interrupt!"
+    exit 1
+}
+
+trap keyboard_interrupt SIGINT
+
 # Python 2.6+ or 3.5+ required
 REQ_MIN_PY2VER=6
 REQ_MIN_PY3VER=5


### PR DESCRIPTION
Quickly cancelling an `eb` command right after starting it currently requires hitting `Ctrl-C` multiple times in a row, because you're only cancelling the initial Python version check, and there are multiple in a row.

We can trap the `SIGINT` signal that occurs when hitting `Ctrl-C` though, and honor that, so a single `Ctrl-C` is always sufficient to cancel the `eb` command.