### PR TITLE
Improve warning about missing intel fftw libs

### DIFF
--- a/.github/workflows/bootstrap_script.yml
+++ b/.github/workflows/bootstrap_script.yml
@@ -107,7 +107,7 @@ jobs:
           EB_BOOTSTRAP_VERSION=$(grep '^EB_BOOTSTRAP_VERSION' easybuild/scripts/bootstrap_eb.py | sed 's/[^0-9.]//g')
           EB_BOOTSTRAP_SHA256SUM=$(sha256sum easybuild/scripts/bootstrap_eb.py | cut -f1 -d' ')
           EB_BOOTSTRAP_FOUND="$EB_BOOTSTRAP_VERSION $EB_BOOTSTRAP_SHA256SUM"
-          EB_BOOTSTRAP_EXPECTED="20210618.01 e5d477d717c6d3648ba2027ab735713ba5804fbf52f4b4adcca0bc1379b44618"
+          EB_BOOTSTRAP_EXPECTED="20210715.01 784dd29063d941be2d8b70e4c2eec12a9afe360f3ef8f753dcb518abf43ca7de"
           test "$EB_BOOTSTRAP_FOUND" = "$EB_BOOTSTRAP_EXPECTED" || (echo "Version check on bootstrap script failed $EB_BOOTSTRAP_FOUND" && exit 1)
 
           # test bootstrap script

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -881,7 +881,7 @@ class EasyConfig(object):
                 raise EasyBuildError("Non-tuple value type for OS dependency specification: %s (type %s)",
                                      dep, type(dep))
 
-            if not any([check_os_dependency(cand_dep) for cand_dep in dep]):
+            if not any(check_os_dependency(cand_dep) for cand_dep in dep):
                 not_found.append(dep)
 
         if not_found:

--- a/easybuild/framework/easyconfig/format/format.py
+++ b/easybuild/framework/easyconfig/format/format.py
@@ -577,7 +577,7 @@ class EBConfigObj(object):
                 self.log.debug("No toolchain version specified, using default %s" % tcversion)
             else:
                 raise EasyBuildError("No toolchain version specified, no default found.")
