### PR TITLE
add get_cuda_cc_template_value method to EasyConfig class

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1814,7 +1814,7 @@ class EasyConfig(object):
             try:
                 return self.template_values[key]
             except KeyError:
-                error_msg = "(get_cuda_cc_template_value) Template value '%s' is not defined!\n"
+                error_msg = "Template value '%s' is not defined!\n"
                 error_msg += "Make sure that either the --cuda-compute-capabilities EasyBuild configuration "
                 error_msg += "option is set, or that the cuda_compute_capabilities easyconfig parameter is defined."
                 raise EasyBuildError(error_msg, key)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1819,7 +1819,7 @@ class EasyConfig(object):
                 error_msg += "option is set, or that the cuda_compute_capabilities easyconfig parameter is defined."
                 raise EasyBuildError(error_msg, key)
         else:
-            error_msg = "%s is not a template value baed on --cuda-compute-capabilities/cuda_compute_capabilities"
+            error_msg = "%s is not a template value based on --cuda-compute-capabilities/cuda_compute_capabilities"
             raise EasyBuildError(error_msg, key)
 
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -59,7 +59,7 @@ from easybuild.framework.easyconfig.format.yeb import YEB_FORMAT_EXTENSION, is_y
 from easybuild.framework.easyconfig.licenses import EASYCONFIG_LICENSES_DICT
 from easybuild.framework.easyconfig.parser import DEPRECATED_PARAMETERS, REPLACED_PARAMETERS
 from easybuild.framework.easyconfig.parser import EasyConfigParser, fetch_parameters_from_easyconfig
-from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS, template_constant_dict
+from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS, TEMPLATE_NAMES_DYNAMIC, template_constant_dict
 from easybuild.tools.build_log import EasyBuildError, print_warning, print_msg
 from easybuild.tools.config import GENERIC_EASYBLOCK_PKG, LOCAL_VAR_NAMING_CHECK_ERROR, LOCAL_VAR_NAMING_CHECK_LOG
 from easybuild.tools.config import LOCAL_VAR_NAMING_CHECK_WARN
@@ -1802,6 +1802,25 @@ class EasyConfig(object):
                 value = resolve_template(value, self.template_values)
             res[key] = value
         return res
