### PR TITLE
Print the hook messages only for debug-mode

### DIFF
--- a/easybuild/tools/hooks.py
+++ b/easybuild/tools/hooks.py
@@ -33,6 +33,7 @@ import os
 
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError, print_msg
+from easybuild.tools.config import build_option
 
 
 _log = fancylogger.getLogger('hooks', fname=False)
@@ -191,7 +192,8 @@ def run_hook(label, hooks, pre_step_hook=False, post_step_hook=False, args=None,
 
         if msg is None:
             msg = "Running %s hook..." % label
-        print_msg(msg)
+        if build_option('debug'):
+            print_msg(msg)
 
         _log.info("Running '%s' hook function (arguments: %s)...", hook.__name__, args)
         res = hook(*args)

--- a/test/framework/hooks.py
+++ b/test/framework/hooks.py
@@ -29,7 +29,7 @@ Unit tests for hooks.py
 """
 import os
 import sys
-from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
+from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
 
 import easybuild.tools.hooks
@@ -123,6 +123,8 @@ class HooksTest(EnhancedTestCase):
         """Test for run_hook function."""
 
         hooks = load_hooks(self.test_hooks_pymod)
+
+        init_config(build_options={'debug': True})
 
         self.mock_stdout(True)
         self.mock_stderr(True)


### PR DESCRIPTION
The output is VERY noisy, especially with parse_hook and module_write hook
The log already has this info and if you want it back you can use --debug