### PR TITLE
enhance sched_getaffinity function to avoid early crash when counting available cores on systems with more than 1024 cores

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -169,7 +169,7 @@ def sched_getaffinity():
     pid = os.getpid()
 
     cpu_setsize = 1024  # Max number of CPUs currently detectable
-    max_cpu_setsize = ctypes.c_ulong(-1).value // 4  # (INT_MAX / 2)
+    max_cpu_setsize = cpu_mask_t(-1).value // 4  # (INT_MAX / 2)
     # Limit it to something reasonable but still big enough
     max_cpu_setsize = min(max_cpu_setsize, 1e9)
     while cpu_setsize < max_cpu_setsize:

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -454,7 +454,7 @@ class SystemToolsTest(EnhancedTestCase):
         """Test getting CPU speed."""
         cpu_speed = get_cpu_speed()
         self.assertTrue(isinstance(cpu_speed, float) or cpu_speed is None)
-        self.assertTrue(cpu_speed > 0.0 or cpu_speed is None)
+        self.assertTrue(cpu_speed is None or cpu_speed > 0.0)
 
     def test_cpu_speed_linux(self):
         """Test getting CPU speed (mocked for Linux)."""


### PR DESCRIPTION
Dynamically determine the size of the cpu_set_t struct doubling it on each try

This is basically what the os module in Python 3.3+ does, see e.g. https://github.com/akheron/cpython/blob/f91d2f2e2e992c3006a5023eb4ba3cf0d082fde8/Modules/posixmodule.c#L5706

Error shown even on `eb --help` is:
> ERROR: sched_getaffinity failed for pid 675186 ec -1