### PR TITLE
Support for OneAPI compilers using 'oneapi': True

### DIFF
--- a/easybuild/toolchains/compiler/intel_compilers.py
+++ b/easybuild/toolchains/compiler/intel_compilers.py
@@ -39,6 +39,8 @@ class IntelCompilers(IntelIccIfort):
     """
 
     COMPILER_MODULE_NAME = ['intel-compilers']
+    COMPILER_UNIQUE_OPTS = dict(IntelIccIfort.COMPILER_UNIQUE_OPTS,
+                                oneapi = (False, "Use oneAPI compilers icx/icpx/ifx instead of classic compilers"))
 
     def _set_compiler_vars(self):
         """Intel compilers-specific adjustments after setting compiler variables."""
@@ -58,6 +60,19 @@ class IntelCompilers(IntelIccIfort):
 
     def set_variables(self):
         """Set the variables."""
+
+        if self.options.get('oneapi', False):
+            self.COMPILER_CXX = 'icpx'
+            self.COMPILER_CC = 'icx'
+            self.COMPILER_F77 = 'ifx'
+            self.COMPILER_F90 = 'ifx'
+            self.COMPILER_FC = 'ifx'
+            # fp-model source is not supported by icx but is equivalent to precise
+            self.options.options_map['defaultprec'] = ['ftz', 'fp-speculation=safe', 'fp-model precise']
+            # icx doesn't like -fp-model fast=1; fp-model fast is equivalent
+            self.options.options_map['loose'] = ['fp-model fast']
+            # recommended in porting guide
+            self.options.options_map['openmp'] = ['fiopenmp']
 
         # skip IntelIccIfort.set_variables (no longer relevant for recent versions)
         Compiler.set_variables(self)


### PR DESCRIPTION
If toolchainopts = {'oneapi': True}, compilers change to icx/icpx/ifx.

The options `-fp-model source` and `-fp-model fast=1` no longer work with
OneAPI. Change them to the equivalent `-fp-model precise` and `-fp-model fast`
options.

See #4009