### PR TITLE
Add per-step timing information

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3530,11 +3530,12 @@ class EasyBlock(object):
                     self.current_step = step_name
                     start_time = datetime.now()
                     self.run_step(step_name, step_methods)
-                    step_duration = datetime.now() - start_time
-                    if step_duration.total_seconds() >= 1:
-                        print_msg("... (took %s)", time2str(step_duration))
-                    elif self.logdebug or build_option('trace'):
-                        print_msg("... (took < 1 sec)")
+                    if not self.dry_run:
+                        step_duration = datetime.now() - start_time
+                        if step_duration.total_seconds() >= 1:
+                            print_msg("... (took %s)", time2str(step_duration), log=self.log, silent=self.silent)
+                        elif self.logdebug or build_option('trace'):
+                            print_msg("... (took < 1 sec)", log=self.log, silent=self.silent)
 
         except StopException:
             pass

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3528,7 +3528,13 @@ class EasyBlock(object):
                     else:
                         print_msg("%s..." % descr, log=self.log, silent=self.silent)
                     self.current_step = step_name
+                    start_time = datetime.now()
                     self.run_step(step_name, step_methods)
+                    step_duration = datetime.now() - start_time
+                    if step_duration.total_seconds() >= 1:
+                        print_msg("... (took %s)", time2str(step_duration))
+                    elif self.logdebug or build_option('trace'):
+                        print_msg("... (took < 1 sec)")
 
         except StopException:
             pass

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3529,13 +3529,15 @@ class EasyBlock(object):
                         print_msg("%s..." % descr, log=self.log, silent=self.silent)
                     self.current_step = step_name
                     start_time = datetime.now()
-                    self.run_step(step_name, step_methods)
-                    if not self.dry_run:
-                        step_duration = datetime.now() - start_time
-                        if step_duration.total_seconds() >= 1:
-                            print_msg("... (took %s)", time2str(step_duration), log=self.log, silent=self.silent)
-                        elif self.logdebug or build_option('trace'):
-                            print_msg("... (took < 1 sec)", log=self.log, silent=self.silent)
+                    try:
+                        self.run_step(step_name, step_methods)
+                    finally:
+                        if not self.dry_run:
+                            step_duration = datetime.now() - start_time
+                            if step_duration.total_seconds() >= 1:
+                                print_msg("... (took %s)", time2str(step_duration), log=self.log, silent=self.silent)
+                            elif self.logdebug or build_option('trace'):
+                                print_msg("... (took < 1 sec)", log=self.log, silent=self.silent)
 
         except StopException:
             pass

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -300,22 +300,21 @@ def time2str(delta):
     if not isinstance(delta, datetime.timedelta):
         raise EasyBuildError("Incorrect value type provided to time2str, should be datetime.timedelta: %s", type(delta))
 
-    delta_secs = delta.days * 3600 * 24 + delta.seconds + delta.microseconds / 10**6
+    delta_secs = delta.total_seconds()
 
-    if delta_secs < 60:
-        res = '%d sec' % int(delta_secs)
-    elif delta_secs < 3600:
-        mins = int(delta_secs / 60)
-        secs = int(delta_secs - (mins * 60))
-        res = '%d min %d sec' % (mins, secs)
-    else:
-        hours = int(delta_secs / 3600)
-        mins = int((delta_secs - hours * 3600) / 60)
-        secs = int(delta_secs - (hours * 3600) - (mins * 60))
-        hours_str = 'hours' if hours > 1 else 'hour'
-        res = '%d %s %d min %d sec' % (hours, hours_str, mins, secs)
+    hours = int(delta_secs / 3600)
+    delta_secs -= hours * 3600
+    mins = int(delta_secs / 60)
+    secs = int(delta_secs - mins * 60)
 
-    return res
+    res = []
+    if hours:
+        res.append('%d %s' % (hours, 'hour' if hours == 1 else 'hours'))
+    if mins or hours:
+        res.append('%d %s' % (mins, 'min' if mins == 1 else 'mins'))
+    res.append('%d %s' % (secs, 'sec' if secs == 1 else 'secs'))
+
+    return ' '.join(res)
 
 
 def natural_keys(key):

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -302,10 +302,8 @@ def time2str(delta):
 
     delta_secs = delta.total_seconds()
 
-    hours = int(delta_secs / 3600)
-    delta_secs -= hours * 3600
-    mins = int(delta_secs / 60)
-    secs = int(delta_secs - mins * 60)
+    hours, remainder = divmod(delta_secs, 3600)
+    mins, secs = divmod(remainder, 60)
 
     res = []
     if hours:

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1895,7 +1895,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                 re.compile(r"^\*\*\* DRY RUN using 'EB_FFTW' easyblock", re.M),
                 re.compile(r"^== building and installing FFTW/3.3.8-gompi-2018b\.\.\.", re.M),
                 re.compile(r"^building... \[DRY RUN\]", re.M),
-                re.compile(r"^== COMPLETED: Installation ended successfully \(took .* sec\)", re.M),
+                re.compile(r"^== COMPLETED: Installation ended successfully \(took .* secs?\)", re.M),
             ]
 
             for msg_regex in msg_regexs:
