### PR TITLE
correctly strip extension from filename in extract_cmd and back_up_file functions

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1320,7 +1320,7 @@ def extract_cmd(filepath, overwrite=False):
     """
     filename = os.path.basename(filepath)
     ext = find_extension(filename)
-    target = filename.rstrip(ext)
+    target = filename[:-len(ext)]
 
     cmd_tmpl = EXTRACT_CMDS[ext.lower()]
     if overwrite:

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2005,8 +2005,8 @@ def back_up_file(src_file, backup_extension='bak', hidden=False, strip_fn=None):
         fn_suffix = '.%s' % backup_extension
 
     src_dir, src_fn = os.path.split(src_file)
-    if strip_fn:
-        src_fn = src_fn.rstrip(strip_fn)
+    if strip_fn and src_fn.endswith(strip_fn):
+        src_fn = src_fn[:-len(strip_fn)]
 
     backup_fp = find_backup_name_candidate(os.path.join(src_dir, fn_prefix + src_fn + fn_suffix))
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -926,7 +926,7 @@ class FileToolsTest(EnhancedTestCase):
         self.assertEqual(ft.read_file(fp), new_txt)
 
         # check whether strip_fn works as expected
-        fp2 = fp + '.lua'
+        fp2 = fp + 'a.lua'
         ft.copy_file(fp, fp2)
         res = ft.back_up_file(fp2)
         self.assertTrue(fp2.endswith('.lua'))
@@ -934,6 +934,8 @@ class FileToolsTest(EnhancedTestCase):
 
         res = ft.back_up_file(fp2, strip_fn='.lua')
         self.assertFalse('.lua' in os.path.basename(res))
+        # strip_fn should not remove the first a in 'a.lua'
+        self.assertTrue(res.startswith(fp + 'a.bak_'))
 
     def test_move_logs(self):
         """Test move_logs function."""

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -97,6 +97,10 @@ class FileToolsTest(EnhancedTestCase):
             ('test.iso', "7z x test.iso"),
             ('test.tar.Z', "tar xzf test.tar.Z"),
             ('test.foo.bar.sh', "cp -a test.foo.bar.sh ."),
+            # check whether extension is stripped correct to determine name of target file
+            # cfr. https://github.com/easybuilders/easybuild-framework/pull/3705
+            ('testbz2.bz2', "bunzip2 -c testbz2.bz2 > testbz2"),
+            ('testgz.gz', "gunzip -c testgz.gz > testgz"),
         ]
         for (fn, expected_cmd) in tests:
             cmd = ft.extract_cmd(fn)
@@ -935,7 +939,9 @@ class FileToolsTest(EnhancedTestCase):
         res = ft.back_up_file(fp2, strip_fn='.lua')
         self.assertFalse('.lua' in os.path.basename(res))
         # strip_fn should not remove the first a in 'a.lua'
-        self.assertTrue(res.startswith(fp + 'a.bak_'))
+        expected = os.path.basename(fp) + 'a.bak_'
+        res_fn = os.path.basename(res)
+        self.assertTrue(res_fn.startswith(expected), "'%s' should start with with '%s'" % (res_fn, expected))
 
     def test_move_logs(self):
         """Test move_logs function."""


### PR DESCRIPTION
If the original module file is named `2020a.lua` then the backup generated will start with `2020.bak_`. This is because `rstrip('.lua')` removes any of the characters `.`, `l`, `u`, or `a` found at the end of the string until it hits a character that is not one of those.

I've searched the framework and these look to be the only problematic uses of `rstrip`.