### PR TITLE
add toolchain option to customize linker command that compiler should use (WIP)

### DIFF
--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -28,7 +28,7 @@ Support for GCC (GNU Compiler Collection) as toolchain compiler.
 :author: Stijn De Weirdt (Ghent University)
 :author: Kenneth Hoste (Ghent University)
 """
-
+import os
 import re
 from distutils.version import LooseVersion
 
@@ -108,7 +108,33 @@ class Gcc(Compiler):
     LIB_MULTITHREAD = ['pthread']
     LIB_MATH = ['m']
 
+    def __init__(self, *args, **kwargs):
+        """Compiler toolchain component constructor."""
+        super(Gcc, self).__init__(*args, **kwargs)
+
+        self.gcc_root = None
+        self.gcc_version = None
+
+    def _det_gcc_root(self):
+        """Determine GCC version being used."""
+        if self.gcc_root is None:
+            self.gcc_root = get_software_root('GCCcore')
+            if self.gcc_root is None:
+                self.gcc_root = get_software_root('GCC')
+                if self.gcc_root is None:
+                    raise EasyBuildError("Failed to determine software root for GCC")
+
+    def _det_gcc_version(self):
+        """Determine GCC version being used."""
+        if self.gcc_version is None:
+            self.gcc_version = get_software_version('GCCcore')
+            if self.gcc_version is None:
+                self.gcc_version = get_software_version('GCC')
+                if self.gcc_version is None:
+                    raise EasyBuildError("Failed to determine software version for GCC")
+
     def _set_compiler_vars(self):
+        """Set the compiler variables"""
         super(Gcc, self)._set_compiler_vars()
 
         if self.options.get('32bit', None):
@@ -122,13 +148,7 @@ class Gcc(Compiler):
         # append lib dir paths to LDFLAGS (only if the paths are actually there)
         # Note: hardcode 'GCC' here; we can not reuse COMPILER_MODULE_NAME because
         # it can be redefined by combining GCC with other compilers (e.g., Clang).
-        gcc_root = get_software_root('GCCcore')
-        if gcc_root is None:
-            gcc_root = get_software_root('GCC')
-            if gcc_root is None:
-                raise EasyBuildError("Failed to determine software root for GCC")
-
-        self.variables.append_subdirs("LDFLAGS", gcc_root, subdirs=["lib64", "lib"])
+        self.variables.append_subdirs("LDFLAGS", self.gcc_root, subdirs=["lib64", "lib"])
 
     def _set_optimal_architecture(self, default_optarch=None):
         """
