### PR TITLE
Add option to ignore failing test step

### DIFF
--- a/easybuild/base/testing.py
+++ b/easybuild/base/testing.py
@@ -35,6 +35,7 @@ import difflib
 import pprint
 import re
 import sys
+from contextlib import contextmanager
 
 try:
     from cStringIO import StringIO  # Python 2
@@ -184,6 +185,26 @@ class TestCase(OrigTestCase):
     def get_stderr(self):
         """Return output captured from stderr until now."""
         return sys.stderr.getvalue()
+
+    @contextmanager
+    def mocked_stdout_stderr(self, mock_stdout=True, mock_stderr=True):
+        """Context manager to mock stdout and stderr"""
+        if mock_stdout:
+            self.mock_stdout(True)
+        if mock_stderr:
+            self.mock_stderr(True)
+        try:
+            if mock_stdout and mock_stderr:
+                yield sys.stdout, sys.stderr
+            elif mock_stdout:
+                yield sys.stdout
+            else:
+                yield sys.stderr
+        finally:
+            if mock_stdout:
+                self.mock_stdout(False)
+            if mock_stderr:
+                self.mock_stderr(False)
 
     def tearDown(self):
         """Cleanup after running a test."""

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1816,14 +1816,16 @@ class EasyBlock(object):
             self.log.info("Removing existing module file %s", self.mod_filepath)
             remove_file(self.mod_filepath)
 
-    def report_test_failure(self, msgOrError):
-        """Report a failing test either via an exception or warning depending on ignore-test-failure
+    def report_test_failure(self, msg_or_error):
+        """
+        Report a failing test either via an exception or warning depending on ignore-test-failure
 
-        msgOrError - Failure description. Either a string or an EasyBuildError"""
+        :param msg_or_error: failure description (string value or an EasyBuildError instance)
+        """
         if self.ignore_test_failure:
-            print_warning("Test failure ignored: " + str(msgOrError), log=self.log)
+            print_warning("Test failure ignored: " + str(msg_or_error), log=self.log)
         else:
-            exception = msgOrError if isinstance(msgOrError, EasyBuildError) else EasyBuildError(msgOrError)
+            exception = msg_or_error if isinstance(msg_or_error, EasyBuildError) else EasyBuildError(msg_or_error)
             raise exception
 
     #
@@ -2245,8 +2247,8 @@ class EasyBlock(object):
         """Run the test_step and handles failures"""
         try:
             self.test_step()
