### PR TITLE
add Fujitsu compiler lib* subdir to both $LIBRARY_PATH and $LDFLAGS

### DIFF
--- a/easybuild/toolchains/compiler/fujitsu.py
+++ b/easybuild/toolchains/compiler/fujitsu.py
@@ -31,6 +31,7 @@ The basic concept is the same as for the Cray Programming Environment.
 """
 import os
 
+import easybuild.tools.environment as env
 import easybuild.tools.systemtools as systemtools
 from easybuild.tools.toolchain.compiler import Compiler, DEFAULT_OPT_LEVEL
 
@@ -85,6 +86,14 @@ class FujitsuCompiler(Compiler):
         (systemtools.AARCH64, systemtools.ARM): '-mcpu=generic -mtune=generic',
     }
 
+    def prepare(self, *args, **kwargs):
+        super(FujitsuCompiler, self).prepare(*args, **kwargs)
+
+        # make sure the fujitsu module libraries are found (and added to rpath by wrapper)
+        libdir = os.path.join(os.getenv(TC_CONSTANT_MODULE_VAR), 'lib64')
+        self.log.debug("Adding %s to $LIBRARY_PATH" % libdir)
+        env.setvar('LIBRARY_PATH', os.pathsep.join([os.getenv('LIBRARY_PATH', ''), libdir]))
+
     def _set_compiler_vars(self):
         super(FujitsuCompiler, self)._set_compiler_vars()
 
@@ -93,7 +102,7 @@ class FujitsuCompiler(Compiler):
         # self.variables.nappend('CFLAGS', ['Nclang'])
         # self.variables.nappend('CXXFLAGS', ['Nclang'])
 
-        # make sure the fujitsu module libraries are found (and added to rpath by wrapper)
+        # also add fujitsu module library path to LDFLAGS
         libdir = os.path.join(os.getenv(TC_CONSTANT_MODULE_VAR), 'lib64')
         self.log.debug("Adding %s to $LDFLAGS" % libdir)
         self.variables.nappend('LDFLAGS', [libdir])


### PR DESCRIPTION
so that it's both always picked up by the RPATH wrappers and present in the toolchain variables, for instance for the `buildenv` modules