### PR TITLE
add support for checking required/optional EasyBuild dependencies via 'eb --check-eb-deps'

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -73,6 +73,7 @@ from easybuild.tools.robot import check_conflicts, dry_run, missing_deps, resolv
 from easybuild.tools.package.utilities import check_pkg_support
 from easybuild.tools.parallelbuild import submit_jobs
 from easybuild.tools.repository.repository import init_repository
+from easybuild.tools.systemtools import check_easybuild_deps
 from easybuild.tools.testing import create_test_report, overall_test_report, regtest, session_state
 
 
@@ -259,6 +260,9 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
         search_easyconfigs(search_query, short=options.search_short, filename_only=options.search_filename,
                            terse=options.terse)
 
+    if options.check_eb_deps:
+        print(check_easybuild_deps(modtool))
+
     # GitHub options that warrant a silent cleanup & exit
     if options.check_github:
         check_github()
@@ -297,6 +301,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     # non-verbose cleanup after handling GitHub integration stuff or printing terse info
     early_stop_options = [
         options.add_pr_labels,
+        options.check_eb_deps,
         options.check_github,
         options.create_index,
         options.install_github_token,

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -68,7 +68,7 @@ from easybuild.tools.github import sync_branch_with_develop, sync_pr_with_develo
 from easybuild.tools.hooks import START, END, load_hooks, run_hook
 from easybuild.tools.modules import modules_tool
 from easybuild.tools.options import set_up_configuration, use_color
-from easybuild.tools.output import create_progress_bar
+from easybuild.tools.output import create_progress_bar, print_checks
 from easybuild.tools.robot import check_conflicts, dry_run, missing_deps, resolve_dependencies, search_easyconfigs
 from easybuild.tools.package.utilities import check_pkg_support
 from easybuild.tools.parallelbuild import submit_jobs
@@ -261,7 +261,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
                            terse=options.terse)
 
     if options.check_eb_deps:
-        print(check_easybuild_deps(modtool))
+        print_checks(check_easybuild_deps(modtool))
 
     # GitHub options that warrant a silent cleanup & exit
     if options.check_github:

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -207,6 +207,15 @@ class ModulesTool(object):
         self.set_and_check_version()
         self.supports_depends_on = False
 
+    def __str__(self):
+        """String representation of this ModulesTool instance."""
+        res = self.NAME
+        if self.version:
+            res += ' ' + self.version
+        else:
+            res += ' (unknown version)'
+        return res
+
     def buildstats(self):
         """Return tuple with data to be included in buildstats"""
         return (self.NAME, self.cmd, self.version)
@@ -1177,7 +1186,7 @@ class ModulesTool(object):
 
 class EnvironmentModulesC(ModulesTool):
     """Interface to (C) environment modules (modulecmd)."""
-    NAME = "Environment Modules v3"
+    NAME = "Environment Modules"
     COMMAND = "modulecmd"
     REQ_VERSION = '3.2.10'
     MAX_VERSION = '3.99'
@@ -1312,7 +1321,7 @@ class EnvironmentModulesTcl(EnvironmentModulesC):
 
 class EnvironmentModules(EnvironmentModulesTcl):
     """Interface to environment modules 4.0+"""
-    NAME = "Environment Modules v4"
+    NAME = "Environment Modules"
     COMMAND = os.path.join(os.getenv('MODULESHOME', 'MODULESHOME_NOT_DEFINED'), 'libexec', 'modulecmd.tcl')
     COMMAND_ENVIRONMENT = 'MODULES_CMD'
     REQ_VERSION = '4.0.0'

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -617,6 +617,8 @@ class EasyBuildOptions(GeneralOption):
             'avail-hooks': ("Show list of known hooks", None, 'store_true', False),
             'avail-toolchain-opts': ("Show options for toolchain", 'str', 'store', None),
             'check-conflicts': ("Check for version conflicts in dependency graphs", None, 'store_true', False),
+            'check-eb-deps': ("Check presence and version of (required and optional) EasyBuild dependencies",
+                              None, 'store_true', False),
             'dep-graph': ("Create dependency graph", None, 'store', None, {'metavar': 'depgraph.<ext>'}),
             'dump-env-script': ("Dump source script to set up build environment based on toolchain/dependencies",
                                 None, 'store_true', False),

