### PR TITLE
change copy_file function to raise an error when trying to copy non-existing file

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2270,7 +2270,8 @@ def copy_file(path, target_path, force_in_dry_run=False):
     :param target_path: path to copy the file to
     :param force_in_dry_run: force copying of file during dry run
     """
-    if not os.path.exists(path):
+    # NOTE: 'exists' will return False if 'path' is a broken symlink
+    if not os.path.exists(path) and not os.path.islink(path):
         raise EasyBuildError("could not copy '%s' it does not exist!" % path)
     if not force_in_dry_run and build_option('extended_dry_run'):
         dry_run_msg("copied file %s to %s" % (path, target_path))

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2272,7 +2272,7 @@ def copy_file(path, target_path, force_in_dry_run=False):
     """
     # NOTE: 'exists' will return False if 'path' is a broken symlink
     if not os.path.exists(path) and not os.path.islink(path):
-        raise EasyBuildError("could not copy '%s' it does not exist!" % path)
+        raise EasyBuildError("Could not copy '%s' it does not exist!" % path)
     if not force_in_dry_run and build_option('extended_dry_run'):
         dry_run_msg("copied file %s to %s" % (path, target_path))
     else:

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2287,16 +2287,14 @@ def copy_file(path, target_path, force_in_dry_run=False):
                 _log.info("Copied contents of file %s to %s", path, target_path)
             else:
                 mkdir(os.path.dirname(target_path), parents=True)
-                if os.path.isfile(path) and not os.path.islink(path):
-                    shutil.copy2(path, target_path)
-                    _log.info("%s copied to %s", path, target_path)
-                elif os.path.islink(path):
+                if os.path.islink(path):
                     # special care for copying broken symlinks
                     link_target = os.readlink(path)
                     symlink(link_target, target_path)
                     _log.info("created symlink from %s to %s", path, target_path)
                 else:
-                    _log.warn("ignoring '%s' since it is neither a file nor a symlink" % path)
+                    shutil.copy2(path, target_path)
+                    _log.info("%s copied to %s", path, target_path)
         except (IOError, OSError, shutil.Error) as err:
             raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1661,6 +1661,10 @@ class FileToolsTest(EnhancedTestCase):
         self.assertTrue(ft.read_file(to_copy) == ft.read_file(target_path))
         self.assertEqual(txt, '')
 
+        # Test that a non-existing file raises an exception
+        src, target = os.path.join(self.test_prefix, 'this_file_does_not_exist'), os.path.join(self.test_prefix, 'toy')
+        self.assertErrorRegex(EasyBuildError, "Could not copy *", ft.copy_file, src, target)
+
     def test_copy_files(self):
         """Test copy_files function."""
         test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')


### PR DESCRIPTION
Previous behavior would simply skip copying a file if it did not exist
and report copy success. This commit changes that behavior to error out
early if the file does not exist and explicitly warn if trying to copy
something that is neither a file nor a symbolic link.