### PR TITLE
make test_run_cmd_async more robust against fluke failures

### DIFF
--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -605,7 +605,9 @@ class RunTest(EnhancedTestCase):
         self.assertEqual(res, {'done': False, 'exit_code': None, 'output': 'sleeping...\n'})
 
         # 2nd check with default output size (1024) gets full output
-        res = check_async_cmd(*cmd_info, output=res['output'])
+        # (keep checking until command is fully done)
+        while not res['done']:
+            res = check_async_cmd(*cmd_info, output=res['output'])
         self.assertEqual(res, {'done': True, 'exit_code': 0, 'output': 'sleeping...\ntest123\n'})
 
         # check asynchronous running of failing command


### PR DESCRIPTION
Avoids fluke failure for this test:

```
FAIL: test_run_cmd_async (test.framework.run.RunTest)
Test asynchronously running of a shell command via run_cmd + complete_cmd.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/runner/4e4709f47e34a1f2fa3b0c9c80f56e62d9a300f1/lib/python3.5/site-packages/easybuild/base/testing.py", line 94, in assertEqual
    super(TestCase, self).assertEqual(a, b)
  File "/opt/hostedtoolcache/Python/3.5.10/x64/lib/python3.5/unittest/case.py", line 829, in assertEqual
    assertion_func(first, second, msg=msg)
AssertionError: {'exit_code': None, 'done': False, 'output': 'sleeping...\ntest123\n'} != {'exit_code': 0, 'done': True, 'output': 'sleeping...\ntest123\n'}
- {'done': False, 'exit_code': None, 'output': 'sleeping...\ntest123\n'}
?          ^^^^                ^^^^

+ {'done': True, 'exit_code': 0, 'output': 'sleeping...\ntest123\n'}
?          ^^^                ^


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/runner/4e4709f47e34a1f2fa3b0c9c80f56e62d9a300f1/lib/python3.5/site-packages/test/framework/run.py", line 609, in test_run_cmd_async
    self.assertEqual(res, {'done': True, 'exit_code': 0, 'output': 'sleeping...\ntest123\n'})
  File "/tmp/runner/4e4709f47e34a1f2fa3b0c9c80f56e62d9a300f1/lib/python3.5/site-packages/easybuild/base/testing.py", line 116, in assertEqual
    raise AssertionError("%s:\nDIFF%s:\n%s" % (msg, limit, ''.join(diff[:self.ASSERT_MAX_DIFF])))
AssertionError: {'exit_code': None, 'done': False, 'output': 'sleeping...\ntest123\n'} != {'exit_code': 0, 'done': True, 'output': 'sleeping...\ntest123\n'}
- {'done': False, 'exit_code': None, 'output': 'sleeping...\ntest123\n'}
?          ^^^^                ^^^^

+ {'done': True, 'exit_code': 0, 'output': 'sleeping...\ntest123\n'}
?          ^^^                ^
:
DIFF:
- {'done': False, 'exit_code': None, 'output': 'sleeping...\ntest123\n'}?          ^^^^                ^^^^
+ {'done': True, 'exit_code': 0, 'output': 'sleeping...\ntest123\n'}

----------------------------------------------------------------------
Ran 803 tests in 871.266s

FAILED (failures=1)
ERROR: Not all tests were successful.
```