### PR TITLE
add toolchain nvpsmpic

### DIFF
--- a/easybuild/toolchains/npsmpic.py
+++ b/easybuild/toolchains/npsmpic.py
@@ -34,6 +34,7 @@ from easybuild.toolchains.nvhpc import NvhpcToolchain
 from easybuild.toolchains.mpi.psmpi import Psmpi
 from easybuild.toolchains.compiler.cuda import Cuda
 
+
 # Order matters!
 class Npsmpic(NvhpcToolchain, Cuda, Psmpi):
     """Compiler toolchain with NVHPC and ParaStationMPI, with CUDA as dependency."""

--- a/easybuild/toolchains/npsmpic.py
+++ b/easybuild/toolchains/npsmpic.py
@@ -1,0 +1,41 @@
+##
+# Copyright 2016-2016 Ghent University
+# Copyright 2016-2016 Forschungszentrum Juelich
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# http://github.com/hpcugent/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for npsmpi compiler toolchain (includes NVHPC and ParaStationMPI, and CUDA as dependency).
+
+@author: Damian Alvarez (Forschungszentrum Juelich)
+"""
+
+from easybuild.toolchains.nvhpc import NvhpcToolchain
+# We pull in MPI and CUDA at once so this maps nicely to HMNS
+from easybuild.toolchains.mpi.psmpi import Psmpi
+from easybuild.toolchains.compiler.cuda import Cuda
+
+# Order matters!
+class Npsmpic(NvhpcToolchain, Cuda, Psmpi):
+    """Compiler toolchain with NVHPC and ParaStationMPI, with CUDA as dependency."""
+    NAME = 'npsmpic'
+    SUBTOOLCHAIN = NvhpcToolchain.NAME

--- a/easybuild/toolchains/nvpsmpic.py
+++ b/easybuild/toolchains/nvpsmpic.py
@@ -30,14 +30,14 @@ EasyBuild support for npsmpi compiler toolchain (includes NVHPC and ParaStationM
 @author: Sebastian Achilles (Forschungszentrum Juelich)
 """
 
-from easybuild.toolchains.nvhpc import NvhpcToolchain
+from easybuild.toolchains.nvhpc import NVHPCToolchain
 # We pull in MPI and CUDA at once so this maps nicely to HMNS
 from easybuild.toolchains.mpi.psmpi import Psmpi
 from easybuild.toolchains.compiler.cuda import Cuda
 
 
 # Order matters!
-class NVpsmpic(NvhpcToolchain, Cuda, Psmpi):
+class NVpsmpic(NVHPCToolchain, Cuda, Psmpi):
     """Compiler toolchain with NVHPC and ParaStationMPI, with CUDA as dependency."""
     NAME = 'nvpsmpic'
-    SUBTOOLCHAIN = NvhpcToolchain.NAME
+    SUBTOOLCHAIN = NVHPCToolchain.NAME

--- a/easybuild/toolchains/nvpsmpic.py
+++ b/easybuild/toolchains/nvpsmpic.py
@@ -1,6 +1,6 @@
 ##
-# Copyright 2016-2016 Ghent University
-# Copyright 2016-2016 Forschungszentrum Juelich
+# Copyright 2016-2021 Ghent University
+# Copyright 2016-2021 Forschungszentrum Juelich
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
@@ -27,6 +27,7 @@
 EasyBuild support for npsmpi compiler toolchain (includes NVHPC and ParaStationMPI, and CUDA as dependency).
 
 @author: Damian Alvarez (Forschungszentrum Juelich)
+@author: Sebastian Achilles (Forschungszentrum Juelich)
 """
 
 from easybuild.toolchains.nvhpc import NvhpcToolchain
@@ -36,7 +37,7 @@ from easybuild.toolchains.compiler.cuda import Cuda
 
 
 # Order matters!
-class Npsmpic(NvhpcToolchain, Cuda, Psmpi):
+class NVpsmpic(NvhpcToolchain, Cuda, Psmpi):
     """Compiler toolchain with NVHPC and ParaStationMPI, with CUDA as dependency."""
-    NAME = 'npsmpic'
+    NAME = 'nvpsmpic'
     SUBTOOLCHAIN = NvhpcToolchain.NAME

--- a/easybuild/toolchains/nvpsmpic.py
+++ b/easybuild/toolchains/nvpsmpic.py
@@ -26,8 +26,8 @@
 """
 EasyBuild support for npsmpi compiler toolchain (includes NVHPC and ParaStationMPI, and CUDA as dependency).
 
-@author: Damian Alvarez (Forschungszentrum Juelich)
-@author: Sebastian Achilles (Forschungszentrum Juelich)
+:author: Damian Alvarez (Forschungszentrum Juelich)
+:author: Sebastian Achilles (Forschungszentrum Juelich)
 """
 
 from easybuild.toolchains.nvhpc import NVHPCToolchain


### PR DESCRIPTION
This PR adds the `npsmpic` toolchain: NVHPC + ParaStationMPI