--- a/easybuild/tools/output.py
+++ b/easybuild/tools/output.py
@@ -32,8 +32,11 @@ Tools for controlling output to terminal produced by EasyBuild.
 import random
 
 from easybuild.tools.config import build_option
+from easybuild.tools.py2vs3 import OrderedDict
 
 try:
+    from rich.console import Console
+    from rich.table import Table
     from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
     HAVE_RICH = True
 except ImportError:
@@ -82,3 +85,71 @@ def create_progress_bar():
         progress_bar = DummyProgress()
 
     return progress_bar
+
+
+def print_checks(checks_data):
+    """Print overview of checks that were made."""
+
+    col_titles = checks_data.pop('col_titles', ('name', 'info', 'description'))
+
+    col2_label = col_titles[1]
+
+    if HAVE_RICH:
+        console = Console()
+        # don't use console.print, which causes SyntaxError in Python 2
+        console_print = getattr(console, 'print')
+        console_print('')
+
+    for section in checks_data:
+        section_checks = checks_data[section]
+
+        if HAVE_RICH:
+            table = Table(title=section)
+            table.add_column(col_titles[0])
+            table.add_column(col_titles[1])
+            # only add 3rd column if there's any information to include in it
+            if any(x[1] for x in section_checks.values()):
+                table.add_column(col_titles[2])
+        else:
+            lines = [
+                '',
+                section + ':',
+                '-' * (len(section) + 1),
+                '',
+            ]
+
+        if isinstance(section_checks, OrderedDict):
+            check_names = section_checks.keys()
+        else:
+            check_names = sorted(section_checks, key=lambda x: x.lower())
+
+        if HAVE_RICH:
+            for check_name in check_names:
+                (info, descr) = checks_data[section][check_name]
+                if info is None:
+                    info = ':yellow_circle:  [yellow]%s?!' % col2_label
+                elif info is False:
+                    info = ':cross_mark:  [red]not found'
+                else:
+                    info = ':white_heavy_check_mark:  [green]%s' % info
+                if descr:
+                    table.add_row(check_name.rstrip(':'), info, descr)
+                else:
+                    table.add_row(check_name.rstrip(':'), info)
+        else:
+            for check_name in check_names:
+                (info, descr) = checks_data[section][check_name]
+                if info is None:
+                    info = '(found, UNKNOWN %s)' % col2_label
+                elif info is False:
+                    info = '(NOT FOUND)'
+                line = "* %s %s" % (check_name, info)
+                if descr:
+                    line = line.ljust(40) + '[%s]' % descr
+                lines.append(line)
+            lines.append('')
+
+        if HAVE_RICH:
+            console_print(table)
+        else:
+            print('\n'.join(lines))

--- a/easybuild/tools/output.py
+++ b/easybuild/tools/output.py
@@ -97,7 +97,7 @@ def print_checks(checks_data):
     if HAVE_RICH:
         console = Console()
         # don't use console.print, which causes SyntaxError in Python 2
-        console_print = getattr(console, 'print')
+        console_print = getattr(console, 'print')  # noqa: B009
         console_print('')
 
     for section in checks_data:

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -179,35 +179,24 @@ SYSTEM_TOOL_CMDS = {
     'Slurm': 'sbatch',
 }
 