@@ -3820,7 +3820,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         msg_regexs = [
             re.compile(r"the actual build \& install procedure that will be performed may diverge", re.M),
             re.compile(r"^\*\*\* DRY RUN using 'EB_toy' easyblock", re.M),
-            re.compile(r"^== COMPLETED: Installation ended successfully \(took .* sec\)", re.M),
+            re.compile(r"^== COMPLETED: Installation ended successfully \(took .* secs?\)", re.M),
             re.compile(r"^\(no ignored errors during dry run\)", re.M),
         ]
         ignoring_error_regex = re.compile(r"WARNING: ignoring error", re.M)
@@ -4804,7 +4804,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args = ['toy-0.0.eb', '--force', '--stop=configure']
         txt, _ = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False, strip=True)
 
-        regex = re.compile(r"COMPLETED: Installation STOPPED successfully \(took .* sec\)", re.M)
+        regex = re.compile(r"COMPLETED: Installation STOPPED successfully \(took .* secs?\)", re.M)
         self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
 
     def test_fetch(self):
@@ -4829,7 +4829,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         patterns = [
             r"^== fetching files\.\.\.$",
-            r"^== COMPLETED: Installation STOPPED successfully \(took .* sec\)$",
+            r"^== COMPLETED: Installation STOPPED successfully \(took .* secs?\)$",
         ]
         for pattern in patterns:
             regex = re.compile(pattern, re.M)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -111,7 +111,7 @@ class ToyBuildTest(EnhancedTestCase):
         full_version = ''.join([versionprefix, version, versionsuffix])
 
         # check for success
-        success = re.compile(r"COMPLETED: Installation ended successfully \(took .* sec\)")
+        success = re.compile(r"COMPLETED: Installation ended successfully \(took .* secs?\)")
         self.assertTrue(success.search(outtxt), "COMPLETED message found in '%s" % outtxt)
 
         # if the module exists, it should be fine

--- a/test/framework/utilities_test.py
+++ b/test/framework/utilities_test.py
@@ -57,21 +57,23 @@ class UtilitiesTest(EnhancedTestCase):
         start = datetime(2019, 7, 30, 5, 14, 23)
 
         test_cases = [
-            (start, "0 sec"),
-            (datetime(2019, 7, 30, 5, 14, 37), "14 sec"),
-            (datetime(2019, 7, 30, 5, 15, 22), "59 sec"),
-            (datetime(2019, 7, 30, 5, 15, 23), "1 min 0 sec"),
-            (datetime(2019, 7, 30, 5, 16, 22), "1 min 59 sec"),
-            (datetime(2019, 7, 30, 5, 37, 26), "23 min 3 sec"),
-            (datetime(2019, 7, 30, 6, 14, 22), "59 min 59 sec"),
-            (datetime(2019, 7, 30, 6, 14, 23), "1 hour 0 min 0 sec"),
-            (datetime(2019, 7, 30, 6, 49, 14), "1 hour 34 min 51 sec"),
-            (datetime(2019, 7, 30, 7, 14, 23), "2 hours 0 min 0 sec"),
-            (datetime(2019, 7, 30, 8, 35, 59), "3 hours 21 min 36 sec"),
-            (datetime(2019, 7, 30, 16, 29, 24), "11 hours 15 min 1 sec"),
-            (datetime(2019, 7, 31, 5, 14, 22), "23 hours 59 min 59 sec"),
-            (datetime(2019, 7, 31, 5, 14, 23), "24 hours 0 min 0 sec"),
-            (datetime(2019, 8, 5, 20, 39, 44), "159 hours 25 min 21 sec"),
+            (start, "0 secs"),
+            (datetime(2019, 7, 30, 5, 14, 37), "14 secs"),
+            (datetime(2019, 7, 30, 5, 15, 22), "59 secs"),
+            (datetime(2019, 7, 30, 5, 15, 23), "1 min 0 secs"),
+            (datetime(2019, 7, 30, 5, 16, 22), "1 min 59 secs"),
+            (datetime(2019, 7, 30, 5, 16, 24), "2 mins 1 sec"),
+            (datetime(2019, 7, 30, 5, 37, 26), "23 mins 3 secs"),
+            (datetime(2019, 7, 30, 6, 14, 22), "59 mins 59 secs"),
+            (datetime(2019, 7, 30, 6, 14, 23), "1 hour 0 mins 0 secs"),
+            (datetime(2019, 7, 30, 6, 49, 14), "1 hour 34 mins 51 secs"),
+            (datetime(2019, 7, 30, 7, 14, 23), "2 hours 0 mins 0 secs"),
+            (datetime(2019, 7, 30, 8, 35, 59), "3 hours 21 mins 36 secs"),
+            (datetime(2019, 7, 30, 16, 29, 24), "11 hours 15 mins 1 sec"),
+            (datetime(2019, 7, 31, 5, 14, 22), "23 hours 59 mins 59 secs"),
+            (datetime(2019, 7, 31, 5, 14, 23), "24 hours 0 mins 0 secs"),
+            (datetime(2019, 7, 31, 5, 15, 24), "24 hours 1 min 1 sec"),
+            (datetime(2019, 8, 5, 20, 39, 44), "159 hours 25 mins 21 secs"),
         ]
         for end, expected in test_cases:
             self.assertEqual(time2str(end - start), expected)


### PR DESCRIPTION
Shows e.g.:
```
== fetching files...
== creating build dir, resetting environment...
== ... (took 2 secs)
== unpacking...
== ... (took 15 secs)
== patching...
== ... (took 7 secs)
```

Requires Python 2.7/3.2