### PR TITLE
add support for update_build_options + enhance update_build_options to return original value 

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -593,6 +593,23 @@ def update_build_option(key, value):
     build_options._FrozenDict__dict[key] = value
     _log.warning("Build option '%s' was updated to: %s", key, build_option(key))
 
+    # Return original value, so they can be restored later if needed
+    return orig_value
+
+def update_build_options(key_value_dict):
+    """
+    Update all build options in the key_value_dict with the value given in that dictionary,
+    by calling update_build_option(key, value) repeatedly.
+    This function can be used e.g. when EasyConfig-specific build options are passed in an EasyStack file.
+    See https://github.com/easybuilders/easybuild-framework/issues/3513#issuecomment-986990195
+    """
+    orig_key_value_dict = {}
+    for key, value in key_value_dict.items():
+        orig_key_value_dict[key] = update_build_option(key, value)
+
+    # Return original key-value pairs in a dictionary.
+    # This way, they can later be restored by a single call to update_build_options(orig_key_value_dict)
+    return orig_key_value_dict
 
 def build_path():
     """

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -590,7 +590,7 @@ def update_build_option(key, value):
     """
     # BuildOptions() is a (singleton) frozen dict, so this is less straightforward that it seems...
     build_options = BuildOptions()
-    orig_value = build_options.__FrozenDict__dict[key]
+    orig_value = build_options._FrozenDict__dict[key]
     build_options._FrozenDict__dict[key] = value
     _log.warning("Build option '%s' was updated to: %s", key, build_option(key))
 

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -600,8 +600,8 @@ def update_build_option(key, value):
 
 def update_build_options(key_value_dict):
     """
-Update build options as specified by the given dictionary (where keys are assumed to be build option names).
-Returns dictionary with original values for the updated build options.
+    Update build options as specified by the given dictionary (where keys are assumed to be build option names).
+    Returns dictionary with original values for the updated build options.
     """
     orig_key_value_dict = {}
     for key, value in key_value_dict.items():

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -590,11 +590,13 @@ def update_build_option(key, value):
     """
     # BuildOptions() is a (singleton) frozen dict, so this is less straightforward that it seems...
     build_options = BuildOptions()
+    orig_value = build_options.__FrozenDict__dict[key]
     build_options._FrozenDict__dict[key] = value
     _log.warning("Build option '%s' was updated to: %s", key, build_option(key))
 
     # Return original value, so they can be restored later if needed
     return orig_value
+
 
 def update_build_options(key_value_dict):
     """
@@ -610,6 +612,7 @@ def update_build_options(key_value_dict):
     # Return original key-value pairs in a dictionary.
     # This way, they can later be restored by a single call to update_build_options(orig_key_value_dict)
     return orig_key_value_dict
+
 
 def build_path():
     """

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -600,10 +600,8 @@ def update_build_option(key, value):
 
 def update_build_options(key_value_dict):
     """
