### PR TITLE
add --easystack to ignore_opts for submit_job()

### DIFF
--- a/easybuild/tools/parallelbuild.py
+++ b/easybuild/tools/parallelbuild.py
@@ -127,7 +127,7 @@ def submit_jobs(ordered_ecs, cmd_line_opts, testing=False, prepare_first=True):
     curdir = os.getcwd()
 
     # regex pattern for options to ignore (help options can't reach here)
-    ignore_opts = re.compile('^--robot$|^--job|^--try-.*$')
+    ignore_opts = re.compile('^--robot$|^--job|^--try-.*$|^--easystack$')
 
     # generate_cmd_line returns the options in form --longopt=value
     opts = [o for o in cmd_line_opts if not ignore_opts.match(o.split('=')[0])]


### PR DESCRIPTION
Currently when using `--job` with `--easystack`, `--easystack` gets passed along to job that in return try to process the easystack, causing parallel builds of the first item in the easystack file (which fail due to already existing locks).

### how to reproduce
example.yml
```yml
software:
    GROMACS:
        toolchains:
            fosscuda-2019b:
                versions: '2020'
```
with `eb --robot --job --experimental --easystack example.yml`
causes
```
== FAILED: Installation ended unsuccessfully (build directory: /scratch/software_build/easybuild/build/GROMACS/2020/fosscuda-2019b): build failed (first 300 chars): Lock /software/.locks/_software_GROMACS_2020-fosscuda-2019b.lock already exists, aborting! (took 0 secs)
```
due to all parallel jobs trying to build the same easyconfig.

### proposed solution
Do not pass `--easystack` to build jobs.
