### PR TITLE
fixup! tweak printing of download instructions in obtain_file + remov…

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -883,8 +883,10 @@ class EasyBlock(object):
                         error_msg += "please follow the download instructions above, and make the file available "
                         error_msg += "in the active source path (%s)" % ':'.join(source_paths())
                     else:
+                        # flatten list to string with '%' characters escaped (literal '%' desired in 'sprintf')
+                        failedpaths_msg = ', '.join(failedpaths).replace('%', '%%')
                         error_msg += "and downloading it didn't work either... "
-                        error_msg += "Paths attempted (in order): %s " % ', '.join(failedpaths)
+                        error_msg += "Paths attempted (in order): %s " % failedpaths_msg
 
                     raise EasyBuildError(error_msg, filename)
 


### PR DESCRIPTION
Urlencoded characters (e.g. '%2F' instead of '/') caused an error while reporting download error.

This is a fixup of PR https://github.com/easybuilders/easybuild-framework/pull/3976 that introduced a regression.

The error would be a `TypeError: not enough arguments for format string`, e.g.:
```
ERROR: Traceback (most recent call last):
  File "/home/ITER/vandell/easybuildinstall/software/EasyBuild/4.5.4/lib/python3.6/site-packages/easybuild/main.py", line 128, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/home/ITER/vandell/easybuildinstall/software/EasyBuild/4.5.4/lib/python3.6/site-packages/easybuild/framework/easyblock.py", line 4058, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/home/ITER/vandell/easybuildinstall/software/EasyBuild/4.5.4/lib/python3.6/site-packages/easybuild/framework/easyblock.py", line 3941, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/home/ITER/vandell/easybuildinstall/software/EasyBuild/4.5.4/lib/python3.6/site-packages/easybuild/framework/easyblock.py", line 3776, in run_step
    step_method(self)()
  File "/home/ITER/vandell/easybuildinstall/software/EasyBuild/4.5.4/lib/python3.6/site-packages/easybuild/easyblocks/generic/configuremake.py", line 219, in fetch_step
    super(ConfigureMake, self).fetch_step(*args, **kwargs)
  File "/home/ITER/vandell/easybuildinstall/software/EasyBuild/4.5.4/lib/python3.6/site-packages/easybuild/framework/easyblock.py", line 2246, in fetch_step
    self.fetch_sources(self.cfg['sources'], checksums=self.cfg['checksums'])
  File "/home/ITER/vandell/easybuildinstall/software/EasyBuild/4.5.4/lib/python3.6/site-packages/easybuild/framework/easyblock.py", line 445, in fetch_sources
    src_spec = self.fetch_source(source, self.get_checksum_for(checksums=checksums, index=index))
  File "/home/ITER/vandell/easybuildinstall/software/EasyBuild/4.5.4/lib/python3.6/site-packages/easybuild/framework/easyblock.py", line 404, in fetch_source
    download_instructions=download_instructions)
  File "/home/ITER/vandell/easybuildinstall/software/EasyBuild/4.5.4/lib/python3.6/site-packages/easybuild/framework/easyblock.py", line 891, in obtain_file
    raise EasyBuildError(error_msg, filename)
  File "/home/ITER/vandell/easybuildinstall/software/EasyBuild/4.5.4/lib/python3.6/site-packages/easybuild/tools/build_log.py", line 86, in __init__
    raise(e)
  File "/home/ITER/vandell/easybuildinstall/software/EasyBuild/4.5.4/lib/python3.6/site-packages/easybuild/tools/build_log.py", line 80, in __init__
    msg = msg % args
TypeError: not enough arguments for format string

```
