### PR TITLE
make sure git clone with a tag argument actually downloads a tag

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2472,7 +2472,7 @@ def get_source_tarball_from_git(filename, targetdir, git_config):
     clone_cmd = ['git', 'clone']
 
     if tag:
-        clone_cmd.extend(['--branch', tag])
+        clone_cmd.extend(['--branch', 'refs/tags/' + tag])
 
     if recursive:
         clone_cmd.append('--recursive')

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2471,11 +2471,17 @@ def get_source_tarball_from_git(filename, targetdir, git_config):
     # compose 'git clone' command, and run it
     clone_cmd = ['git', 'clone']
 
+    if not keep_git_dir:
+        # Speed up cloning by only fetching the most recent commit, not the whole history
+        # When we don't want to keep the .git folder there won't be a difference in the result
+        clone_cmd.extend(['--depth', '1'])
+
     if tag:
         clone_cmd.extend(['--branch', 'refs/tags/' + tag])
-
-    if recursive:
-        clone_cmd.append('--recursive')
+        if recursive:
+            clone_cmd.append('--recursive')
+    else:
+        clone_cmd.append('--no-checkout')  # We do that manually below
 
     clone_cmd.append('%s/%s.git' % (url, repo_name))
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2503,6 +2503,9 @@ def get_source_tarball_from_git(filename, targetdir, git_config):
         # Note: Disable logging to also disable the error handling in run_cmd
         (out, ec) = run.run_cmd(cmd, log_ok=False, log_all=False, regexp=False, path=repo_name)
         if ec != 0 or tag not in out.splitlines():
+            print_warning('Tag %s was not downloaded in the first try due to %s/%s containing a branch'
+                          ' with the same name. You might want to alert the maintainers of %s about that issue.',
+                          tag, url, repo_name, repo_name)
             cmds = []
             if not keep_git_dir:
                 # Make the repo unshallow, same as git fetch --unshallow in git 1.8.3+

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2491,15 +2491,21 @@ class FileToolsTest(EnhancedTestCase):
         git_config = {
             'repo_name': 'testrepository',
             'url': 'https://github.com/easybuilders',
-            'tag': 'main',
+            'tag': 'tag_for_tests',
         }
         target_dir = os.path.join(self.test_prefix, 'target')
 
         try:
             ft.get_source_tarball_from_git('test.tar.gz', target_dir, git_config)
             # (only) tarball is created in specified target dir
-            self.assertTrue(os.path.isfile(os.path.join(target_dir, 'test.tar.gz')))
+            test_file = os.path.join(target_dir, 'test.tar.gz')
+            self.assertTrue(os.path.isfile(test_file))
             self.assertEqual(os.listdir(target_dir), ['test.tar.gz'])
+
+            # Check that we indeed downloaded the tag and not a branch
+            extracted_dir = tempfile.mkdtemp(prefix='extracted_dir')
+            target_dir = ft.extract_file(test_file, extracted_dir, change_into_dir=False)
+            self.assertTrue(os.path.isfile(os.path.join(target_dir, 'this-is-a-tag.txt')))
 
             del git_config['tag']
             git_config['commit'] = '8456f86'
@@ -2516,7 +2522,7 @@ class FileToolsTest(EnhancedTestCase):
         git_config = {
             'repo_name': 'testrepository',
             'url': 'git@github.com:easybuilders',
-            'tag': 'master',
+            'tag': 'tag_for_tests',
         }
         args = ['test.tar.gz', self.test_prefix, git_config]
 
