### PR TITLE
add support for --skip-extensions

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -263,6 +263,7 @@ BUILD_OPTIONS_CMDLINE = {
         'search_paths',
         'sequential',
         'set_gid_bit',
+        'skip_extensions',
         'skip_test_cases',
         'skip_test_step',
         'generate_devel_module',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -466,6 +466,7 @@ class EasyBuildOptions(GeneralOption):
             'set-gid-bit': ("Set group ID bit on newly created directories", None, 'store_true', False),
             'silence-deprecation-warnings': ("Silence specified deprecation warnings", 'strlist', 'extend', None),
             'sticky-bit': ("Set sticky bit on newly created directories", None, 'store_true', False),
+            'skip-extensions': ("Skip installation of extensions", None, 'store_true', False),
             'skip-test-cases': ("Skip running test cases", None, 'store_true', False, 't'),
             'skip-test-step': ("Skip running the test step (e.g. unit tests)", None, 'store_true', False),
             'generate-devel-module': ("Generate a develop module file, implies --force if disabled",

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5858,7 +5858,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             self.assertTrue(regex.search(error_msg), "Pattern '%s' should be found in: %s" % (regex.pattern, error_msg))
 
         # failing sanity check for extension can be bypassed via --skip-extensions
-        self.eb_main(args + ['--skip-extensions'], do_build=True, return_error=True)
+        outtxt = self.eb_main(args + ['--skip-extensions'], do_build=True, raise_error=True)
+        self.assertTrue("Sanity check for toy successful" in outtxt)
 
     def test_skip_extensions(self):
         """Test use of --skip-extensions."""

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5857,6 +5857,41 @@ class CommandLineOptionsTest(EnhancedTestCase):
             regex = re.compile(error_pattern)
             self.assertTrue(regex.search(error_msg), "Pattern '%s' should be found in: %s" % (regex.pattern, error_msg))
 
+        # failing sanity check for extension can be bypassed via --skip-extensions
+        self.eb_main(args + ['--skip-extensions'], do_build=True, return_error=True)
+
+    def test_skip_extensions(self):
+        """Test use of --skip-extensions."""
+        topdir = os.path.abspath(os.path.dirname(__file__))
+        toy_ec = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
+
+        # add extension, which should be skipped
+        test_ec = os.path.join(self.test_prefix, 'test.ec')
+        test_ec_txt = read_file(toy_ec)
+        test_ec_txt += '\n' + '\n'.join([
+            "exts_list = [",
+            "    ('barbar', '0.0', {",
+            "        'start_dir': 'src',",
+            "        'exts_filter': ('ls -l lib/lib%(ext_name)s.a', ''),",
+            "    })",
+            "]",
+        ])
+        write_file(test_ec, test_ec_txt)
+
+        args = [test_ec, '--force', '--skip-extensions']
+        self.eb_main(args, do_build=True, return_error=True)
+
+        toy_mod = os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0')
+        if get_module_syntax() == 'Lua':
+            toy_mod += '.lua'
+
+        self.assertTrue(os.path.exists(toy_mod), "%s should exist" % toy_mod)
+
+        toy_installdir = os.path.join(self.test_installpath, 'software', 'toy', '0.0')
+        for path in (os.path.join('bin', 'barbar'), os.path.join('lib', 'libbarbar.a')):
+            path = os.path.join(toy_installdir, path)
+            self.assertFalse(os.path.exists(path), "Path %s should not exist" % path)
+
     def test_fake_vsc_include(self):
         """Test whether fake 'vsc' namespace is triggered for modules included via --include-*."""
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1730,6 +1730,12 @@ class ToyBuildTest(EnhancedTestCase):
                                   do_build=True, raise_error=True)
         self.assertFalse(os.path.exists(toy_mod))
 
+        # failing sanity check for barbar extension is ignored when using --module-only --skip-extensions
+        for extra_args in (['--module-only'], ['--module-only', '--rebuild']):
+            self.eb_main([test_ec, '--skip-extensions'] + extra_args, do_build=True, raise_error=True)
+            self.assertTrue(os.path.exists(toy_mod))
+            remove_file(toy_mod)
+
         # we can force module generation via --force (which skips sanity check entirely)
         self.eb_main([test_ec, '--module-only', '--force'], do_build=True, raise_error=True)
         self.assertTrue(os.path.exists(toy_mod))


### PR DESCRIPTION
#3655 fixed the behavior of `--module-only` to also cover extensions during the sanity check, which trumps the use case of generating a module file for an `R` installation when not all extensions have been installed.

To restore this capability, the new `--skip-extensions` options can be used in combination with `--module-only`.
It can also be used to install `R` (or `Python`, `Perl`, etc.) without extensions first, and then enhance the installation via `eb --skip` afterwards.

fixes #3672