### PR TITLE
Filter out duplicate paths added to module files

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3192,21 +3192,18 @@ class EasyBlock(object):
         else:
             trace_msg("generating module file @ %s" % self.mod_filepath)
 
-        txt = self.module_generator.prepare_module_creation()
+        with self.module_generator.start_module_creation() as txt:
+            if self.modules_header:
+                txt += self.modules_header + '\n'
 
-        if self.modules_header:
-            txt += self.modules_header + '\n'
-
-        txt += self.make_module_description()
-        txt += self.make_module_group_check()
-        txt += self.make_module_deppaths()
-        txt += self.make_module_dep()
-        txt += self.make_module_extend_modpath()
-        txt += self.make_module_req()
-        txt += self.make_module_extra()
-        txt += self.make_module_footer()
-
-        self.module_generator.finalize_module_creation()
+            txt += self.make_module_description()
+            txt += self.make_module_group_check()
+            txt += self.make_module_deppaths()
+            txt += self.make_module_dep()
+            txt += self.make_module_extend_modpath()
+            txt += self.make_module_req()
+            txt += self.make_module_extra()
+            txt += self.make_module_footer()
 
         hook_txt = run_hook(MODULE_WRITE, self.hooks, args=[self, mod_filepath, txt])
         if hook_txt is not None:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3192,9 +3192,7 @@ class EasyBlock(object):
         else:
             trace_msg("generating module file @ %s" % self.mod_filepath)
 
-        txt = self.module_generator.MODULE_SHEBANG
-        if txt:
-            txt += '\n'
+        txt = self.module_generator.prepare_module_creation()
 
         if self.modules_header:
             txt += self.modules_header + '\n'
@@ -3207,6 +3205,8 @@ class EasyBlock(object):
         txt += self.make_module_req()
         txt += self.make_module_extra()
         txt += self.make_module_footer()
+
+        self.module_generator.finalize_module_creation()
 
         hook_txt = run_hook(MODULE_WRITE, self.hooks, args=[self, mod_filepath, txt])
         if hook_txt is not None:

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -41,7 +41,7 @@ from distutils.version import LooseVersion
 from textwrap import wrap
 
 from easybuild.base import fancylogger
-from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option, get_module_syntax, install_path
 from easybuild.tools.filetools import convert_name, mkdir, read_file, remove_file, resolve_path, symlink, write_file
 from easybuild.tools.modules import ROOT_ENV_VAR_NAME_PREFIX, EnvironmentModulesC, Lmod, modules_tool
@@ -214,8 +214,9 @@ class ModuleGenerator(object):
             filtered_paths = [x for x in paths if x not in self.added_paths and not self.added_paths.add(x)]
         if filtered_paths != paths:
             removed_paths = paths if filtered_paths is None else [x for x in paths if x not in filtered_paths]
-            self.log.warning("Supressed adding the following path(s) to the module as they were already added: %s",
-                             removed_paths)
+            print_warning("Supressed adding the following path(s) to the module as they were already added: %s",
+                          removed_paths,
+                          log=self.log)
         return filtered_paths
 
     def append_paths(self, key, paths, allow_abs=False, expand_relpaths=True):

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1102,7 +1102,7 @@ class EasyBlockTest(EnhancedTestCase):
         # purposely use a 'nasty' description, that includes (unbalanced) special chars: [, ], {, }
         descr = "This {is a}} [fancy]] [[description]]. {{[[TEST}]"
         modextravars = {'PI': '3.1415', 'FOO': 'bar'}
-        modextrapaths = {'PATH': 'pibin', 'CPATH': 'pi/include'}
+        modextrapaths = {'PATH': ('bin', 'pibin'), 'CPATH': 'pi/include'}
         self.contents = '\n'.join([
             'easyblock = "ConfigureMake"',
             'name = "%s"' % name,
@@ -1126,6 +1126,10 @@ class EasyBlockTest(EnhancedTestCase):
         eb.check_readiness_step()
         eb.make_builddir()
         eb.prepare_step()
+
+        # Create a dummy file in bin to test if the duplicate entry of modextrapaths is ignored
+        os.mkdir(os.path.join(eb.installdir, 'bin'))
+        write_file(os.path.join(eb.installdir, 'bin', 'dummy_exe'), 'hello')
 
         modpath = os.path.join(eb.make_module_step(), name, version)
         if get_module_syntax() == 'Lua':
@@ -1168,6 +1172,9 @@ class EasyBlockTest(EnhancedTestCase):
             else:
                 self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
             self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
+            # Check for duplicates
+            num_prepends = len(regex.finditer(txt))
+            self.assertEqual(num_prepends, 1, "Expected exactly 1 %s command in %s" % (regex.pattern, txt))
 
         for (name, ver) in [('GCC', '6.4.0-2.28')]:
             if get_module_syntax() == 'Tcl':


### PR DESCRIPTION
This basically fixes faulty EC files which result in modules like:
```
prepend_path("EBPYTHONPREFIXES", root)
prepend_path("QT_PLUGIN_PATH", pathJoin(root, "plugins"))
prepend_path("EBPYTHONPREFIXES", root)
```

The idea is to use a context manager around the creation of a module, store all added paths and reject duplicate ones that way clearing the stored paths at the end.