### PR TITLE
take into account changed error raised by Python 3.9.7 when copying directory via shutil.copyfile

### DIFF
--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1610,7 +1610,9 @@ class FileToolsTest(EnhancedTestCase):
 
         # clean error when trying to copy a directory with copy_file
         src, target = os.path.dirname(to_copy), os.path.join(self.test_prefix, 'toy')
-        self.assertErrorRegex(EasyBuildError, "Failed to copy file.*Is a directory", ft.copy_file, src, target)
+        # error message was changed in Python 3.9.7 to "FileNotFoundError: Directory does not exist"
+        error_pattern = "Failed to copy file.*(Is a directory|Directory does not exist)"
+        self.assertErrorRegex(EasyBuildError, error_pattern, ft.copy_file, src, target)
 
         # test overwriting of existing file owned by someone else,
         # which should make copy_file use shutil.copyfile rather than shutil.copy2


### PR DESCRIPTION
Fix for failing test for `copy_file`, due to changes in Python 3.9.7, which is now being used by GitHub Actions to run the tests with Python 3.9

```
FAIL: test_copy_file (test.framework.filetools.FileToolsTest)
Test copy_file function.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/shutil.py", line 265, in copyfile
    with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
IsADirectoryError: [Errno 21] Is a directory: '/tmp/runner/4644539d1162d1bce3b2733a569c795ffd4b1d94/lib/python3.9/site-packages/test/framework/easyconfigs/test_ecs/t/toy'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/tmp/runner/4644539d1162d1bce3b2733a569c795ffd4b1d94/lib/python3.9/site-packages/easybuild/tools/filetools.py", line 2289, in copy_file
    shutil.copy2(path, target_path)
  File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/shutil.py", line 443, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
FileNotFoundError: Directory does not exist: /tmp/eb-uy57tn3z/eb-a541ef4s/eb-kgknsy5e/toy

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/runner/4644539d1162d1bce3b2733a569c795ffd4b1d94/lib/python3.9/site-packages/easybuild/base/testing.py", line 155, in assertErrorRegex
    call(*args, **kwargs)
  File "/tmp/runner/4644539d1162d1bce3b2733a569c795ffd4b1d94/lib/python3.9/site-packages/easybuild/tools/filetools.py", line 2296, in copy_file
    raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
easybuild.tools.build_log.EasyBuildError: 'Failed to copy file /tmp/runner/4644539d1162d1bce3b2733a569c795ffd4b1d94/lib/python3.9/site-packages/test/framework/easyconfigs/test_ecs/t/toy to /tmp/eb-uy57tn3z/eb-a541ef4s/eb-kgknsy5e/toy: Directory does not exist: /tmp/eb-uy57tn3z/eb-a541ef4s/eb-kgknsy5e/toy'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/runner/4644539d1162d1bce3b2733a569c795ffd4b1d94/lib/python3.9/site-packages/test/framework/filetools.py", line 1613, in test_copy_file
    self.assertErrorRegex(EasyBuildError, "Failed to copy file.*Is a directory", ft.copy_file, src, target)
  File "/tmp/runner/4644539d1162d1bce3b2733a569c795ffd4b1d94/lib/python3.9/site-packages/easybuild/base/testing.py", line 163, in assertErrorRegex
    self.assertTrue(regex.search(msg), "Pattern '%s' is found in '%s'" % (regex.pattern, msg))
AssertionError: None is not true : Pattern 'Failed to copy file.*Is a directory' is found in 'Failed to copy file /tmp/runner/4644539d1162d1bce3b2733a569c795ffd4b1d94/lib/python3.9/site-packages/test/framework/easyconfigs/test_ecs/t/toy to /tmp/eb-uy57tn3z/eb-a541ef4s/eb-kgknsy5e/toy: Directory does not exist: /tmp/eb-uy57tn3z/eb-a541ef4s/eb-kgknsy5e/toy'
```

From the [Python 3.9.7 changelog](https://docs.python.org/release/3.9.7/whatsnew/changelog.html):

```
Update shutil.copyfile() to raise FileNotFoundError instead of confusing IsADirectoryError when a path ending with a os.path.sep does not exist; shutil.copy() and shutil.copy2() are also affected.
```
(see also https://bugs.python.org/issue43219)