### PR TITLE
Fix get_os_name and get_os_version

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -697,9 +697,6 @@ def get_os_name():
         res = name_regex.search(os_release_txt)
         if res:
             os_name = res.group('name')
-    else:
-        # no easy way to determine name of Linux distribution
-        os_name = None
 
     os_name_map = {
         'red hat enterprise linux server': 'RHEL',
@@ -742,8 +739,6 @@ def get_os_version():
             res = version_regex.search(os_release_txt)
             if res:
                 os_version = res.group('version')
-    else:
-        os_version = None
 
     if os_version:
         if get_os_name() in ["suse", "SLES"]:


### PR DESCRIPTION
Currently `UNKONWN` is returned in `get_os_name` even if `os_name` can be found:
```
$ eb --show-system | grep name
  -> name: UNKNOWN
  -> platform name: x86_64-unknown-linux
```

I overlooked this when I merged https://github.com/easybuilders/easybuild-framework/pull/3930. This PR removes the no longer needed `else` condition.