### PR TITLE
Fix typo in Agreement

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1895,7 +1895,7 @@ class EasyBlock(object):
             self.log.info("EULA for %s is accepted", name)
         else:
             error_lines = [
-                "The End User License Argreement (EULA) for %(name)s is currently not accepted!",
+                "The End User License Agreement (EULA) for %(name)s is currently not accepted!",
             ]
             if more_info:
                 error_lines.append("(see %s for more information)" % more_info)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -6242,7 +6242,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         # by default, no EULAs are accepted at all
         args = [test_ec, '--force']
-        error_pattern = r"The End User License Argreement \(EULA\) for toy is currently not accepted!"
+        error_pattern = r"The End User License Agreement \(EULA\) for toy is currently not accepted!"
         self.assertErrorRegex(EasyBuildError, error_pattern, self.eb_main, args, do_build=True, raise_error=True)
         toy_modfile = os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0')
         if get_module_syntax() == 'Lua':


### PR DESCRIPTION
It was typed as "Argreement", both in the easyblock implementation itself and the test.