### PR TITLE
drop support for Python 2.6

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -50,7 +50,6 @@ except ImportError:
 
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import build_option
 from easybuild.tools.filetools import is_readable, read_file, which
 from easybuild.tools.py2vs3 import string_type
 from easybuild.tools.run import run_cmd

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -1032,17 +1032,9 @@ def check_python_version():
     python_ver = '%d.%d' % (python_maj_ver, python_min_ver)
     _log.info("Found Python version %s", python_ver)
 
-    silence_deprecation_warnings = build_option('silence_deprecation_warnings') or []
-
     if python_maj_ver == 2:
-        if python_min_ver < 6:
-            raise EasyBuildError("Python 2.6 or higher is required when using Python 2, found Python %s", python_ver)
-        elif python_min_ver == 6:
-            depr_msg = "Running EasyBuild with Python 2.6 is deprecated"
-            if 'Python26' in silence_deprecation_warnings:
-                _log.warning(depr_msg)
-            else:
-                _log.deprecated(depr_msg, '5.0')
+        if python_min_ver < 7:
+            raise EasyBuildError("Python 2.7 is required when using Python 2, found Python %s", python_ver)
         else:
             _log.info("Running EasyBuild with Python 2 (version %s)", python_ver)
 

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -850,8 +850,8 @@ class SystemToolsTest(EnhancedTestCase):
         error_pattern = r"EasyBuild is not compatible \(yet\) with Python 4.0"
         self.assertErrorRegex(EasyBuildError, error_pattern, check_python_version)
 
-        mock_python_ver(2, 5)
-        error_pattern = r"Python 2.6 or higher is required when using Python 2, found Python 2.5"
+        mock_python_ver(2, 6)
+        error_pattern = r"Python 2.7 is required when using Python 2, found Python 2.6"
         self.assertErrorRegex(EasyBuildError, error_pattern, check_python_version)
 
         # no problems when running with a supported Python version
@@ -859,44 +859,18 @@ class SystemToolsTest(EnhancedTestCase):
             mock_python_ver(*pyver)
             self.assertEqual(check_python_version(), pyver)
 
-        mock_python_ver(2, 6)
-        # deprecation warning triggers an error in test environment
-        error_pattern = r"Running EasyBuild with Python 2.6 is deprecated"
-        self.assertErrorRegex(EasyBuildError, error_pattern, check_python_version)
-
-        # we may trigger a deprecation warning below (when testing with Python 2.6)
-        py26_depr_warning = "\nWARNING: Deprecated functionality, will no longer work in v5.0: "
-        py26_depr_warning += "Running EasyBuild with Python 2.6 is deprecated"
-
-        self.allow_deprecated_behaviour()
-
-        # first test with mocked Python 2.6
-        self.mock_stderr(True)
-        check_python_version()
-        stderr = self.get_stderr()
-        self.mock_stderr(False)
-
-        # we should always get a deprecation warning here
-        self.assertTrue(stderr.startswith(py26_depr_warning))
-
-        # restore Python version info to check with Python version used to run tests
-        st.sys.version_info = self.orig_sys_version_info
-
         # shouldn't raise any errors, since Python version used to run tests should be supported;
         self.mock_stderr(True)
         (py_maj_ver, py_min_ver) = check_python_version()
         stderr = self.get_stderr()
         self.mock_stderr(False)
+        self.assertFalse(stderr)
 
         self.assertTrue(py_maj_ver in [2, 3])
         if py_maj_ver == 2:
-            self.assertTrue(py_min_ver in [6, 7])
+            self.assertTrue(py_min_ver == 7)
         else:
             self.assertTrue(py_min_ver >= 5)
-
-        # only deprecation warning when actually testing with Python 2.6
-        if sys.version_info[:2] == (2, 6):
-            self.assertTrue(stderr.startswith(py26_depr_warning))
 
     def test_pick_dep_version(self):
         """Test pick_dep_version function."""


### PR DESCRIPTION
The time is right to no longer support for Python 2.6, let's squeeze in this change for the upcoming EasyBuild v4.4.0 release...

The impact of this on the EasyBuild community should be very low, see results of latest EasyBuild User Survey (slide 19
 at https://easybuild.io/eum21/003_eum21_easybuild_state_of_the_union.pdf).

![EasyBuild User Survey results on support for Python 2.6](https://user-images.githubusercontent.com/620876/120203519-16af4e00-c228-11eb-86be-900c54029ed4.png)
