### PR TITLE
 Fix ignore_test_failure not set for Extensions 

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -258,8 +258,6 @@ class EasyBlock(object):
         if group_name is not None:
             self.group = use_group(group_name)
 
-        self.ignore_test_failure = build_option('ignore_test_failure')
-
         # generate build/install directories
         self.gen_builddir()
         self.gen_installdir()
@@ -1831,7 +1829,7 @@ class EasyBlock(object):
 
         :param msg_or_error: failure description (string value or an EasyBuildError instance)
         """
-        if self.ignore_test_failure:
+        if build_option('ignore_test_failure'):
             print_warning("Test failure ignored: " + str(msg_or_error), log=self.log)
         else:
             exception = msg_or_error if isinstance(msg_or_error, EasyBuildError) else EasyBuildError(msg_or_error)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -127,6 +127,8 @@ class EasyBlockTest(EnhancedTestCase):
         extra_options = exeb1.extra_options()
         check_extra_options_format(extra_options)
         self.assertTrue('options' in extra_options)
+        # Reporting test failure should work also for the extension EB
+        self.assertRaises(EasyBuildError, exeb1.report_test_failure, "Fails")
 
         # test extensioneasyblock, as easyblock
         exeb2 = ExtensionEasyBlock(ec)
@@ -135,6 +137,8 @@ class EasyBlockTest(EnhancedTestCase):
         extra_options = exeb2.extra_options()
         check_extra_options_format(extra_options)
         self.assertTrue('options' in extra_options)
+        # Reporting test failure should work also for the extension EB
+        self.assertRaises(EasyBuildError, exeb2.report_test_failure, "Fails")
 
         class TestExtension(ExtensionEasyBlock):
             @staticmethod


### PR DESCRIPTION
The ExtensionEasyBlock does not call `__init__` from EasyBlock and hence that value is not set making uses of report_test_failure fail.