### PR TITLE
fix 'eb --show-system-info' on Apple M1 system

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -94,6 +94,7 @@ ARCH_KEY_PREFIX = 'arch='
 # Vendor constants
 AMD = 'AMD'
 APM = 'Applied Micro'
+APPLE = 'Apple'
 ARM = 'ARM'
 BROADCOM = 'Broadcom'
 CAVIUM = 'Cavium'
@@ -123,7 +124,7 @@ PROC_MEMINFO_FP = '/proc/meminfo'
 
 CPU_ARCHITECTURES = [AARCH32, AARCH64, POWER, RISCV32, RISCV64, X86_64]
 CPU_FAMILIES = [AMD, ARM, INTEL, POWER, POWER_LE, RISCV]
-CPU_VENDORS = [AMD, APM, ARM, BROADCOM, CAVIUM, DEC, IBM, INTEL, MARVELL, MOTOROLA, NVIDIA, QUALCOMM]
+CPU_VENDORS = [AMD, APM, APPLE, ARM, BROADCOM, CAVIUM, DEC, IBM, INTEL, MARVELL, MOTOROLA, NVIDIA, QUALCOMM]
 # ARM implementer IDs (i.e., the hexadeximal keys) taken from ARMv8-A Architecture Reference Manual
 # (ARM DDI 0487A.j, Section G6.2.102, Page G6-4493)
 VENDOR_IDS = {
@@ -384,11 +385,18 @@ def get_cpu_vendor():
 
     elif os_type == DARWIN:
         cmd = "sysctl -n machdep.cpu.vendor"
-        out, ec = run_cmd(cmd, force_in_dry_run=True, trace=False, stream_output=False)
+        out, ec = run_cmd(cmd, force_in_dry_run=True, trace=False, stream_output=False, log_ok=False)
         out = out.strip()
         if ec == 0 and out in VENDOR_IDS:
             vendor = VENDOR_IDS[out]
             _log.debug("Determined CPU vendor on DARWIN as being '%s' via cmd '%s" % (vendor, cmd))
+        else:
+            cmd = "sysctl -n machdep.cpu.brand_string"
+            out, ec = run_cmd(cmd, force_in_dry_run=True, trace=False, stream_output=False, log_ok=False)
+            out = out.strip().split(' ')[0]
+            if ec == 0 and out in CPU_VENDORS:
+                vendor = out
+                _log.debug("Determined CPU vendor on DARWIN as being '%s' via cmd '%s" % (vendor, cmd))
 
     if vendor is None:
         vendor = UNKNOWN
@@ -533,9 +541,11 @@ def get_cpu_speed():
         cmd = "sysctl -n hw.cpufrequency_max"
         _log.debug("Trying to determine CPU frequency on Darwin via cmd '%s'" % cmd)
         out, ec = run_cmd(cmd, force_in_dry_run=True, trace=False, stream_output=False)
-        if ec == 0:
+        out = out.strip()
+        cpu_freq = None
+        if ec == 0 and out:
             # returns clock frequency in cycles/sec, but we want MHz
-            cpu_freq = float(out.strip()) // (1000 ** 2)
+            cpu_freq = float(out) // (1000 ** 2)
 
     else:
         raise SystemToolsException("Could not determine CPU clock frequency (OS: %s)." % os_type)
@@ -578,7 +588,7 @@ def get_cpu_features():
         for feature_set in ['extfeatures', 'features', 'leaf7_features']:
             cmd = "sysctl -n machdep.cpu.%s" % feature_set
             _log.debug("Trying to determine CPU features on Darwin via cmd '%s'", cmd)
-            out, ec = run_cmd(cmd, force_in_dry_run=True, trace=False, stream_output=False)
+            out, ec = run_cmd(cmd, force_in_dry_run=True, trace=False, stream_output=False, log_ok=False)
             if ec == 0:
                 cpu_feat.extend(out.strip().lower().split())
 


### PR DESCRIPTION
This fixes various small issues that pop up on Apple M1:
* add fallback to "`sysctl -n machdep.cpu.brand_string`" in `get_cpu_vendor` to determine CPU type, since "`sysctl -n machdep.cpu.vendor`" is not supported on Apple M1 systems;
* add `Apple` as known CPU vendor;
* avoid that `get_cpu_speed` crashes when it fails to determine CPU speed via "`sysctl -n hw.cpufrequency_max`" (which returns empty string on Apple M1), and just return `None`;
* avoid crash in `get_cpu_features` because "`sysctl -n machdep.cpu.extfeatures`" is not supported on Apple M1 (and leave list of CPU features empty, for now);
* also includes fixes for `systemtools` tests so they pass on Apple M1;

Also requires #4014 for all `systemtools` tests to pass on Apple M1

fixes #4013