### PR TITLE
tweak is_patch_for function to make it more robust

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1018,9 +1018,13 @@ def is_patch_for(patch_name, ec):
 
     with ec.disable_templating():
         # take into account both list of extensions (via exts_list) and components (cfr. Bundle easyblock)
-        for entry in itertools.chain(ec['exts_list'], ec.get('components', [])):
+        for entry in itertools.chain(ec['exts_list'], ec.get('components') or []):
             if isinstance(entry, (list, tuple)) and len(entry) == 3 and isinstance(entry[2], dict):
-                templates = {'name': entry[0], 'version': entry[1]}
+                templates = {
+                    'name': entry[0],
+                    'namelower': entry[0].lower(),
+                    'version': entry[1],
+                }
                 options = entry[2]
                 patches.extend(p[0] % templates if isinstance(p, (tuple, list)) else p % templates
                                for p in options.get('patches', []))


### PR DESCRIPTION
Adding a patch file to a PR via `--update-pr` was sort of broken because the `is_patch_for` function wasn't robust enough.
There were two problematic cases:

1) An easyconfig for which `components` was set to `None`, which is the case for `AOMP` easyconfigs because the custom easyblock for `AOMP` uses `None` as default value for `components`:

(see details below for traceback)
<details>

```
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/kehoste/work/easybuild-framework/easybuild/main.py", line 597, in <module>
    main()
  File "/Users/kehoste/work/easybuild-framework/easybuild/main.py", line 510, in main
    update_pr(options.update_pr, categorized_paths, ordered_ecs)
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/github.py", line 1924, in update_pr
    update_branch(branch_name, paths, ecs, github_account=github_account, commit_msg=commit_msg)
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/github.py", line 1894, in update_branch
    _, _, _, _, diff_stat, pr_target_repo = _easyconfigs_pr_common(paths, ecs, start_branch=branch_name,
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/github.py", line 862, in _easyconfigs_pr_common
    patch_specs = det_patch_specs(paths['patch_files'], file_info, [target_dir])
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/github.py", line 1060, in det_patch_specs
    soft_name = find_software_name_for_patch(patch_file, ec_dirs)
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/github.py", line 1121, in find_software_name_for_patch
    if is_patch_for(patch_name, ec['ec']):
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/github.py", line 1023, in is_patch_for
    for entry in itertools.chain(ec['exts_list'], ec.get('components', [])):
TypeError: 'NoneType' object is not iterable
```

</details>

2) An easyconfig where `%(namelower)s` is used in the name of a patch file of an extension, like in`dd-0.5.6-foss-2020a-Python-3.8.2.eb`:

(see details below for traceback)
<details>

```
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/kehoste/work/easybuild-framework/easybuild/main.py", line 597, in <module>
    main()
  File "/Users/kehoste/work/easybuild-framework/easybuild/main.py", line 510, in main
    update_pr(options.update_pr, categorized_paths, ordered_ecs)
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/github.py", line 1924, in update_pr
    update_branch(branch_name, paths, ecs, github_account=github_account, commit_msg=commit_msg)
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/github.py", line 1894, in update_branch
    _, _, _, _, diff_stat, pr_target_repo = _easyconfigs_pr_common(paths, ecs, start_branch=branch_name,
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/github.py", line 862, in _easyconfigs_pr_common
    patch_specs = det_patch_specs(paths['patch_files'], file_info, [target_dir])
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/github.py", line 1060, in det_patch_specs
    soft_name = find_software_name_for_patch(patch_file, ec_dirs)
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/github.py", line 1121, in find_software_name_for_patch
    if is_patch_for(patch_name, ec['ec']):
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/github.py", line 1027, in is_patch_for
    patches.extend(p[0] % templates if isinstance(p, (tuple, list)) else p % templates
  File "/Users/kehoste/work/easybuild-framework/easybuild/tools/github.py", line 1027, in <genexpr>
    patches.extend(p[0] % templates if isinstance(p, (tuple, list)) else p % templates
KeyError: 'namelower'
```

</details>