### PR TITLE
Allow optarch values to be partial maps including vector extensions

### DIFF
--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -74,13 +74,15 @@ class IntelIccIfort(Compiler):
 
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {
-        (systemtools.X86_64, systemtools.AMD): '-xHost',
-        (systemtools.X86_64, systemtools.INTEL): '-xHost',
+        systemtools.X86_64: 'xHost',
+        # Intel compilers don't auto-detect AMD features and default to SSE2
+        (systemtools.X86_64, systemtools.AMD, systemtools.SSSE3): 'mssse3',
+        (systemtools.X86_64, systemtools.AMD, systemtools.SSE4_2): 'msse4.2',
+        (systemtools.X86_64, systemtools.AMD, systemtools.AVX2): 'march=core-avx2',
     }
     # used with --optarch=GENERIC
     COMPILER_GENERIC_OPTION = {
-        (systemtools.X86_64, systemtools.AMD): '-xSSE2',
-        (systemtools.X86_64, systemtools.INTEL): '-xSSE2',
+        systemtools.X86_64: 'xSSE2',
     }
 
     COMPILER_CC = 'icc'

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -74,15 +74,15 @@ class IntelIccIfort(Compiler):
 
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {
-        systemtools.X86_64: 'xHost',
+        systemtools.X86_64: '-xHost',
         # Intel compilers don't auto-detect AMD features and default to SSE2
-        (systemtools.X86_64, systemtools.AMD, systemtools.SSSE3): 'mssse3',
-        (systemtools.X86_64, systemtools.AMD, systemtools.SSE4_2): 'msse4.2',
-        (systemtools.X86_64, systemtools.AMD, systemtools.AVX2): 'march=core-avx2',
+        (systemtools.X86_64, systemtools.AMD, systemtools.SSSE3): '-mssse3',
+        (systemtools.X86_64, systemtools.AMD, systemtools.SSE4_2): '-msse4.2',
+        (systemtools.X86_64, systemtools.AMD, systemtools.AVX2): '-march=core-avx2',
     }
     # used with --optarch=GENERIC
     COMPILER_GENERIC_OPTION = {
-        systemtools.X86_64: 'xSSE2',
+        systemtools.X86_64: '-xSSE2',
     }
 
     COMPILER_CC = 'icc'

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -118,6 +118,9 @@ ARCH_KEY_PREFIX = 'arch='
 # Vector extension constants
 SSE = 'sse'
 SSE2 = 'sse2'
+SSSE3 = 'ssse3'
+SSE4_1 = 'sse4_1'
+SSE4_2 = 'sse4_2'
 AVX = 'avx'
 AVX2 = 'avx2'
 AVX512F = 'avx512f'
@@ -157,7 +160,7 @@ CPU_ARCHITECTURES = [AARCH32, AARCH64, POWER, RISCV32, RISCV64, X86_64]
 CPU_FAMILIES = [AMD, ARM, INTEL, POWER, POWER_LE, RISCV]
 CPU_VENDORS = [AMD, APM, APPLE, ARM, BROADCOM, CAVIUM, DEC, IBM, INTEL, MARVELL, MOTOROLA, NVIDIA, QUALCOMM]
 # Vector extensions of CPUs in ascending order (later => better)