@@ -2570,10 +2576,10 @@ class FileToolsTest(EnhancedTestCase):
         git_config = {
             'repo_name': 'testrepository',
             'url': 'git@github.com:easybuilders',
-            'tag': 'master',
+            'tag': 'tag_for_tests',
         }
         expected = '\n'.join([
-            r'  running command "git clone --branch master git@github.com:easybuilders/testrepository.git"',
+            r'  running command "git clone --branch refs/tags/tag_for_tests git@github.com:easybuilders/testrepository.git"',
             r"  \(in .*/tmp.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
             r"  \(in .*/tmp.*\)",
@@ -2582,7 +2588,7 @@ class FileToolsTest(EnhancedTestCase):
 
         git_config['recursive'] = True
         expected = '\n'.join([
-            r'  running command "git clone --branch master --recursive git@github.com:easybuilders/testrepository.git"',
+            r'  running command "git clone --branch refs/tags/tag_for_tests --recursive git@github.com:easybuilders/testrepository.git"',
             r"  \(in .*/tmp.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
             r"  \(in .*/tmp.*\)",
@@ -2591,7 +2597,7 @@ class FileToolsTest(EnhancedTestCase):
 
         git_config['keep_git_dir'] = True
         expected = '\n'.join([
-            r'  running command "git clone --branch master --recursive git@github.com:easybuilders/testrepository.git"',
+            r'  running command "git clone --branch refs/tags/tag_for_tests --recursive git@github.com:easybuilders/testrepository.git"',
             r"  \(in .*/tmp.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz testrepository"',
             r"  \(in .*/tmp.*\)",

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2496,9 +2496,10 @@ class FileToolsTest(EnhancedTestCase):
         target_dir = os.path.join(self.test_prefix, 'target')
 
         try:
-            ft.get_source_tarball_from_git('test.tar.gz', target_dir, git_config)
+            res = ft.get_source_tarball_from_git('test.tar.gz', target_dir, git_config)
             # (only) tarball is created in specified target dir
             test_file = os.path.join(target_dir, 'test.tar.gz')
+            self.assertEqual(res, test_file)
             self.assertTrue(os.path.isfile(test_file))
             self.assertEqual(os.listdir(target_dir), ['test.tar.gz'])
 
@@ -2509,8 +2510,10 @@ class FileToolsTest(EnhancedTestCase):
 
             del git_config['tag']
             git_config['commit'] = '8456f86'
-            ft.get_source_tarball_from_git('test2.tar.gz', target_dir, git_config)
-            self.assertTrue(os.path.isfile(os.path.join(target_dir, 'test2.tar.gz')))
+            res = ft.get_source_tarball_from_git('test2.tar.gz', target_dir, git_config)
+            test_file = os.path.join(target_dir, 'test2.tar.gz')
+            self.assertEqual(res, test_file)
+            self.assertTrue(os.path.isfile(test_file))
             self.assertEqual(sorted(os.listdir(target_dir)), ['test.tar.gz', 'test2.tar.gz'])
 
         except EasyBuildError as err:
@@ -2559,13 +2562,10 @@ class FileToolsTest(EnhancedTestCase):
 
         def run_check():
             """Helper function to run get_source_tarball_from_git & check dry run output"""
-            self.mock_stdout(True)
-            self.mock_stderr(True)
-            res = ft.get_source_tarball_from_git('test.tar.gz', target_dir, git_config)
-            stdout = self.get_stdout()
-            stderr = self.get_stderr()
-            self.mock_stdout(False)
-            self.mock_stderr(False)
+            with self.mocked_stdout_stderr():
+                res = ft.get_source_tarball_from_git('test.tar.gz', target_dir, git_config)
+                stdout = self.get_stdout()
+                stderr = self.get_stderr()
             self.assertEqual(stderr, '')
             regex = re.compile(expected)
             self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2515,54 +2515,55 @@ class FileToolsTest(EnhancedTestCase):
             'url': 'git@github.com:easybuilders',
             'tag': 'tag_for_tests',
         }
+        git_repo = {'git_repo': 'git@github.com:easybuilders/testrepository.git'}  # Just to make the below shorter
         expected = '\n'.join([
-            r'  running command "git clone --depth 1 --branch refs/tags/tag_for_tests git@github.com:easybuilders/testrepository.git"',
+            r'  running command "git clone --depth 1 --branch refs/tags/tag_for_tests %(git_repo)s"',
             r"  \(in .*/tmp.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
             r"  \(in .*/tmp.*\)",
-        ])
+        ]) % git_repo
         run_check()
 
         git_config['recursive'] = True
         expected = '\n'.join([
-            r'  running command "git clone --depth 1 --branch refs/tags/tag_for_tests --recursive git@github.com:easybuilders/testrepository.git"',
+            r'  running command "git clone --depth 1 --branch refs/tags/tag_for_tests --recursive %(git_repo)s"',
             r"  \(in .*/tmp.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
             r"  \(in .*/tmp.*\)",
-        ])
+        ]) % git_repo
         run_check()
 
         git_config['keep_git_dir'] = True
         expected = '\n'.join([
-            r'  running command "git clone --branch refs/tags/tag_for_tests --recursive git@github.com:easybuilders/testrepository.git"',
+            r'  running command "git clone --branch refs/tags/tag_for_tests --recursive %(git_repo)s"',
             r"  \(in .*/tmp.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz testrepository"',
             r"  \(in .*/tmp.*\)",
-        ])
+        ]) % git_repo
         run_check()
         del git_config['keep_git_dir']
 
         del git_config['tag']
         git_config['commit'] = '8456f86'
         expected = '\n'.join([
-            r'  running command "git clone --depth 1 --no-checkout git@github.com:easybuilders/testrepository.git"',
+            r'  running command "git clone --depth 1 --no-checkout %(git_repo)s"',
             r"  \(in .*/tmp.*\)",
             r'  running command "git checkout 8456f86 && git submodule update --init --recursive"',
             r"  \(in testrepository\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
             r"  \(in .*/tmp.*\)",
-        ])
+        ]) % git_repo
         run_check()
 
         del git_config['recursive']
         expected = '\n'.join([
-            r'  running command "git clone --depth 1 --no-checkout git@github.com:easybuilders/testrepository.git"',
+            r'  running command "git clone --depth 1 --no-checkout %(git_repo)s"',
             r"  \(in .*/tmp.*\)",
             r'  running command "git checkout 8456f86"',
             r"  \(in testrepository\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
             r"  \(in .*/tmp.*\)",
-        ])
+        ]) % git_repo
         run_check()
 
         # Test with real data
