### PR TITLE
use sources.easybuild.io as backup URL for downloading Environment Modules sources to run test suite

### DIFF
--- a/easybuild/scripts/install_eb_dep.sh
+++ b/easybuild/scripts/install_eb_dep.sh
@@ -18,12 +18,13 @@ PRECONFIG_CMD=
 
 if [ "$PKG_NAME" == 'modules' ] && [ "$PKG_VERSION" == '3.2.10' ]; then
     PKG_URL="http://prdownloads.sourceforge.net/modules/${PKG}.tar.gz"
-    BACKUP_PKG_URL="https://easybuilders.github.io/easybuild/files/${PKG}.tar.gz"
+    BACKUP_PKG_URL="https://sources.easybuild.io/e/EnvironmentModules/${PKG}.tar.gz"
     export PATH="$PREFIX/Modules/$PKG_VERSION/bin:$PATH"
     export MOD_INIT="$PREFIX/Modules/$PKG_VERSION/init/bash"
 
 elif [ "$PKG_NAME" == 'modules' ]; then
     PKG_URL="http://prdownloads.sourceforge.net/modules/${PKG}.tar.gz"
+    BACKUP_PKG_URL="https://sources.easybuild.io/e/EnvironmentModules/${PKG}.tar.gz"
     export PATH="$PREFIX/bin:$PATH"
     export MOD_INIT="$PREFIX/init/bash"
 

--- a/easybuild/scripts/install_eb_dep.sh
+++ b/easybuild/scripts/install_eb_dep.sh
@@ -16,17 +16,16 @@ PKG_VERSION="${PKG##*-}"
 CONFIG_OPTIONS=
 PRECONFIG_CMD=
 
-if [ "$PKG_NAME" == 'modules' ] && [ "$PKG_VERSION" == '3.2.10' ]; then
+if [ "$PKG_NAME" == 'modules' ]; then
     PKG_URL="http://prdownloads.sourceforge.net/modules/${PKG}.tar.gz"
     BACKUP_PKG_URL="https://sources.easybuild.io/e/EnvironmentModules/${PKG}.tar.gz"
-    export PATH="$PREFIX/Modules/$PKG_VERSION/bin:$PATH"
-    export MOD_INIT="$PREFIX/Modules/$PKG_VERSION/init/bash"
-
-elif [ "$PKG_NAME" == 'modules' ]; then
-    PKG_URL="http://prdownloads.sourceforge.net/modules/${PKG}.tar.gz"
-    BACKUP_PKG_URL="https://sources.easybuild.io/e/EnvironmentModules/${PKG}.tar.gz"
-    export PATH="$PREFIX/bin:$PATH"
-    export MOD_INIT="$PREFIX/init/bash"
+    if [ "$PKG_VERSION" == '3.2.10' ]; then
+        export PATH="$PREFIX/Modules/$PKG_VERSION/bin:$PATH"
+        export MOD_INIT="$PREFIX/Modules/$PKG_VERSION/init/bash"
+    else
+        export PATH="$PREFIX/bin:$PATH"
+        export MOD_INIT="$PREFIX/init/bash"
+    fi
 
 elif [ "$PKG_NAME" == 'lua' ]; then
     PKG_URL="http://downloads.sourceforge.net/project/lmod/${PKG}.tar.gz"


### PR DESCRIPTION
Download of `modules-4.1.4.tar.gz` is failing due to trouble with SourceForge, we can work around that by using https://sources.easybuild.io/e/EnvironmentModules/ as backup download URL...