### PR TITLE
make sure that ARCH constant has 'aarch64' (rather than 'arm64') as value on macOS ARM

### DIFF
--- a/easybuild/framework/easyconfig/constants.py
+++ b/easybuild/framework/easyconfig/constants.py
@@ -34,7 +34,8 @@ import os
 import platform
 
 from easybuild.base import fancylogger
-from easybuild.tools.systemtools import get_os_name, get_os_type, get_os_version
+from easybuild.tools.build_log import print_warning
+from easybuild.tools.systemtools import KNOWN_ARCH_CONSTANTS, get_os_name, get_os_type, get_os_version
 
 
 _log = fancylogger.getLogger('easyconfig.constants', fname=False)
@@ -52,6 +53,9 @@ def _get_arch_constant():
     # macOS on Arm produces 'arm64' rather than 'aarch64'
     if arch == 'arm64':
         arch = 'aarch64'
+
+    if arch not in KNOWN_ARCH_CONSTANTS:
+        print_warning("Using unknown value for ARCH constant: %s", arch)
 
     return arch
 

--- a/easybuild/framework/easyconfig/constants.py
+++ b/easybuild/framework/easyconfig/constants.py
@@ -42,9 +42,23 @@ _log = fancylogger.getLogger('easyconfig.constants', fname=False)
 
 EXTERNAL_MODULE_MARKER = 'EXTERNAL_MODULE'
 
+
+def _get_arch_constant():
+    """
+    Get value for ARCH constant.
+    """
+    arch = platform.uname()[4]
+
+    # macOS on Arm produces 'arm64' rather than 'aarch64'
+    if arch == 'arm64':
+        arch = 'aarch64'
+
+    return arch
+
+
 # constants that can be used in easyconfig
 EASYCONFIG_CONSTANTS = {
-    'ARCH': (platform.uname()[4], "CPU architecture of current system (aarch64, x86_64, ppc64le, ...)"),
+    'ARCH': (_get_arch_constant(), "CPU architecture of current system (aarch64, x86_64, ppc64le, ...)"),
     'EXTERNAL_MODULE': (EXTERNAL_MODULE_MARKER, "External module marker"),
     'HOME': (os.path.expanduser('~'), "Home directory ($HOME)"),
     'OS_TYPE': (get_os_type(), "System type (e.g. 'Linux' or 'Darwin')"),

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -89,6 +89,9 @@ X86_64 = 'x86_64'
 RISCV32 = 'RISC-V-32'
 RISCV64 = 'RISC-V-64'
 
+# known values for ARCH constant (determined by _get_arch_constant in easybuild.framework.easyconfig.constants)
+KNOWN_ARCH_CONSTANTS = ('aarch64', 'ppc64le', 'riscv64', 'x86_64')
+
 ARCH_KEY_PREFIX = 'arch='
 
 # Vendor constants

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -4597,6 +4597,12 @@ class EasyConfigTest(EnhancedTestCase):
         test_ec = EasyConfig(test_ec)
         self.assertEqual(test_ec.count_files(), 11)
 
+    def test_ARCH(self):
+        """Test ARCH easyconfig constant."""
+        arch = easyconfig.constants.EASYCONFIG_CONSTANTS['ARCH'][0]
+        known_arch_values = ('aarch64', 'ppc64le', 'riscv64', 'x86_64')
+        self.assertTrue(arch in known_arch_values, "Unexpected value for ARCH constant: %s" % arch)
+
 
 def suite():
     """ returns all the testcases in this module """

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -73,7 +73,8 @@ from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.options import parse_external_modules_metadata
 from easybuild.tools.py2vs3 import OrderedDict, reload
 from easybuild.tools.robot import resolve_dependencies
-from easybuild.tools.systemtools import AARCH64, POWER, X86_64, get_cpu_architecture, get_shared_lib_ext
+from easybuild.tools.systemtools import AARCH64, KNOWN_ARCH_CONSTANTS, POWER, X86_64
+from easybuild.tools.systemtools import get_cpu_architecture, get_shared_lib_ext
 from easybuild.tools.toolchain.utilities import search_toolchain
 from easybuild.tools.utilities import quote_str, quote_py_str
 from test.framework.utilities import find_full_path
@@ -4600,8 +4601,7 @@ class EasyConfigTest(EnhancedTestCase):
     def test_ARCH(self):
         """Test ARCH easyconfig constant."""
         arch = easyconfig.constants.EASYCONFIG_CONSTANTS['ARCH'][0]
-        known_arch_values = ('aarch64', 'ppc64le', 'riscv64', 'x86_64')
-        self.assertTrue(arch in known_arch_values, "Unexpected value for ARCH constant: %s" % arch)
+        self.assertTrue(arch in KNOWN_ARCH_CONSTANTS, "Unexpected value for ARCH constant: %s" % arch)
 
 
 def suite():


### PR DESCRIPTION
Fix for problems that occur when parsing an easyconfig that relies on the `ARCH` constant:

```
$ eb Pandoc-2.13.eb -D
== Temporary log file in case of crash /tmp/eb-vbgmw5al/easybuild-shentmri.log
ERROR: Failed to process easyconfig /home/example/easybuild-easyconfigs/easybuild/easyconfigs/p/Pandoc/Pandoc-2.13.eb: Parsing easyconfig file failed: 'arm64' (line 13)
```