### PR TITLE
make sure that tests requiring a github token have 'github' in the test name so that they can be easily filtered

### DIFF
--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -95,13 +95,13 @@ class GithubTest(EnhancedTestCase):
 
         super(GithubTest, self).tearDown()
 
-    def test_pick_default_branch(self):
+    def test_github_pick_default_branch(self):
         """Test pick_default_branch function."""
 
         self.assertEqual(pick_default_branch('easybuilders'), 'main')
         self.assertEqual(pick_default_branch('foobar'), 'master')
 
-    def test_walk(self):
+    def test_github_walk(self):
         """test the gitubfs walk function"""
         if self.skip_github_tests:
             print("Skipping test_walk, no GitHub token available?")
@@ -117,7 +117,7 @@ class GithubTest(EnhancedTestCase):
         except IOError:
             pass
 
-    def test_read_api(self):
+    def test_github_read_api(self):
         """Test the githubfs read function"""
         if self.skip_github_tests:
             print("Skipping test_read_api, no GitHub token available?")
@@ -128,7 +128,7 @@ class GithubTest(EnhancedTestCase):
         except IOError:
             pass
 
-    def test_read(self):
+    def test_github_read(self):
         """Test the githubfs read function without using the api"""
         if self.skip_github_tests:
             print("Skipping test_read, no GitHub token available?")
@@ -141,7 +141,7 @@ class GithubTest(EnhancedTestCase):
         except (IOError, OSError):
             pass
 
-    def test_add_pr_labels(self):
+    def test_github_add_pr_labels(self):
         """Test add_pr_labels function."""
         if self.skip_github_tests:
             print("Skipping test_add_pr_labels, no GitHub token available?")
@@ -183,7 +183,7 @@ class GithubTest(EnhancedTestCase):
         self.mock_stderr(False)
         self.assertTrue("PR #8006 should be labelled 'update'" in stdout)
 
-    def test_fetch_pr_data(self):
+    def test_github_fetch_pr_data(self):
         """Test fetch_pr_data function."""
         if self.skip_github_tests:
             print("Skipping test_fetch_pr_data, no GitHub token available?")
@@ -205,7 +205,7 @@ class GithubTest(EnhancedTestCase):
         self.assertEqual(pr_data['reviews'][0]['user']['login'], 'boegel')
         self.assertEqual(pr_data['status_last_commit'], None)
 
-    def test_list_prs(self):
+    def test_github_list_prs(self):
         """Test list_prs function."""
         if self.skip_github_tests:
             print("Skipping test_list_prs, no GitHub token available?")
@@ -227,7 +227,7 @@ class GithubTest(EnhancedTestCase):
 
         self.assertEqual(expected, output)
 
-    def test_reasons_for_closing(self):
+    def test_github_reasons_for_closing(self):
         """Test reasons_for_closing function."""
         if self.skip_github_tests:
             print("Skipping test_reasons_for_closing, no GitHub token available?")
@@ -267,7 +267,7 @@ class GithubTest(EnhancedTestCase):
         for pattern in patterns:
             self.assertTrue(pattern in stdout, "Pattern '%s' found in: %s" % (pattern, stdout))
 
-    def test_close_pr(self):
+    def test_github_close_pr(self):
         """Test close_pr function."""
         if self.skip_github_tests:
             print("Skipping test_close_pr, no GitHub token available?")
@@ -312,7 +312,7 @@ class GithubTest(EnhancedTestCase):
         for pattern in patterns:
             self.assertTrue(pattern in stdout, "Pattern '%s' found in: %s" % (pattern, stdout))
 
-    def test_fetch_easyblocks_from_pr(self):
+    def test_github_fetch_easyblocks_from_pr(self):
         """Test fetch_easyblocks_from_pr function."""
         if self.skip_github_tests:
             print("Skipping test_fetch_easyblocks_from_pr, no GitHub token available?")
@@ -339,7 +339,7 @@ class GithubTest(EnhancedTestCase):
             except URLError as err:
                 print("Ignoring URLError '%s' in test_fetch_easyblocks_from_pr" % err)
 
-    def test_fetch_easyconfigs_from_pr(self):
+    def test_github_fetch_easyconfigs_from_pr(self):
         """Test fetch_easyconfigs_from_pr function."""
         if self.skip_github_tests:
             print("Skipping test_fetch_easyconfigs_from_pr, no GitHub token available?")
@@ -390,7 +390,7 @@ class GithubTest(EnhancedTestCase):
             except URLError as err:
                 print("Ignoring URLError '%s' in test_fetch_easyconfigs_from_pr" % err)
 
