### PR TITLE
make check for running failing command asynchronously more robust w.r.t. obtaining full output

### DIFF
--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -619,7 +619,7 @@ class RunTest(EnhancedTestCase):
         res = check_async_cmd(*cmd_info, fail_on_error=False)
         # keep checking until command is fully done
         while not res['done']:
-            res = check_async_cmd(*cmd_info, fail_on_error=False)
+            res = check_async_cmd(*cmd_info, fail_on_error=False, output=res['output'])
         self.assertEqual(res, {'done': True, 'exit_code': 123, 'output': "FAIL!\n"})
 
         # also test with a command that produces a lot of output,


### PR DESCRIPTION
`test_run_cmd_async` fails occasionally because command output is consumed before command is fully completed:

```
 FAIL: test_run_cmd_async (test.framework.run.RunTest)
Test asynchronously running of a shell command via run_cmd + complete_cmd.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/runner/5948e8b85c06402503a29543e1b0c4ace6c14528/lib/python3.9/site-packages/easybuild/base/testing.py", line 94, in assertEqual
    super(TestCase, self).assertEqual(a, b)
  File "/opt/hostedtoolcache/Python/3.9.7/x64/lib/python3.9/unittest/case.py", line 829, in assertEqual
    assertion_func(first, second, msg=msg)
AssertionError: {'done': True, 'exit_code': 123, 'output': ''} != {'done': True, 'exit_code': 123, 'output': 'FAIL!\n'}
- {'done': True, 'exit_code': 123, 'output': ''}
+ {'done': True, 'exit_code': 123, 'output': 'FAIL!\n'}
?                                             +++++++
```