### PR TITLE
take into account that patch files can also be zipped when checking filename extension for patches

### DIFF
--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1638,11 +1638,14 @@ class FileToolsTest(EnhancedTestCase):
         stderr = self.get_stderr()
         self.mock_stderr(False)
         self.disallow_deprecated_behaviour()
-        expected_warning = "Use of patch file with filename that doesn't end with .patch: foo.txt"
-        self.assertTrue(expected_warning in stderr)
+        expected_warning = "Use of patch file with filename that doesn't end with correct extension: foo.txt "
+        expected_warning += "(should be any of: .patch, .patch.bz2, .patch.gz, .patch.xz)"
+        fail_msg = "Warning '%s' should appear in stderr output: %s" % (expected_warning, stderr)
+        self.assertTrue(expected_warning in stderr, fail_msg)
 
         # deprecation warning is treated as an error in context of unit test suite
-        self.assertErrorRegex(EasyBuildError, expected_warning, ft.create_patch_info, 'foo.txt')
+        expected_error = expected_warning.replace('(', '\\(').replace(')', '\\)')
+        self.assertErrorRegex(EasyBuildError, expected_error, ft.create_patch_info, 'foo.txt')
 
         # faulty input
         error_msg = "Wrong patch spec"


### PR DESCRIPTION
Support for zipped patch files was implemented in #2128, and we didn't take this into account in #3920 

This is rarely used (in the central easyconfigs), so it was easy to overlook...