-    def test_fetch_files_from_pr_cache(self):
+    def test_github_fetch_files_from_pr_cache(self):
         """Test caching for fetch_files_from_pr."""
         if self.skip_github_tests:
             print("Skipping test_fetch_files_from_pr_cache, no GitHub token available?")
@@ -451,7 +451,7 @@ class GithubTest(EnhancedTestCase):
         res = gh.fetch_easyblocks_from_pr(12345, tmpdir)
         self.assertEqual(sorted(pr12345_files), sorted(res))
 
-    def test_fetch_latest_commit_sha(self):
+    def test_github_fetch_latest_commit_sha(self):
         """Test fetch_latest_commit_sha function."""
         if self.skip_github_tests:
             print("Skipping test_fetch_latest_commit_sha, no GitHub token available?")
@@ -463,7 +463,7 @@ class GithubTest(EnhancedTestCase):
                                          branch='develop')
         self.assertTrue(re.match('^[0-9a-f]{40}$', sha))
 
-    def test_download_repo(self):
+    def test_github_download_repo(self):
         """Test download_repo function."""
         if self.skip_github_tests:
             print("Skipping test_download_repo, no GitHub token available?")
@@ -562,7 +562,7 @@ class GithubTest(EnhancedTestCase):
         if token_old_format:
             self.assertTrue(gh.validate_github_token(token_old_format, GITHUB_TEST_ACCOUNT))
 
-    def test_find_easybuild_easyconfig(self):
+    def test_github_find_easybuild_easyconfig(self):
         """Test for find_easybuild_easyconfig function"""
         if self.skip_github_tests:
             print("Skipping test_find_easybuild_easyconfig, no GitHub token available?")
@@ -573,7 +573,7 @@ class GithubTest(EnhancedTestCase):
         self.assertTrue(regex.search(path), "Pattern '%s' found in '%s'" % (regex.pattern, path))
         self.assertTrue(os.path.exists(path), "Path %s exists" % path)
 
-    def test_find_patches(self):
+    def test_github_find_patches(self):
         """ Test for find_software_name_for_patch """
         testdir = os.path.dirname(os.path.abspath(__file__))
         ec_path = os.path.join(testdir, 'easyconfigs')
@@ -595,7 +595,7 @@ class GithubTest(EnhancedTestCase):
         reg = re.compile(r'[1-9]+ of [1-9]+ easyconfigs checked')
         self.assertTrue(re.search(reg, txt))
 
-    def test_det_commit_status(self):
+    def test_github_det_commit_status(self):
         """Test det_commit_status function."""
 
         if self.skip_github_tests:
@@ -642,7 +642,7 @@ class GithubTest(EnhancedTestCase):
         res = gh.det_commit_status('easybuilders', GITHUB_REPO, commit_sha, GITHUB_TEST_ACCOUNT)
         self.assertEqual(res, None)
 
-    def test_check_pr_eligible_to_merge(self):
+    def test_github_check_pr_eligible_to_merge(self):
         """Test check_pr_eligible_to_merge function"""
         def run_check(expected_result=False):
             """Helper function to check result of check_pr_eligible_to_merge"""
@@ -770,7 +770,7 @@ class GithubTest(EnhancedTestCase):
         expected_warning = ''
         self.assertEqual(run_check(True), '')
 
-    def test_det_pr_labels(self):
+    def test_github_det_pr_labels(self):
         """Test for det_pr_labels function."""
 
         file_info = {'new_folder': [False], 'new_file_in_existing_folder': [True]}
@@ -789,7 +789,7 @@ class GithubTest(EnhancedTestCase):
         res = gh.det_pr_labels(file_info, GITHUB_EASYBLOCKS_REPO)
         self.assertEqual(res, ['new'])
 
-    def test_det_patch_specs(self):
+    def test_github_det_patch_specs(self):
         """Test for det_patch_specs function."""
 
         patch_paths = [os.path.join(self.test_prefix, p) for p in ['1.patch', '2.patch', '3.patch']]
@@ -841,7 +841,7 @@ class GithubTest(EnhancedTestCase):
         self.assertEqual(os.path.basename(res[2][0]), '3.patch')
         self.assertEqual(res[2][1], 'patched_ext')
 
-    def test_restclient(self):
+    def test_github_restclient(self):
         """Test use of RestClient."""
         if self.skip_github_tests:
             print("Skipping test_restclient, no GitHub token available?")
@@ -876,7 +876,7 @@ class GithubTest(EnhancedTestCase):
             httperror_hit = True
         self.assertTrue(httperror_hit, "expected HTTPError not encountered")
 
