### PR TITLE
fix extending message for changed files in new_pr_from_branch

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1607,7 +1607,7 @@ def new_pr_from_branch(branch_name, title=None, descr=None, pr_target_repo=None,
                 msg.extend(["  " + x for x in patch_paths])
             if deleted_paths:
                 msg.append("* %d deleted file(s)" % len(deleted_paths))
-                msg.append(["  " + x for x in deleted_paths])
+                msg.extend(["  " + x for x in deleted_paths])
 
             print_msg('\n'.join(msg), log=_log)
         else:


### PR DESCRIPTION
fix for following crash in `test_new_pr_from_branch`, but it's unclear to me why it doesn't pop up consistently...

```
ERROR: test_new_pr_from_branch (test.framework.options.CommandLineOptionsTest)
Test --new-pr-from-branch.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/runner/3d5a10931cf2e751ef06d2399c598a7f9581f7da/lib/python3.8/site-packages/test/framework/options.py", line 3987, in test_new_pr_from_branch
    txt, _ = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False)
  File "/tmp/runner/3d5a10931cf2e751ef06d2399c598a7f9581f7da/lib/python3.8/site-packages/test/framework/options.py", line 3883, in _run_mock_eb
    self.eb_main(args, **kwargs)
  File "/tmp/runner/3d5a10931cf2e751ef06d2399c598a7f9581f7da/lib/python3.8/site-packages/test/framework/utilities.py", line 314, in eb_main
    raise myerr
  File "/tmp/runner/3d5a10931cf2e751ef06d2399c598a7f9581f7da/lib/python3.8/site-packages/test/framework/utilities.py", line 287, in eb_main
    main(args=args, logfile=logfile, do_build=do_build, testing=testing, modtool=self.modtool)
  File "/tmp/runner/3d5a10931cf2e751ef06d2399c598a7f9581f7da/lib/python3.8/site-packages/easybuild/main.py", line 456, in main
    new_pr_from_branch(options.new_pr_from_branch)
  File "/tmp/runner/3d5a10931cf2e751ef06d2399c598a7f9581f7da/lib/python3.8/site-packages/easybuild/tools/github.py", line 1612, in new_pr_from_branch
    print_msg('\n'.join(msg), log=_log)
TypeError: sequence item 4: expected str instance, list found
```