-        elif any([tc.test(tcname, tcversion) for tc in tcs]):
+        elif any(tc.test(tcname, tcversion) for tc in tcs):
             self.log.debug("Toolchain '%s' version '%s' is supported in easyconfig" % (tcname, tcversion))
         else:
             raise EasyBuildError("Toolchain '%s' version '%s' not supported in easyconfig (only %s)",

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -62,7 +62,7 @@ else:
     import urllib.request as std_urllib
 
 
-EB_BOOTSTRAP_VERSION = '20210618.01'
+EB_BOOTSTRAP_VERSION = '20210715.01'
 
 # argparse preferrred, optparse deprecated >=2.7
 HAVE_ARGPARSE = False

--- a/easybuild/scripts/bootstrap_eb.py
+++ b/easybuild/scripts/bootstrap_eb.py
@@ -925,7 +925,7 @@ def main():
     for path in orig_sys_path:
         include_path = True
         # exclude path if it's potentially an EasyBuild/VSC package, providing the 'easybuild'/'vsc' namespace, resp.
-        if any([os.path.exists(os.path.join(path, pkg, '__init__.py')) for pkg in ['easyblocks', 'easybuild', 'vsc']]):
+        if any(os.path.exists(os.path.join(path, pkg, '__init__.py')) for pkg in ['easyblocks', 'easybuild', 'vsc']):
             include_path = False
         # exclude any .egg paths
         if path.endswith('.egg'):

--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -98,7 +98,7 @@ class IntelFFTW(Fftw):
 
         def fftw_lib_exists(libname):
             """Helper function to check whether FFTW library with specified name exists."""
-            return any([os.path.exists(os.path.join(d, "lib%s.a" % libname)) for d in fft_lib_dirs])
+            return any(os.path.exists(os.path.join(d, "lib%s.a" % libname)) for d in fft_lib_dirs)
 
         if not fftw_lib_exists(interface_lib) and LooseVersion(imklver) >= LooseVersion("10.2"):
             # interface libs can be optional:

--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -112,14 +112,15 @@ class IntelFFTW(Fftw):
         # filter out libraries from list of FFTW libraries to check for if they are not provided by Intel MKL
         check_fftw_libs = [lib for lib in fftw_libs if lib not in ['dl', 'gfortran']]
 
-        if all([fftw_lib_exists(lib) for lib in check_fftw_libs]):
-            self.FFT_LIB = fftw_libs
-        else:
+        missing_fftw_libs = [lib for lib in check_fftw_libs if not fftw_lib_exists(lib)]
+        if missing_fftw_libs:
             msg = "Not all FFTW interface libraries %s are found in %s" % (check_fftw_libs, fft_lib_dirs)
-            msg += ", can't set $FFT_LIB."
+            msg += ", can't set $FFT_LIB. Missing: %s" % (missing_fftw_libs)
             if self.dry_run:
                 dry_run_warning(msg, silent=build_option('silent'))
             else:
                 raise EasyBuildError(msg)
+        else:
+            self.FFT_LIB = fftw_libs
 
         self.FFT_LIB_MT = fftw_mt_libs

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -528,7 +528,7 @@ def det_common_path_prefix(paths):
     found_common = False
     while not found_common and prefix != os.path.dirname(prefix):
         prefix = os.path.dirname(prefix)
-        found_common = all([p.startswith(prefix) for p in paths])
+        found_common = all(p.startswith(prefix) for p in paths)
 
     if found_common:
         # prefix may be empty string for relative paths with a non-common prefix

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1275,7 +1275,7 @@ def reasons_for_closing(pr_data):
     if uses_archived_tc:
         possible_reasons.append('archived')
 
-    if any([e['name'] in pr_data['title'] for e in obsoleted]):
+    if any(e['name'] in pr_data['title'] for e in obsoleted):
         possible_reasons.append('obsolete')
 
     return possible_reasons
@@ -1804,7 +1804,7 @@ def det_pr_target_repo(paths):
 
             # if all Python files are easyblocks, target repo should be easyblocks;
             # otherwise, target repo is assumed to be framework
-            if all([get_easyblock_class_name(path) for path in py_files]):
+            if all(get_easyblock_class_name(path) for path in py_files):
                 pr_target_repo = GITHUB_EASYBLOCKS_REPO
                 _log.info("All Python files are easyblocks, target repository is assumed to be %s", pr_target_repo)
             else:

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -883,14 +883,14 @@ class EasyBuildOptions(GeneralOption):
             self._postprocess_include()
 
         # prepare for --list/--avail
-        if any([self.options.avail_easyconfig_params, self.options.avail_easyconfig_templates,
+        if any((self.options.avail_easyconfig_params, self.options.avail_easyconfig_templates,
                 self.options.list_easyblocks, self.options.list_toolchains, self.options.avail_cfgfile_constants,
                 self.options.avail_easyconfig_constants, self.options.avail_easyconfig_licenses,
                 self.options.avail_repositories, self.options.show_default_moduleclasses,
                 self.options.avail_modules_tools, self.options.avail_module_naming_schemes,
                 self.options.show_default_configfiles, self.options.avail_toolchain_opts,
                 self.options.avail_hooks, self.options.show_system_info,
-                ]):
+                )):
             build_easyconfig_constants_dict()  # runs the easyconfig constants sanity check
             self._postprocess_list_avail()
 

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -260,7 +260,7 @@ class DocsTest(EnhancedTestCase):
         ]
         txt = list_software(output_format='txt', detailed=True)
         lines = txt.split('\n')
-        expected_found = any([lines[i:i + len(expected)] == expected for i in range(len(lines))])
+        expected_found = any(lines[i:i + len(expected)] == expected for i in range(len(lines)))
         self.assertTrue(expected_found, "%s found in: %s" % (expected, lines))
 
         expected = [
@@ -283,7 +283,7 @@ class DocsTest(EnhancedTestCase):
         ]
         txt = list_software(output_format='rst', detailed=True)
         lines = txt.split('\n')
