### PR TITLE
move -Nclang back to $C[XX]FLAGS in toolchain support for Fujitsu compiler

### DIFF
--- a/easybuild/toolchains/compiler/fujitsu.py
+++ b/easybuild/toolchains/compiler/fujitsu.py
@@ -46,9 +46,8 @@ class FujitsuCompiler(Compiler):
     COMPILER_MODULE_NAME = [TC_CONSTANT_MODULE_NAME]
     COMPILER_FAMILY = TC_CONSTANT_FUJITSU
 
-    # make sure fcc is always called in clang compatibility mode
-    COMPILER_CC = 'fcc -Nclang'
-    COMPILER_CXX = 'FCC -Nclang'
+    COMPILER_CC = 'fcc'
+    COMPILER_CXX = 'FCC'
 
     COMPILER_F77 = 'frt'
     COMPILER_F90 = 'frt'
@@ -89,9 +88,8 @@ class FujitsuCompiler(Compiler):
         super(FujitsuCompiler, self)._set_compiler_vars()
 
         # enable clang compatibility mode
-        # moved to compiler constants to make sure it is always used
-        # self.variables.nappend('CFLAGS', ['Nclang'])
-        # self.variables.nappend('CXXFLAGS', ['Nclang'])
+        self.variables.nappend('CFLAGS', ['Nclang'])
+        self.variables.nappend('CXXFLAGS', ['Nclang'])
 
         # make sure the fujitsu module libraries are found (and added to rpath by wrapper)
         libdir = os.path.join(os.getenv(TC_CONSTANT_MODULE_VAR), 'lib64')


### PR DESCRIPTION
having it in `CC` and `CXX` broke the RPATH wrappers

moving it back to`C[XX]FLAGS` has been tested with ~60 easyconfigs derived from the `GCCcore/10.3.0`/`foss/2021a` toolchain, both with and without RPATH, and the only place where it fails is within the bundled `_ctypes/libffi` of Python *2* 

this seems to be the best way to go for now until a better solution is found...((https://github.com/easybuilders/easybuild/issues/701#issuecomment-851316265)