-    def test_create_delete_gist(self):
+    def test_github_create_delete_gist(self):
         """Test create_gist and delete_gist."""
         if self.skip_github_tests:
             print("Skipping test_restclient, no GitHub token available?")
@@ -888,7 +888,7 @@ class GithubTest(EnhancedTestCase):
         gist_id = gist_url.split('/')[-1]
         gh.delete_gist(gist_id, github_user=GITHUB_TEST_ACCOUNT, github_token=self.github_token)
 
-    def test_det_account_branch_for_pr(self):
+    def test_github_det_account_branch_for_pr(self):
         """Test det_account_branch_for_pr."""
         if self.skip_github_tests:
             print("Skipping test_det_account_branch_for_pr, no GitHub token available?")
@@ -918,7 +918,7 @@ class GithubTest(EnhancedTestCase):
         self.assertEqual(account, 'migueldiascosta')
         self.assertEqual(branch, 'fix_inject_checksums')
 
-    def test_det_pr_target_repo(self):
+    def test_github_det_pr_target_repo(self):
         """Test det_pr_target_repo."""
 
         self.assertEqual(build_option('pr_target_repo'), None)
@@ -1002,7 +1002,7 @@ class GithubTest(EnhancedTestCase):
         regex = re.compile(pattern)
         self.assertTrue(regex.match(stdout.strip()), "Pattern '%s' doesn't match: %s" % (regex.pattern, stdout))
 
-    def test_pr_test_report(self):
+    def test_github_pr_test_report(self):
         """Test for post_pr_test_report function."""
         if self.skip_github_tests:
             print("Skipping test_post_pr_test_report, no GitHub token available?")