-        expected_found = any([lines[i:i + len(expected)] == expected for i in range(len(lines))])
+        expected_found = any(lines[i:i + len(expected)] == expected for i in range(len(lines)))
         self.assertTrue(expected_found, "%s found in: %s" % (expected, lines))
 
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1009,7 +1009,7 @@ class FileToolsTest(EnhancedTestCase):
 
         # no postinstallcmds in toy-0.0-deps.eb
         expected = "29 %s+ postinstallcmds = " % green
-        self.assertTrue(any([line.startswith(expected) for line in lines]))
+        self.assertTrue(any(line.startswith(expected) for line in lines))
         expected = "30 %s+%s (1/2) toy-0.0" % (green, endcol)
         self.assertTrue(any(line.startswith(expected) for line in lines), "Found '%s' in: %s" % (expected, lines))
         self.assertEqual(lines[-1], "=====")

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -1096,7 +1096,7 @@ class ModulesTest(EnhancedTestCase):
         mkdir(nonpath)
         self.modtool.use(nonpath)
         modulepaths = [p for p in os.environ.get('MODULEPATH', '').split(os.pathsep) if p]
-        self.assertTrue(any([os.path.samefile(nonpath, mp) for mp in modulepaths]))
+        self.assertTrue(any(os.path.samefile(nonpath, mp) for mp in modulepaths))
         shutil.rmtree(nonpath)
 
         # create symlink to entry in $MODULEPATH we're going to use, and add it to $MODULEPATH
@@ -1136,9 +1136,9 @@ class ModulesTest(EnhancedTestCase):
 
         # invalidate caches with correct path
         modulepaths = [p for p in os.environ.get('MODULEPATH', '').split(os.pathsep) if p]
-        self.assertTrue(any([os.path.exists(mp) and os.path.samefile(test_mods_path, mp) for mp in modulepaths]))
+        self.assertTrue(any(os.path.exists(mp) and os.path.samefile(test_mods_path, mp) for mp in modulepaths))
         paths_in_key = [p for p in avail_cache_key[0].split('=')[1].split(os.pathsep) if p]
-        self.assertTrue(any([os.path.exists(p) and os.path.samefile(test_mods_path, p) for p in paths_in_key]))
+        self.assertTrue(any(os.path.exists(p) and os.path.samefile(test_mods_path, p) for p in paths_in_key))
 
         # verify cache invalidation, caches should be empty again
         invalidate_module_caches_for(test_mods_path)

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -1029,7 +1029,7 @@ class RobotTest(EnhancedTestCase):
         ordered_ecs, new_easyconfigs, new_avail_modules = find_resolved_modules(ecs, mods, self.modtool)
 
         # all dependencies are resolved for easyconfigs included in ordered_ecs
-        self.assertFalse(any([ec['dependencies'] for ec in ordered_ecs]))
+        self.assertFalse(any(ec['dependencies'] for ec in ordered_ecs))
 
         # nodeps/ondep easyconfigs have all dependencies resolved
         self.assertEqual(len(ordered_ecs), 2)

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -489,7 +489,7 @@ class SystemToolsTest(EnhancedTestCase):
         cpu_feat = get_cpu_features()
         self.assertTrue(isinstance(cpu_feat, list))
         self.assertTrue(len(cpu_feat) > 0)
-        self.assertTrue(all([isinstance(x, string_type) for x in cpu_feat]))
+        self.assertTrue(all(isinstance(x, string_type) for x in cpu_feat))
 
     def test_cpu_features_linux(self):
         """Test getting CPU features (mocked for Linux)."""


### PR DESCRIPTION
This now also shows the missing libraries which helps when debugging such an error 

Also some cleanup I've seen there and fixed the same issue in all files:
`any([...])` evaluates everything, allocates a list, then iterates over those to check for any false value, while `any(...)` does only evaluate what is requires stopping early and doing no additional allocation --> Shorter and faster