### PR TITLE
Consider sources provided as dict in EasyBlock.check_checksums_for

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2012,6 +2012,7 @@ class EasyBlock(object):
 
         for fn, checksum in zip(sources + patches, checksums):
             if isinstance(checksum, dict):
+                # sources entry may be a dictionary rather than just a string value with filename
                 if isinstance(fn, dict):
                     filename = fn['filename']
                 else:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2012,7 +2012,11 @@ class EasyBlock(object):
 
         for fn, checksum in zip(sources + patches, checksums):
             if isinstance(checksum, dict):
-                checksum = checksum.get(fn)
+                if isinstance(fn, dict):
+                    filename = fn['filename']
+                else:
+                    filename = fn
+                checksum = checksum.get(filename)
 
             # take into account that we may encounter a tuple of valid SHA256 checksums
             # (see https://github.com/easybuilders/easybuild-framework/pull/2958)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2073,6 +2073,21 @@ class EasyBlockTest(EnhancedTestCase):
         # no checksum issues
         self.assertEqual(eb.check_checksums(), [])
 
+        # checksums as dict for some files
+        eb.cfg['checksums'] = [
+            {
+                'toy-0.0.tar.gz': '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',
+                'toy-0.1.tar.gz': '123456789abcdef123456789abcdef123456789abcdef123456789abcdef1234',
+            },
+            '81a3accc894592152f81814fbf133d39afad52885ab52c25018722c7bda92487',  # toy-*.patch
+            '4196b56771140d8e2468fb77f0240bc48ddbf5dabafe0713d612df7fafb1e458',  # toy-extra.txt
+        ]
+        self.assertEqual(eb.check_checksums(), [])
+
+        # sources can also have dict entries
+        eb.cfg['sources'] = [{'filename': 'toy-0.0.tar.gz', 'download_fileame': 'toy.tar.gz'}]
+        self.assertEqual(eb.check_checksums(), [])
+
     def test_this_is_easybuild(self):
         """Test 'this_is_easybuild' function (and get_git_revision function used by it)."""
         # make sure both return a non-Unicode string


### PR DESCRIPTION
I managed to break the tests by making an easyconfig where `sources` is a dict **and** `checksums` is also a dict. :slightly_smiling_face: 

Fixes failing tests in https://github.com/easybuilders/easybuild-easyconfigs/pull/13141