### PR TITLE
update HierarchicalMNS to also return 'Toolchain/<name>/<version>' as $MODULEPATH extension for cpe* Cray toolchains

### DIFF
--- a/easybuild/tools/module_naming_scheme/hierarchical_mns.py
+++ b/easybuild/tools/module_naming_scheme/hierarchical_mns.py
@@ -70,6 +70,12 @@ COMP_NAME_VERSION_TEMPLATES = {
     'xlc,xlf': ('xlcxlf', '%(xlc)s'),
 }
 
+# possible prefixes for Cray toolchain names
+# example: CrayGNU, CrayCCE, cpeGNU, cpeCCE, ...;
+# important for determining $MODULEPATH extensions in det_modpath_extensions,
+# cfr. https://github.com/easybuilders/easybuild-framework/issues/3575
+CRAY_TOOLCHAIN_NAME_PREFIXES = ('Cray', 'cpe')
+
 
 class HierarchicalMNS(ModuleNamingScheme):
     """Class implementing an example hierarchical module naming scheme."""
@@ -236,8 +242,9 @@ class HierarchicalMNS(ModuleNamingScheme):
                 paths.append(os.path.join(MPI, tc_comp_name, tc_comp_ver, ec['name'], fullver))
 
         # special case for Cray toolchains
-        elif modclass == MODULECLASS_TOOLCHAIN and tc_comp_info is None and ec.name.startswith('Cray'):
-            paths.append(os.path.join(TOOLCHAIN, ec.name, ec.version))
+        elif modclass == MODULECLASS_TOOLCHAIN and tc_comp_info is None:
+            if any(ec.name.startswith(x) for x in CRAY_TOOLCHAIN_NAME_PREFIXES):
+                paths.append(os.path.join(TOOLCHAIN, ec.name, ec.version))
 
         return paths
 

--- a/test/framework/easyconfigs/test_ecs/c/cpeGNU/cpeGNU-21.04.eb
+++ b/test/framework/easyconfigs/test_ecs/c/cpeGNU/cpeGNU-21.04.eb
@@ -1,0 +1,16 @@
+easyblock = 'Toolchain'
+
+name = 'cpeGNU'
+version = '21.04'
+
+homepage = 'https://pubs.cray.com'
+description = """Toolchain using Cray compiler wrapper with gcc module (CPE release: %(version)s)."""
+
+toolchain = SYSTEM
+
+dependencies = [
+   ('PrgEnv-gnu', EXTERNAL_MODULE),
+   ('cpe/%(version)s', EXTERNAL_MODULE),
+]
+
+moduleclass = 'toolchain'

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2071,7 +2071,7 @@ class FileToolsTest(EnhancedTestCase):
         # test with specified path with and without trailing '/'s
         for path in [test_ecs, test_ecs + '/', test_ecs + '//']:
             index = ft.create_index(path)
-            self.assertEqual(len(index), 84)
+            self.assertEqual(len(index), 85)
 
             expected = [
                 os.path.join('b', 'bzip2', 'bzip2-1.0.6-GCC-4.9.2.eb'),

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -1326,6 +1326,10 @@ class ModuleGeneratorTest(EnhancedTestCase):
                                   ['Toolchain/CrayCCE/5.1.29'],
                                   ['Toolchain/CrayCCE/5.1.29'],
                                   ['Core']),
+            'cpeGNU-21.04.eb': ('cpeGNU/21.04', 'Core',
+                                ['Toolchain/cpeGNU/21.04'],
+                                ['Toolchain/cpeGNU/21.04'],
+                                ['Core']),
             'HPL-2.1-CrayCCE-5.1.29.eb': ('HPL/2.1', 'Toolchain/CrayCCE/5.1.29', [], [], ['Core']),
         }
         for ecfile, mns_vals in test_ecs.items():


### PR DESCRIPTION
fixes #3575