-    Update all build options in the key_value_dict with the value given in that dictionary,
-    by calling update_build_option(key, value) repeatedly.
-    This function can be used e.g. when EasyConfig-specific build options are passed in an EasyStack file.
-    See https://github.com/easybuilders/easybuild-framework/issues/3513#issuecomment-986990195
+Update build options as specified by the given dictionary (where keys are assumed to be build option names).
+Returns dictionary with original values for the updated build options.
     """
     orig_key_value_dict = {}
     for key, value in key_value_dict.items():

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -594,7 +594,7 @@ def update_build_option(key, value):
     build_options._FrozenDict__dict[key] = value
     _log.warning("Build option '%s' was updated to: %s", key, build_option(key))
 
-    # Return original value, so they can be restored later if needed
+    # Return original value, so it can be restored later if needed
     return orig_value
 
 

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -40,7 +40,8 @@ import easybuild.tools.options as eboptions
 from easybuild.tools import run
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option, build_path, get_build_log_path, get_log_filename, get_repositorypath
-from easybuild.tools.config import install_path, log_file_format, log_path, source_paths, update_build_option, update_build_options
+from easybuild.tools.config import install_path, log_file_format, log_path, source_paths
+from easybuild.tools.config import update_build_option, update_build_options
 from easybuild.tools.config import BuildOptions, ConfigurationVariables
 from easybuild.tools.config import DEFAULT_PATH_SUBDIRS, init_build_options
 from easybuild.tools.filetools import copy_dir, mkdir, write_file

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -688,20 +688,20 @@ class EasyBuildConfigTest(EnhancedTestCase):
     def test_update_build_options(self):
         """Test updating of a dictionary of build options."""
         self.assertEqual(build_option('banned_linked_shared_libs'), None)
-	self.assertEqual(build_option('filter_env_vars'), None)
+        self.assertEqual(build_option('filter_env_vars'), None)
 
         new_opt_dict = {
             'banned_linked_shared_libs': '/usr/lib64/libssl.so.1.1',
             'filter_env_vars': 'LD_LIBRARY_PATH',
         }
 
-        original_opt_dict = update_build_options(new_opt_dict) 
+        original_opt_dict = update_build_options(new_opt_dict)
         self.assertEqual(build_option('banned_linked_shared_libs'), '/usr/lib64/libssl.so.1.1')
-	self.assertEqual(build_option('filter_env_vars'), 'LD_LIBRARY_PATH')
+        self.assertEqual(build_option('filter_env_vars'), 'LD_LIBRARY_PATH')
 
         # Check the returned dictionary by simply restoring the variables and checking if the build
         # options have their original values again
-	update_build_options(original_opt_dict)
+        update_build_options(original_opt_dict)
         self.assertEqual(build_option('banned_linked_shared_libs'), None)
         self.assertEqual(build_option('filter_env_vars'), None)
 

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -680,12 +680,11 @@ class EasyBuildConfigTest(EnhancedTestCase):
 
     def test_update_build_option(self):
         """Test updating of a build option."""
-        # Test if new build option is set:
         self.assertEqual(build_option('banned_linked_shared_libs'), None)
-        update_build_option('banned_linked_shared_libs', '/usr/lib64/libssl.so.1.1')
+        orig_banned_linked_shared_libs = update_build_option('banned_linked_shared_libs', '/usr/lib64/libssl.so.1.1')
         self.assertEqual(build_option('banned_linked_shared_libs'), '/usr/lib64/libssl.so.1.1')
+        self.assertEqual(orig_banned_linked_shared_libs, None)
 
-        # Test also if the correct old value is returned
         self.assertTrue(build_option('cleanup_builddir'))
         orig_cleanup_builddir = update_build_option('cleanup_builddir', False)
         self.assertFalse(build_option('cleanup_builddir')

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -687,7 +687,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
 
         self.assertTrue(build_option('cleanup_builddir'))
         orig_cleanup_builddir = update_build_option('cleanup_builddir', False)
-        self.assertFalse(build_option('cleanup_builddir')
+        self.assertFalse(build_option('cleanup_builddir'))
         self.assertTrue(orig_cleanup_builddir)
 
         self.assertEqual(build_option('pr_target_account'), 'easybuilders')
@@ -700,7 +700,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
         # Check if original defaults are as expected:
         self.assertEqual(build_option('banned_linked_shared_libs'), None)
         self.assertEqual(build_option('filter_env_vars'), None)
-        self.assertTrue(build_option('cleanup_builddir')
+        self.assertTrue(build_option('cleanup_builddir'))
         self.assertEqual(build_option('pr_target_account'), 'easybuilders')
 
         # Update build options based on dictionary

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -681,8 +681,29 @@ class EasyBuildConfigTest(EnhancedTestCase):
         """Test updating of a build option."""
         self.assertEqual(build_option('banned_linked_shared_libs'), None)
 
-        update_build_option('banned_linked_shared_libs', '/usr/lib64/libssl.so.1.1')
+        old_val = update_build_option('banned_linked_shared_libs', '/usr/lib64/libssl.so.1.1')
         self.assertEqual(build_option('banned_linked_shared_libs'), '/usr/lib64/libssl.so.1.1')
+        self.assertEqual(old_val, None)
+
+    def test_update_build_options(self):
+        """Test updating of a dictionary of build options."""
+        self.assertEqual(build_option('banned_linked_shared_libs'), None)
+	self.assertEqual(build_option('filter_env_vars'), None)
+
+        new_opt_dict = {
+            'banned_linked_shared_libs': '/usr/lib64/libssl.so.1.1',
+            'filter_env_vars': 'LD_LIBRARY_PATH',
+        }
+
+        original_opt_dict = update_build_options(new_opt_dict) 
+        self.assertEqual(build_option('banned_linked_shared_libs'), '/usr/lib64/libssl.so.1.1')
+	self.assertEqual(build_option('filter_env_vars'), 'LD_LIBRARY_PATH')
+
+        # Check the returned dictionary by simply restoring the variables and checking if the build
+        # options have their original values again
+	update_build_options(original_opt_dict)
+        self.assertEqual(build_option('banned_linked_shared_libs'), None)
+        self.assertEqual(build_option('filter_env_vars'), None)
 
 
 def suite():

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -680,31 +680,45 @@ class EasyBuildConfigTest(EnhancedTestCase):
 
     def test_update_build_option(self):
         """Test updating of a build option."""
+        # Test if new build option is set:
         self.assertEqual(build_option('banned_linked_shared_libs'), None)
-
-        old_val = update_build_option('banned_linked_shared_libs', '/usr/lib64/libssl.so.1.1')
+        update_build_option('banned_linked_shared_libs', '/usr/lib64/libssl.so.1.1')
         self.assertEqual(build_option('banned_linked_shared_libs'), '/usr/lib64/libssl.so.1.1')
-        self.assertEqual(old_val, None)
+
+        # Test also if the correct old value is returned
+        self.assertTrue(build_option('cleanup_builddir'))
+        orig_cleanup_builddir = update_build_option('cleanup_builddir', False)
+        self.assertFalse(build_option('cleanup_builddir')
+        self.assertTrue(orig_cleanup_builddir)
 
     def test_update_build_options(self):
         """Test updating of a dictionary of build options."""
+        # Check if original defaults are as expected:
         self.assertEqual(build_option('banned_linked_shared_libs'), None)
         self.assertEqual(build_option('filter_env_vars'), None)
+        self.assertTrue(build_option('cleanup_builddir')
+        self.assertEqual(build_option('pr_target_account'), 'easybuilders')
 
+        # Update build options based on dictionary
         new_opt_dict = {
             'banned_linked_shared_libs': '/usr/lib64/libssl.so.1.1',
             'filter_env_vars': 'LD_LIBRARY_PATH',
+            'cleanup_builddir': False,
+            'pr_target_account': 'john_doe',
         }
-
         original_opt_dict = update_build_options(new_opt_dict)
         self.assertEqual(build_option('banned_linked_shared_libs'), '/usr/lib64/libssl.so.1.1')
         self.assertEqual(build_option('filter_env_vars'), 'LD_LIBRARY_PATH')
+        self.assertFalse(build_option('cleanup_builddir'))
+        self.assertEqual(build_option('pr_target_account'), 'john_doe')
 
         # Check the returned dictionary by simply restoring the variables and checking if the build
         # options have their original values again
         update_build_options(original_opt_dict)
         self.assertEqual(build_option('banned_linked_shared_libs'), None)
         self.assertEqual(build_option('filter_env_vars'), None)
+        self.assertTrue(build_option('cleanup_builddir'))
+        self.assertEqual(build_option('pr_target_account'), 'easybuilders')
 
 
 def suite():

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -40,7 +40,7 @@ import easybuild.tools.options as eboptions
 from easybuild.tools import run
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option, build_path, get_build_log_path, get_log_filename, get_repositorypath
-from easybuild.tools.config import install_path, log_file_format, log_path, source_paths, update_build_option
+from easybuild.tools.config import install_path, log_file_format, log_path, source_paths, update_build_option, update_build_options
 from easybuild.tools.config import BuildOptions, ConfigurationVariables
 from easybuild.tools.config import DEFAULT_PATH_SUBDIRS, init_build_options
 from easybuild.tools.filetools import copy_dir, mkdir, write_file

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -691,6 +691,11 @@ class EasyBuildConfigTest(EnhancedTestCase):
         self.assertFalse(build_option('cleanup_builddir')
         self.assertTrue(orig_cleanup_builddir)
 
+        self.assertEqual(build_option('pr_target_account'), 'easybuilders')
+        orig_pr_target_account = update_build_option('pr_target_account', 'test_pr_target_account')
+        self.assertEqual(build_option('pr_target_account'), 'test_pr_target_account')
+        self.assertEqual(orig_pr_target_account, 'easybuilders')
+
     def test_update_build_options(self):
         """Test updating of a dictionary of build options."""
         # Check if original defaults are as expected:
@@ -704,13 +709,13 @@ class EasyBuildConfigTest(EnhancedTestCase):
             'banned_linked_shared_libs': '/usr/lib64/libssl.so.1.1',
             'filter_env_vars': 'LD_LIBRARY_PATH',
             'cleanup_builddir': False,
-            'pr_target_account': 'john_doe',
+            'pr_target_account': 'test_pr_target_account',
         }
         original_opt_dict = update_build_options(new_opt_dict)
         self.assertEqual(build_option('banned_linked_shared_libs'), '/usr/lib64/libssl.so.1.1')
         self.assertEqual(build_option('filter_env_vars'), 'LD_LIBRARY_PATH')
         self.assertFalse(build_option('cleanup_builddir'))
-        self.assertEqual(build_option('pr_target_account'), 'john_doe')
+        self.assertEqual(build_option('pr_target_account'), 'test_pr_target_account')
 
         # Check the returned dictionary by simply restoring the variables and checking if the build
         # options have their original values again


### PR DESCRIPTION
To be able to define (per-)EasyConfig specific options in an `EasyStack` file, as discussed [here](https://github.com/easybuilders/easybuild-framework/issues/3513#issuecomment-986990195) we need to easily be able to set entire dictionaries of new configuration options - and restore them to their original values later.

This PR provides that functionality by 

1) extending `update_build_option` so that it returns the original value (so it can later be restored)

2) implementing `update_build_options`, which takes a dictionary, calls `update_build_option` on each key-value pair in the dictionary, and collects & returns the original values for each in another dictionary. This allows one to call _another_ `update_build_options` on the returned dictionary to reset the original values.

Example usage:

```
# Have a dictionary of dictionaries, each specifying a list of options that need to be changed for that specific EasyConfig
    opts_per_ec = {
        'OpenFOAM-8-foss-2020a': {
            'parallel': '6',
            'robot': True,
        },
        'GROMACS-2020.4-foss-2020a-Python-3.8.2': {
            'debug': True,
            'trace': True,
            'from_pr': '1234',
            'include_easyblocks_from_pr': 123,
            'parallel': 6,
            'robot': True,
        },
    }
...
   old_val_dict = update_build_options(opts_per_ec['OpenFOAM-8-foss-2020a'])
...
   # actually build OpenFOAM-8-foss-202a, now using the options that were set of this specific EasyConfig
...
   # Restore the original configuration, so that the original configuration is used to build any _further_ EasyConfigs
   update_build_options(old_val_dict)
...
```

Of course, the `opts_per_ec` would normally not be hardcoded, but will (eventually) be returned by the `parse_easystack` function if it encounters EasyConfig-specific options in the EasyStack file.
