### PR TITLE
Add bash completion for easyconfigs from local dir but not robot search path

### DIFF
--- a/eb_bash_completion_local.bash
+++ b/eb_bash_completion_local.bash
@@ -1,0 +1,12 @@
+_eb()
+{
+    local cur prev quoted
+    _get_comp_words_by_ref cur prev
+    _quote_readline_by_ref "$cur" quoted
+
+	case $cur in 
+		--*) _optcomplete "$@"; return 0 ;;
+		*)  COMPREPLY=( $(compgen -f -X '!*.eb' -- $cur ) ) ;;
+	esac
+}
+complete -F _eb eb


### PR DESCRIPTION
This PR adds bash completion for easyconfigs only from local dir but not robot search path. This option might be useful if you are working on a slow shared filesystem and searching the entire robot search path is too slow.

This bash completion can be enabled with:
```
source $EBROOTEASYBUILD/bin/minimal_bash_completion.bash;
source $EBROOTEASYBUILD/bin/optcomplete.bash;
source $EBROOTEASYBUILD/bin/eb_bash_completion_local.bash;
complete -F _eb eb
```