### PR TITLE
Add option to make sanity_check_paths arch dependent

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -97,7 +97,7 @@ from easybuild.tools.package.utilities import package
 from easybuild.tools.py2vs3 import extract_method_name, string_type
 from easybuild.tools.repository.repository import init_repository
 from easybuild.tools.systemtools import check_linked_shared_libs, det_parallelism, get_linked_libs_raw
-from easybuild.tools.systemtools import get_shared_lib_ext, use_group
+from easybuild.tools.systemtools import get_shared_lib_ext, pick_system_specific_value, use_group
 from easybuild.tools.utilities import INDENT_4SPACES, get_class_for, nub, quote_str
 from easybuild.tools.utilities import remove_unwanted_chars, time2str, trace_msg
 from easybuild.tools.version import this_is_easybuild, VERBOSE_VERSION, VERSION
@@ -3218,6 +3218,15 @@ class EasyBlock(object):
             error_msg = "Incorrect format for sanity_check_paths: should (only) have %s keys, "
             error_msg += "values should be lists (at least one non-empty)."
             raise EasyBuildError(error_msg % ', '.join("'%s'" % k for k in known_keys))
+
+        # Resolve arch specific entries
+        for values in paths.values():
+            new_values = []
+            for value in values:
+                value = pick_system_specific_value('sanity_check_paths', value, allow_none=True)
+                if value is not None:
+                    new_values.append(value)
+            values[:] = new_values
 
         # if enhance_sanity_check is not enabled, only sanity_check_commands specified in the easyconfig file are used,
         # the ones provided by the easyblock (via custom_commands) are ignored

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -405,7 +405,8 @@ def to_sanity_check_paths_entry(spec):
                                          value, type(value))
             result.append(elem)
         else:
-            raise EasyBuildError("Expected elements to be of type string, tuple or list, got %s (%s)", elem, type(elem))
+            raise EasyBuildError("Expected elements to be of type string, tuple/list or dict, got %s (%s)",
+                                 elem, type(elem))
 
     return result
 

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -375,6 +375,43 @@ def to_list_of_strings_and_tuples_and_dicts(spec):
     return str_tup_list
 
 
+def to_sanity_check_paths_entry(spec):
+    """
+    Convert a 'list of lists and strings' to a 'list of tuples and strings' while allowing dicts of lists or strings
+
+    Example:
+        ['foo', ['bar', 'baz'], {'f42': ['a', 'b']}]
+        to
+        ['foo', ('bar', 'baz'), {'f42': ('a', 'b')}]
+    """
+    result = []
+
+    if not isinstance(spec, (list, tuple)):
+        raise EasyBuildError("Expected value to be a list, found %s (%s)", spec, type(spec))
+
+    for elem in spec:
+        if isinstance(elem, (string_type, tuple)):
+            result.append(elem)
+        elif isinstance(elem, list):
+            result.append(tuple(elem))
+        elif isinstance(elem, dict):
+            result.append({})
+            for key, value in elem.items():
+                if not isinstance(key, string_type):
+                    raise EasyBuildError("Expected keys to be of type string, got %s (%s)", key, type(key))
+                if isinstance(value, (string_type, tuple)):
+                    result[-1][key] = value
+                elif isinstance(value, list):
+                    result[-1][key] = tuple(value)
+                else:
+                    raise EasyBuildError("Expected elements to be of type string, tuple or list, got %s (%s)",
+                                         value, type(value))
+        else:
+            raise EasyBuildError("Expected elements to be of type string, tuple or list, got %s (%s)", elem, type(elem))
+
+    return result
+
+
 def to_sanity_check_paths_dict(spec):
     """
     Convert a sanity_check_paths dict as received by yaml (a dict with list values that contain either lists or strings)
@@ -389,7 +426,7 @@ def to_sanity_check_paths_dict(spec):
 
     sanity_check_dict = {}
     for key in spec:
-        sanity_check_dict[key] = to_list_of_strings_and_tuples(spec[key])
+        sanity_check_dict[key] = to_sanity_check_paths_entry(spec[key])
     return sanity_check_dict
 
 
@@ -552,11 +589,18 @@ STRING_DICT = (dict, as_hashable(
         'key_types': [str],
     }
 ))
+STRING_OR_TUPLE_DICT = (dict, as_hashable(
+    {
+        'elem_types': [str],
+        'key_types': [str, TUPLE_OF_STRINGS],
+    }
+))
 STRING_OR_TUPLE_OR_DICT_LIST = (list, as_hashable({'elem_types': [str, TUPLE_OF_STRINGS, STRING_DICT]}))
+SANITY_CHECK_PATHS_ENTRY = (list, as_hashable({'elem_types': [str, TUPLE_OF_STRINGS, STRING_OR_TUPLE_DICT]}))
 SANITY_CHECK_PATHS_DICT = (dict, as_hashable({
     'elem_types': {
-        SANITY_CHECK_PATHS_FILES: [STRING_OR_TUPLE_LIST],
-        SANITY_CHECK_PATHS_DIRS: [STRING_OR_TUPLE_LIST],
+        SANITY_CHECK_PATHS_FILES: [SANITY_CHECK_PATHS_ENTRY],
+        SANITY_CHECK_PATHS_DIRS: [SANITY_CHECK_PATHS_ENTRY],
     },
     'opt_keys': [],
     'req_keys': [SANITY_CHECK_PATHS_FILES, SANITY_CHECK_PATHS_DIRS],
@@ -571,8 +615,8 @@ CHECKSUM_LIST = (list, as_hashable({'elem_types': [str, tuple, STRING_DICT]}))
 CHECKSUMS = (list, as_hashable({'elem_types': [str, tuple, STRING_DICT, CHECKSUM_LIST]}))
 
 CHECKABLE_TYPES = [CHECKSUM_LIST, CHECKSUMS, DEPENDENCIES, DEPENDENCY_DICT, LIST_OF_STRINGS,
-                   SANITY_CHECK_PATHS_DICT, STRING_DICT, STRING_OR_TUPLE_LIST, STRING_OR_TUPLE_OR_DICT_LIST,
-                   TOOLCHAIN_DICT, TUPLE_OF_STRINGS]
+                   SANITY_CHECK_PATHS_DICT, SANITY_CHECK_PATHS_ENTRY, STRING_DICT, STRING_OR_TUPLE_LIST,
+                   STRING_OR_TUPLE_DICT, STRING_OR_TUPLE_OR_DICT_LIST, TOOLCHAIN_DICT, TUPLE_OF_STRINGS]
 
 # easy types, that can be verified with isinstance
 EASY_TYPES = [string_type, bool, dict, int, list, str, tuple]

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -395,17 +395,15 @@ def to_sanity_check_paths_entry(spec):
         elif isinstance(elem, list):
             result.append(tuple(elem))
         elif isinstance(elem, dict):
-            result.append({})
             for key, value in elem.items():
                 if not isinstance(key, string_type):
                     raise EasyBuildError("Expected keys to be of type string, got %s (%s)", key, type(key))
-                if isinstance(value, (string_type, tuple)):
-                    result[-1][key] = value
                 elif isinstance(value, list):
-                    result[-1][key] = tuple(value)
-                else:
+                    elem[key] = tuple(value)
+                elif not isinstance(value, (string_type, tuple)):
                     raise EasyBuildError("Expected elements to be of type string, tuple or list, got %s (%s)",
                                          value, type(value))
+            result.append(elem)
         else:
             raise EasyBuildError("Expected elements to be of type string, tuple or list, got %s (%s)", elem, type(elem))
 

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -1281,14 +1281,14 @@ def pick_dep_version(dep_version):
     * a string value (or None)
     * a dict with options to choose from
 
-    Return value is the version to use.
+    Return value is the version to use or False to skip this dependency.
     """
     if dep_version is None:
         _log.debug("Version is None, OK")
         result = None
     else:
         result = pick_system_specific_value("version", dep_version)
