### PR TITLE
Don't add empty PATH or LD_LIBRARY_PATH

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1099,8 +1099,9 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filen
 def dir_contains_files(path, recursive=True):
     """
     Return True if the given directory does contain any file
-    
-    :recursive If False only the path itself is considered, else all subdirectories are also searched"""
+
+    :recursive If False only the path itself is considered, else all subdirectories are also searched
+    """
     if recursive:
         return any(files for _root, _dirs, files in os.walk(path))
     else:

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1096,9 +1096,15 @@ def search_file(paths, query, short=False, ignore_dirs=None, silent=False, filen
     return var_defs, hits
 
 
-def dir_contains_files(path):
-    """Return True if the given directory does contain any file in itself or any subdirectory"""
-    return any(files for _root, _dirs, files in os.walk(path))
+def dir_contains_files(path, recursive=True):
+    """
+    Return True if the given directory does contain any file
+    
+    :recursive If False only the path itself is considered, else all subdirectories are also searched"""
+    if recursive:
+        return any(files for _root, _dirs, files in os.walk(path))
+    else:
+        return any(os.path.isfile(os.path.join(path, x)) for x in os.listdir(path))
 
 
 def find_eb_script(script_name):

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -563,7 +563,7 @@ class EasyBlockTest(EnhancedTestCase):
         if get_module_syntax() == 'Tcl':
             self.assertFalse(re.search(r"prepend-path\s+LD_LIBRARY_PATH\s+\$%s\n" % sub_lib_path,
                                        txt, re.M))
-            self.assertFalse(re.search(r"prepend-path\s+PATH\s+\$%d\n" % sub_path_path, txt, re.M))
+            self.assertFalse(re.search(r"prepend-path\s+PATH\s+\$%s\n" % sub_path_path, txt, re.M))
         else:
             assert get_module_syntax() == 'Lua'
             self.assertFalse(re.search(r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "%s"\)\)\n' % sub_lib_path,

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -551,6 +551,25 @@ class EasyBlockTest(EnhancedTestCase):
         else:
             self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
 
+        # If PATH or LD_LIBRARY_PATH contain only folders, do not add an entry
+        sub_lib_path = os.path.join('lib', 'path_folders')
+        sub_path_path = os.path.join('bin', 'path_folders')
+        eb.make_module_req_guess = lambda: {'LD_LIBRARY_PATH': sub_lib_path, 'PATH': sub_path_path}
+        for path in (sub_lib_path, sub_path_path):
+            full_path = os.path.join(eb.installdir, path, 'subpath')
+            os.makedirs(full_path)
+            write_file(os.path.join(full_path, 'any.file'), 'test')
+        txt = eb.make_module_req()
+        if get_module_syntax() == 'Tcl':
+            self.assertFalse(re.search(r"prepend-path\s+LD_LIBRARY_PATH\s+\$%s\n" % sub_lib_path,
+                                       txt, re.M))
+            self.assertFalse(re.search(r"prepend-path\s+PATH\s+\$%d\n" % sub_path_path, txt, re.M))
+        else:
+            assert get_module_syntax() == 'Lua'
+            self.assertFalse(re.search(r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "%s"\)\)\n' % sub_lib_path,
+                                       txt, re.M))
+            self.assertFalse(re.search(r'prepend_path\("PATH", pathJoin\(root, "%s"\)\)\n' % sub_path_path, txt, re.M))
+
         # cleanup
         eb.close_log()
         os.remove(eb.logfile)

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2330,21 +2330,26 @@ class FileToolsTest(EnhancedTestCase):
 
         empty_dir = makedirs_in_test('empty_dir')
         self.assertFalse(ft.dir_contains_files(empty_dir))
+        self.assertFalse(ft.dir_contains_files(empty_dir, recursive=False))
 
         dir_w_subdir = makedirs_in_test('dir_w_subdir', 'sub_dir')
         self.assertFalse(ft.dir_contains_files(dir_w_subdir))
+        self.assertFalse(ft.dir_contains_files(dir_w_subdir, recursive=False))
 
         dir_subdir_file = makedirs_in_test('dir_subdir_file', 'sub_dir_w_file')
         ft.write_file(os.path.join(dir_subdir_file, 'sub_dir_w_file', 'file.h'), '')
         self.assertTrue(ft.dir_contains_files(dir_subdir_file))
+        self.assertFalse(ft.dir_contains_files(dir_subdir_file, recursive=False))
 
         dir_w_file = makedirs_in_test('dir_w_file')
         ft.write_file(os.path.join(dir_w_file, 'file.h'), '')
         self.assertTrue(ft.dir_contains_files(dir_w_file))
+        self.assertTrue(ft.dir_contains_files(dir_w_file, recursive=False))
 
         dir_w_dir_and_file = makedirs_in_test('dir_w_dir_and_file', 'sub_dir')
         ft.write_file(os.path.join(dir_w_dir_and_file, 'file.h'), '')
         self.assertTrue(ft.dir_contains_files(dir_w_dir_and_file))
+        self.assertTrue(ft.dir_contains_files(dir_w_dir_and_file, recursive=False))
 
     def test_find_eb_script(self):
         """Test find_eb_script function."""


### PR DESCRIPTION
While we already have detection of those containing any files recursively that is not enough: Those paths are NOT searched recursively, hence we need to check those folders only.

This happens a lot e.g. for Python packages where we have `lib/python3.7/site-packages/foo.py` with an otherwise empty `lib`.

And as each path added to those 2 env vars slows down execution/library loading it makes sense to clean those more.