### PR TITLE
tweak apply_patch to not create .orig files (by default) when applying patch files

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -250,6 +250,7 @@ BUILD_OPTIONS_CMDLINE = {
         'add_dummy_to_minimal_toolchains',
         'add_system_to_minimal_toolchains',
         'allow_modules_tool_mismatch',
+        'backup_patched_files',
         'consider_archived_easyconfigs',
         'container_build_image',
         'debug',

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1622,7 +1622,8 @@ def apply_patch(patch_file, dest, fn=None, copy=False, level=None, use_git_am=Fa
         else:
             _log.debug("Using specified patch level %d for patch %s" % (level, patch_file))
 
-        patch_cmd = "patch -b -p%s -i %s" % (level, abs_patch_file)
+        backup_option = '-b ' if build_option('backup_patched_files') else ''
+        patch_cmd = "patch " + backup_option + "-p%s -i %s" % (level, abs_patch_file)
 
     out, ec = run.run_cmd(patch_cmd, simple=False, path=abs_dest, log_ok=False, trace=False)
 

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -351,6 +351,8 @@ class EasyBuildOptions(GeneralOption):
                                                           None, 'store_true', False),
             'backup-modules': ("Back up an existing module file, if any. Only works when using --module-only",
                                None, 'store_true', None),  # default None to allow auto-enabling if not disabled
+            'backup-patched-files': ("Create a backup (*.orig) file when applying a patch",
+                                     None, 'store_true', False),
             'banned-linked-shared-libs': ("Comma-separated list of shared libraries (names, file names, or paths) "
                                           "which are not allowed to be linked in any installed binary/library",
                                           'strlist', 'extend', None),

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -44,7 +44,7 @@ from easybuild.framework.easyconfig.tools import avail_easyblocks, process_easyc
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools import config
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import get_module_syntax
+from easybuild.tools.config import get_module_syntax, update_build_option
 from easybuild.tools.filetools import change_dir, copy_dir, copy_file, mkdir, read_file, remove_file
 from easybuild.tools.filetools import verify_checksum, write_file
 from easybuild.tools.module_generator import module_generator
@@ -1971,8 +1971,21 @@ class EasyBlockTest(EnhancedTestCase):
         eb.patch_step()
         # verify that patches were applied
         toydir = os.path.join(eb.builddir, 'toy-0.0')
+        self.assertEqual(sorted(os.listdir(toydir)), ['toy-extra.txt', 'toy.source'])
+        self.assertTrue("and very proud of it" in read_file(os.path.join(toydir, 'toy.source')))
+        self.assertEqual(read_file(os.path.join(toydir, 'toy-extra.txt')), 'moar!\n')
+
+        # check again with backup of patched files enabled
+        update_build_option('backup_patched_files', True)
+        eb = EasyBlock(ec['ec'])
+        eb.fetch_step()
+        eb.extract_step()
+        eb.patch_step()
+        # verify that patches were applied
+        toydir = os.path.join(eb.builddir, 'toy-0.0')
         self.assertEqual(sorted(os.listdir(toydir)), ['toy-extra.txt', 'toy.source', 'toy.source.orig'])
         self.assertTrue("and very proud of it" in read_file(os.path.join(toydir, 'toy.source')))
+        self.assertFalse("and very proud of it" in read_file(os.path.join(toydir, 'toy.source.orig')))
         self.assertEqual(read_file(os.path.join(toydir, 'toy-extra.txt')), 'moar!\n')
 
     def test_extensions_sanity_check(self):

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1677,10 +1677,21 @@ class FileToolsTest(EnhancedTestCase):
         toy_patch_fn = 'toy-0.0_fix-silly-typo-in-printf-statement.patch'
         toy_patch = os.path.join(testdir, 'sandbox', 'sources', 'toy', toy_patch_fn)
 
-        self.assertTrue(ft.apply_patch(toy_patch, path))
-        patched = ft.read_file(os.path.join(path, 'toy-0.0', 'toy.source'))
-        pattern = "I'm a toy, and very proud of it"
-        self.assertTrue(pattern in patched)
+        for with_backup in (True, False):
+            update_build_option('backup_patched_files', with_backup)
+            self.assertTrue(ft.apply_patch(toy_patch, path))
+            src_file = os.path.join(path, 'toy-0.0', 'toy.source')
+            backup_file = src_file + '.orig'
+            patched = ft.read_file(src_file)
+            pattern = "I'm a toy, and very proud of it"
+            self.assertTrue(pattern in patched)
+            if with_backup:
+                self.assertTrue(os.path.exists(backup_file))
+                self.assertTrue(pattern not in ft.read_file(backup_file))
+                # Restore file to original after first(!) iteration
+                os.replace(backup_file, src_file)
+            else:
+                self.assertFalse(os.path.exists(backup_file))
 
         # This patch is dependent on the previous one
         toy_patch_gz = os.path.join(testdir, 'sandbox', 'sources', 'toy', 'toy-0.0_gzip.patch.gz')

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1689,7 +1689,7 @@ class FileToolsTest(EnhancedTestCase):
                 self.assertTrue(os.path.exists(backup_file))
                 self.assertTrue(pattern not in ft.read_file(backup_file))
                 # Restore file to original after first(!) iteration
-                os.replace(backup_file, src_file)
+                ft.move_file(backup_file, src_file)
             else:
                 self.assertFalse(os.path.exists(backup_file))
 


### PR DESCRIPTION
Add an option `--backup-patched-files` to enable the old behavior.
But usually creation of those backup files is not required as the build
directory will be deleted after a build anyway.