### PR TITLE
check type of source_tmpl value for extensions, ensure it's a string value (not a list)

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -593,7 +593,13 @@ class EasyBlock(object):
                         default_source_tmpl = resolve_template('%(name)s-%(version)s.tar.gz', template_values)
 
                         # if no sources are specified via 'sources', fall back to 'source_tmpl'
-                        src_fn = ext_options.get('source_tmpl', default_source_tmpl)
+                        src_fn = ext_options.get('source_tmpl')
+                        if src_fn is None:
+                            src_fn = default_source_tmpl
+                        elif not isinstance(src_fn, string_type):
+                            error_msg = "source_tmpl value must be a string! (found value of type '%s'): %s"
+                            raise EasyBuildError(error_msg, type(src_fn).__name__, src_fn)
+
                         src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,
                                                     force_download=force_download)
                         if src_path:

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1052,6 +1052,33 @@ class EasyBlockTest(EnhancedTestCase):
         error_pattern = "ConfigureMake easyblock can not be used to install extensions"
         self.assertErrorRegex(EasyBuildError, error_pattern, eb.init_ext_instances)
 
+    def test_extension_source_tmpl(self):
+        """Test type checking for 'source_tmpl' value of an extension."""
+        self.contents = '\n'.join([
+            "easyblock = 'ConfigureMake'",
+            "name = 'toy'",
+            "version = '0.0'",
+            "homepage = 'https://example.com'",
+            "description = 'test'",
+            "toolchain = SYSTEM",
+            "exts_list = [",
+            "    ('bar', '0.0', {",
+            "         'source_tmpl': [SOURCE_TAR_GZ],",
+            "    }),",
+            "]",
+        ])
+        self.writeEC()
+        eb = EasyBlock(EasyConfig(self.eb_file))
+
+        error_pattern = r"source_tmpl value must be a string! "
+        error_pattern += r"\(found value of type 'list'\): \['bar-0\.0\.tar\.gz'\]"
+        self.assertErrorRegex(EasyBuildError, error_pattern, eb.fetch_step)
+
+        self.contents = self.contents.replace("'source_tmpl': [SOURCE_TAR_GZ]", "'source_tmpl': SOURCE_TAR_GZ")
+        self.writeEC()
+        eb = EasyBlock(EasyConfig(self.eb_file))
+        eb.fetch_step()
+
     def test_skip_extensions_step(self):
         """Test the skip_extensions_step"""
 


### PR DESCRIPTION
Without the changes in `easyblock.py`, the added test fails with:

```
ERROR: test_extension_source_tmpl (__main__.EasyBlockTest)
Test type checking for 'source_tmpl' value of an extension.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Volumes/work/easybuild-framework/test/framework/easyblock.py", line 1075, in test_extension_source_tmpl
    self.assertErrorRegex(EasyBuildError, error_pattern, eb.fetch_step)
  File "/Volumes/work/easybuild-framework/easybuild/base/testing.py", line 155, in assertErrorRegex
    call(*args, **kwargs)
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyblock.py", line 1972, in fetch_step
    self.exts = self.fetch_extension_sources(skip_checksums=skip_checksums)
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyblock.py", line 597, in fetch_extension_sources
    src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyblock.py", line 682, in obtain_file
    if re.match(r"^(https?|ftp)://", filename):
  File "/usr/local/Cellar/python@3.9/3.9.5/Frameworks/Python.framework/Versions/3.9/lib/python3.9/re.py", line 191, in match
    return _compile(pattern, flags).match(string)
TypeError: expected string or bytes-like object

----------------------------------------------------------------------
Ran 1 test in 0.187s

FAILED (errors=1)
```

which reproduces the problem reported in https://github.com/easybuilders/easybuild-easyconfigs/issues/13657

With the changes included in this PR, we get a clean/clear error:

```
$ eb foo.eb
...
ERROR: Build of /home/example/foo.eb failed (err: "build failed (first 300 chars): source_tmpl value must be a string! (found value of type 'list'): ['isodate-0.6.0-py2.py3-none-any.whl']")
```