@@ -138,13 +158,7 @@ class Gcc(Compiler):
                                 (--optarch and --optarch=GENERIC still override this value)
         """
         if default_optarch is None and self.arch == systemtools.AARCH64:
-            gcc_version = get_software_version('GCCcore')
-            if gcc_version is None:
-                gcc_version = get_software_version('GCC')
-                if gcc_version is None:
-                    raise EasyBuildError("Failed to determine software version for GCC")
-
-            if LooseVersion(gcc_version) < LooseVersion('6'):
+            if LooseVersion(self.gcc_version) < LooseVersion('6'):
                 # on AArch64, -mcpu=native is not supported prior to GCC 6,
                 # so try to guess a proper default optarch if none was specified
                 default_optarch = self._guess_aarch64_default_optarch()
@@ -182,3 +196,33 @@ class Gcc(Compiler):
                 self.log.debug("Using architecture-specific compiler optimization flag '%s'", default_optarch)
 
         return default_optarch
+
+    def _mold_linker_flag(self):
+        """Set correct compiler flag for using mold as linker."""
+        # for GCC < 12.1, -fuse-ld=mold is not supported yet, but -B option can be used instead;
+        # see https://github.com/rui314/mold#how-to-use ("classic way to use mold")
+        if self.options.get('linker', None) == 'mold' and LooseVersion(self.gcc_version) < LooseVersion('12.0'):
+            mold_root = get_software_root('mold')
+            if mold_root is None:
+                raise EasyBuildError("Failed to determine software root for mold")
+
+            mold_libexec_path = os.path.join(mold_root, 'libexec', 'mold')
+            if not os.path.exists(os.path.join(mold_libexec_path, 'ld')):
+                raise EasyBuildError("ld not found in %s" % mold_libexec_path)
+
+            self.options['linker'] = None
+            for flags_prefix in ('c', 'cxx', 'f', 'f90', 'fc'):
+                key = 'extra_%sflags' % flags_prefix
+                mold_ld_flag = '-B%s' % mold_libexec_path
+                flags = self.options.get(key, None)
+                if flags is not None:
+                    self.options[key] = ' '.join([mold_ld_flag, flags])
+                else:
+                    self.options[key] = mold_ld_flag
+
+    def set_variables(self, *args, **kwargs):
+        """Set environment variables that define build environment."""
+        self._det_gcc_root()
+        self._det_gcc_version()
+        self._mold_linker_flag()
+        super(Gcc, self).set_variables(*args, **kwargs)

--- a/easybuild/toolchains/compiler/intel_compilers.py
+++ b/easybuild/toolchains/compiler/intel_compilers.py
@@ -57,7 +57,7 @@ class IntelCompilers(IntelIccIfort):
         self.variables.append_subdirs("LDFLAGS", root, subdirs=libpaths)
 
     def set_variables(self):
-        """Set the variables."""
+        """Set environment variables that define build environment."""
 
         # skip IntelIccIfort.set_variables (no longer relevant for recent versions)
         Compiler.set_variables(self)

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -132,7 +132,7 @@ class IntelIccIfort(Compiler):
         self.variables.append_subdirs("LDFLAGS", icc_root, subdirs=libpaths)
 
     def set_variables(self):
-        """Set the variables."""
+        """Set environment variables that define build environment."""
         # -fopenmp is not supported in old versions (11.x)
         icc_version, _ = self.get_software_version(self.COMPILER_MODULE_NAME)[0:2]
         if LooseVersion(icc_version) < LooseVersion('12'):

--- a/easybuild/toolchains/iimpi.py
+++ b/easybuild/toolchains/iimpi.py
@@ -101,7 +101,7 @@ class Iimpi(IccIfort, IntelCompilersToolchain, IntelMPI):
             IccIfort._set_compiler_vars(self)
 
     def set_variables(self):
-        """Intel compilers-specific adjustments after setting compiler variables."""
+        """Set environment variables that define build environment."""
         if self.oneapi_gen:
             IntelCompilersToolchain.set_variables(self)
         else:

--- a/easybuild/toolchains/iompi.py
+++ b/easybuild/toolchains/iompi.py
@@ -87,7 +87,7 @@ class Iompi(IccIfort, IntelCompilersToolchain, OpenMPI):
             IccIfort._set_compiler_vars(self)
 
     def set_variables(self):
-        """Intel compilers-specific adjustments after setting compiler variables."""
+        """Set environment variables that define build environment."""
         if self.oneapi_gen:
             IntelCompilersToolchain.set_variables(self)
         else:

--- a/easybuild/toolchains/linalg/fujitsussl.py
+++ b/easybuild/toolchains/linalg/fujitsussl.py
@@ -111,7 +111,7 @@ class FujitsuSSL(LinAlg):
         return tc_def
 
     def set_variables(self):
-        """Set the variables"""
+        """Set environment variables that define build environment."""
         self._set_blas_variables()
         self._set_lapack_variables()
         self._set_scalapack_variables()

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -87,7 +87,7 @@ class IntelMKL(LinAlg):
         super(IntelMKL, self).__init__(*args, **kwargs)
 
     def set_variables(self):
-        """Set the variables"""
+        """Set environment variables that define build environment."""
 
         # for recent versions of Intel MKL, -ldl should be used for linking;
         # the Intel MKL Link Advisor specifies to always do this,

--- a/easybuild/toolchains/mpi/intelmpi.py
+++ b/easybuild/toolchains/mpi/intelmpi.py
@@ -91,7 +91,7 @@ class IntelMPI(Mpich2):
     MPI_LINK_INFO_OPTION = '-show'
 
     def set_variables(self):
-        """Intel MPI-specific updates to variables."""
+        """Set environment variables that define build environment."""
         super(IntelMPI, self).set_variables()
         # add -mt_mpi flag to ensure linking against thread-safe MPI library when OpenMP is enabled
         if self.options.get('openmp', None) and self.options.get('usempi', None):

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -169,7 +169,7 @@ class Compiler(Toolchain):
         super(Compiler, self).set_options(options)
 
     def set_variables(self):
-        """Set the variables"""
+        """Set environment variables that define build environment."""
         self._set_compiler_vars()
         self._set_optimal_architecture()
         self._set_compiler_flags()

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -98,6 +98,7 @@ class Compiler(Toolchain):
         'extra_fflags': (None, "Specify extra FFLAGS options."),
         'extra_fcflags': (None, "Specify extra FCFLAGS options."),
         'extra_f90flags': (None, "Specify extra F90FLAGS options."),
+        'linker': (None, "Specify linker command to use"),
     }
 
     COMPILER_UNIQUE_OPTION_MAP = None
@@ -120,12 +121,14 @@ class Compiler(Toolchain):
         'extra_fflags': '%(value)s',
         'extra_fcflags': '%(value)s',
         'extra_f90flags': '%(value)s',
+        'linker': 'fuse-ld=%(value)s',
     }
 
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = None
     COMPILER_GENERIC_OPTION = None
 
-    COMPILER_FLAGS = ['debug', 'ieee', 'openmp', 'pic', 'shared', 'static', 'unroll', 'verbose']  # any compiler
+    # toolchain options that correspond to flags for any compiler
+    COMPILER_FLAGS = ['debug', 'ieee', 'linker', 'openmp', 'pic', 'shared', 'static', 'unroll', 'verbose']
     COMPILER_OPT_FLAGS = ['noopt', 'lowopt', DEFAULT_OPT_LEVEL, 'opt']  # optimisation args, ordered !
     COMPILER_PREC_FLAGS = ['strict', 'precise', 'defaultprec', 'loose', 'veryloose']  # precision flags, ordered !
 

--- a/easybuild/tools/toolchain/fft.py
+++ b/easybuild/tools/toolchain/fft.py
@@ -80,7 +80,7 @@ class Fft(Toolchain):
         self._add_dependency_variables(self.FFT_MODULE_NAME)
 
     def set_variables(self):
-        """Set the variables"""
+        """Set environment variables that define build environment."""
         self._set_fft_variables()
 
         self.log.devel('set_variables: FFT variables %s', self.variables)

--- a/easybuild/tools/toolchain/linalg.py
+++ b/easybuild/tools/toolchain/linalg.py
@@ -86,7 +86,7 @@ class LinAlg(Toolchain):
         super(LinAlg, self).__init__(*args, **kwargs)
 
     def set_variables(self):
-        """Set the variables"""
+        """Set environment variables that define build environment."""
         # TODO is link order fully preserved with this order ?
         self._set_blas_variables()
         self._set_lapack_variables()

--- a/easybuild/tools/toolchain/mpi.py
+++ b/easybuild/tools/toolchain/mpi.py
@@ -182,7 +182,7 @@ class Mpi(Toolchain):
         self.log.devel('_set_mpi_options: all current options %s', self.options)
 
     def set_variables(self):
-        """Set the variables"""
+        """Set environment variables that define build environment."""
         self._set_mpi_compiler_variables()
         self._set_mpi_variables()
 

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -365,9 +365,7 @@ class Toolchain(object):
         return res
 
     def set_variables(self):
-        """Do nothing? Everything should have been set by others
-            Needs to be defined for super() relations
-        """
+        """Set environment variables that define build environment."""
         if self.options.option('packed-linker-options'):
             self.log.devel("set_variables: toolchain variables. packed-linker-options.")
             self.variables.try_function_on_element('set_packed_linker_options')

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -623,13 +623,16 @@ class ToolchainTest(EnhancedTestCase):
                         self.assertTrue(flag not in flags, "%s: False means no %s in %s" % (opt, flag, flags))
                 self.modtool.purge()
 
-        value = '--see-if-this-propagates'
+        extra_flag = '--see-if-this-propagates'
         for var in flag_vars:
             opt = 'extra_' + var.lower()
             tc = self.get_toolchain('foss', version='2018a')
-            tc.set_options({opt: value})
+            tc.set_options({opt: extra_flag, 'linker': 'test'})
             tc.prepare()
-            self.assertTrue(tc.get_variable(var).endswith(' ' + value))
+            val = tc.get_variable(var)
+            self.assertTrue(val.endswith(' ' + extra_flag), "'%s' should end with '%s'" % (val, extra_flag))
+            expected_ld_opt = '-fuse-ld=test'
+            self.assertTrue(' %s ' % expected_ld_opt in val, "'%s' should be found in '%s'" % (expected_ld_opt, val))
             self.modtool.purge()
 
         value = '--only-in-cxxflags'


### PR DESCRIPTION
Usage to use `mold` as a linker:

```python
toolchainopts = {'linker': 'mold'}
```

For non-GCC compilers (Clang, Intel) and GCC 12.1, this is equivalent with adding `-fuse-ld=mold` to `$CFLAGS` and friends.
For GCC < 12.1, this is equivalent to adding `-B$EBROOTMOLD/libexec/mold` to `$CFLAGS` and co.
See also `classic way to use mold` at https://github.com/rui314/mold#how-to-use.

Of course this also requires that `mold` is actually available, so it should be added as a build dependency (or be available system-wide).

Marked as WIP because:
* these change broke one of the tests for some reason (to be figured out);
* need to make sure that tests cover old/new GCC, Intel, Clang;
* using this with Intel compilers doesn't actually seem to work; tested with GSL 2.7:
  ```
  $ ls software/GSL/*/bin/gsl-histogram | xargs readelf -p .comment | egrep '^File|mold'
  File: software/GSL/2.7-ClangGCC-13.0.1-11.2.0/bin/gsl-histogram
    [    53]  mold 1.2.1 (compatible with GNU ld)
  File: software/GSL/2.7-GCC-11.3.0/bin/gsl-histogram
    [    2c]  mold 1.2.1 (compatible with GNU ld)
  File: software/GSL/2.7-intel-compilers-2022.1.0/bin/gsl-histogram
  ```