### PR TITLE
add support for collecting GPU info (via nvidia-smi), and include it in --show-system-info and test report

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -99,7 +99,7 @@ from easybuild.tools.toolchain.compiler import DEFAULT_OPT_LEVEL, OPTARCH_MAP_CH
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
 from easybuild.tools.repository.repository import avail_repositories
 from easybuild.tools.systemtools import UNKNOWN, check_python_version, get_cpu_architecture, get_cpu_family
-from easybuild.tools.systemtools import get_cpu_features, get_system_info
+from easybuild.tools.systemtools import get_cpu_features, get_gpu_info, get_system_info
 from easybuild.tools.version import this_is_easybuild
 
 
@@ -1292,6 +1292,7 @@ class EasyBuildOptions(GeneralOption):
         """Show system information."""
         system_info = get_system_info()
         cpu_features = get_cpu_features()
+        gpu_info = get_gpu_info()
         cpu_arch_name = system_info['cpu_arch_name']
         lines = [
             "System information (%s):" % system_info['hostname'],
@@ -1323,6 +1324,16 @@ class EasyBuildOptions(GeneralOption):
             "  -> Python binary: %s" % sys.executable,
             "  -> Python version: %s" % sys.version.split(' ')[0],
         ])
+
+        if gpu_info:
+            lines.extend([
+                '',
+                "* GPU:",
+            ])
+            for vendor in gpu_info:
+                lines.append("  -> %s" % vendor)
+                for gpu, num in gpu_info[vendor].items():
+                    lines.append("    -> %s: %s" % (gpu, num))
 
         return '\n'.join(lines)
 

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -588,15 +588,16 @@ def get_gpu_info():
             out, ec = run_cmd(cmd, force_in_dry_run=True, trace=False, stream_output=False)
             if ec == 0:
                 for line in out.strip().split('\n'):
-                    if 'NVIDIA' in gpu_info and line in gpu_info['NVIDIA']:
-                        gpu_info['NVIDIA'][line] += 1
-                    else:
-                        gpu_info['NVIDIA'] = {}
-                        gpu_info['NVIDIA'][line] = 1
-        except Exception:
-            _log.debug("No NVIDIA GPUs detected")
+                    nvidia_gpu_info = gpu_info.setdefault('NVIDIA', {})
+                    nvidia_gpu_info.setdefault(line, 0)
+                    nvidia_gpu_info[line] += 1
+            else:
+                _log.debug("None zero exit (%s) from nvidia-smi: %s" % (ec, out))
+        except Exception as err:
+            _log.debug("Exception was raised when running nvidia-smi: %s", err)
+            _log.info("No NVIDIA GPUs detected")
     else:
-        _log.debug("Only know how to get GPU info on Linux")
+        _log.info("Only know how to get GPU info on Linux, assuming no GPUs are present")
 
     return gpu_info
 

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -574,6 +574,33 @@ def get_cpu_features():
     return cpu_feat
 
 
+def get_gpu_info():
+    """
+    Get the GPU info
+    """
+    gpu_info = {}
+    os_type = get_os_type()
+
+    if os_type == LINUX:
+        try:
+            cmd = "nvidia-smi --query-gpu=gpu_name,driver_version --format=csv,noheader"
+            _log.debug("Trying to determine NVIDIA GPU info on Linux via cmd '%s'", cmd)
+            out, ec = run_cmd(cmd, force_in_dry_run=True, trace=False, stream_output=False)
+            if ec == 0:
+                for line in out.strip().split('\n'):
+                    if 'NVIDIA' in gpu_info and line in gpu_info['NVIDIA']:
+                        gpu_info['NVIDIA'][line] += 1
+                    else:
+                        gpu_info['NVIDIA'] = {}
+                        gpu_info['NVIDIA'][line] = 1
+        except Exception:
+            _log.debug("No NVIDIA GPUs detected")
+    else:
+        _log.debug("Only know how to get GPU info on Linux")
+
+    return gpu_info
+
+
 def get_kernel_name():
     """NO LONGER SUPPORTED: use get_os_type() instead"""
     _log.nosupport("get_kernel_name() is replaced by get_os_type()", '2.0')

