### PR TITLE
only add fujitsu libdir to LIBRARY_PATH if it's not already there

### DIFF
--- a/easybuild/toolchains/compiler/fujitsu.py
+++ b/easybuild/toolchains/compiler/fujitsu.py
@@ -89,9 +89,11 @@ class FujitsuCompiler(Compiler):
         super(FujitsuCompiler, self).prepare(*args, **kwargs)
 
         # make sure the fujitsu module libraries are found (and added to rpath by wrapper)
+        library_path = os.getenv('LIBRARY_PATH', '')
         libdir = os.path.join(os.getenv(TC_CONSTANT_MODULE_VAR), 'lib64')
-        self.log.debug("Adding %s to $LIBRARY_PATH" % libdir)
-        env.setvar('LIBRARY_PATH', os.pathsep.join([os.getenv('LIBRARY_PATH', ''), libdir]))
+        if libdir not in library_path:
+            self.log.debug("Adding %s to $LIBRARY_PATH" % libdir)
+            env.setvar('LIBRARY_PATH', os.pathsep.join([library_path, libdir]))
 
     def _set_compiler_vars(self):
         super(FujitsuCompiler, self)._set_compiler_vars()


### PR DESCRIPTION
otherwise this can end up being repeated many times, in particular when there are extensions...