### PR TITLE
fall back to sequential installation for extensions with unknown dependencies

### DIFF
--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -225,7 +225,8 @@ class Extension(object):
     @property
     def required_deps(self):
         """Return list of required dependencies for this extension."""
-        raise NotImplementedError("Don't know how to determine required dependencies for extension '%s'" % self.name)
+        self.log.info("Don't know how to determine required dependencies for extension '%s'", self.name)
+        return None
 
     @property
     def toolchain(self):

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1816,32 +1816,8 @@ class ToyBuildTest(EnhancedTestCase):
         ])
         self.assertEqual(stdout, expected_stdout)
 
-        # check behaviour when using Toy_Extension easyblock that doesn't implement required_deps method;
-        # framework should fall back to installing extensions sequentially
-        toy_ext_eb = os.path.join(topdir, 'sandbox', 'easybuild', 'easyblocks', 'generic', 'toy_extension.py')
-        copy_file(toy_ext_eb, self.test_prefix)
-        toy_ext_eb = os.path.join(self.test_prefix, 'toy_extension.py')
-        toy_ext_eb_txt = read_file(toy_ext_eb)
-        toy_ext_eb_txt = toy_ext_eb_txt.replace('def required_deps', 'def xxx_required_deps')
-        write_file(toy_ext_eb, toy_ext_eb_txt)
-
-        args.append('--include-easyblocks=%s' % toy_ext_eb)
-        stdout, stderr = self.run_test_toy_build_with_output(ec_file=test_ec, extra_args=args)
-        self.assertEqual(stderr, '')
-        expected_stdout = '\n'.join([
-            "== 0 out of 4 extensions installed (3 queued, 1 running: ls)",
-            "== 1 out of 4 extensions installed (2 queued, 1 running: bar)",
-            "== 2 out of 4 extensions installed (1 queued, 1 running: barbar)",
-            "== 3 out of 4 extensions installed (0 queued, 1 running: toy)",
-            "== 4 out of 4 extensions installed (0 queued, 0 running: )",
-            '',
-        ])
-        self.assertEqual(stdout, expected_stdout)
-
-        remove_file(toy_ext_eb)
-
-        # also test skipping of extensions in parallel (so do not use patched you easyblock)
-        args[-1] = '--skip'
+        # also test skipping of extensions in parallel
+        args.append('--skip')
         stdout, stderr = self.run_test_toy_build_with_output(ec_file=test_ec, extra_args=args)
         self.assertEqual(stderr, '')
 
@@ -1857,6 +1833,28 @@ class ToyBuildTest(EnhancedTestCase):
             regex = re.compile(pattern, re.M)
             error_msg = "Expected pattern '%s' should be found in %s'" % (regex.pattern, stdout)
             self.assertTrue(regex.search(stdout), error_msg)
+
+        # check behaviour when using Toy_Extension easyblock that doesn't implement required_deps method;
+        # framework should fall back to installing extensions sequentially
+        toy_ext_eb = os.path.join(topdir, 'sandbox', 'easybuild', 'easyblocks', 'generic', 'toy_extension.py')
+        copy_file(toy_ext_eb, self.test_prefix)
+        toy_ext_eb = os.path.join(self.test_prefix, 'toy_extension.py')
+        toy_ext_eb_txt = read_file(toy_ext_eb)
+        toy_ext_eb_txt = toy_ext_eb_txt.replace('def required_deps', 'def xxx_required_deps')
+        write_file(toy_ext_eb, toy_ext_eb_txt)
+
+        args[-1] = '--include-easyblocks=%s' % toy_ext_eb
+        stdout, stderr = self.run_test_toy_build_with_output(ec_file=test_ec, extra_args=args)
+        self.assertEqual(stderr, '')
+        expected_stdout = '\n'.join([
+            "== 0 out of 4 extensions installed (3 queued, 1 running: ls)",
+            "== 1 out of 4 extensions installed (2 queued, 1 running: bar)",
+            "== 2 out of 4 extensions installed (1 queued, 1 running: barbar)",
+            "== 3 out of 4 extensions installed (0 queued, 1 running: toy)",
+            "== 4 out of 4 extensions installed (0 queued, 0 running: )",
+            '',
+        ])
+        self.assertEqual(stdout, expected_stdout)
 
     def test_backup_modules(self):
         """Test use of backing up of modules with --module-only."""


### PR DESCRIPTION
This avoids a hard crash that occurs currently when trying to use `--parallel-extensions-install --experimental --robot` and an easyconfig that includes Python packages as extensions.

For example:

```
NotImplementedError: Don't know how to determine required dependencies for extension 'setuptools'
```

This occurs because the `PythonPackage` easyblock does not define the `required_deps` method, and hence the default implementation from the `Extension` easyblock is used.

The changes include here include:
* changing the default implementation of `required_deps` to just return `None`;
* fall back to sequential installation for an extension with unknown dependencies, that is wait until all preceding extensions have been installed first (since the order in the list of extensions should then be honored).

The added test verifies that this is working as expected.