### PR TITLE
(WIP) Supporting checksums.json

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -352,12 +352,15 @@ class EasyBlock(object):
     def get_checksums(self):
         # if checksum not specified in recipe, try to load checksums.yaml
         if not self.cfg['checksums']:
-            path = self.obtain_file("checksums.yaml")
-            self.log.info("Loading checksums from file %s", path)
-            yaml_txt = read_file(path)
-            checksums = yaml.safe_load(yaml_txt)
-            self.log.info("Checksums loaded %s", str(checksums))
-            self.cfg['checksums'] = checksums
+            try:
+                path = self.obtain_file("checksums.yaml")
+                self.log.info("Loading checksums from file %s", path)
+                yaml_txt = read_file(path)
+                checksums = yaml.safe_load(yaml_txt)
+                self.cfg['checksums'] = checksums
+            # if the file can't be found, return self.cfg['checksums']
+            except EasyBuildError:
+                pass
 
         return self.cfg['checksums']
 


### PR DESCRIPTION
This is an admittedly naive implementation (a proof of concept). In particular, problems left to be resolved: 

- [ ] no test implemented or validate
- [ ] not sure what to do with `--inject-checksums` 
- [ ] not sure what to do with `--new-pr` for the yaml file

I have tested this PR with `Python-3.8.2-GCCcore-9.3.0.eb` by removing the checksums from the EasyConfig, and with `--enforce-checksums` enabled. 

It allows to remove checksums both for the main file and for the exts_list. 

This is for issue https://github.com/easybuilders/easybuild-framework/issues/3746
