### PR TITLE
pick up $MODULES_CMD to facilitate using Environment Modules 4.x as modules tool

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -187,7 +187,6 @@ class ModulesTool(object):
                 self.cmd = env_cmd_path
                 self.log.debug("Set %s command via environment variable %s: %s",
                                self.NAME, self.COMMAND_ENVIRONMENT, self.cmd)
-            # check whether paths obtained via $PATH and $LMOD_CMD are different
             elif cmd_path != env_cmd_path:
                 self.log.debug("Different paths found for %s command '%s' via which/$PATH and $%s: %s vs %s",
                                self.NAME, self.COMMAND, self.COMMAND_ENVIRONMENT, cmd_path, env_cmd_path)
@@ -1315,6 +1314,7 @@ class EnvironmentModules(EnvironmentModulesTcl):
     """Interface to environment modules 4.0+"""
     NAME = "Environment Modules v4"
     COMMAND = os.path.join(os.getenv('MODULESHOME', 'MODULESHOME_NOT_DEFINED'), 'libexec', 'modulecmd.tcl')
+    COMMAND_ENVIRONMENT = 'MODULES_CMD'
     REQ_VERSION = '4.0.0'
     MAX_VERSION = None
     VERSION_REGEXP = r'^Modules\s+Release\s+(?P<version>\d\S*)\s'


### PR DESCRIPTION
`$MODULES_CMD` is defined since Environment Modules 4.1.0, see https://github.com/cea-hpc/modules/commit/33941816c0ff41e7eb9a9246ca7c9223ceec9989

If `$MODULES_CMD` is defined, the exact location of the `modulecmd.tcl` doesn't matter much anymore, as long as it points to an existing path.

fixes #3815