-OPT_DEPS = {
-    'archspec': "determining name of CPU microarchitecture",
-    'autopep8': "auto-formatting for dumped easyconfigs",
-    'GC3Pie': "backend for --job",
-    'GitPython': "GitHub integration + using Git repository as easyconfigs archive",
-    'graphviz-python': "rendering dependency graph with Graphviz: --dep-graph",
-    'keyring': "storing GitHub token",
-    'pbs-python': "using Torque as --job backend",
-    'pep8': "fallback for code style checking: --check-style, --check-contrib",
-    'pycodestyle': "code style checking: --check-style, --check-contrib",
-    'pysvn': "using SVN repository as easyconfigs archive",
-    'python-graph-core': "creating dependency graph: --dep-graph",
-    'python-graph-dot': "saving dependency graph as dot file: --dep-graph",
-    'python-hglib': "using Mercurial repository as easyconfigs archive",
-    'requests': "fallback library for downloading files",
-    'Rich': "eb command rich terminal output",
-    'PyYAML': "easystack files and .yeb easyconfig format",
-    'setuptools': "obtaining information on Python packages via pkg_resources module",
-}
-
-OPT_DEP_PKG_NAMES = {
-    'GC3Pie': 'gc3libs',
-    'GitPython': 'git',
-    'graphviz-python': 'gv',
-    'pbs-python': 'pbs',
-    'python-graph-core': 'pygraph.classes.digraph',
-    'python-graph-dot': 'pygraph.readwrite.dot',
-    'python-hglib': 'hglib',
-    'PyYAML': 'yaml',
+EASYBUILD_OPTIONAL_DEPENDENCIES = {
+    'archspec': (None, "determining name of CPU microarchitecture"),
+    'autopep8': (None, "auto-formatting for dumped easyconfigs"),
+    'GC3Pie': ('gc3libs', "backend for --job"),
+    'GitPython': ('git', "GitHub integration + using Git repository as easyconfigs archive"),
+    'graphviz-python': ('gv', "rendering dependency graph with Graphviz: --dep-graph"),
+    'keyring': (None, "storing GitHub token"),
+    'pbs-python': ('pbs', "using Torque as --job backend"),
+    'pep8': (None, "fallback for code style checking: --check-style, --check-contrib"),
+    'pycodestyle': (None, "code style checking: --check-style, --check-contrib"),
+    'pysvn': (None, "using SVN repository as easyconfigs archive"),
+    'python-graph-core': ('pygraph.classes.digraph', "creating dependency graph: --dep-graph"),
+    'python-graph-dot': ('pygraph.readwrite.dot', "saving dependency graph as dot file: --dep-graph"),
+    'python-hglib': ('hglib', "using Mercurial repository as easyconfigs archive"),
+    'requests': (None, "fallback library for downloading files"),
+    'Rich': (None, "eb command rich terminal output"),
+    'PyYAML': ('yaml', "easystack files and .yeb easyconfig format"),
+    'setuptools': ('pkg_resources', "obtaining information on Python packages via pkg_resources module"),
 }
 
 
@@ -1209,9 +1198,11 @@ def check_easybuild_deps(modtool):
     python_version = extract_version(sys.executable)
 
     opt_dep_versions = {}
-    for key in OPT_DEPS:
+    for key in EASYBUILD_OPTIONAL_DEPENDENCIES:
 
-        pkg = OPT_DEP_PKG_NAMES.get(key, key.lower())
+        pkg = EASYBUILD_OPTIONAL_DEPENDENCIES[key][0]
+        if pkg is None:
+            pkg = key.lower()
 
         try:
             mod = __import__(pkg)
@@ -1235,8 +1226,8 @@ def check_easybuild_deps(modtool):
     opt_deps_key = "Optional dependencies"
     checks_data[opt_deps_key] = {}
 
-    for pkg in opt_dep_versions:
-        checks_data[opt_deps_key][pkg] = (opt_dep_versions[pkg], OPT_DEPS[pkg])
+    for key in opt_dep_versions:
+        checks_data[opt_deps_key][key] = (opt_dep_versions[key], EASYBUILD_OPTIONAL_DEPENDENCIES[key][1])
 
     sys_tools_key = "System tools"
     checks_data[sys_tools_key] = {}

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5845,6 +5845,28 @@ class CommandLineOptionsTest(EnhancedTestCase):
             regex = re.compile(pattern, re.M)
             self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
 
+    def test_check_eb_deps(self):
+        """Test for --check-eb-deps."""
+        txt, _ = self._run_mock_eb(['--check-eb-deps'], raise_error=True)
+        patterns = [
+            r"^Required dependencies:",
+            r"^\* Python [23][0-9.]+$",
+            r"^\* [A-Za-z ]+ [0-9.]+ \(modules tool\)$",
+            r"^Optional dependencies:",
+            r"^\* archspec ([0-9.]+|\(NOT AVAILABLE\))+\s+\[determining name of CPU microarchitecture\]$",
+            r"^\* GitPython ([0-9.]+|\(NOT AVAILABLE\))+\s+\[GitHub integration .*\]$",
+            r"^\* Rich ([0-9.]+|\(NOT AVAILABLE\))+\s+\[eb command rich terminal output\]$",
+            r"^System tools:",
+            r"^\* make ([0-9.]+|\(NOT AVAILABLE\)|\(available, UNKNOWN version\))$",
+            r"^\* patch ([0-9.]+|\(NOT AVAILABLE\)|\(available, UNKNOWN version\))$",
+            r"^\* sed ([0-9.]+|\(NOT AVAILABLE\)|\(available, UNKNOWN version\))$",
+            r"^\* Slurm ([0-9.]+|\(NOT AVAILABLE\)|\(available, UNKNOWN version\))$",
+        ]
+
+        for pattern in patterns:
+            regex = re.compile(pattern, re.M)
+            self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
+
     def test_tmp_logdir(self):
         """Test use of --tmp-logdir."""
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5848,21 +5848,24 @@ class CommandLineOptionsTest(EnhancedTestCase):
     def test_check_eb_deps(self):
         """Test for --check-eb-deps."""
         txt, _ = self._run_mock_eb(['--check-eb-deps'], raise_error=True)
-        opt_dep_version_pattern = r'([0-9.]+|\(NOT AVAILABLE\)|\(unknown version\))'
+
+        # keep in mind that these patterns should match with both normal output and Rich output!
+        opt_dep_info_pattern = r'([0-9.]+|\(NOT FOUND\)|not found|\(unknown version\))'
+        tool_info_pattern = r'([0-9.]+|\(NOT FOUND\)|not found|\(found, UNKNOWN version\)|version\?\!)'
         patterns = [
-            r"^Required dependencies:",
-            r"^\* Python [23][0-9.]+$",
-            r"^\* [A-Za-z ]+ [0-9.]+ \(modules tool\)$",
-            r"^Optional dependencies:",
-            r"^\* archspec %s\s+\[determining name of CPU microarchitecture\]$" % opt_dep_version_pattern,
-            r"^\* GitPython %s\s+\[GitHub integration .*\]$" % opt_dep_version_pattern,
-            r"^\* Rich %s\s+\[eb command rich terminal output\]$" % opt_dep_version_pattern,
-            r"^\* setuptools %s\s+\[obtaining information on Python packages .*\]$" % opt_dep_version_pattern,
-            r"^System tools:",
-            r"^\* make ([0-9.]+|\(NOT AVAILABLE\)|\(available, UNKNOWN version\))$",
-            r"^\* patch ([0-9.]+|\(NOT AVAILABLE\)|\(available, UNKNOWN version\))$",
-            r"^\* sed ([0-9.]+|\(NOT AVAILABLE\)|\(available, UNKNOWN version\))$",
-            r"^\* Slurm ([0-9.]+|\(NOT AVAILABLE\)|\(available, UNKNOWN version\))$",
+            r"Required dependencies",
+            r"Python.* [23][0-9.]+",
+            r"modules tool.* [A-Za-z0-9.\s-]+",
+            r"Optional dependencies",
+            r"archspec.* %s.*determining name" % opt_dep_info_pattern,
+            r"GitPython.* %s.*GitHub integration" % opt_dep_info_pattern,
+            r"Rich.* %s.*eb command rich terminal output" % opt_dep_info_pattern,
+            r"setuptools.* %s.*information on Python packages" % opt_dep_info_pattern,
+            r"System tools",
+            r"make.* %s" % tool_info_pattern,
+            r"patch.* %s" % tool_info_pattern,
+            r"sed.* %s" % tool_info_pattern,
+            r"Slurm.* %s" % tool_info_pattern,
         ]
 
         for pattern in patterns:

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5848,14 +5848,16 @@ class CommandLineOptionsTest(EnhancedTestCase):
     def test_check_eb_deps(self):
         """Test for --check-eb-deps."""
         txt, _ = self._run_mock_eb(['--check-eb-deps'], raise_error=True)
+        opt_dep_version_pattern = r'([0-9.]+|\(NOT AVAILABLE\)|\(unknown version\))'
         patterns = [
             r"^Required dependencies:",
             r"^\* Python [23][0-9.]+$",
             r"^\* [A-Za-z ]+ [0-9.]+ \(modules tool\)$",
             r"^Optional dependencies:",
-            r"^\* archspec ([0-9.]+|\(NOT AVAILABLE\))+\s+\[determining name of CPU microarchitecture\]$",
-            r"^\* GitPython ([0-9.]+|\(NOT AVAILABLE\))+\s+\[GitHub integration .*\]$",
-            r"^\* Rich ([0-9.]+|\(NOT AVAILABLE\))+\s+\[eb command rich terminal output\]$",
+            r"^\* archspec %s\s+\[determining name of CPU microarchitecture\]$" % opt_dep_version_pattern,
+            r"^\* GitPython %s\s+\[GitHub integration .*\]$" % opt_dep_version_pattern,
+            r"^\* Rich %s\s+\[eb command rich terminal output\]$" % opt_dep_version_pattern,
+            r"^\* setuptools %s\s+\[obtaining information on Python packages .*\]$" % opt_dep_version_pattern,
             r"^System tools:",
             r"^\* make ([0-9.]+|\(NOT AVAILABLE\)|\(available, UNKNOWN version\))$",
             r"^\* patch ([0-9.]+|\(NOT AVAILABLE\)|\(available, UNKNOWN version\))$",


### PR DESCRIPTION
Example output when using Python 3 and having `rich` installed (misaligned lines in tables is only due to copy-pasting)

```
$ eb --check-eb-deps

     Required dependencies
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃ name         ┃ version      ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│ Python       │ ✅  3.9.5    │
│ modules tool │ ✅  Lmod 8.3 │
└──────────────┴──────────────┘
                                          Optional dependencies
┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ name              ┃ version       ┃ used for                                                          ┃
┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ archspec          │ ✅  0.1.2     │ determining name of CPU microarchitecture                         │
│ autopep8          │ ✅  1.5.7     │ auto-formatting for dumped easyconfigs                            │
│ GC3Pie            │ ✅  2.6.8     │ backend for --job                                                 │
│ GitPython         │ ✅  3.1.11    │ GitHub integration + using Git repository as easyconfigs archive  │
│ graphviz-python   │ ❌  not found │ rendering dependency graph with Graphviz: --dep-graph             │
│ keyring           │ ✅  21.4.0    │ storing GitHub token                                              │
│ pbs-python        │ ❌  not found │ using Torque as --job backend                                     │
│ pep8              │ ❌  not found │ fallback for code style checking: --check-style, --check-contrib  │
│ pycodestyle       │ ✅  2.7.0     │ code style checking: --check-style, --check-contrib               │
│ pysvn             │ ❌  not found │ using SVN repository as easyconfigs archive                       │
│ python-graph-core │ ❌  not found │ creating dependency graph: --dep-graph                            │
│ python-graph-dot  │ ❌  not found │ saving dependency graph as dot file: --dep-graph                  │
│ python-hglib      │ ✅  2.6.2     │ using Mercurial repository as easyconfigs archive                 │
│ PyYAML            │ ✅  5.3.1     │ easystack files and .yeb easyconfig format                        │
│ requests          │ ✅  2.24.0    │ fallback library for downloading files                            │
│ Rich              │ ✅  10.4.0    │ eb command rich terminal output                                   │
│ setuptools        │ ✅  56.0.0    │ obtaining information on Python packages via pkg_resources module │
└───────────────────┴───────────────┴───────────────────────────────────────────────────────────────────┘
        System tools
┏━━━━━━━━━┳━━━━━━━━━━━━━━━━┓
┃ name    ┃ version        ┃
┡━━━━━━━━━╇━━━━━━━━━━━━━━━━┩
│ 7z      │ ❌  not found  │
│ bunzip2 │ ✅  1.0.6      │
│ dpkg    │ ❌  not found  │
│ gunzip  │ ✅  321.100.11 │
│ make    │ ✅  3.81       │
│ patch   │ ✅  2.5.8      │
│ rpm     │ ❌  not found  │
│ sed     │ 🟡  version?!  │
│ Slurm   │ ❌  not found  │
│ tar     │ ✅  3.3.2      │
│ unxz    │ ✅  5.2.5      │
│ unzip   │ ✅  6.00       │
└─────────┴────────────────┘
```