### PR TITLE
speed up set_parallel method in EasyBlock class

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1794,13 +1794,12 @@ class EasyBlock(object):
         cfg_par = self.cfg['parallel']
         if cfg_par is None:
             self.log.debug("Desired parallelism specified via 'parallel' build option: %s", par)
+        elif par is None:
+            par = cfg_par
+            self.log.debug("Desired parallelism specified via 'parallel' easyconfig parameter: %s", par)
         else:
-            if par is None:
-                par = cfg_par
-                self.log.debug("Desired parallelism specified via 'parallel' easyconfig parameter: %s", par)
-            else:
-                par = min(int(par), int(cfg_par))
-                self.log.debug("Desired parallelism: minimum of 'parallel' build option/easyconfig parameter: %s", par)
+            par = min(int(par), int(cfg_par))
+            self.log.debug("Desired parallelism: minimum of 'parallel' build option/easyconfig parameter: %s", par)
 
         par = det_parallelism(par, maxpar=self.cfg['maxparallel'])
         self.log.info("Setting parallelism: %s" % par)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1791,18 +1791,20 @@ class EasyBlock(object):
         """Set 'parallel' easyconfig parameter to determine how many cores can/should be used for parallel builds."""
         # set level of parallelism for build
         par = build_option('parallel')
-        if self.cfg['parallel'] is not None:
+        cfg_par = self.cfg['parallel']
+        if cfg_par is None:
+            self.log.debug("Desired parallelism specified via 'parallel' build option: %s", par)
+        else:
             if par is None:
-                par = self.cfg['parallel']
+                par = cfg_par
                 self.log.debug("Desired parallelism specified via 'parallel' easyconfig parameter: %s", par)
             else:
-                par = min(int(par), int(self.cfg['parallel']))
+                par = min(int(par), int(cfg_par))
                 self.log.debug("Desired parallelism: minimum of 'parallel' build option/easyconfig parameter: %s", par)
-        else:
-            self.log.debug("Desired parallelism specified via 'parallel' build option: %s", par)
 
-        self.cfg['parallel'] = det_parallelism(par=par, maxpar=self.cfg['maxparallel'])
-        self.log.info("Setting parallelism: %s" % self.cfg['parallel'])
+        par = det_parallelism(par, maxpar=self.cfg['maxparallel'])
+        self.log.info("Setting parallelism: %s" % par)
+        self.cfg['parallel'] = par
 
     def remove_module_file(self):
         """Remove module file (if it exists), and check for ghost installation directory (and deal with it)."""

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -996,7 +996,7 @@ def det_parallelism(par=None, maxpar=None):
             par_guess = (maxuserproc - 15) // 6
             if par_guess < par:
                 par = par_guess
-                _log.info("Limit parallel builds to %s because max user processes is %s" % (par, out))
+                _log.info("Limit parallel builds to %s because max user processes is %s", par, out)
             # Cache value
             det_parallelism._default_parallelism = par
         return par
@@ -1010,7 +1010,7 @@ def det_parallelism(par=None, maxpar=None):
             raise EasyBuildError("Specified level of parallelism '%s' is not an integer value: %s", par, err)
 
     if maxpar is not None and maxpar < par:
-        _log.info("Limiting parallellism from %s to %s" % (par, maxpar))
+        _log.info("Limiting parallellism from %s to %s", par, maxpar)
         par = maxpar
 
     return par

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3052,6 +3052,10 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(res, expected)
 
         # mock get_avail_core_count which is used by set_parallel -> det_parallelism
+        try:
+            del st.det_parallelism._default_parallelism  # Remove cache value
+        except AttributeError:
+            pass  # Ignore if not present
         orig_get_avail_core_count = st.get_avail_core_count
         st.get_avail_core_count = lambda: 42
 


### PR DESCRIPTION
- Small refactoring to reduce dictionary access to cfg[parallel] option
- Cache default parallel value in det_parallelism to avoid systemcalls