+
+    def get_cuda_cc_template_value(self, key):
+        """
+        Get template value based on --cuda-compute-capabilities EasyBuild configuration option
+        and cuda_compute_capabilities easyconfig parameter.
+        Returns user-friendly error message in case neither are defined,
+        or if an unknown key is used.
+        """
+        if key.startswith('cuda_') and key in [x for (x, _) in TEMPLATE_NAMES_DYNAMIC]:
+            if key in self.template_values:
+                return self.template_values[key]
+            else:
+                error_msg = "(get_cuda_cc_template_value) Template value '%s' is not defined!\n"
+                error_msg += "Make sure that either the --cuda-compute-capabilities EasyBuild configuration "
+                error_msg += "option is set, or that the cuda_compute_capabilities easyconfig parameter is defined."
+                raise EasyBuildError(error_msg, key)
+        else:
+            error_msg = "%s is not a template value baed on --cuda-compute-capabilities/cuda_compute_capabilities"
+            raise EasyBuildError(error_msg, key)
 
 
 def det_installversion(version, toolchain_name, toolchain_version, prefix, suffix):

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1810,10 +1810,10 @@ class EasyConfig(object):
         Returns user-friendly error message in case neither are defined,
         or if an unknown key is used.
         """
-        if key.startswith('cuda_') and key in [x for (x, _) in TEMPLATE_NAMES_DYNAMIC]:
-            if key in self.template_values:
+        if key.startswith('cuda_') and any(x[0] == key for x in TEMPLATE_NAMES_DYNAMIC):
+            try:
                 return self.template_values[key]
-            else:
+            except KeyError:
                 error_msg = "(get_cuda_cc_template_value) Template value '%s' is not defined!\n"
                 error_msg += "Make sure that either the --cuda-compute-capabilities EasyBuild configuration "
                 error_msg += "option is set, or that the cuda_compute_capabilities easyconfig parameter is defined."

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -4498,7 +4498,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.prep()
         ec = EasyConfig(self.eb_file)
 
-        error_pattern = "foobar is not a template value baed on --cuda-compute-capabilities/cuda_compute_capabilities"
+        error_pattern = "foobar is not a template value based on --cuda-compute-capabilities/cuda_compute_capabilities"
         self.assertErrorRegex(EasyBuildError, error_pattern, ec.get_cuda_cc_template_value, 'foobar')
 
         error_pattern = r"\(get_cuda_cc_template_value\) Template value '%s' is not defined!\n"

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -4501,7 +4501,7 @@ class EasyConfigTest(EnhancedTestCase):
         error_pattern = "foobar is not a template value based on --cuda-compute-capabilities/cuda_compute_capabilities"
         self.assertErrorRegex(EasyBuildError, error_pattern, ec.get_cuda_cc_template_value, 'foobar')
 
-        error_pattern = r"\(get_cuda_cc_template_value\) Template value '%s' is not defined!\n"
+        error_pattern = r"Template value '%s' is not defined!\n"
         error_pattern += r"Make sure that either the --cuda-compute-capabilities EasyBuild configuration "
         error_pattern += "option is set, or that the cuda_compute_capabilities easyconfig parameter is defined."
         cuda_template_values = {

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -4483,6 +4483,56 @@ class EasyConfigTest(EnhancedTestCase):
         error_pattern = r"Failed to copy '.*' easyconfig parameter"
         self.assertErrorRegex(EasyBuildError, error_pattern, EasyConfig, test_ec)
 
+    def test_get_cuda_cc_template_value(self):
+        """
+        Test getting template value based on --cuda-compute-capabilities / cuda_compute_capabilities.
+        """
+        self.contents = '\n'.join([
+            'easyblock = "ConfigureMake"',
+            'name = "pi"',
+            'version = "3.14"',
+            'homepage = "http://example.com"',
+            'description = "test easyconfig"',
+            'toolchain = SYSTEM',
+        ])
+        self.prep()
+        ec = EasyConfig(self.eb_file)
+
+        error_pattern = "foobar is not a template value baed on --cuda-compute-capabilities/cuda_compute_capabilities"
+        self.assertErrorRegex(EasyBuildError, error_pattern, ec.get_cuda_cc_template_value, 'foobar')
+
+        error_pattern = r"\(get_cuda_cc_template_value\) Template value '%s' is not defined!\n"
+        error_pattern += r"Make sure that either the --cuda-compute-capabilities EasyBuild configuration "
+        error_pattern += "option is set, or that the cuda_compute_capabilities easyconfig parameter is defined."
+        cuda_template_values = {
+            'cuda_compute_capabilities': '6.5,7.0',
+            'cuda_cc_space_sep': '6.5 7.0',
+            'cuda_cc_semicolon_sep': '6.5;7.0',
+            'cuda_sm_comma_sep': 'sm_65,sm_70',
+            'cuda_sm_space_sep': 'sm_65 sm_70',
+        }
+        for key in cuda_template_values:
+            self.assertErrorRegex(EasyBuildError, error_pattern % key, ec.get_cuda_cc_template_value, key)
+
+        update_build_option('cuda_compute_capabilities', ['6.5', '7.0'])
+        ec = EasyConfig(self.eb_file)
+
+        for key in cuda_template_values:
+            self.assertEqual(ec.get_cuda_cc_template_value(key), cuda_template_values[key])
+
+        update_build_option('cuda_compute_capabilities', None)
+        ec = EasyConfig(self.eb_file)
+
+        for key in cuda_template_values:
+            self.assertErrorRegex(EasyBuildError, error_pattern % key, ec.get_cuda_cc_template_value, key)
+
+        self.contents += "\ncuda_compute_capabilities = ['6.5', '7.0']"
+        self.prep()
+        ec = EasyConfig(self.eb_file)
+
+        for key in cuda_template_values:
+            self.assertEqual(ec.get_cuda_cc_template_value(key), cuda_template_values[key])
+
 
 def suite():
     """ returns all the testcases in this module """


### PR DESCRIPTION
This comes in useful in easyblocks for GPU-capable software like TensorFlow and jaxlib, since it results in a clean error message when neither `--cuda-compute-capabilities` (EasyBuild configuration option) nor `cuda_compute_capabilities` (easyconfig parameter) are defined.

See also the discussion at https://github.com/easybuilders/easybuild-easyblocks/pull/2545/files#r691193863