### PR TITLE
check for correct version values when parsing easystack file

### DIFF
--- a/test/framework/easystack.py
+++ b/test/framework/easystack.py
@@ -1,0 +1,97 @@
+# #
+# Copyright 2013-2021 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+# #
+"""
+Unit tests for easystack files
+
+@author: Denis Kristak (Inuits)
+@author: Kenneth Hoste (Ghent University)
+"""
+import os
+import sys
+from unittest import TextTestRunner
+
+import easybuild.tools.build_log
+from easybuild.framework.easystack import parse_easystack
+from easybuild.tools.build_log import EasyBuildError
+from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
+
+
+class EasyStackTest(EnhancedTestCase):
+    """Testcases for easystack files."""
+
+    logfile = None
+
+    def setUp(self):
+        """Set up test."""
+        super(EasyStackTest, self).setUp()
+        self.orig_experimental = easybuild.tools.build_log.EXPERIMENTAL
+
+    def tearDown(self):
+        """Clean up after test."""
+        easybuild.tools.build_log.EXPERIMENTAL = self.orig_experimental
+        super(EasyStackTest, self).tearDown()
+
+    def test_easystack_wrong_structure(self):
+        """Test for --easystack <easystack.yaml> when yaml easystack has wrong structure"""
+        easybuild.tools.build_log.EXPERIMENTAL = True
+        topdir = os.path.dirname(os.path.abspath(__file__))
+        test_easystack = os.path.join(topdir, 'easystacks', 'test_easystack_wrong_structure.yaml')
+
+        expected_err = r"[\S\s]*An error occurred when interpreting the data for software Bioconductor:"
+        expected_err += r"( 'float' object is not subscriptable[\S\s]*"
+        expected_err += r"| 'float' object is unsubscriptable"
+        expected_err += r"| 'float' object has no attribute '__getitem__'[\S\s]*)"
+        self.assertErrorRegex(EasyBuildError, expected_err, parse_easystack, test_easystack)
+
+    def test_easystack_asterisk(self):
+        """Test for --easystack <easystack.yaml> when yaml easystack contains asterisk (wildcard)"""
+        easybuild.tools.build_log.EXPERIMENTAL = True
+        topdir = os.path.dirname(os.path.abspath(__file__))
+        test_easystack = os.path.join(topdir, 'easystacks', 'test_easystack_asterisk.yaml')
+
+        expected_err = "EasyStack specifications of 'binutils' in .*/test_easystack_asterisk.yaml contain asterisk. "
+        expected_err += "Wildcard feature is not supported yet."
+
+        self.assertErrorRegex(EasyBuildError, expected_err, parse_easystack, test_easystack)
+
+    def test_easystack_labels(self):
+        """Test for --easystack <easystack.yaml> when yaml easystack contains exclude-labels / include-labels"""
+        easybuild.tools.build_log.EXPERIMENTAL = True
+        topdir = os.path.dirname(os.path.abspath(__file__))
+        test_easystack = os.path.join(topdir, 'easystacks', 'test_easystack_labels.yaml')
+
+        error_msg = "EasyStack specifications of 'binutils' in .*/test_easystack_labels.yaml contain labels. "
+        error_msg += "Labels aren't supported yet."
+        self.assertErrorRegex(EasyBuildError, error_msg, parse_easystack, test_easystack)
+
+
+def suite():
+    """ returns all the testcases in this module """
+    return TestLoaderFiltered().loadTestsFromTestCase(EasyStackTest, sys.argv[1:])
+
+
+if __name__ == '__main__':
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/easystack.py
+++ b/test/framework/easystack.py
@@ -183,6 +183,19 @@ class EasyStackTest(EnhancedTestCase):
             expected = ['foo-1.2.3.eb', 'foo-%s.eb' % version, 'foo-3.2.1-foo.eb']
             self.assertEqual(sorted(ec_fns), sorted(expected))
 
+        # also check toolchain version that could be interpreted as a non-string value...
+        test_easystack_txt = '\n'.join([
+            'software:',
+            '  test:',
+            '    toolchains:',
+            '      intel-2021.03:',
+            "        versions: [1.2.3, '2.3']",
+        ])
+        write_file(test_easystack, test_easystack_txt)
+        ec_fns, _ = parse_easystack(test_easystack)
+        expected = ['test-1.2.3-intel-2021.03.eb', 'test-2.3-intel-2021.03.eb']
+        self.assertEqual(sorted(ec_fns), sorted(expected))
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/easystacks/test_easystack_basic.yaml
+++ b/test/framework/easystacks/test_easystack_basic.yaml
@@ -3,8 +3,8 @@ software:
     toolchains:
       GCCcore-4.9.3:
         versions:
-          2.25:
-          2.26:
+          '2.25':
+          '2.26':
   foss:
     toolchains:
       SYSTEM:
@@ -13,5 +13,5 @@ software:
     toolchains:
       gompi-2018a:
         versions:
-          0.0:
+          '0.0':
             versionsuffix: '-test'

--- a/test/framework/easystacks/test_easystack_labels.yaml
+++ b/test/framework/easystacks/test_easystack_labels.yaml
@@ -3,5 +3,5 @@ software:
     toolchains:
       GCCcore-4.9.3:
         versions:
-            3.11:
+            '3.11':
               exclude-labels: arch:aarch64

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -42,7 +42,6 @@ import easybuild.tools.options
 import easybuild.tools.toolchain
 from easybuild.base import fancylogger
 from easybuild.framework.easyblock import EasyBlock
-from easybuild.framework.easystack import parse_easystack
 from easybuild.framework.easyconfig import BUILD, CUSTOM, DEPENDENCIES, EXTENSIONS, FILEMANAGEMENT, LICENSE
 from easybuild.framework.easyconfig import MANDATORY, MODULES, OTHER, TOOLCHAIN
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, get_easyblock_class, robot_find_easyconfig
@@ -6032,39 +6031,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
         for pattern in patterns:
             regex = re.compile(pattern)
             self.assertTrue(regex.search(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
-
-    def test_easystack_wrong_structure(self):
-        """Test for --easystack <easystack.yaml> when yaml easystack has wrong structure"""
-        easybuild.tools.build_log.EXPERIMENTAL = True
-        topdir = os.path.dirname(os.path.abspath(__file__))
-        toy_easystack = os.path.join(topdir, 'easystacks', 'test_easystack_wrong_structure.yaml')
-
-        expected_err = r"[\S\s]*An error occurred when interpreting the data for software Bioconductor:"
-        expected_err += r"( 'float' object is not subscriptable[\S\s]*"
-        expected_err += r"| 'float' object is unsubscriptable"
-        expected_err += r"| 'float' object has no attribute '__getitem__'[\S\s]*)"
-        self.assertErrorRegex(EasyBuildError, expected_err, parse_easystack, toy_easystack)
-
-    def test_easystack_asterisk(self):
-        """Test for --easystack <easystack.yaml> when yaml easystack contains asterisk (wildcard)"""
-        easybuild.tools.build_log.EXPERIMENTAL = True
-        topdir = os.path.dirname(os.path.abspath(__file__))
-        toy_easystack = os.path.join(topdir, 'easystacks', 'test_easystack_asterisk.yaml')
-
-        expected_err = "EasyStack specifications of 'binutils' in .*/test_easystack_asterisk.yaml contain asterisk. "
-        expected_err += "Wildcard feature is not supported yet."
-
-        self.assertErrorRegex(EasyBuildError, expected_err, parse_easystack, toy_easystack)
-
-    def test_easystack_labels(self):
-        """Test for --easystack <easystack.yaml> when yaml easystack contains exclude-labels / include-labels"""
-        easybuild.tools.build_log.EXPERIMENTAL = True
-        topdir = os.path.dirname(os.path.abspath(__file__))
-        toy_easystack = os.path.join(topdir, 'easystacks', 'test_easystack_labels.yaml')
-
-        error_msg = "EasyStack specifications of 'binutils' in .*/test_easystack_labels.yaml contain labels. "
-        error_msg += "Labels aren't supported yet."
-        self.assertErrorRegex(EasyBuildError, error_msg, parse_easystack, toy_easystack)
 
 
 def suite():

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -49,8 +49,9 @@ import test.framework.easyblock as b
 import test.framework.easyconfig as e
 import test.framework.easyconfigparser as ep
 import test.framework.easyconfigformat as ef
-import test.framework.ebconfigobj as ebco
 import test.framework.easyconfigversion as ev
+import test.framework.easystack as es
+import test.framework.ebconfigobj as ebco
 import test.framework.environment as env
 import test.framework.docs as d
 import test.framework.filetools as f
@@ -119,7 +120,7 @@ log = fancylogger.getLogger()
 # call suite() for each module and then run them all
 # note: make sure the options unit tests run first, to avoid running some of them with a readily initialized config
 tests = [gen, bl, o, r, ef, ev, ebco, ep, e, mg, m, mt, f, run, a, robot, b, v, g, tcv, tc, t, c, s, lic, f_c,
-         tw, p, i, pkg, d, env, et, y, st, h, ct, lib, u]
+         tw, p, i, pkg, d, env, et, y, st, h, ct, lib, u, es]
 
 SUITE = unittest.TestSuite([x.suite() for x in tests])
 res = unittest.TextTestRunner().run(SUITE)


### PR DESCRIPTION
This should help a lot to avoid problems like the ones reported in #3687, since you'll get a clear error message like this:

```yml
$ cat test.yml
software:
  binutils:
    toolchains:
      SYSTEM:
        versions:
          2.32:
```

```
$ eb --easystack test.yml --experimental
== Temporary log file in case of crash /tmp/eb-jy8oppza/easybuild-gjc50tnl.log
ERROR: Value 2.32 (of type <class 'float'>) obtained for binutils (with system toolchain) does not represent a valid version!
Make sure to wrap the value in single quotes (like '2.32') to avoid that it is interpreted by the YAML parser as a non-string value.
```

and

```yml
$ cat test.yml
software:
  Autotools:
    toolchains:
      SYSTEM:
        versions:
          20150215:
```

```
$ eb --easystack test.yml --experimental
== Temporary log file in case of crash /tmp/eb-5qedfcz2/easybuild-tzj9ie4u.log
ERROR: Value 20150215 (of type <class 'int'>) obtained for Autotools (with system toolchain) does not represent a valid version!
Make sure to wrap the value in single quotes (like '20150215') to avoid that it is interpreted by the YAML parser as a non-string value.
```