### PR TITLE
fix CI by excluding GC3Pie 2.6.7 (which is broken with Python 2) and improve error reporting for option parsing

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1392,7 +1392,7 @@ def parse_options(args=None, with_include=True):
         eb_go = EasyBuildOptions(usage=usage, description=description, prog='eb', envvar_prefix=CONFIG_ENV_VAR_PREFIX,
                                  go_args=eb_args, error_env_options=True, error_env_option_method=raise_easybuilderror,
                                  with_include=with_include)
-    except Exception as err:
+    except EasyBuildError as err:
         raise EasyBuildError("Failed to parse configuration options: %s" % err)
 
     return eb_go

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,8 @@ pycodestyle; python_version < '2.7'
 flake8; python_version >= '2.7'
 
 # 2.6.7 uses invalid Python 2 syntax
-GC3Pie!=2.6.7
+GC3Pie!=2.6.7; python_version < '3.0'
+GC3Pie; python_version >= '3.0'
 python-graph-dot
 python-hglib
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,8 @@ PyYAML; python_version >= '2.7'
 pycodestyle; python_version < '2.7'
 flake8; python_version >= '2.7'
 
-GC3Pie
+# 2.6.7 uses invalid Python 2 syntax
+GC3Pie!=2.6.7
 python-graph-dot
 python-hglib
 requests


### PR DESCRIPTION
GC3Pie 2.6.7 has a bug which makes it fail to import on Python2 fixed with https://github.com/gc3pie/gc3pie/commit/db8275470f2afa90192152994cc9cd73acb3c2af

Also our error reporting doesn't really help to find this as it just says: `Failed to parse configuration options: invalid syntax (__init__.py, line 2159)` which isn't exactly helpful
Hence only catch our error