-CPU_VECTOR_EXTS = [SSE, SSE2, AVX, AVX2, AVX512F]
+CPU_VECTOR_EXTS = [SSE, SSE2, SSSE3, SSE4_1, SSE4_2, AVX, AVX2, AVX512F]
 # ARM implementer IDs (i.e., the hexadeximal keys) taken from ARMv8-A Architecture Reference Manual
 # (ARM DDI 0487A.j, Section G6.2.102, Page G6-4493)
 VENDOR_IDS = {

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -1557,6 +1557,8 @@ def pick_opt_arch(options, arch, cpu_family, vector_exts):
         yield (arch, )
         # Also allow single string entry
         yield arch
+        # Default fallback for any arch
+        yield None
 
     result = None
     for key in create_possible_keys():

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -115,6 +115,13 @@ KNOWN_ARCH_CONSTANTS = ('aarch64', 'ppc64le', 'riscv64', 'x86_64')
 
 ARCH_KEY_PREFIX = 'arch='
 
+# Vector extension constants
+SSE = 'sse'
+SSE2 = 'sse2'
+AVX = 'avx'
+AVX2 = 'avx2'
+AVX512F = 'avx512f'
+
 # Vendor constants
 AMD = 'AMD'
 APM = 'Applied Micro'
@@ -149,6 +156,8 @@ PROC_MEMINFO_FP = '/proc/meminfo'
 CPU_ARCHITECTURES = [AARCH32, AARCH64, POWER, RISCV32, RISCV64, X86_64]
 CPU_FAMILIES = [AMD, ARM, INTEL, POWER, POWER_LE, RISCV]
 CPU_VENDORS = [AMD, APM, APPLE, ARM, BROADCOM, CAVIUM, DEC, IBM, INTEL, MARVELL, MOTOROLA, NVIDIA, QUALCOMM]
+# Vector extensions of CPUs in ascending order (later => better)
+CPU_VECTOR_EXTS = [SSE, SSE2, AVX, AVX2, AVX512F]
 # ARM implementer IDs (i.e., the hexadeximal keys) taken from ARMv8-A Architecture Reference Manual
 # (ARM DDI 0487A.j, Section G6.2.102, Page G6-4493)
 VENDOR_IDS = {
@@ -668,6 +677,13 @@ def get_isa_riscv():
     else:
         _log.debug(f"Could not determine ISA string (OS: {os_type}), defaulting to {isa_string}")
     return isa_string
+
+
+def get_cpu_vector_exts():
+    """Get list of (relevant) CPU vector extensions"""
+    cpu_features = set(get_cpu_features())
+    # Values of the vector extension constants purposely match the cpu feature value
+    return [i for i in CPU_VECTOR_EXTS if i in cpu_features]
 
 
 def get_gpu_info(environment=None):
@@ -1517,6 +1533,35 @@ def pick_dep_version(dep_version):
             typ = type(dep_version)
             raise EasyBuildError("Unknown value type for version: %s (%s), should be string value", typ, dep_version)
 
+    return result
+
+
+def pick_opt_arch(options, arch, cpu_family, vector_exts):
+    """
+    Pick the best matching entry from the options dict based on CPU arch and features
+
+    :param options: Dictionary mapping tuples of system specs to optarchs.
+                    E.g. (X86_64, AMD, AVX2): 'mavx2'
+    :param arch: Current CPU arch
+    :param cpu_family: Current CPU family
+    :param vector_exts: Vector extensions supported by current CPU
+    """
+    def create_possible_keys():
+        """Yield a list of possible keys from most specific to least specific"""
+        for ext in vector_exts:
+            yield (arch, cpu_family, ext)
+        yield (arch, cpu_family)
+        yield (arch, )
+        # Also allow single string entry
+        yield arch
+
+    result = None
+    for key in create_possible_keys():
+        try:
+            result = options[key]
+            break
+        except KeyError:
+            pass
     return result
 
 

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -31,9 +31,11 @@ Authors:
 * Kenneth Hoste (Ghent University)
 * Damian Alvarez (Forschungszentrum Juelich GmbH)
 """
+from easybuild.base import fancylogger
 from easybuild.tools import systemtools
 from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option
+from easybuild.tools.systemtools import CPU_ARCHITECTURES, CPU_FAMILIES, CPU_VECTOR_EXTS
 from easybuild.tools.toolchain.constants import COMPILER_VARIABLES
 from easybuild.tools.toolchain.toolchain import Toolchain
 
@@ -48,6 +50,8 @@ OPTARCH_GENERIC = 'GENERIC'
 OPTARCH_SEP = ';'
 OPTARCH_MAP_CHAR = ':'
 
+_log = fancylogger.getLogger('compiler', fname=False)
+
 
 def mk_infix(prefix):
     """Create an infix based on the given prefix."""
@@ -55,6 +59,99 @@ def mk_infix(prefix):
     if prefix is not None:
         infix = '%s_' % prefix
     return infix
+
+
+def parse_optarch_string(optarch, include_compiler):
+    """
+    Parse an optarch string into a dict if multiple options are found, else keeps it as a string
+
+    Format: optarch := <string>|<map>
+            map     := <entry>(;<space>*<entry>)*
+            include_compiler is True:
+              entry := <compiler>(,<cpu-arch>(,<cpu-family>?(,<vector-ext>)?)?)?:<flag-string>
+            include_compiler is False:
+              entry := <cpu-arch>(,<cpu-family>(,<vector-ext>)?)?:<flag-string>
+    Example values:
+        "GENERIC"
+        "march=native"
+        "Intel,x86:xHost; Intel,x86,AMD,AVX2:mavx2 -fma; GCC:march=native"
+    """
+    # Split into entries, and each entry into key-value pairs
+    optarch_parts = [i.strip().split(OPTARCH_MAP_CHAR) for i in optarch.split(OPTARCH_SEP)]
+
+    # We should either have a single value or a list of key-value pairs, and nothing else
+    is_single_value = len(optarch_parts) == 1 and len(optarch_parts[0]) == 1
+    if not is_single_value and any(len(i) != 2 for i in optarch_parts):
+        raise EasyBuildError("The optarch option has an incorrect syntax: %s", optarch)
+
+    # if there are options for different compilers, we set up a dict
+    if is_single_value:
+        # if optarch is not in mapping format, we do nothing and just keep the string
+        _log.info("Keeping optarch raw: %s", optarch)
+    else:
+        optarch_dict = {}
+        for key, compiler_opt in optarch_parts:
+            # key can be either a compiler (only) or compiler and archspec(s)
+            key_parts = key.split(',')
+            if include_compiler:
+                compiler = key_parts.pop(0)
+            elif not key:
+                # When no compiler is present an empty key is the default fallback
+                key_parts = None
+            if key_parts:
+                # Validate
+                allowed_values_list = (CPU_ARCHITECTURES, CPU_FAMILIES, CPU_VECTOR_EXTS)
+                if len(key_parts) > len(allowed_values_list):
+                    raise EasyBuildError("The optarch option has an incorrect syntax: %s\n"
+                                         "'%s' should be of the format: <cpu-arch>,<cpu-family>,<vector-ext> "
+                                         "where trailing elements can be ommitted.",
+                                         optarch, key_parts)
+                for i, (part, allowed_values) in enumerate(zip(key_parts, allowed_values_list)):
+                    if part not in allowed_values:
+                        # Try again fixing up casing
+                        try:
+                            idx = [value.lower() for value in allowed_values].index(part.lower())
+                        except ValueError:  # Thrown when item does not exist
+                            raise EasyBuildError("The optarch option has an incorrect syntax: %s\n"
+                                                 "'%s' of '%s' is not in allowed values: %s",
+                                                 optarch, part, key, allowed_values)
+                        key_parts[i] = allowed_values[idx]
+                arch_specs = tuple(key_parts) if len(key_parts) > 1 else key_parts[0]
+            else:
+                arch_specs = None
+            # If we include the compiler, the optarch dict has it as the first level
+            # Else we use the optarch dict directly
+            if include_compiler:
+                try:
+                    compiler_dict = optarch_dict[compiler]
+                except KeyError:
+                    # Keep the dict flat when no archspecs are given
+                    if arch_specs is None:
+                        optarch_dict[compiler] = compiler_opt
+                    else:
+                        optarch_dict[compiler] = {arch_specs: compiler_opt}
+                    # All done
+                    continue
+                # Convert single entry to dict if required
+                if not isinstance(compiler_dict, dict):
+                    compiler_dict = {None: compiler_dict}
+                    optarch_dict[compiler] = compiler_dict
+            else:
+                compiler_dict = optarch_dict
+            # Disallow duplicates
+            if arch_specs in compiler_dict:
+                if arch_specs is None:
+                    raise EasyBuildError("The optarch option contains a duplicated entry for compiler %s: %s",
+                                         compiler, optarch)
+                else:
+                    raise EasyBuildError("The optarch option contains a duplicated entry %s "
+                                         "for compiler %s: %s",
+                                         arch_specs, compiler, optarch)
+            else:
+                compiler_dict[arch_specs] = compiler_opt
+        _log.info("Transforming optarch into a dict: %s", optarch_dict)
+        optarch = optarch_dict
+    return optarch
 
 
 class Compiler(Toolchain):
@@ -366,32 +463,29 @@ class Compiler(Toolchain):
         """
         ec_optarch = self.options.get('optarch')
         if isinstance(ec_optarch, str):
-            if OPTARCH_MAP_CHAR in ec_optarch:
-                error_msg = "When setting optarch in the easyconfig (found %s), " % ec_optarch
-                error_msg += "the <compiler%sflags> syntax is not allowed. " % OPTARCH_MAP_CHAR
-                error_msg += "Use <flags> (omitting the first dash) for the specific compiler."
-                raise EasyBuildError(error_msg)
-            else:
-                optarch = ec_optarch
+            optarch = parse_optarch_string(ec_optarch, include_compiler=False)
+            optarch = self._pick_optarch_entry(optarch)
         else:
+            # TODO: Maybe parse optarch from cmdline here?
             optarch = build_option('optarch')
 
-        # --optarch is specified with flags to use
-        if isinstance(optarch, dict):
-            # optarch has been validated as complex string with multiple compilers and converted to a dictionary
-            # first try module names, then the family in optarch
-            current_compiler_names = self.COMPILER_MODULE_NAME or []
-            if self.COMPILER_FAMILY:
-                current_compiler_names.append(self.COMPILER_FAMILY)
-            compiler_optarch = None
-            for current_compiler in current_compiler_names:
-                if current_compiler in optarch:
-                    compiler_optarch = optarch[current_compiler]
-                    break
-            if compiler_optarch is None:
-                self.log.info("_set_optimal_architecture: no optarch found for compiler %s. Ignoring option.",
-                              current_compiler_names)
-            optarch = self._pick_optarch_entry(compiler_optarch)
+            # --optarch is specified with flags to use
+            if isinstance(optarch, dict):
+                # optarch has been validated as complex string with multiple compilers and converted to a dictionary
+                # first try module names, then the family in optarch
+                current_compiler_names = self.COMPILER_MODULE_NAME or []
+                if self.COMPILER_FAMILY:
+                    # Create new list to NOT modify self.COMPILER_MODULE_NAME
+                    current_compiler_names = current_compiler_names + [self.COMPILER_FAMILY]
+                compiler_optarch = None
+                for current_compiler in current_compiler_names:
+                    if current_compiler in optarch:
+                        compiler_optarch = optarch[current_compiler]
+                        break
+                if compiler_optarch is None:
+                    self.log.info("_set_optimal_architecture: no optarch found for compiler %s. Ignoring option.",
+                                  current_compiler_names)
+                optarch = self._pick_optarch_entry(compiler_optarch)
 
         if isinstance(optarch, str):
             use_generic = (optarch == OPTARCH_GENERIC)

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -73,8 +73,8 @@ def parse_optarch_string(optarch, include_compiler):
               entry := <cpu-arch>(,<cpu-family>(,<vector-ext>)?)?:<flag-string>
     Example values:
         "GENERIC"
-        "march=native"
-        "Intel,x86:xHost; Intel,x86,AMD,AVX2:mavx2 -fma; GCC:march=native"
+        "-march=native"
+        "Intel,x86:-xHost; Intel,x86,AMD,AVX2:-mavx2 -fma; GCC:-march=native"
     """
     # Split into entries, and each entry into key-value pairs
     optarch_parts = [i.strip().split(OPTARCH_MAP_CHAR) for i in optarch.split(OPTARCH_SEP)]

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5868,40 +5868,40 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, error_msg, options.postprocess)
 
         # Check the parsing itself
-        gcc_generic_flags = "march=x86-64 -mtune=generic"
+        gcc_generic_flags = "-march=x86-64 -mtune=generic"
         test_cases = [
             ('', ''),
-            ('xHost', 'xHost'),
+            ('-xHost', '-xHost'),
             ('GENERIC', 'GENERIC'),
-            ('Intel:xHost', {'Intel': 'xHost'}),
+            ('Intel:-xHost', {'Intel': '-xHost'}),
             ('Intel:GENERIC', {'Intel': 'GENERIC'}),
-            ('Intel:xHost;GCC:%s' % gcc_generic_flags, {'Intel': 'xHost', 'GCC': gcc_generic_flags}),
+            ('Intel:-xHost;GCC:%s' % gcc_generic_flags, {'Intel': '-xHost', 'GCC': gcc_generic_flags}),
             # Allow empty values and spaces
             ('Intel:; GCC:%s' % gcc_generic_flags, {'Intel': '', 'GCC': gcc_generic_flags}),
             # Arch specific values. With Compiler only selection at different places in the list
             (
-                'Intel,x86_64,Intel,sse:i86iSSE; Intel,x86_64,AMD:i86AMD; Intel,POWER:iPwr; Intel:xHost; '
-                'GCC:GENERIC; Clang:cl; Clang,POWER:clPwr',
+                'Intel,x86_64,Intel,sse:-i86iSSE; Intel,x86_64,AMD:-i86AMD; Intel,POWER:-iPwr; Intel:-xHost; '
+                'GCC:GENERIC; Clang:-cl; Clang,POWER:-clPwr',
                 {
                     'Intel': {
-                        ('x86_64', 'Intel', 'sse'): 'i86iSSE',
-                        ('x86_64', 'AMD'): 'i86AMD',
-                        'POWER': 'iPwr',
-                        None: 'xHost',
+                        ('x86_64', 'Intel', 'sse'): '-i86iSSE',
+                        ('x86_64', 'AMD'): '-i86AMD',
+                        'POWER': '-iPwr',
+                        None: '-xHost',
                     },
                     'GCC': 'GENERIC',
                     'Clang': {
-                        None: 'cl',
-                        'POWER': 'clPwr',
+                        None: '-cl',
+                        'POWER': '-clPwr',
                     },
                 },
             ),
             (
                 # Case insensitive arch values
-                'Intel,X86_64,intel,SSE:i86iSSE; Clang,POWER:clPwr',
+                'Intel,X86_64,intel,SSE:-i86iSSE; Clang,POWER:-clPwr',
                 {
-                    'Intel': {('x86_64', 'Intel', 'sse'): 'i86iSSE'},
-                    'Clang': {'POWER': 'clPwr'},
+                    'Intel': {('x86_64', 'Intel', 'sse'): '-i86iSSE'},
+                    'Clang': {'POWER': '-clPwr'},
                 },
             ),
         ]

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5863,7 +5863,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         options.options.optarch = 'Intel:something;GCC:somethingelse;Intel:anothersomething'
         self.assertErrorRegex(EasyBuildError, error_msg, options.postprocess)
 
-        error_msg = "'x86' of 'x86' is not in allowed values"
+        error_msg = "'x86' of 'Intel,x86' is not in allowed values"
         options.options.optarch = 'Intel,x86:something'
         self.assertErrorRegex(EasyBuildError, error_msg, options.postprocess)
 
@@ -5894,6 +5894,14 @@ class CommandLineOptionsTest(EnhancedTestCase):
                         None: 'cl',
                         'POWER': 'clPwr',
                     },
+                },
+            ),
+            (
+                # Case insensitive arch values
+                'Intel,X86_64,intel,SSE:i86iSSE; Clang,POWER:clPwr',
+                {
+                    'Intel': {('x86_64', 'Intel', 'sse'): 'i86iSSE'},
+                    'Clang': {'POWER': 'clPwr'},
                 },
             ),
         ]

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -1225,6 +1225,30 @@ class SystemToolsTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, error_pattern, pick_system_specific_value, 'test-desc',
                               {'foo': '1', 'arch=POWER': '2'})
 
+    def test_pick_opt_arch(self):
+        """Test pick_opt_arch"""
+        options = {
+            (st.X86_64, ): 'opt-x86',
+            (st.X86_64, st.AMD): 'opt-amd',
+            (st.X86_64, st.AMD, st.AVX2): 'opt-amd-avx2',
+            (st.AARCH32, st.INTEL): 'opt-aarch32',
+            st.AARCH64: 'opt-aarch64',
+            (st.AARCH64, st.INTEL, st.SSE): 'opt-aarch64-sse',
+        }
+        avx = [st.SSE, st.SSE2, st.AVX]
+        avx2 = avx + [st.AVX2]
+        avx512 = avx2 + [st.AVX512F]
+        self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.INTEL, avx2), 'opt-x86')
+        self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.INTEL, []), 'opt-x86')
+        self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.AMD, avx), 'opt-amd')
+        self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.AMD, avx2), 'opt-amd-avx2')
+        self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.AMD, avx512), 'opt-amd-avx2')
+        self.assertEqual(st.pick_opt_arch(options, st.AARCH64, st.AMD, avx2), 'opt-aarch64')
+        self.assertEqual(st.pick_opt_arch(options, st.AARCH64, st.INTEL, avx2), 'opt-aarch64-sse')
+        self.assertEqual(st.pick_opt_arch(options, st.AARCH64, st.INTEL, [st.SSE]), 'opt-aarch64-sse')
+        self.assertEqual(st.pick_opt_arch(options, st.AARCH32, st.AMD, avx2), None)
+        self.assertEqual(st.pick_opt_arch(options, st.POWER, st.IBM, []), None)
+
     def test_check_os_dependency(self):
         """Test check_os_dependency."""
 

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -1238,16 +1238,24 @@ class SystemToolsTest(EnhancedTestCase):
         avx = [st.SSE, st.SSE2, st.AVX]
         avx2 = avx + [st.AVX2]
         avx512 = avx2 + [st.AVX512F]
-        self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.INTEL, avx2), 'opt-x86')
-        self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.INTEL, []), 'opt-x86')
-        self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.AMD, avx), 'opt-amd')
-        self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.AMD, avx2), 'opt-amd-avx2')
-        self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.AMD, avx512), 'opt-amd-avx2')
-        self.assertEqual(st.pick_opt_arch(options, st.AARCH64, st.AMD, avx2), 'opt-aarch64')
-        self.assertEqual(st.pick_opt_arch(options, st.AARCH64, st.INTEL, avx2), 'opt-aarch64-sse')
-        self.assertEqual(st.pick_opt_arch(options, st.AARCH64, st.INTEL, [st.SSE]), 'opt-aarch64-sse')
-        self.assertEqual(st.pick_opt_arch(options, st.AARCH32, st.AMD, avx2), None)
-        self.assertEqual(st.pick_opt_arch(options, st.POWER, st.IBM, []), None)
+        for include_none in (False, True):
+            if include_none:
+                # Special fallback option when no entry matches
+                options[None] = 'opt-none'
+            self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.INTEL, avx2), 'opt-x86')
+            self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.INTEL, []), 'opt-x86')
+            self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.AMD, avx), 'opt-amd')
+            self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.AMD, avx2), 'opt-amd-avx2')
+            self.assertEqual(st.pick_opt_arch(options, st.X86_64, st.AMD, avx512), 'opt-amd-avx2')
+            self.assertEqual(st.pick_opt_arch(options, st.AARCH64, st.AMD, avx2), 'opt-aarch64')
+            self.assertEqual(st.pick_opt_arch(options, st.AARCH64, st.INTEL, avx2), 'opt-aarch64-sse')
+            self.assertEqual(st.pick_opt_arch(options, st.AARCH64, st.INTEL, [st.SSE]), 'opt-aarch64-sse')
+            if include_none:
+                self.assertEqual(st.pick_opt_arch(options, st.AARCH32, st.AMD, avx2), 'opt-none')
+                self.assertEqual(st.pick_opt_arch(options, st.POWER, st.IBM, []), 'opt-none')
+            else:
+                self.assertEqual(st.pick_opt_arch(options, st.AARCH32, st.AMD, avx2), None)
+                self.assertEqual(st.pick_opt_arch(options, st.POWER, st.IBM, []), None)
 
     def test_check_os_dependency(self):
         """Test check_os_dependency."""

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -821,11 +821,19 @@ class ToolchainTest(EnhancedTestCase):
             optarch_var['Intel'] = intel_flags
             optarch_var['GCC'] = gcc_flags
             optarch_var['GCCcore'] = gcccore_flags
+
+            # Save current tmp dir
+            old_vars = {name: os.environ.get(name) for name in ('TMPDIR', 'TEMP', 'TMP')}
+
             init_config(build_options={'optarch': optarch_var, 'silent': True})
             tc = self.get_toolchain(toolchain_name, version=toolchain_ver)
             tc.set_options({'optarch': enable})
             with self.mocked_stdout_stderr():
                 tc.prepare()
+
+            # Restore tmp dir
+            os.environ.update(old_vars)
+
             flags = None
             if toolchain_name == 'iccifort':
                 flags = intel_flags_exp

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -890,17 +890,17 @@ class ToolchainTest(EnhancedTestCase):
         toy_txt = read_file(eb_file)
 
         # check that using compilers in optarch raises an error
-        write_file(test_ec, toy_txt + "\ntoolchainopts = {'optarch': 'GCC:march=sandybridge;Intel:xAVX'}")
+        write_file(test_ec, toy_txt + "\ntoolchainopts = {'optarch': 'GCC:-march=sandybridge;Intel:-xAVX'}")
         msg = "The optarch option has an incorrect syntax"
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, msg, self.eb_main, [test_ec], raise_error=True, do_build=True)
 
         # check that setting optarch flags work
         test_cases = [
-            ('march=sandybridge', 'march=sandybridge'),
+            ('-march=sandybridge', '-march=sandybridge'),
             # <cpu-arch>,<cpu-family>,<vector-ext>
-            ('POWER,POWER:march=ppc; x86_64,Intel,AVX:march=avx', 'march=avx'),
-            ('POWER,POWER:march=ppc; x86_64,Intel,AVX2:march=avx; :GENERIC', 'march=x86-64 -mtune=generic'),
+            ('POWER,POWER:-march=ppc; x86_64,Intel,AVX:-march=avx', '-march=avx'),
+            ('POWER,POWER:-march=ppc; x86_64,Intel,AVX2:-march=avx; :GENERIC', '-march=x86-64 -mtune=generic'),
         ]
         with mock_object(st, 'get_cpu_arch_name', lambda: st.X86_64), \
                 mock_object(st, 'get_cpu_family', lambda: st.INTEL), \

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -4335,8 +4335,8 @@ class ToyBuildTest(EnhancedTestCase):
 
             all_args = extra_args + opts
 
-            # use context manager to remove lock after 3 seconds
-            with RemoveLockAfter(3, toy_lock_path):
+            # use context manager to remove lock after 5 seconds
+            with RemoveLockAfter(5, toy_lock_path):
                 self.mock_stderr(True)
                 self.mock_stdout(True)
                 self._test_toy_build(extra_args=all_args, verify=False, raise_error=True, testing=False)
@@ -4348,7 +4348,7 @@ class ToyBuildTest(EnhancedTestCase):
 
                 wait_matches = wait_regex.findall(stdout)
                 # we can't rely on an exact number of 'waiting' messages, so let's go with a range...
-                self.assertIn(len(wait_matches), range(1, 5))
+                self.assertIn(len(wait_matches), range(1, 7))
 
                 self.assertTrue(ok_regex.search(stdout), "Pattern '%s' found in: %s" % (ok_regex.pattern, stdout))
 

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -84,6 +84,17 @@ for key in list(os.environ):
         os.environ[newkey] = val
 
 
+@contextmanager
+def mock_object(target, attribute, new_value):
+    """Patch the named attribute/member of the given target object with the new_value"""
+    old_value = getattr(target, attribute)
+    setattr(target, attribute, new_value)
+    try:
+        yield
+    finally:
+        setattr(target, attribute, old_value)
+
+
 class EnhancedTestCase(TestCase):
     """Enhanced test case, provides extra functionality (e.g. an assertErrorRegex method)."""
 


### PR DESCRIPTION
Instead of only setting optimal compiler arguments based on architecture and CPU family/vendor also include the supported vector extensions as criteria to choose flags.
To simplify specifying generic flags allow partial matches, e.g. a fallback setting for any x86 arch which doesn't have more specific values.
Example:
```
    COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {
        (systemtools.X86_64, ): 'xHost',
        (systemtools.X86_64, systemtools.AMD, systemtools.AVX2): 'mavx2',
    }
```

Closes #3793