### PR TITLE
set LDFLAGS instead of LIBRARY_PATH and add new `required` keyword to `_get_software_root` for Fujitsu toolchain

### DIFF
--- a/easybuild/toolchains/compiler/fujitsu.py
+++ b/easybuild/toolchains/compiler/fujitsu.py
@@ -31,7 +31,6 @@ The basic concept is the same as for the Cray Programming Environment.
 """
 import os
 
-import easybuild.tools.environment as env
 import easybuild.tools.systemtools as systemtools
 from easybuild.tools.toolchain.compiler import Compiler, DEFAULT_OPT_LEVEL
 
@@ -86,14 +85,6 @@ class FujitsuCompiler(Compiler):
         (systemtools.AARCH64, systemtools.ARM): '-mcpu=generic -mtune=generic',
     }
 
-    def prepare(self, *args, **kwargs):
-        super(FujitsuCompiler, self).prepare(*args, **kwargs)
-
-        # make sure the fujitsu module libraries are found (and added to rpath by wrapper)
-        libdir = os.path.join(os.getenv(TC_CONSTANT_MODULE_VAR), 'lib64')
-        self.log.debug("Adding %s to $LIBRARY_PATH" % libdir)
-        env.setvar('LIBRARY_PATH', os.pathsep.join([os.getenv('LIBRARY_PATH'), libdir]))
-
     def _set_compiler_vars(self):
         super(FujitsuCompiler, self)._set_compiler_vars()
 
@@ -101,3 +92,8 @@ class FujitsuCompiler(Compiler):
         # moved to compiler constants to make sure it is always used
         # self.variables.nappend('CFLAGS', ['Nclang'])
         # self.variables.nappend('CXXFLAGS', ['Nclang'])
+
+        # make sure the fujitsu module libraries are found (and added to rpath by wrapper)
+        libdir = os.path.join(os.getenv(TC_CONSTANT_MODULE_VAR), 'lib64')
+        self.log.debug("Adding %s to $LDFLAGS" % libdir)
+        self.variables.nappend('LDFLAGS', [libdir])

--- a/easybuild/toolchains/linalg/fujitsussl.py
+++ b/easybuild/toolchains/linalg/fujitsussl.py
@@ -68,7 +68,7 @@ class FujitsuSSL(LinAlg):
     SCALAPACK_INCLUDE_DIR = ['']
     SCALAPACK_FAMILY = TC_CONSTANT_FUJITSU_SSL
 
-    def _get_software_root(self, name):
+    def _get_software_root(self, name, required=True):
         """Get install prefix for specified software name; special treatment for Fujitsu modules."""
         if name == TC_CONSTANT_MODULE_NAME:
             env_var = TC_CONSTANT_MODULE_VAR
@@ -78,7 +78,7 @@ class FujitsuSSL(LinAlg):
             else:
                 self.log.debug("Obtained install prefix for %s via $%s: %s", name, env_var, root)
         else:
-            root = super(FujitsuSSL, self)._get_software_root(name)
+            root = super(FujitsuSSL, self)._get_software_root(name, required=required)
 
         return root
 


### PR DESCRIPTION
the `required` keyword was introduced in https://github.com/easybuilders/easybuild-framework/pull/3555