### PR TITLE
explictly disable rebase when pulling develop branch to create a merge commit, since not specifying how to reconcile divergent branches is an error with Git 2.33.1 and newer

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -2409,7 +2409,7 @@ def sync_with_develop(git_repo, branch_name, github_account, github_repo):
     remote = create_remote(git_repo, github_account, github_repo, https=True)
 
     # fetch latest version of develop branch
-    pull_out = git_repo.git.pull(remote.name, GITHUB_DEVELOP_BRANCH)
+    pull_out = git_repo.git.pull(remote.name, GITHUB_DEVELOP_BRANCH, no_rebase=True)
     _log.debug("Output of 'git pull %s %s': %s", remote.name, GITHUB_DEVELOP_BRANCH, pull_out)
 
     # fetch to make sure we can check out the 'develop' branch


### PR DESCRIPTION
fixes #3873