### PR TITLE
make sure that test for --list-easyblocks is run first, before other tests that pick up additional easyblocks

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -807,7 +807,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
             os.remove(dummylogfn)
         sys.path[:] = orig_sys_path
 
-    def test_list_easyblocks(self):
+    # use test_000_* to ensure this test is run *first*,
+    # before any tests that pick up additional easyblocks (which are difficult to clean up)
+    def test_000_list_easyblocks(self):
         """Test listing easyblock hierarchy."""
 
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')


### PR DESCRIPTION
The relative order of `test_list_easyblocks` and `test_xxx_include_easyblocks_from_pr` was changed in #3730 when `test_xxx_include_easyblocks_from_pr` was renamed to `test_github_xxx_include_easyblocks_from_pr `, but this broke `test_list_easyblocks` when the tests that require a GitHub token are being run (not for PRs, only after a PR is merged).

Simplest fix is to rename `test_list_easyblocks` to `test_000_list_easyblocks` to ensure it's run first, since cleaning up the easyblock that get imported by `test_github_xxx_include_easyblocks_from_pr` is not trivial...

This fixes the failing test in #3764 (which only happens there because no "external" branch is involved, the tests that require a GitHub token *are* run in that case).