--- a/easybuild/tools/testing.py
+++ b/easybuild/tools/testing.py
@@ -301,7 +301,7 @@ def post_pr_test_report(pr_nrs, repo_type, test_report, msg, init_session_state,
     if gpu_info:
         for vendor in gpu_info:
             for gpu, num in gpu_info[vendor].items():
-                gpu_str += ", %s %s x %s" % (vendor, num, gpu)
+                gpu_str += ", %s x %s %s" % (num, vendor, gpu)
 
     os_info = '%(hostname)s - %(os_type)s %(os_name)s %(os_version)s' % system_info
     short_system_info = "%(os_info)s, %(cpu_arch)s, %(cpu_model)s%(gpu)s, Python %(pyver)s" % {

--- a/easybuild/tools/testing.py
+++ b/easybuild/tools/testing.py
@@ -297,13 +297,11 @@ def post_pr_test_report(pr_nrs, repo_type, test_report, msg, init_session_state,
 
     # add GPU info, if known
     gpu_info = get_gpu_info()
+    gpu_str = ""
     if gpu_info:
-        gpu_str = " gpu: "
         for vendor in gpu_info:
             for gpu, num in gpu_info[vendor].items():
-                gpu_str += "%s %s x %s; " % (vendor, num, gpu)
-    else:
-        gpu_str = ""
+                gpu_str += ", %s %s x %s" % (vendor, num, gpu)
 
     os_info = '%(hostname)s - %(os_type)s %(os_name)s %(os_version)s' % system_info
     short_system_info = "%(os_info)s, %(cpu_arch)s, %(cpu_model)s%(gpu)s, Python %(pyver)s" % {

--- a/easybuild/tools/testing.py
+++ b/easybuild/tools/testing.py
@@ -50,7 +50,7 @@ from easybuild.tools.github import GITHUB_EASYBLOCKS_REPO, GITHUB_EASYCONFIGS_RE
 from easybuild.tools.jenkins import aggregate_xml_in_dirs
 from easybuild.tools.parallelbuild import build_easyconfigs_in_parallel
 from easybuild.tools.robot import resolve_dependencies
-from easybuild.tools.systemtools import UNKNOWN, get_system_info
+from easybuild.tools.systemtools import UNKNOWN, get_gpu_info, get_system_info
 from easybuild.tools.version import FRAMEWORK_VERSION, EASYBLOCKS_VERSION
 
 
@@ -295,11 +295,22 @@ def post_pr_test_report(pr_nrs, repo_type, test_report, msg, init_session_state,
     if system_info['cpu_arch_name'] != UNKNOWN:
         system_info['cpu_model'] += " (%s)" % system_info['cpu_arch_name']
 
+    # add GPU info, if known
+    gpu_info = get_gpu_info()
+    if gpu_info:
+        gpu_str = " gpu: "
+        for vendor in gpu_info:
+            for gpu, num in gpu_info[vendor].items():
+                gpu_str += "%s %s x %s; " % (vendor, num, gpu)
+    else:
+        gpu_str = ""
+
     os_info = '%(hostname)s - %(os_type)s %(os_name)s %(os_version)s' % system_info
-    short_system_info = "%(os_info)s, %(cpu_arch)s, %(cpu_model)s, Python %(pyver)s" % {
+    short_system_info = "%(os_info)s, %(cpu_arch)s, %(cpu_model)s%(gpu)s, Python %(pyver)s" % {
         'os_info': os_info,
         'cpu_arch': system_info['cpu_arch'],
         'cpu_model': system_info['cpu_model'],
+        'gpu': gpu_str,
         'pyver': system_info['python_version'].split(' ')[0],
     }
 


### PR DESCRIPTION
closes #3825

Add GPU info to
 * `eb --show-system-info`
 * the PR post for a test report

Only supports NVIDIA GPUs on linux as that is all I have.