### PR TITLE
fix crash in get_config_dict when copying modules that were imported in easyconfig file (like 'import os')

### DIFF
--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -135,10 +135,11 @@ class FormatOneZero(EasyConfigFormatConfigObj):
         # we can't use copy.deepcopy() directly because in Python 2 copying the (irrelevant) __builtins__ key fails...
         cfg_copy = {}
         for key in cfg:
-            try:
-                cfg_copy[key] = copy.deepcopy(cfg[key])
-            except TypeError:
-                self.log.info("Contents of key '%s' can't be pickled: '%s'", key, cfg[key])
+            if key != '__builtins__':
+                try:
+                    cfg_copy[key] = copy.deepcopy(cfg[key])
+                except TypeError:
+                    self.log.info("Contents of key '%s' can't be pickled: '%s'", key, cfg[key])
 
         return cfg_copy
 

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -137,7 +137,12 @@ class FormatOneZero(EasyConfigFormatConfigObj):
         for key in cfg:
             # skip special variables like __builtins__, and imported modules (like 'os')
             if key != '__builtins__' and "'module'" not in str(type(cfg[key])):
-                cfg_copy[key] = copy.deepcopy(cfg[key])
+                try:
+                    cfg_copy[key] = copy.deepcopy(cfg[key])
+                except Exception as err:
+                    raise EasyBuildError("Failed to copy '%s' easyconfig parameter: %s" % (key, err))
+            else:
+                self.log.debug("Not copying '%s' variable from parsed easyconfig", key)
 
         return cfg_copy
 

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -135,8 +135,10 @@ class FormatOneZero(EasyConfigFormatConfigObj):
         # we can't use copy.deepcopy() directly because in Python 2 copying the (irrelevant) __builtins__ key fails...
         cfg_copy = {}
         for key in cfg:
-            if key != '__builtins__':
+            try:
                 cfg_copy[key] = copy.deepcopy(cfg[key])
+            except TypeError:
+                self.log.info("Contents of key '%s' can't be pickled: '%s'", key, cfg[key])
 
         return cfg_copy
 

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -135,11 +135,9 @@ class FormatOneZero(EasyConfigFormatConfigObj):
         # we can't use copy.deepcopy() directly because in Python 2 copying the (irrelevant) __builtins__ key fails...
         cfg_copy = {}
         for key in cfg:
-            if key != '__builtins__':
-                try:
-                    cfg_copy[key] = copy.deepcopy(cfg[key])
-                except TypeError:
-                    self.log.info("Contents of key '%s' can't be pickled: '%s'", key, cfg[key])
+            # skip special variables like __builtins__, and imported modules (like 'os')
+            if key != '__builtins__' and "'module'" not in str(type(cfg[key])):
+                cfg_copy[key] = copy.deepcopy(cfg[key])
 
         return cfg_copy
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -4428,6 +4428,28 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(ec_dict_bis.get('exts_default_options'), None)
         self.assertEqual(ec_dict.get('sanity_check_paths'), {'dirs': ['bin'], 'files': [('bin/yot', 'bin/toy')]})
 
+    def test_easyconfig_import(self):
+        """
+        Test parsing of an easyconfig file that includes import statements.
+        """
+        test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+        toy_ec = os.path.join(test_ecs_dir, 't', 'toy', 'toy-0.0.eb')
+
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        test_ec_txt = read_file(toy_ec)
+        test_ec_txt += '\n' + '\n'.join([
+            "import os",
+            "local_test = os.getenv('TEST_TOY')",
+            "sanity_check_commands = ['toy | grep %s' % local_test]",
+        ])
+        write_file(test_ec, test_ec_txt)
+
+        os.environ['TEST_TOY'] = '123'
+
+        ec = EasyConfig(test_ec)
+
+        self.assertEqual(ec['sanity_check_commands'], ['toy | grep 123'])
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -4450,6 +4450,19 @@ class EasyConfigTest(EnhancedTestCase):
 
         self.assertEqual(ec['sanity_check_commands'], ['toy | grep 123'])
 
+        # inject weird stuff, like a class definition that creates a logger instance, to check clean error handling
+        test_ec_txt += '\n' + '\n'.join([
+            "import logging",
+            "class _TestClass(object):",
+            "    def __init__(self):",
+            "        self.log = logging.Logger('alogger')",
+            "local_test = _TestClass()",
+        ])
+        write_file(test_ec, test_ec_txt)
+
+        error_pattern = r"Failed to copy '.*' easyconfig parameter"
+        self.assertErrorRegex(EasyBuildError, error_pattern, EasyConfig, test_ec)
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -4450,13 +4450,15 @@ class EasyConfigTest(EnhancedTestCase):
 
         self.assertEqual(ec['sanity_check_commands'], ['toy | grep 123'])
 
-        # inject weird stuff, like a class definition that creates a logger instance, to check clean error handling
+        # inject weird stuff, like a class definition that creates a logger instance
+        # and a local variable with a list of imported modules, to check clean error handling
         test_ec_txt += '\n' + '\n'.join([
             "import logging",
             "class _TestClass(object):",
             "    def __init__(self):",
             "        self.log = logging.Logger('alogger')",
             "local_test = _TestClass()",
+            "local_modules = [logging, os]",
         ])
         write_file(test_ec, test_ec_txt)
 


### PR DESCRIPTION
can't be serialized. For instance `os`, if it is imported in a eb file

edit: fix for traceback:

```
Traceback (most recent call last):
  ...
  File "/Volumes/work/easybuild-framework/test/framework/easyconfig.py", line 4449, in test_easyconfig_import
    ec = EasyConfig(test_ec)
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 514, in __init__
    self.parse()
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 698, in parse
    ec_vars = self.parser.get_config_dict()
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyconfig/parser.py", line 222, in get_config_dict
    cfg = self._formatter.get_config_dict()
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyconfig/format/one.py", line 139, in get_config_dict
    if key != '__builtins__' and "'module'" not in type(cfg[key]):
TypeError: argument of type 'type' is not iterable
```