-        except EasyBuildError as e:
-            self.report_test_failure(e)
+        except EasyBuildError as err:
+            self.report_test_failure(err)
 
     def stage_install_step(self):
         """
@@ -3384,7 +3386,7 @@ class EasyBlock(object):
         for step_method in step_methods:
             # Remove leading underscore from e.g. "_test_step"
             method_name = extract_method_name(step_method).lstrip('_')
-            self.log.info("Running method %s part of step %s" % (method_name, step))
+            self.log.info("Running method %s part of step %s", method_name, step)
 
             if self.dry_run:
                 self.dry_run_msg("[%s method]", method_name)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3382,10 +3382,12 @@ class EasyBlock(object):
         run_hook(step, self.hooks, pre_step_hook=True, args=[self])
 
         for step_method in step_methods:
-            self.log.info("Running method %s part of step %s" % (extract_method_name(step_method), step))
+            # Remove leading underscore from e.g. "_test_step"
+            method_name = extract_method_name(step_method).lstrip('_')
+            self.log.info("Running method %s part of step %s" % (method_name, step))
 
             if self.dry_run:
-                self.dry_run_msg("[%s method]", step_method(self).__name__)
+                self.dry_run_msg("[%s method]", method_name)
 
                 # if an known possible error occurs, just report it and continue
                 try:

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -55,6 +55,7 @@ from easybuild.framework.easyconfig.tools import categorize_files_by_type, dep_g
 from easybuild.framework.easyconfig.tools import det_easyconfig_paths, dump_env_script, get_paths_for
 from easybuild.framework.easyconfig.tools import parse_easyconfigs, review_pr, run_contrib_checks, skip_available
 from easybuild.framework.easyconfig.tweak import obtain_ec_for, tweak
+from easybuild.tools.build_log import print_warning
 from easybuild.tools.config import find_last_log, get_repository, get_repositorypath, build_option
 from easybuild.tools.containers.common import containerize
 from easybuild.tools.docs import list_software
@@ -303,6 +304,14 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     init_session_state.update({'easybuild_configuration': eb_config})
     init_session_state.update({'module_list': modlist})
     _log.debug("Initial session state: %s" % init_session_state)
+
+    if options.skip_test_step:
+        if options.ignore_test_failure:
+            raise EasyBuildError("Found both ignore-test-failure and skip-test-step being set. "
+                                 "Please use only one of them.")
+        else:
+            print_warning("Will not run the test step as requested via skip-test-step. "
+                          "Consider using ignore-test-failure instead and verify the results afterwards")
 
     # determine easybuild-easyconfigs package install path
     easyconfigs_pkg_paths = get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR)

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -307,7 +307,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
 
     if options.skip_test_step:
         if options.ignore_test_failure:
-            raise EasyBuildError("Found both ignore-test-failure and skip-test-step being set. "
+            raise EasyBuildError("Found both ignore-test-failure and skip-test-step enabled. "
                                  "Please use only one of them.")
         else:
             print_warning("Will not run the test step as requested via skip-test-step. "

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -248,6 +248,7 @@ BUILD_OPTIONS_CMDLINE = {
         'ignore_checksums',
         'ignore_index',
         'ignore_locks',
+        'ignore_test_failure',
         'install_latest_eb_release',
         'logtostdout',
         'minimal_toolchains',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -418,6 +418,7 @@ class EasyBuildOptions(GeneralOption):
                                           "\"client[A-z0-9]*.example.com': ['Authorization: Basic token']\".",
                                           None, 'append', None, {'metavar': '[URLPAT::][HEADER:]FILE|FIELD'}),
             'ignore-checksums': ("Ignore failing checksum verification", None, 'store_true', False),
+            'ignore-test-failure': ("Ignore a failing test step", None, 'store_true', False),
             'ignore-osdeps': ("Ignore any listed OS dependencies", None, 'store_true', False),
             'install-latest-eb-release': ("Install latest known version of easybuild", None, 'store_true', False),
             'lib-lib64-symlink': ("Automatically create symlinks for lib/ pointing to lib64/ if the former is missing",

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -398,6 +398,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         """Test ignore failing tests (--ignore-test-failure)."""
 
         topdir = os.path.abspath(os.path.dirname(__file__))
+        # This EC uses a `runtest` command which does not exist and hence will make the test step fail
         toy_ec = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0-test.eb')
 
         args = [toy_ec, '--ignore-test-failure', '--force']
@@ -407,13 +408,13 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         msg = 'Test failure ignored'
         self.assertTrue(re.search(msg, outtxt),
-                        "Ignored test failure message in log not found, outtxt: %s" % outtxt)
+                        "Ignored test failure message in log should be found, outtxt: %s" % outtxt)
         self.assertTrue(re.search(msg, stderr.getvalue()),
-                        "Ignored test failure message in stderr not found, stderr: %s" % stderr.getvalue())
+                        "Ignored test failure message in stderr should be found, stderr: %s" % stderr.getvalue())
 
         # Passing skip and ignore options is disallowed
         args.append('--skip-test-step')
-        error_pattern = 'Found both ignore-test-failure and skip-test-step being set'
+        error_pattern = 'Found both ignore-test-failure and skip-test-step enabled'
         self.assertErrorRegex(EasyBuildError, error_pattern, self.eb_main, args, do_build=True, raise_error=True)
 
     def test_job(self):

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -394,6 +394,28 @@ class CommandLineOptionsTest(EnhancedTestCase):
         found = re.search(test_run_msg, outtxt)
         self.assertFalse(found, "Test execution command is NOT present, outtxt: %s" % outtxt)
 
+    def test_ignore_test_failure(self):
+        """Test ignore failing tests (--ignore-test-failure)."""
+
+        topdir = os.path.abspath(os.path.dirname(__file__))
+        toy_ec = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0-test.eb')
+
+        args = [toy_ec, '--ignore-test-failure', '--force']
+
+        with self.mocked_stdout_stderr() as (_, stderr):
+            outtxt = self.eb_main(args, do_build=True)
+
+        msg = 'Test failure ignored'
+        self.assertTrue(re.search(msg, outtxt),
+                        "Ignored test failure message in log not found, outtxt: %s" % outtxt)
+        self.assertTrue(re.search(msg, stderr.getvalue()),
+                        "Ignored test failure message in stderr not found, stderr: %s" % stderr.getvalue())
+
+        # Passing skip and ignore options is disallowed
+        args.append('--skip-test-step')
+        error_pattern = 'Found both ignore-test-failure and skip-test-step being set'
+        self.assertErrorRegex(EasyBuildError, error_pattern, self.eb_main, args, do_build=True, raise_error=True)
+
     def test_job(self):
         """Test submitting build as a job."""
 


### PR DESCRIPTION
Users can now use --ignore-test-failure instead of --skip-test-step which will run the tests but does not abort on error and just prints it instead.

Using both options doesn't make sense and is hence disallowed and a warning is show to make users move to ignoring failures instead of skipping the test completely.