-        if not isinstance(result, string_type):
+        if not isinstance(result, string_type) and result is not False:
             typ = type(dep_version)
             raise EasyBuildError("Unknown value type for version: %s (%s), should be string value", typ, dep_version)
 

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -1234,6 +1234,46 @@ def check_python_version():
     return (python_maj_ver, python_min_ver)
 
 
+def pick_system_specific_value(description, options_or_value, allow_none=False):
+    """Pick an entry for the current system when the input has multiple options
+
+    :param description: Descriptive string about the value to be retrieved. Used for logging.
+    :param options_or_value: Either a dictionary with options to choose from or a value of any other type
+    :param allow_none: When True and no matching arch key was found, return None instead of an error
+
+    :return options_or_value when it is not a dictionary or the matching entry (if existing)
+    """
+    result = options_or_value
+    if isinstance(options_or_value, dict):
+        if not options_or_value:
+            raise EasyBuildError("Found empty dict as %s!", description)
+        other_keys = [x for x in options_or_value.keys() if not x.startswith(ARCH_KEY_PREFIX)]
+        if other_keys:
+            other_keys = ','.join(sorted(other_keys))
+            raise EasyBuildError("Unexpected keys in %s: %s (only '%s' keys are supported)",
+                                 description, other_keys, ARCH_KEY_PREFIX)
+        host_arch_key = ARCH_KEY_PREFIX + get_cpu_architecture()
+        star_arch_key = ARCH_KEY_PREFIX + '*'
+        # check for specific 'arch=' key first
+        try:
+            result = options_or_value[host_arch_key]
+            _log.info("Selected %s from %s for %s (using key %s)",
+                      result, options_or_value, description, host_arch_key)
+        except KeyError:
+            # fall back to 'arch=*'
+            try:
+                result = options_or_value[star_arch_key]
+                _log.info("Selected %s from %s for %s (using fallback key %s)",
+                          result, options_or_value, description, star_arch_key)
+            except KeyError:
+                if allow_none:
+                    result = None
+                else:
+                    raise EasyBuildError("No matches for %s in %s (looking for %s)",
+                                         description, options_or_value, host_arch_key)
+    return result
+
+
 def pick_dep_version(dep_version):
     """
     Pick the correct dependency version to use for this system.
@@ -1243,39 +1283,14 @@ def pick_dep_version(dep_version):
 
     Return value is the version to use.
     """
