### PR TITLE
make update_progress_bar a bit more robust by just doing nothing if the corresponding progress bar was not started (and making stopping of a non-started progress bar fatal)

### DIFF
--- a/easybuild/tools/output.py
+++ b/easybuild/tools/output.py
@@ -250,22 +250,15 @@ def extensions_progress_bar():
     return progress_bar
 
 
-def get_progress_bar(bar_type, size=None):
+def get_progress_bar(bar_type, ignore_cache=False, size=None):
     """
     Get progress bar of given type.
     """
-    progress_bar_types = {
-        PROGRESS_BAR_DOWNLOAD_ALL: download_all_progress_bar,
-        PROGRESS_BAR_DOWNLOAD_ONE: download_one_progress_bar,
-        PROGRESS_BAR_EXTENSIONS: extensions_progress_bar,
-        PROGRESS_BAR_EASYCONFIG: easyconfig_progress_bar,
-        STATUS_BAR: status_bar,
-    }
 
     if bar_type == PROGRESS_BAR_DOWNLOAD_ONE and not size:
-        pbar = download_one_progress_bar_unknown_size()
-    elif bar_type in progress_bar_types:
-        pbar = progress_bar_types[bar_type]()
+        pbar = download_one_progress_bar_unknown_size(ignore_cache=ignore_cache)
+    elif bar_type in PROGRESS_BAR_TYPES:
+        pbar = PROGRESS_BAR_TYPES[bar_type](ignore_cache=ignore_cache)
     else:
         raise EasyBuildError("Unknown progress bar type: %s", bar_type)
 
@@ -388,3 +381,13 @@ def print_checks(checks_data):
             console_print(table)
         else:
             print('\n'.join(lines))
+
+
+# this constant must be defined at the end, since functions used as values need to be defined
+PROGRESS_BAR_TYPES = {
+    PROGRESS_BAR_DOWNLOAD_ALL: download_all_progress_bar,
+    PROGRESS_BAR_DOWNLOAD_ONE: download_one_progress_bar,
+    PROGRESS_BAR_EXTENSIONS: extensions_progress_bar,
+    PROGRESS_BAR_EASYCONFIG: easyconfig_progress_bar,
+    STATUS_BAR: status_bar,
+}


### PR DESCRIPTION
Without these changes, calling `update_progress_bar` when the progress bar was not started yet means trouble:

```
Traceback (most recent call last):
   ...
  File "/home/kehoste/easybuild-framework/easybuild/tools/output.py", line 304, in update_progress_bar
    (pbar, task_id) = _progress_bar_cache[bar_type]
KeyError: 'extensions'
```

Raising a `KeyError` is pretty nasty, since it gives zero info when it's reported without the traceback.

In https://github.com/easybuilders/easybuild-framework/pull/3667 I've moved `update_progress_bar` into `EasyBlock.init_ext_instances` for example, which sometimes gets called without the `start_progress_bar` in `extensions_step`.
In that case, updating the progress bar doesn't make much sense, and making sure it's only called when an extensions progress bar is actually "active" would be tricky (and lead to ugly code).