### PR TITLE
deprecate use of patch files that don't have a filename ending with .patch

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1493,6 +1493,9 @@ def create_patch_info(patch_spec):
                                  str(patch_spec))
 
     elif isinstance(patch_spec, string_type):
+        if not patch_spec.endswith('.patch'):
+            _log.deprecated("Add '.patch' suffix to patch file, or use 2-element list/tuple to specify "
+                            "path to where non-patch file should be copied: %s" % patch_spec, '5.0')
         patch_info = {'name': patch_spec}
     else:
         error_msg = "Wrong patch spec, should be string of 2-tuple with patch name + argument: %s"

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1494,8 +1494,7 @@ def create_patch_info(patch_spec):
 
     elif isinstance(patch_spec, string_type):
         if not patch_spec.endswith('.patch'):
-            _log.deprecated("Add '.patch' suffix to patch file, or use 2-element list/tuple to specify "
-                            "path to where non-patch file should be copied: %s" % patch_spec, '5.0')
+            _log.deprecated("Use of patch file with filename that doesn't end with .patch: %s" % patch_spec, '5.0')
         patch_info = {'name': patch_spec}
     else:
         error_msg = "Wrong patch spec, should be string of 2-tuple with patch name + argument: %s"

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -461,7 +461,7 @@ class EasyConfigTest(EnhancedTestCase):
             '   ("ext1", "1.0"),',
             '   ("ext2", "2.0", {',
             '       "source_urls": [("http://example.com", "suffix")],'
-            '       "patches": [("toy-0.0.eb", '.')],',  # dummy patch to avoid downloading fail
+            '       "patches": [("toy-0.0.eb", ".")],',  # dummy patch to avoid downloading fail
             '       "checksums": [',
                         # SHA256 checksum for source (gzip-1.4.eb)
             '           "6a5abcab719cefa95dca4af0db0d2a9d205d68f775a33b452ec0f2b75b6a3a45",',

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -461,7 +461,7 @@ class EasyConfigTest(EnhancedTestCase):
             '   ("ext1", "1.0"),',
             '   ("ext2", "2.0", {',
             '       "source_urls": [("http://example.com", "suffix")],'
-            '       "patches": ["toy-0.0.eb"],',  # dummy patch to avoid downloading fail
+            '       "patches": [("toy-0.0.eb", '.')],',  # dummy patch to avoid downloading fail
             '       "checksums": [',
                         # SHA256 checksum for source (gzip-1.4.eb)
             '           "6a5abcab719cefa95dca4af0db0d2a9d205d68f775a33b452ec0f2b75b6a3a45",',

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -488,7 +488,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(exts_sources[1]['options'], {
             'checksums': ['6a5abcab719cefa95dca4af0db0d2a9d205d68f775a33b452ec0f2b75b6a3a45',
                           '2d964e0e8f05a7cce0dd83a3e68c9737da14b87b61b8b8b0291d58d4c8d1031c'],
-            'patches': ['toy-0.0.eb'],
+            'patches': [('toy-0.0.eb', '.')],
             'source_tmpl': 'gzip-1.4.eb',
             'source_urls': [('http://example.com', 'suffix')],
         })

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1632,6 +1632,7 @@ class FileToolsTest(EnhancedTestCase):
         self.assertEqual(ft.create_patch_info(('foo.patch', 'subdir')), {'name': 'foo.patch', 'sourcepath': 'subdir'})
         self.assertEqual(ft.create_patch_info(('foo.txt', 'subdir')), {'name': 'foo.txt', 'copy': 'subdir'})
 
+        # deprecation warning (which is an error in this context)
         error_pattern = "Add '.patch' suffix to patch file, or use 2-element list/tuple to specify "
         error_pattern += "path to where non-patch file should be copied: foo.txt"
         self.assertErrorRegex(EasyBuildError, error_pattern, ft.create_patch_info, 'foo.txt')

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1628,10 +1628,13 @@ class FileToolsTest(EnhancedTestCase):
         """Test create_patch_info function."""
 
         self.assertEqual(ft.create_patch_info('foo.patch'), {'name': 'foo.patch'})
-        self.assertEqual(ft.create_patch_info('foo.txt'), {'name': 'foo.txt'})
         self.assertEqual(ft.create_patch_info(('foo.patch', 1)), {'name': 'foo.patch', 'level': 1})
         self.assertEqual(ft.create_patch_info(('foo.patch', 'subdir')), {'name': 'foo.patch', 'sourcepath': 'subdir'})
         self.assertEqual(ft.create_patch_info(('foo.txt', 'subdir')), {'name': 'foo.txt', 'copy': 'subdir'})
+
+        error_pattern = "Add '.patch' suffix to patch file, or use 2-element list/tuple to specify "
+        error_pattern += "path to where non-patch file should be copied: foo.txt"
+        self.assertErrorRegex(EasyBuildError, error_pattern, ft.create_patch_info, 'foo.txt')
 
         # faulty input
         error_msg = "Wrong patch spec"


### PR DESCRIPTION
fixes #3688