-    if isinstance(dep_version, string_type):
-        _log.debug("Version is already a string ('%s'), OK", dep_version)
-        result = dep_version
-
-    elif dep_version is None:
+    if dep_version is None:
         _log.debug("Version is None, OK")
         result = None
-
-    elif isinstance(dep_version, dict):
-        arch_keys = [x for x in dep_version.keys() if x.startswith(ARCH_KEY_PREFIX)]
-        other_keys = [x for x in dep_version.keys() if x not in arch_keys]
-        if other_keys:
-            other_keys = ','.join(sorted(other_keys))
-            raise EasyBuildError("Unexpected keys in version: %s (only 'arch=' keys are supported)", other_keys)
-        if arch_keys:
-            host_arch_key = ARCH_KEY_PREFIX + get_cpu_architecture()
-            star_arch_key = ARCH_KEY_PREFIX + '*'
-            # check for specific 'arch=' key first
-            if host_arch_key in dep_version:
-                result = dep_version[host_arch_key]
-                _log.info("Version selected from %s using key %s: %s", dep_version, host_arch_key, result)
-            # fall back to 'arch=*'
-            elif star_arch_key in dep_version:
-                result = dep_version[star_arch_key]
-                _log.info("Version selected for %s using fallback key %s: %s", dep_version, star_arch_key, result)
-            else:
-                raise EasyBuildError("No matches for version in %s (looking for %s)", dep_version, host_arch_key)
-        else:
-            raise EasyBuildError("Found empty dict as version!")
-
     else:
-        typ = type(dep_version)
-        raise EasyBuildError("Unknown value type for version: %s (%s), should be string value", typ, dep_version)
+        result = pick_system_specific_value("version", dep_version)
+        if not isinstance(result, string_type):
+            typ = type(dep_version)
+            raise EasyBuildError("Unknown value type for version: %s (%s), should be string value", typ, dep_version)
 
     return result
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -38,6 +38,7 @@ from inspect import cleandoc
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
 
+import easybuild.tools.systemtools as st
 from easybuild.framework.easyblock import EasyBlock, get_easyblock_instance
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.easyconfig.easyconfig import EasyConfig
@@ -2542,6 +2543,32 @@ class EasyBlockTest(EnhancedTestCase):
         hpl = easyblocks['easybuild.easyblocks.hpl']
         self.assertEqual(hpl['class'], 'EB_HPL')
         self.assertTrue(hpl['loc'].endswith('sandbox/easybuild/easyblocks/h/hpl.py'))
+
+    def test_arch_specific_sanity_check(self):
+        """Tests that the correct version is chosen for this architecture"""
+
+        my_arch = st.get_cpu_architecture()
+
+        self.contents = '\n'.join([
+            'easyblock = "ConfigureMake"',
+            'name = "test"',
+            'version = "0.2"',
+            'homepage = "https://example.com"',
+            'description = "test"',
+            'toolchain = SYSTEM',
+            'sanity_check_paths = {',
+            "  'files': [{'arch=%s': 'correct.a'}, 'default.a']," % my_arch,
+            "  'dirs': [{'arch=%s': ('correct', 'alternative')}, {'arch=no-arch': 'not-used'}]," % my_arch,
+            '}',
+        ])
+        self.writeEC()
+        ec = EasyConfig(self.eb_file)
+        eb = EasyBlock(ec)
+        paths, _, _ = eb._sanity_check_step_common(None, None)
+
+        self.assertEqual(set(paths.keys()), set(('files', 'dirs')))
+        self.assertEqual(paths['files'], ['correct.a', 'default.a'])
+        self.assertEqual(paths['dirs'], [('correct', 'alternative')])
 
     def test_sanity_check_paths_verification(self):
         """Test verification of sanity_check_paths w.r.t. keys & values."""

--- a/test/framework/type_checking.py
+++ b/test/framework/type_checking.py
@@ -701,7 +701,7 @@ class TypeCheckingTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, "Expected value to be a dict", to_sanity_check_paths_dict, [])
         error_msg = "Expected value to be a list"
         self.assertErrorRegex(EasyBuildError, error_msg, to_sanity_check_paths_dict, {'files': 'foo', 'dirs': []})
-        error_msg = "Expected elements to be of type string, tuple or list"
+        error_msg = "Expected elements to be of type string, tuple/list or dict"
         self.assertErrorRegex(EasyBuildError, error_msg, to_sanity_check_paths_dict, {'files': [], 'dirs': [1]})
 
     def test_to_checksums(self):


### PR DESCRIPTION
- Factor out `pick_system_specific_value` to be used by `pick_dep_version`
- Allow arch specific entries in sanity check paths

Example: `'files': [{'arch=x86_64': 'correct.a'}, 'all_archs.a']`

Note that the arch-specific stuff are single files or alternatives (tuple), not a full list of files (again) to keep it simple.