@@ -1051,7 +1051,7 @@ class GithubTest(EnhancedTestCase):
             regex = re.compile(pattern, re.M)
             self.assertTrue(regex.search(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
 
-    def test_create_test_report(self):
+    def test_github_create_test_report(self):
         """Test create_test_report function."""
         logfile = os.path.join(self.test_prefix, 'log.txt')
         write_file(logfile, "Bazel failed with: error")

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1196,7 +1196,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         error_pattern = "One or more files to copy should be specified!"
         self.assertErrorRegex(EasyBuildError, error_pattern, self.eb_main, args, raise_error=True)
 
-    def test_copy_ec_from_pr(self):
+    def test_github_copy_ec_from_pr(self):
         """Test combination of --copy-ec with --from-pr."""
         if self.github_token is None:
             print("Skipping test_copy_ec_from_pr, no GitHub token available?")
@@ -1684,7 +1684,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         if os.path.exists(dummylogfn):
             os.remove(dummylogfn)
 
-    def test_from_pr(self):
+    def test_github_from_pr(self):
         """Test fetching easyconfigs from a PR."""
         if self.github_token is None:
             print("Skipping test_from_pr, no GitHub token available?")
@@ -1771,7 +1771,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             print("Ignoring URLError '%s' in test_from_pr" % err)
             shutil.rmtree(tmpdir)
 
-    def test_from_pr_token_log(self):
+    def test_github_from_pr_token_log(self):
         """Check that --from-pr doesn't leak GitHub token in log."""
         if self.github_token is None:
             print("Skipping test_from_pr_token_log, no GitHub token available?")
@@ -1804,7 +1804,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         except URLError as err:
             print("Ignoring URLError '%s' in test_from_pr" % err)
 
-    def test_from_pr_listed_ecs(self):
+    def test_github_from_pr_listed_ecs(self):
         """Test --from-pr in combination with specifying easyconfigs on the command line."""
         if self.github_token is None:
             print("Skipping test_from_pr, no GitHub token available?")
@@ -1859,7 +1859,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             print("Ignoring URLError '%s' in test_from_pr" % err)
             shutil.rmtree(tmpdir)
 
-    def test_from_pr_x(self):
+    def test_github_from_pr_x(self):
         """Test combination of --from-pr with --extended-dry-run."""
         if self.github_token is None:
             print("Skipping test_from_pr_x, no GitHub token available?")
@@ -3318,7 +3318,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     # must be run after test for --list-easyblocks, hence the '_xxx_'
     # cleaning up the imported easyblocks is quite difficult...
-    def test_xxx_include_easyblocks_from_pr(self):
+    def test_github_xxx_include_easyblocks_from_pr(self):
         """Test --include-easyblocks-from-pr."""
         if self.github_token is None:
             print("Skipping test_preview_pr, no GitHub token available?")
@@ -3660,7 +3660,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         tweaked_dir = os.path.join(tmpdir, tmpdir_files[0], 'tweaked_easyconfigs')
         self.assertTrue(os.path.exists(os.path.join(tweaked_dir, 'toy-1.0.eb')))
 
-    def test_preview_pr(self):
+    def test_github_preview_pr(self):
         """Test --preview-pr."""
         if self.github_token is None:
             print("Skipping test_preview_pr, no GitHub token available?")
@@ -3682,7 +3682,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         regex = re.compile(r"^Comparing bzip2-1.0.6\S* with bzip2-1.0.6")
         self.assertTrue(regex.search(txt), "Pattern '%s' not found in: %s" % (regex.pattern, txt))
 
-    def test_review_pr(self):
+    def test_github_review_pr(self):
         """Test --review-pr."""
         if self.github_token is None:
             print("Skipping test_review_pr, no GitHub token available?")
@@ -4004,7 +4004,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         self._assert_regexs(regexs, txt)
 
-    def test_new_pr_from_branch(self):
+    def test_github_new_pr_from_branch(self):
         """Test --new-pr-from-branch."""
         if self.github_token is None:
             print("Skipping test_new_pr_from_branch, no GitHub token available?")
@@ -4073,7 +4073,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         self._assert_regexs(regexs, txt)
 
-    def test_new_update_pr(self):
+    def test_github_new_update_pr(self):
         """Test use of --new-pr (dry run only)."""
         if self.github_token is None:
             print("Skipping test_new_update_pr, no GitHub token available?")
@@ -4283,7 +4283,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         self._assert_regexs(regexs, txt, assert_true=False)
 
-    def test_sync_pr_with_develop(self):
+    def test_github_sync_pr_with_develop(self):
         """Test use of --sync-pr-with-develop (dry run only)."""
         if self.github_token is None:
             print("Skipping test_sync_pr_with_develop, no GitHub token available?")
@@ -4313,7 +4313,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         regex = re.compile(pattern)
         self.assertTrue(regex.match(txt), "Pattern '%s' doesn't match: %s" % (regex.pattern, txt))
 
-    def test_sync_branch_with_develop(self):
+    def test_github_sync_branch_with_develop(self):
         """Test use of --sync-branch-with-develop (dry run only)."""
         if self.github_token is None:
             print("Skipping test_sync_pr_with_develop, no GitHub token available?")
@@ -4343,7 +4343,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         regex = re.compile(pattern)
         self.assertTrue(regex.match(stdout), "Pattern '%s' doesn't match: %s" % (regex.pattern, stdout))
 
-    def test_new_pr_python(self):
+    def test_github_new_pr_python(self):
         """Check generated PR title for --new-pr on easyconfig that includes Python dependency."""
         if self.github_token is None:
             print("Skipping test_new_pr_python, no GitHub token available?")
@@ -4388,7 +4388,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         regex = re.compile(r"^\* title: \"\{tools\}\[system/system\] toy v0.0 w/ Python 2.7.15 \+ 3.7.2\"$", re.M)
         self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
 
-    def test_new_pr_delete(self):
+    def test_github_new_pr_delete(self):
         """Test use of --new-pr to delete easyconfigs."""
 
         if self.github_token is None:
@@ -4413,7 +4413,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         self._assert_regexs(regexs, txt)
 
-    def test_new_pr_dependencies(self):
+    def test_github_new_pr_dependencies(self):
         """Test use of --new-pr with automatic dependency lookup."""
 
         if self.github_token is None:
@@ -4461,7 +4461,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         self._assert_regexs(regexs, txt)
 
-    def test_merge_pr(self):
+    def test_github_merge_pr(self):
         """
         Test use of --merge-pr (dry run)"""
         if self.github_token is None:
@@ -4566,7 +4566,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ])
         self.assertTrue(expected_stdout in stdout)
 
-    def test_empty_pr(self):
+    def test_github_empty_pr(self):
         """Test use of --new-pr (dry run only) with no changes"""
         if self.github_token is None:
             print("Skipping test_empty_pr, no GitHub token available?")

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -696,7 +696,7 @@ class RobotTest(EnhancedTestCase):
         regex = re.compile(r"^ \* %s$" % os.path.join(self.test_prefix, test_ec), re.M)
         self.assertTrue(regex.search(outtxt), "Found pattern %s in %s" % (regex.pattern, outtxt))
 
-    def test_det_easyconfig_paths_from_pr(self):
+    def test_github_det_easyconfig_paths_from_pr(self):
         """Test det_easyconfig_paths function, with --from-pr enabled as well."""
         if self.github_token is None:
             print("Skipping test_from_pr, no GitHub token available?")


### PR DESCRIPTION
@boegel shall we also make sure all tests in `github.py` have `github` in the name, even though it looks redundant, so that all of those are also picked up by ` -m test.framework.suite github`?