### PR TITLE
Add separate progress bar for extensions

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2433,6 +2433,7 @@ class EasyBlock(object):
             ext_task_id = self.progress_bar.add_task("Extension", total=len(self.ext_instances), software="")
             # Step size to advance progress bar for extensions
             ext_step_size = 1.0 / 4.0
+
         def _advance_ext_bar():
             """
             Helper method to update the extension progress bar

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -88,7 +88,6 @@ from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.modules import Lmod, curr_module_paths, invalidate_module_caches_for, get_software_root
 from easybuild.tools.modules import ROOT_ENV_VAR_NAME_PREFIX, VERSION_ENV_VAR_NAME_PREFIX, DEVEL_ENV_VAR_NAME_PREFIX
 from easybuild.tools.modules import get_software_root_env_var_name, get_software_version_env_var_name
-from easybuild.tools.output import create_progress_bar
 from easybuild.tools.package.utilities import package
 from easybuild.tools.py2vs3 import extract_method_name, string_type
 from easybuild.tools.repository.repository import init_repository

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -117,7 +117,7 @@ def build_and_install_software(ecs, init_session_state, exit_on_failure=True, pr
 
     # Initialize progress bar with overall installation task
     if progress_bar:
-        task_id = progress_bar.add_task("", total=len(ecs))
+        task_id = progress_bar.add_task("Installing", total=len(ecs), software="")
     else:
         task_id = None
 
@@ -125,7 +125,7 @@ def build_and_install_software(ecs, init_session_state, exit_on_failure=True, pr
     for ec in ecs:
 
         if progress_bar:
-            progress_bar.update(task_id, description=ec['short_mod_name'])
+            progress_bar.update(task_id, software=ec['short_mod_name'])
 
         ec_res = {}
         try:

--- a/easybuild/tools/output.py
+++ b/easybuild/tools/output.py
@@ -80,7 +80,8 @@ def create_progress_bar():
         progress_bar = Progress(
             SpinnerColumn(spinner),
             "[progress.percentage]{task.percentage:>3.1f}%",
-            TextColumn("[bold blue]Installing {task.description} ({task.completed:.0f}/{task.total} done)"),
+            TextColumn("[blue bold]{task.description} {task.fields[software]}"
+                       " ({task.completed:.0f}/{task.total} done)"),
             BarColumn(bar_width=None),
             TimeElapsedColumn(),
             transient=True,


### PR DESCRIPTION
Slightly updated the way the progress bar is configured by adding a new
field value `software` describing the name that is currently installing
and using `description` for the act that is happening.

When installing extensions this PR creates a new task which is then removed once done installing extensions.