### PR TITLE
update Lmod used to run tests to version 8.7.4

### DIFF
--- a/.github/workflows/bootstrap_script.yml
+++ b/.github/workflows/bootstrap_script.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
         lmod7: Lmod-7.8.22
-        lmod8: Lmod-8.4.27
+        lmod8: Lmod-8.7.4
         modulesTcl: modules-tcl-1.147
         modules3: modules-3.2.10
         modules4: modules-4.1.4

--- a/.github/workflows/container_tests.yml
+++ b/.github/workflows/container_tests.yml
@@ -39,7 +39,7 @@ jobs:
           cd $HOME
           export INSTALL_DEP=$GITHUB_WORKSPACE/easybuild/scripts/install_eb_dep.sh
           # install Lmod
-          source $INSTALL_DEP Lmod-8.4.27 $HOME
+          source $INSTALL_DEP Lmod-8.7.4 $HOME
           # changes in environment are not passed to other steps, so need to create files...
           echo $MOD_INIT > mod_init
           echo $PATH > path

--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -38,7 +38,7 @@ jobs:
           cd $HOME
           export INSTALL_DEP=$GITHUB_WORKSPACE/easybuild/scripts/install_eb_dep.sh
           # install Lmod
-          source $INSTALL_DEP Lmod-8.4.26 $HOME
+          source $INSTALL_DEP Lmod-8.7.4 $HOME
           # changes in environment are not passed to other steps, so need to create files...
           echo $MOD_INIT > mod_init
           echo $PATH > path

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
         lmod7: Lmod-7.8.22
-        lmod8: Lmod-8.4.27
+        lmod8: Lmod-8.7.4
         modulesTcl: modules-tcl-1.147
         modules3: modules-3.2.10
         modules4: modules-4.1.4

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -958,7 +958,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
             txt += '\n'
         txt += self.modgen.get_description()
         test_envvar = 'TEST_FLAGS'
-        test_flags = '-Xflags1="foo bar" -Xflags2="more flags" '
+        test_flags = '-Xflags1="foo bar" -Xflags2="more flags"'
         txt += self.modgen.set_environment(test_envvar, test_flags)
 
         version_one = '1.0'


### PR DESCRIPTION
I'm hitting a bug in Lmod that's apparently fixed in Lmod 8.7.4 while working on adding support for using `pushenv`, so let's bump to latest current Lmod release for running the tests...