### PR TITLE
don't use a different module name for FFTW in the Fujitsu toolchain

### DIFF
--- a/easybuild/toolchains/fft/fujitsufftw.py
+++ b/easybuild/toolchains/fft/fujitsufftw.py
@@ -33,5 +33,4 @@ from easybuild.toolchains.fft.fftw import Fftw
 class FujitsuFFTW(Fftw):
     """Fujitsu FFTW FFT library"""
 
-    FFT_MODULE_NAME = ['FFTW3-sve']
     FFTW_API_VERSION = '3'


### PR DESCRIPTION
a `versionsuffix` will be used instead (https://github.com/easybuilders/easybuild-easyconfigs/pull/12863#discussion_r639503172), so `FujitsuFFTW` can simply inherit `FFT_MODULE_NAME` from `Fftw`