### PR TITLE
introduce EasyBlock.post_init method to correctly define builddir variable when build-in-installdir mode is enabled in easyconfig or easyblock

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -268,11 +268,6 @@ class EasyBlock(object):
         # generate build/install directories
         self.gen_builddir()
         self.gen_installdir()
-        if self.build_in_installdir:
-            # self.builddir is set by self.gen_builddir(),
-            # but needs to be correct if the build is performed in the installation directory
-            self.log.info("Changing build dir to %s", self.installdir)
-            self.builddir = self.installdir
 
         self.ignored_errors = False
 
@@ -280,6 +275,16 @@ class EasyBlock(object):
             self.init_dry_run()
 
         self.log.info("Init completed for application name %s version %s" % (self.name, self.version))
+
+    def post_init(self):
+        """
+        Run post-initialization tasks.
+        """
+        if self.build_in_installdir:
+            # self.builddir is set by self.gen_builddir(),
+            # but needs to be correct if the build is performed in the installation directory
+            self.log.info("Changing build dir to %s", self.installdir)
+            self.builddir = self.installdir
 
     # INIT/CLOSE LOG
     def _init_log(self):
@@ -3839,6 +3844,9 @@ class EasyBlock(object):
                 # create lock to avoid that another installation running in parallel messes things up
                 create_lock(lock_name)
                 lock_created = True
+
+            # run post-initialization tasks first, before running any steps
+            self.post_init()
 
             for step_name, descr, step_methods, skippable in steps:
                 if self.skip_step(step_name, skippable):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -268,6 +268,11 @@ class EasyBlock(object):
         # generate build/install directories
         self.gen_builddir()
         self.gen_installdir()
+        if self.build_in_installdir:
+            # self.builddir is set by self.gen_builddir(),
+            # but needs to be correct if the build is performed in the installation directory
+            self.log.info("Changing build dir to %s", self.installdir)
+            self.builddir = self.installdir
 
         self.ignored_errors = False
 
@@ -941,9 +946,6 @@ class EasyBlock(object):
                 raise EasyBuildError("self.builddir not set, make sure gen_builddir() is called first!")
             self.log.debug("Creating the build directory %s (cleanup: %s)", self.builddir, self.cfg['cleanupoldbuild'])
         else:
-            self.log.info("Changing build dir to %s" % self.installdir)
-            self.builddir = self.installdir
-
             self.log.info("Overriding 'cleanupoldinstall' (to False), 'cleanupoldbuild' (to True) "
                           "and 'keeppreviousinstall' because we're building in the installation directory.")
             # force cleanup before installation

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1335,8 +1335,6 @@ class EasyConfigTest(EnhancedTestCase):
         self.prep()
         ec = EasyConfig(self.eb_file)
         eb = EasyBlock(ec)
-        eb.gen_builddir()
-        eb.gen_installdir()
         eb.make_builddir()
         eb.make_installdir()
         self.assertEqual(eb.builddir, eb.installdir)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1335,6 +1335,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.prep()
         ec = EasyConfig(self.eb_file)
         eb = EasyBlock(ec)
+        eb.post_init()
         eb.make_builddir()
         eb.make_installdir()
         self.assertEqual(eb.builddir, eb.installdir)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -6069,11 +6069,20 @@ class CommandLineOptionsTest(EnhancedTestCase):
         test_ec_txt = test_ec_txt.replace('buildininstalldir = True', '')
         write_file(test_ec, test_ec_txt)
 
+        orig_local_sys_path = sys.path[:]
         args.append('--include-easyblocks=%s' % toy_eb)
         self.eb_main(args, do_build=True, raise_error=True)
 
         # undo import of the toy easyblock, to avoid problems with other tests
         del sys.modules['easybuild.easyblocks.toy']
+        sys.path = orig_local_sys_path
+        import easybuild.easyblocks
+        reload(easybuild.easyblocks)
+        import easybuild.easyblocks.toy
+        reload(easybuild.easyblocks.toy)
+        # need to reload toy_extension, which imports EB_toy, to ensure right EB_toy is picked up in later tests
+        import easybuild.easyblocks.generic.toy_extension
+        reload(easybuild.easyblocks.generic.toy_extension)
 
     def test_skip_extensions(self):
         """Test use of --skip-extensions."""

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -6037,6 +6037,21 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         stdout = self.mocked_main(args + ['--trace'], do_build=True, raise_error=True, testing=False)
 
+        # check whether %(builddir)s value is correct
+        # when build_in_installdir is enabled and --sanity-check-only is used
+        # (see https://github.com/easybuilders/easybuild-framework/issues/3895)
+        test_ec_txt += '\n' + '\n'.join([
+            "buildininstalldir = True",
+            "sanity_check_commands = [",
+            # build and install directory should be the same path
+            "    'test %(builddir)s = %(installdir)s',",
+            # build/install directory must exist (even though step that creates build dir was never run)
+            "    'test -d %(builddir)s',",
+            "]",
+        ])
+        write_file(test_ec, test_ec_txt)
+        self.eb_main(args, do_build=True, raise_error=True)
+
     def test_skip_extensions(self):
         """Test use of --skip-extensions."""
         topdir = os.path.abspath(os.path.dirname(__file__))

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -6072,6 +6072,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args.append('--include-easyblocks=%s' % toy_eb)
         self.eb_main(args, do_build=True, raise_error=True)
 
+        # undo import of the toy easyblock, to avoid problems with other tests
+        del sys.modules['easybuild.easyblocks.toy']
+
     def test_skip_extensions(self):
         """Test use of --skip-extensions."""
         topdir = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
fixes #3895