### PR TITLE
don't try to ensure absolute path for path part of repositorypath

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1092,21 +1092,19 @@ class EasyBuildOptions(GeneralOption):
     def _postprocess_config(self):
         """Postprocessing of configuration options"""
 
-        # resolve relative paths for configuration options that specify a location;
+        # resolve relative paths for configuration options that specify a location,
+        # to avoid incorrect paths being used when EasyBuild changes the current working directory
+        # (see https://github.com/easybuilders/easybuild-framework/issues/3619);
         # ensuring absolute paths for 'robot' is handled separately below,
-        # because we need to be careful with the argument pass to --robot
+        # because we need to be careful with the argument pass to --robot;
+        # note: repositorypath is purposely not listed here, because it's a special case:
+        # - the value could consist of a 2-tuple (<path>, <relative_subdir>);
+        # - the <path> could also specify the location of a *remote* (Git( repository,
+        #   which can be done in variety of formats (git@<url>:<org>/<repo>), https://<url>, etc.)
+        #   (see also https://github.com/easybuilders/easybuild-framework/issues/3892);
         path_opt_names = ['buildpath', 'containerpath', 'git_working_dirs_path', 'installpath',
                           'installpath_modules', 'installpath_software', 'prefix', 'packagepath',
                           'robot_paths', 'sourcepath']
-
-        # repositorypath is a special case: only first part is a path;
-        # 2nd (optional) part is a relative subdir and should not be resolved to an absolute path!
-        repositorypath = self.options.repositorypath
-        if isinstance(repositorypath, (list, tuple)) and len(repositorypath) == 2:
-            abs_path = self.get_cfg_opt_abs_path('repositorypath', repositorypath[0])
-            self.options.repositorypath = (abs_path, repositorypath[1])
-        else:
-            path_opt_names.append('repositorypath')
 
         for opt_name in path_opt_names:
             self._ensure_abs_path(opt_name)

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -302,7 +302,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
         self.assertEqual(install_path('mod'), installpath_modules),  # via config file
         self.assertEqual(source_paths(), [testpath2])  # via command line
         self.assertEqual(build_path(), testpath1)  # via config file
-        self.assertEqual(get_repositorypath(), (os.path.join(topdir, 'ebfiles_repo'), 'somesubdir'))  # via config file
+        self.assertEqual(get_repositorypath(), [os.path.join(topdir, 'ebfiles_repo'), 'somesubdir'])  # via config file
 
         # hardcoded first entry
         self.assertEqual(options.robot_paths[0], '/tmp/foo')

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -6334,7 +6334,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             r"^containerpath\s+\(F\) = /.*/test_topdir/test_middle_dir$",
             r"^installpath\s+\(E\) = /.*/test_topdir$",
             r"^prefix\s+\(C\) = /.*/test_topdir/test_middle_dir$",
-            r"^repositorypath\s+\(F\) = \('/apps/easyconfigs_archive', ' somesubdir'\)$",
+            r"^repositorypath\s+\(F\) = /apps/easyconfigs_archive,\s+somesubdir$",
             r"^sourcepath\s+\(C\) = /.*/test_topdir/test_middle_dir/test_subdir$",
             r"^robot-paths\s+\(E\) = /.*/test_topdir$",
         ]

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -6377,7 +6377,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args[0] = '--repositorypath=%s,some/subdir' % repositorypath
         txt, _ = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False, strip=True)
 
-        regex = re.compile(r"repositorypath\s+\(C\) = \('%s', 'some/subdir'\)" % repositorypath, re.M)
+        regex = re.compile(r"repositorypath\s+\(C\) = %s, some/subdir" % repositorypath, re.M)
         self.assertTrue(regex.search(txt), "Pattern '%s' should be found in: %s" % (regex.pattern, txt))
 
     # end-to-end testing of unknown filename


### PR DESCRIPTION
#3893 was an incomplete fix for #3892

The easy way out is to just leave the `repositorypath` value untouched (i.e. don't try to ensure it's an absolute path), which is difficult to do since it could specify the location to a *remote* repository in a variety of formats...

fixes #3892