### PR TITLE
Don't parse patch files as easyconfigs when searching for where patch file is used

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1069,11 +1069,13 @@ def find_software_name_for_patch(patch_name, ec_dirs):
 
     soft_name = None
 
+    ignore_dirs = build_option('ignore_dirs')
     all_ecs = []
     for ec_dir in ec_dirs:
         for (dirpath, dirnames, filenames) in os.walk(ec_dir):
-            # Don't visit any hidden folders, such as .git
-            dirnames[:] = [i for i in dirnames if not i.startswith('.')]
+            # Exclude ignored dirs
+            if ignore_dirs:
+                dirnames[:] = [i for i in dirnames if i not in ignore_dirs]
             for fn in filenames:
                 # TODO: In EasyBuild 5.x only check for '*.eb' files
                 if fn != 'TEMPLATE.eb' and os.path.splitext(fn)[1] not in ('.py', '.patch'):

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -839,7 +839,7 @@ def _easyconfigs_pr_common(paths, ecs, start_branch=None, pr_branch=None, start_
     # copy easyconfig files to right place
     target_dir = os.path.join(git_working_dir, pr_target_repo)
     print_msg("copying files to %s..." % target_dir)
-    file_info = COPY_FUNCTIONS[pr_target_repo](ec_paths, os.path.join(git_working_dir, pr_target_repo))
+    file_info = COPY_FUNCTIONS[pr_target_repo](ec_paths, target_dir)
 
     # figure out commit message to use
     if commit_msg:
@@ -1071,7 +1071,9 @@ def find_software_name_for_patch(patch_name, ec_dirs):
 
     all_ecs = []
     for ec_dir in ec_dirs:
-        for (dirpath, _, filenames) in os.walk(ec_dir):
+        for (dirpath, dirnames, filenames) in os.walk(ec_dir):
+            # Don't visit any hidden folders, such as .git
+            dirnames[:] = [i for i in dirnames if not i.startswith('.')]
             for fn in filenames:
                 # TODO: In EasyBuild 5.x only check for '*.eb' files
                 if fn != 'TEMPLATE.eb' and os.path.splitext(fn)[1] not in ('.py', '.patch'):

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1074,7 +1074,7 @@ def find_software_name_for_patch(patch_name, ec_dirs):
         for (dirpath, _, filenames) in os.walk(ec_dir):
             for fn in filenames:
                 # TODO: In EasyBuild 5.x only check for '*.eb' files
-                if fn != 'TEMPLATE.eb' and os.path.splitext(fn) not in ('.py', '.patch'):
+                if fn != 'TEMPLATE.eb' and os.path.splitext(fn)[1] not in ('.py', '.patch'):
                     path = os.path.join(dirpath, fn)
                     rawtxt = read_file(path)
                     if 'patches' in rawtxt:

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1073,7 +1073,8 @@ def find_software_name_for_patch(patch_name, ec_dirs):
     for ec_dir in ec_dirs:
         for (dirpath, _, filenames) in os.walk(ec_dir):
             for fn in filenames:
-                if fn != 'TEMPLATE.eb' and not fn.endswith('.py'):
+                # TODO: In EasyBuild 5.x only check for '*.eb' files
+                if fn != 'TEMPLATE.eb' and os.path.splitext(fn) not in ('.py', '.patch'):
                     path = os.path.join(dirpath, fn)
                     rawtxt = read_file(path)
                     if 'patches' in rawtxt:
@@ -1083,7 +1084,6 @@ def find_software_name_for_patch(patch_name, ec_dirs):
     for idx, path in enumerate(all_ecs):
         if soft_name:
             break
-        rawtxt = read_file(path)
         try:
             ecs = process_easyconfig(path, validate=False)
             for ec in ecs:

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1080,6 +1080,24 @@ def find_software_name_for_patch(patch_name, ec_dirs):
                     if 'patches' in rawtxt:
                         all_ecs.append(path)
 
+    # Usual patch names are <software>-<version>_fix_foo.patch
+    # So search those ECs first
+    patch_stem = os.path.splitext(patch_name)[0]
+    # Extract possible sw name and version according to above scheme
+    # Those might be the same as the whole patch stem, which is OK
+    possible_sw_name = patch_stem.split('-')[0].lower()
+    possible_sw_name_version = patch_stem.split('_')[0].lower()
+
+    def ec_key(path):
+        filename = os.path.basename(path).lower()
+        # Put files with one of those as the prefix first, then sort by name
+        return (
+            not filename.startswith(possible_sw_name_version),
+            not filename.startswith(possible_sw_name),
+            filename
+        )
+    all_ecs.sort(key=ec_key)
+
     nr_of_ecs = len(all_ecs)
     for idx, path in enumerate(all_ecs):
         if soft_name:

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -595,6 +595,15 @@ class GithubTest(EnhancedTestCase):
         reg = re.compile(r'[1-9]+ of [1-9]+ easyconfigs checked')
         self.assertTrue(re.search(reg, txt))
 
+        self.assertEqual(gh.find_software_name_for_patch('test.patch', []), None)
+
+        # check behaviour of find_software_name_for_patch when non-UTF8 patch files are present
+        non_utf8_patch = os.path.join(self.test_prefix, 'problem.patch')
+        with open(non_utf8_patch, 'wb') as fp:
+            fp.write(bytes("+  ximage->byte_order=T1_byte_order; /* Set t1lib\xb4s byteorder */\n", 'iso_8859_1'))
+
+        self.assertEqual(gh.find_software_name_for_patch('test.patch', [self.test_prefix]), None)
+
     def test_github_det_commit_status(self):
         """Test det_commit_status function."""
 

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -597,12 +597,13 @@ class GithubTest(EnhancedTestCase):
 
         self.assertEqual(gh.find_software_name_for_patch('test.patch', []), None)
 
-        # check behaviour of find_software_name_for_patch when non-UTF8 patch files are present
-        non_utf8_patch = os.path.join(self.test_prefix, 'problem.patch')
-        with open(non_utf8_patch, 'wb') as fp:
-            fp.write(bytes("+  ximage->byte_order=T1_byte_order; /* Set t1lib\xb4s byteorder */\n", 'iso_8859_1'))
+        # check behaviour of find_software_name_for_patch when non-UTF8 patch files are present (only with Python 3)
+        if sys.version_info[0] >= 3:
+            non_utf8_patch = os.path.join(self.test_prefix, 'problem.patch')
+            with open(non_utf8_patch, 'wb') as fp:
+                fp.write(bytes("+  ximage->byte_order=T1_byte_order; /* Set t1lib\xb4s byteorder */\n", 'iso_8859_1'))
 
-        self.assertEqual(gh.find_software_name_for_patch('test.patch', [self.test_prefix]), None)
+            self.assertEqual(gh.find_software_name_for_patch('test.patch', [self.test_prefix]), None)
 
     def test_github_det_commit_status(self):
         """Test det_commit_status function."""


### PR DESCRIPTION
Exclude *.patch files during search
Remove C&P bug that needlessly reads the file a third time

Fixes #3781

While at it I also included a major speedup by checking ECs prefixed with the patch name (or parts of it) first.
Example: The `test_github_find_patches` test now parses exactly 1 EC to find a matching one.