### PR TITLE
fix crash in create_test_report with --upload-test-report --from-pr when one or more test installations failed

### DIFF
--- a/easybuild/tools/testing.py
+++ b/easybuild/tools/testing.py
@@ -193,7 +193,7 @@ def create_test_report(msg, ecs_with_res, init_session_state, pr_nrs=None, gist_
                 descr = "(partial) EasyBuild log for failed build of %s" % ec['spec']
 
                 if pr_nrs is not None:
-                    descr += " (PR #%s)" % ', #'.join(pr_nrs)
+                    descr += " (PR #%s)" % ', #'.join(str(pr_nr) for pr_nr in pr_nrs)
 
                 if easyblock_pr_nrs:
                     descr += "".join(" (easyblock PR #%s)" % nr for nr in easyblock_pr_nrs)


### PR DESCRIPTION
PR numbers are integers which cannot be joined to a string directly but need to be converted first

Introduced by https://github.com/easybuilders/easybuild-framework/pull/3605

Error:
```
  File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/h3/s3248973/.local/EasyBuildDev/easybuild-framework/easybuild/main.py", line 548, in <module>
    main()
  File "/home/h3/s3248973/.local/EasyBuildDev/easybuild-framework/easybuild/main.py", line 527, in main
    test_report_msg = overall_test_report(ecs_with_res, len(paths), overall_success, success_msg, init_session_state)
  File "/home/s3248973/.local/EasyBuildDev/easybuild-framework/easybuild/tools/testing.py", line 351, in overall_test_report
    easyblock_pr_nrs=easyblock_pr_nrs)
  File "/home/s3248973/.local/EasyBuildDev/easybuild-framework/easybuild/tools/testing.py", line 196, in create_test_report
    descr += " (PR #%s)" % ', #'.join(pr_nrs)
TypeError: sequence item 0: expected string, int found
```
