### PR TITLE
Change 'eb' command to import easybuild to check if it's working.

### DIFF
--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -73,7 +73,7 @@ jobs:
           pymajver=$(python -c 'import sys; print(sys.version_info[0])')
           pymajminver=$(python -c 'import sys; print(".".join(str(x) for x in sys.version_info[:2]))')
           # check patterns in verbose output
-          for pattern in "^>> Considering .python.\.\.\." "^>> .python. version: ${pymajminver}\.[0-9]\+, which matches Python ${pymajver} version requirement" "^>> 'python' is able to import 'easybuild.main', so retaining it" "^>> Selected Python command: python \(.*/bin/python\)" "^This is EasyBuild 4\.[0-9.]\+"; do
+          for pattern in "^>> Considering .python.\.\.\." "^>> .python. version: ${pymajminver}\.[0-9]\+, which matches Python ${pymajver} version requirement" "^>> 'python' is able to import 'easybuild', so retaining it" "^>> Selected Python command: python \(.*/bin/python\)" "^This is EasyBuild 4\.[0-9.]\+"; do
               echo "Looking for pattern \"${pattern}\" in eb_version.out..."
               grep "$pattern" eb_version.out
           done
@@ -81,7 +81,7 @@ jobs:
           for eb_python in "python${pymajver}" "python${pymajminver}"; do
               export EB_PYTHON="${eb_python}"
               eb --version | tee eb_version.out 2>&1
-              for pattern in "^>> Considering .${eb_python}.\.\.\." "^>> .${eb_python}. version: ${pymajminver}\.[0-9]\+, which matches Python ${pymajver} version requirement" "^>> '${eb_python}' is able to import 'easybuild.main', so retaining it" "^>> Selected Python command: ${eb_python} \(.*/bin/${eb_python}\)" "^This is EasyBuild 4\.[0-9.]\+"; do
+              for pattern in "^>> Considering .${eb_python}.\.\.\." "^>> .${eb_python}. version: ${pymajminver}\.[0-9]\+, which matches Python ${pymajver} version requirement" "^>> '${eb_python}' is able to import 'easybuild', so retaining it" "^>> Selected Python command: ${eb_python} \(.*/bin/${eb_python}\)" "^This is EasyBuild 4\.[0-9.]\+"; do
                   echo "Looking for pattern \"${pattern}\" in eb_version.out..."
                   grep "$pattern" eb_version.out
               done

--- a/eb
+++ b/eb
@@ -80,7 +80,7 @@ for python_cmd in ${EB_PYTHON} ${EB_INSTALLPYTHON} 'python' 'python3' 'python2';
 
         if [ ! -z $PYTHON ]; then
             # check whether easybuild.main is available for selected python command
-            $PYTHON -c "import $EASYBUILD_MAIN" 2> /dev/null
+            $PYTHON -c "import easybuild" 2> /dev/null
             if [ $? -eq 0 ]; then
                 verbose "'$python_cmd' is able to import '$EASYBUILD_MAIN', so retaining it"
             else

--- a/eb
+++ b/eb
@@ -82,10 +82,10 @@ for python_cmd in ${EB_PYTHON} ${EB_INSTALLPYTHON} 'python' 'python3' 'python2';
             # check whether easybuild.main is available for selected python command
             $PYTHON -c "import easybuild" 2> /dev/null
             if [ $? -eq 0 ]; then
-                verbose "'$python_cmd' is able to import '$EASYBUILD_MAIN', so retaining it"
+                verbose "'$python_cmd' is able to import 'easybuild', so retaining it"
             else
                 # if easybuild.main is not available, don't use this python command, keep searching...
-                verbose "'$python_cmd' is NOT able to import '$EASYBUILD_MAIN', so NOT retaining it"
+                verbose "'$python_cmd' is NOT able to import 'easybuild' so NOT retaining it"
                 unset PYTHON
             fi
         fi

--- a/eb
+++ b/eb
@@ -79,12 +79,12 @@ for python_cmd in ${EB_PYTHON} ${EB_INSTALLPYTHON} 'python' 'python3' 'python2';
         fi
 
         if [ ! -z $PYTHON ]; then
-            # check whether easybuild.main is available for selected python command
+            # check whether easybuild is available for selected python command
             $PYTHON -c "import easybuild" 2> /dev/null
             if [ $? -eq 0 ]; then
                 verbose "'$python_cmd' is able to import 'easybuild', so retaining it"
             else
-                # if easybuild.main is not available, don't use this python command, keep searching...
+                # if easybuild is not available, don't use this python command, keep searching...
                 verbose "'$python_cmd' is NOT able to import 'easybuild' so NOT retaining it"
                 unset PYTHON
             fi


### PR DESCRIPTION
This is a much cheaper test than `import easybuild.main` and still
solves the same issue as #3610.

This reduces the wall time for `eb --version` from 1.35s to 0.73s
in our configuration.