### PR TITLE
run post-install commands specified for a specific extension 

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2436,20 +2436,33 @@ class EasyBlock(object):
                             contents = shebang + '\n' + contents
                             write_file(path, contents)
 
+    def run_post_install_commands(self, commands=None):
+        """
+        Run post install commands that are specified via 'postinstallcmds' easyconfig parameter.
+        """
+        if commands is None:
+            commands = self.cfg['postinstallcmds']
+
+        if commands:
+            self.log.debug("Specified post install commands: %s", commands)
+
+            # make sure we have a list of commands
+            if not isinstance(commands, (list, tuple)):
+                error_msg = "Invalid value for 'postinstallcmds', should be list or tuple of strings: %s"
+                raise EasyBuildError(error_msg, commands)
+
+            for cmd in commands:
+                if not isinstance(cmd, string_type):
+                    raise EasyBuildError("Invalid element in 'postinstallcmds', not a string: %s", cmd)
+                run_cmd(cmd, simple=True, log_ok=True, log_all=True)
+
     def post_install_step(self):
         """
         Do some postprocessing
         - run post install commands if any were specified
         """
 
-        if self.cfg['postinstallcmds'] is not None:
-            # make sure we have a list of commands
-            if not isinstance(self.cfg['postinstallcmds'], (list, tuple)):
-                raise EasyBuildError("Invalid value for 'postinstallcmds', should be list or tuple of strings.")
-            for cmd in self.cfg['postinstallcmds']:
-                if not isinstance(cmd, string_type):
-                    raise EasyBuildError("Invalid element in 'postinstallcmds', not a string: %s", cmd)
-                run_cmd(cmd, simple=True, log_ok=True, log_all=True)
+        self.run_post_install_commands()
 
         self.fix_shebang()
 

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -113,8 +113,8 @@ class Extension(object):
         self.cfg.template_values.update(template_constant_dict({'name': name, 'version': version}))
 
         # Add install/builddir templates with values from master.
-        for name in TEMPLATE_NAMES_EASYBLOCK_RUN_STEP:
-            self.cfg.template_values[name[0]] = str(getattr(self.master, name[0], None))
+        for key in TEMPLATE_NAMES_EASYBLOCK_RUN_STEP:
+            self.cfg.template_values[key[0]] = str(getattr(self.master, key[0], None))
 
         # list of source/patch files: we use an empty list as default value like in EasyBlock
         self.src = resolve_template(self.ext.get('src', []), self.cfg.template_values)

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -105,9 +105,10 @@ class Extension(object):
 
         name, version = self.ext['name'], self.ext.get('version', None)
 
-        # parent sanity check paths/commands are not relevant for extension
+        # parent sanity check paths/commands and postinstallcmds are not relevant for extension
         self.cfg['sanity_check_commands'] = []
         self.cfg['sanity_check_paths'] = []
+        self.cfg['postinstallcmds'] = []
 
         # construct dict with template values that can be used
         self.cfg.template_values.update(template_constant_dict({'name': name, 'version': version}))
@@ -169,7 +170,7 @@ class Extension(object):
         """
         Stuff to do after installing a extension.
         """
-        pass
+        self.master.run_post_install_commands(commands=self.cfg.get('postinstallcmds', []))
 
     @property
     def toolchain(self):


### PR DESCRIPTION
Without this change, specifying `postinstallcmds` for a specific extension is futile, they're just ignored because `post_install_step` is not run for extensions.

A workaround was implemented in the `PythonPackage` eaysblock for this in https://github.com/easybuilders/easybuild-easyblocks/pull/2381 which introduces a custom easyconfig paramter named `ext_postinstallcmds`, which is no longer needed thanks to the changes here.

Both #3663 and https://github.com/easybuilders/easybuild-easyblocks/pull/2404 can be closed once this is merged.

The custom `ext_postinstallcmds` easyconfig parameter for `PythonPackage` should be removed again (it's only there in `develop`, not included yet with an EasyBuild release), and the 2 easyconfigs that use it should be tweaked to use `postinstallcmds` instead (`DROP-1.0.3-foss-2020b-R-4.0.3.eb` and `CNVkit-0.9.8-foss-2020b-R-4.0.3.eb`).