### PR TITLE
determine which extensions can be skipped in parallel (if --parallel-extensions-install is enabled)

### DIFF
--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1820,15 +1820,19 @@ class ToyBuildTest(EnhancedTestCase):
         args.append('--skip')
         stdout, stderr = self.run_test_toy_build_with_output(ec_file=test_ec, extra_args=args)
         self.assertEqual(stderr, '')
-        expected_stdout = '\n'.join([
-            "skipping installed extensions (in parallel)",
-            "== skipping extension ls",
-            "== skipping extension bar",
-            "== skipping extension barbar",
-            "== skipping extension toy",
-        ])
-        error_msg = "Expected output '%s' should be found in %s'" % (expected_stdout, stdout)
-        self.assertTrue(expected_stdout in stdout, error_msg)
+
+        # order in which these patterns occur is not fixed, so check them one by one
+        patterns = [
+            r"^== skipping installed extensions \(in parallel\)$",
+            r"^== skipping extension ls$",
+            r"^== skipping extension bar$",
+            r"^== skipping extension barbar$",
+            r"^== skipping extension toy$",
+        ]
+        for pattern in patterns:
+            regex = re.compile(pattern, re.M)
+            error_msg = "Expected pattern '%s' should be found in %s'" % (regex.pattern, stdout)
+            self.assertTrue(regex.search(stdout), error_msg)
 
     def test_backup_modules(self):
         """Test use of backing up of modules with --module-only."""

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1804,7 +1804,7 @@ class ToyBuildTest(EnhancedTestCase):
         ])
         write_file(test_ec, test_ec_txt)
 
-        args = ['--parallel-extensions-install', '--experimental', '--force']
+        args = ['--parallel-extensions-install', '--experimental', '--force', '--parallel=3']
         stdout, stderr = self.run_test_toy_build_with_output(ec_file=test_ec, extra_args=args)
         self.assertEqual(stderr, '')
         expected_stdout = '\n'.join([
@@ -1815,6 +1815,20 @@ class ToyBuildTest(EnhancedTestCase):
             '',
         ])
         self.assertEqual(stdout, expected_stdout)
+
+        # also test skipping of extensions in parallel
+        args.append('--skip')
+        stdout, stderr = self.run_test_toy_build_with_output(ec_file=test_ec, extra_args=args)
+        self.assertEqual(stderr, '')
+        expected_stdout = '\n'.join([
+            "skipping installed extensions (in parallel)",
+            "== skipping extension ls",
+            "== skipping extension bar",
+            "== skipping extension barbar",
+            "== skipping extension toy",
+        ])
+        error_msg = "Expected output '%s' should be found in %s'" % (expected_stdout, stdout)
+        self.assertTrue(expected_stdout in stdout, error_msg)
 
     def test_backup_modules(self):
         """Test use of backing up of modules with --module-only."""


### PR DESCRIPTION
When running sequentially, checking which extensions can be skipped in parallel for `R-4.1.0-foss-2021a.eb` takes about 30 minutes (incl. creating the `Extension` instances, which takes about 5 min.)

With this enhancement, this is sped up significantly using `--parallel-extensions-install --experimental` (measured on an AMD EPYC 7552 - Rome system, in a Slurm job with 24 cores available)

* Using all 24 cores: 11 min. 30 sec.
* Using `--parallel=6`: 14 min. sec.