### PR TITLE
Update prepare_rpath_wrappers to enable wrapper shipping with a module (WIP)

### DIFF
--- a/easybuild/tools/toolchain/utilities.py
+++ b/easybuild/tools/toolchain/utilities.py
@@ -36,6 +36,7 @@ Based on VSC-tools vsc.mympirun.mpi.mpi and vsc.mympirun.rm.sched
 import copy
 import re
 import sys
+import os
 
 import easybuild.tools.toolchain
 from easybuild.base import fancylogger
@@ -157,7 +158,7 @@ def create_rpath_wrappers(targetdir, toolchain_name, toolchain_version, rpath_fi
             rpath_filter_dirs=rpath_filter_dirs,
             rpath_include_dirs=rpath_include_dirs,
             new_wrapper_dir=targetdir,
-            single_subdir=False,
-            disable_wrapper_log=True
+            disable_wrapper_log=True,
+            cmdDir=os.path.join(targetdir, '..')
             )
-    print("Installed RPATH wrappers in %s" % (str(wrapperpath)))
+    _log.debug("Installed RPATH wrappers in %s" % (str(wrapperpath)))

--- a/easybuild/tools/toolchain/utilities.py
+++ b/easybuild/tools/toolchain/utilities.py
@@ -148,3 +148,16 @@ def get_toolchain(tc, tcopts, mns=None, tcdeps=None, modtool=None):
     tc_inst.set_options(tcopts)
 
     return tc_inst
+
+
+def create_rpath_wrappers(targetdir, toolchain_name, toolchain_version, rpath_filter_dirs=[], rpath_include_dirs=[]):
+    tc = get_toolchain({'name': toolchain_name, 'version': toolchain_version}, {})
+
+    wrapperpath = tc.prepare_rpath_wrappers(
+            rpath_filter_dirs=rpath_filter_dirs,
+            rpath_include_dirs=rpath_include_dirs,
+            new_wrapper_dir=targetdir,
+            single_subdir=False,
+            disable_wrapper_log=True
+            )
+    print("Installed RPATH wrappers in %s" % (str(wrapperpath)))


### PR DESCRIPTION
This WIP PR is part of a suggested feature to ship rpath wrappers e.g. with GCCcore.
More information in related issues and PRs:
- [easybuilders/easybuild-framework/issues/3918](https://github.com/easybuilders/easybuild-framework/issues/3918)
- [easybuild-easyblocks/pull/2638](https://github.com/easybuilders/easybuild-easyblocks/pull/2638)

This PR contains a first working version, with a couple of dirty hacks, so it is definitely not ready to be merged.

`prepare_rpath_wrappers` is currently preparing the wrappers in temporary directories. Wrappers are then used in the module's build step so far!
Updating `prepare_rpath_wrappers` to also install wrappers in the module install is maybe stretching the purpose of a single function.
Would you suggest that I refactor the code a bit to produce 2 smaller functions? One prepares wrappers for build, the other does installation. There is probably a bit of shared code though.

I'll also point out a specific section of the code in the comments below.

Tagging @boegel