### PR TITLE
run 'apt-get update' in GitHub Actions workflow for container tests to update container package list before installing anything

### DIFF
--- a/.github/workflows/container_tests.yml
+++ b/.github/workflows/container_tests.yml
@@ -20,6 +20,8 @@ jobs:
 
     - name: install OS & Python packages
       run: |
+        # ensure package list is up to date to avoid 404's for old packages
+        sudo apt-get update -yqq
         # for building Singularity images
         sudo apt-get install rpm
         sudo apt-get install yum


### PR DESCRIPTION
fixes the 404 issues seen in the https://github.com/easybuilders/easybuild-framework/pull/3979 container tests of the form:

``` Err:9 http://ppa.launchpad.net/ondrej/php/ubuntu bionic/main amd64 libxml2-dev amd64 2.9.12+dfsg-0+ubuntu18.04.1+deb.sury.org+1
  404  Not Found [IP: 91.189.95.85 80]
Err:10 http://ppa.launchpad.net/ondrej/php/ubuntu bionic/main amd64 libxml2 amd64 2.9.12+dfsg-0+ubuntu18.04.1+deb.sury.org+1
  404  Not Found [IP: 91.189.95.85 80]
Err:11 http://ppa.launchpad.net/ondrej/php/ubuntu bionic/main amd64 python-libxml2 amd64 2.9.12+dfsg-0+ubuntu18.04.1+deb.sury.org+1
  404  Not Found [IP: 91.189.95.85 80]
Fetched 855 kB in 0s (1765 kB/s)
E: Failed to fetch http://ppa.launchpad.net/ondrej/php/ubuntu/pool/main/libx/libxml2/libxml2-dev_2.9.12+dfsg-0+ubuntu18.04.1+deb.sury.org+1_amd64.deb  404  Not Found [IP: 91.189.95.85 80]
E: Failed to fetch http://ppa.launchpad.net/ondrej/php/ubuntu/pool/main/libx/libxml2/libxml2_2.9.12+dfsg-0+ubuntu18.04.1+deb.sury.org+1_amd64.deb  404  Not Found [IP: 91.189.95.85 80]
E: Failed to fetch http://ppa.launchpad.net/ondrej/php/ubuntu/pool/main/libx/libxml2/python-libxml2_2.9.12+dfsg-0+ubuntu18.04.1+deb.sury.org+1_amd64.deb  404  Not Found [IP: 91.189.95.85 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.```