### PR TITLE
fix verify_imports by deleting all imported modules before re-importing them one by one 

### DIFF
--- a/easybuild/tools/include.py
+++ b/easybuild/tools/include.py
@@ -128,15 +128,17 @@ def set_up_eb_package(parent_path, eb_pkg_name, subpkgs=None, pkg_init_body=None
 def verify_imports(pymods, pypkg, from_path):
     """Verify that import of specified modules from specified package and expected location works."""
 
-    for pymod in pymods:
-        pymod_spec = '%s.%s' % (pypkg, pymod)
-
+    pymod_specs = ['%s.%s' % (pypkg, pymod) for pymod in pymods]
+    for pymod_spec in pymod_specs:
         # force re-import if the specified modules was already imported;
         # this is required to ensure that an easyblock that is included via --include-easyblocks-from-pr
         # gets preference over one that is included via --include-easyblocks
         if pymod_spec in sys.modules:
             del sys.modules[pymod_spec]
 
+    # After all modules to be reloaded have been removed, import them again
+    # Note that removing them here may delete transitively loaded modules and not import them again
+    for pymod_spec in pymod_specs:
         try:
             pymod = __import__(pymod_spec, fromlist=[pypkg])
         # different types of exceptions may be thrown, not only ImportErrors

--- a/easybuild/tools/include.py
+++ b/easybuild/tools/include.py
@@ -180,8 +180,8 @@ def include_easyblocks(tmpdir, paths):
         if not os.path.exists(target_path):
             symlink(easyblock_module, target_path)
 
-    included_ebs = [x for x in os.listdir(easyblocks_dir) if x not in ['__init__.py', 'generic']]
-    included_generic_ebs = [x for x in os.listdir(os.path.join(easyblocks_dir, 'generic')) if x != '__init__.py']
+    included_ebs = sorted(x for x in os.listdir(easyblocks_dir) if x not in ['__init__.py', 'generic'])
+    included_generic_ebs = sorted(x for x in os.listdir(os.path.join(easyblocks_dir, 'generic')) if x != '__init__.py')
     _log.debug("Included generic easyblocks: %s", included_generic_ebs)
     _log.debug("Included software-specific easyblocks: %s", included_ebs)
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3291,9 +3291,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
             eb_inst = klass(ec)
             self.assertTrue(eb_inst is not None, "Instantiating the injected class %s works" % name)
 
-        # 'undo' import of foo easyblock
-        del sys.modules['easybuild.easyblocks.afoo']
-        del sys.modules['easybuild.easyblocks.foo']
+        # 'undo' import of the easyblocks
+        for name in ('afoo', 'foo', 'zfoo'):
+            del sys.modules['easybuild.easyblocks.' + name]
 
     # must be run after test for --list-easyblocks, hence the '_xxx_'
     # cleaning up the imported easyblocks is quite difficult...


### PR DESCRIPTION
Avoids errors on on Python2 when we delete a subclass after importing
a module with a class depending on it.
Fixes #3779

Thanks @migueldiascosta who was on spot with https://github.com/easybuilders/easybuild-framework/issues/3779#issuecomment-882368072