@@ -2630,7 +2631,6 @@ class FileToolsTest(EnhancedTestCase):
         error_pattern = "git_config currently only supports filename ending in .tar.gz"
         self.assertErrorRegex(EasyBuildError, error_pattern, ft.get_source_tarball_from_git, *args)
         args[0] = 'test.tar.gz'
-
 
     def test_is_sha256_checksum(self):
         """Test for is_sha256_checksum function."""

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2579,7 +2579,7 @@ class FileToolsTest(EnhancedTestCase):
             'tag': 'tag_for_tests',
         }
         expected = '\n'.join([
-            r'  running command "git clone --branch refs/tags/tag_for_tests git@github.com:easybuilders/testrepository.git"',
+            r'  running command "git clone --depth 1 --branch refs/tags/tag_for_tests git@github.com:easybuilders/testrepository.git"',
             r"  \(in .*/tmp.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
             r"  \(in .*/tmp.*\)",
@@ -2588,7 +2588,7 @@ class FileToolsTest(EnhancedTestCase):
 
         git_config['recursive'] = True
         expected = '\n'.join([
-            r'  running command "git clone --branch refs/tags/tag_for_tests --recursive git@github.com:easybuilders/testrepository.git"',
+            r'  running command "git clone --depth 1 --branch refs/tags/tag_for_tests --recursive git@github.com:easybuilders/testrepository.git"',
             r"  \(in .*/tmp.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
             r"  \(in .*/tmp.*\)",
@@ -2608,7 +2608,7 @@ class FileToolsTest(EnhancedTestCase):
         del git_config['tag']
         git_config['commit'] = '8456f86'
         expected = '\n'.join([
-            r'  running command "git clone --recursive git@github.com:easybuilders/testrepository.git"',
+            r'  running command "git clone --depth 1 --no-checkout git@github.com:easybuilders/testrepository.git"',
             r"  \(in .*/tmp.*\)",
             r'  running command "git checkout 8456f86 && git submodule update --init --recursive"',
             r"  \(in testrepository\)",
@@ -2619,7 +2619,7 @@ class FileToolsTest(EnhancedTestCase):
 
         del git_config['recursive']
         expected = '\n'.join([
-            r'  running command "git clone git@github.com:easybuilders/testrepository.git"',
+            r'  running command "git clone --depth 1 --no-checkout git@github.com:easybuilders/testrepository.git"',
             r"  \(in .*/tmp.*\)",
             r'  running command "git checkout 8456f86"',
             r"  \(in testrepository\)",

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2589,7 +2589,10 @@ class FileToolsTest(EnhancedTestCase):
 
             # use a tag that clashes with a branch name and make sure this is handled correctly
             git_config['tag'] = 'tag_for_tests'
-            res = ft.get_source_tarball_from_git('test.tar.gz', target_dir, git_config)
+            with self.mocked_stdout_stderr():
+                res = ft.get_source_tarball_from_git('test.tar.gz', target_dir, git_config)
+                stderr = self.get_stderr()
+            self.assertIn('Tag tag_for_tests was not downloaded in the first try', stderr)
             self.assertEqual(res, test_file)
             self.assertTrue(os.path.isfile(test_file))
             # Check that we indeed downloaded the tag and not the branch


### PR DESCRIPTION
The `git clone` command accept a `--branch` argument to clone a specific branch.
We use that to clone/download as tarball tags as it also accepts tags as the branch-argument.

However in case there is both a branch and a tag with the same name (happened in PyTorch) this will download the branch instead.

As contrary to `git checkout` `git clone --branch` does not accept neither a commit nor a direct tag reference (`refs/tags/foo`) we cannot reliably clone a tag only. But doing so (especially with `--depth 1` aka "shallow clone") is considerably faster and saves bandwidth.

So the current solution assumes that no branch with the same name as the tag exists and does the clone as before. It then checks, if we indeed cloned a tag
We could error out here, or (as done now) fetch the full history (as in a full clone) and check out the tag and submodules via `refs/tags/foo`.

--> In almost all cases the download is as fast as possible and it still works in the naughty case where maintainers screwed up and created a branch with the same name as a tag.