### PR TITLE
add support for setting environment variables via 'pushenv' with modextravars

### DIFF
--- a/.github/workflows/bootstrap_script.yml
+++ b/.github/workflows/bootstrap_script.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
         lmod7: Lmod-7.8.22
-        lmod8: Lmod-8.7.4
+        lmod8: Lmod-8.7.6
         modulesTcl: modules-tcl-1.147
         modules3: modules-3.2.10
         modules4: modules-4.1.4

--- a/.github/workflows/container_tests.yml
+++ b/.github/workflows/container_tests.yml
@@ -39,7 +39,7 @@ jobs:
           cd $HOME
           export INSTALL_DEP=$GITHUB_WORKSPACE/easybuild/scripts/install_eb_dep.sh
           # install Lmod
-          source $INSTALL_DEP Lmod-8.7.4 $HOME
+          source $INSTALL_DEP Lmod-8.7.6 $HOME
           # changes in environment are not passed to other steps, so need to create files...
           echo $MOD_INIT > mod_init
           echo $PATH > path

--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -38,7 +38,7 @@ jobs:
           cd $HOME
           export INSTALL_DEP=$GITHUB_WORKSPACE/easybuild/scripts/install_eb_dep.sh
           # install Lmod
-          source $INSTALL_DEP Lmod-8.7.4 $HOME
+          source $INSTALL_DEP Lmod-8.7.6 $HOME
           # changes in environment are not passed to other steps, so need to create files...
           echo $MOD_INIT > mod_init
           echo $PATH > path

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
         lmod7: Lmod-7.8.22
-        lmod8: Lmod-8.7.4
+        lmod8: Lmod-8.7.6
         modulesTcl: modules-tcl-1.147
         modules3: modules-3.2.10
         modules4: modules-4.1.4

--- a/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
@@ -69,7 +69,7 @@ class Toy_Extension(ExtensionEasyBlock):
             if self.cfg['toy_ext_param']:
                 run_cmd(self.cfg['toy_ext_param'])
 
-            return self.module_generator.set_environment('TOY_EXT_%s' % self.name.upper(), self.name)
+            return self.module_generator.set_environment('TOY_EXT_%s' % self.name.upper().replace('-', '_'), self.name)
 
     def prerun(self):
         """


### PR DESCRIPTION
Use case here is internal, but it's basically an environment variable we want to define via `pushenv` through a custom hook implementation.

General support for `pushenv` is useful, since it avoids the need to resort to `modluafooter`...