### PR TITLE
don't use -ftz for Intel oneAPI compilers versions before 2022.x

### DIFF
--- a/easybuild/toolchains/compiler/intel_compilers.py
+++ b/easybuild/toolchains/compiler/intel_compilers.py
@@ -29,6 +29,8 @@ Support for Intel compilers (icc, ifort) as toolchain compilers, version 2021.x 
 """
 import os
 
+from distutils.version import LooseVersion
+
 from easybuild.toolchains.compiler.inteliccifort import IntelIccIfort
 from easybuild.tools.toolchain.compiler import Compiler
 
@@ -68,7 +70,9 @@ class IntelCompilers(IntelIccIfort):
             self.COMPILER_F90 = 'ifx'
             self.COMPILER_FC = 'ifx'
             # fp-model source is not supported by icx but is equivalent to precise
-            self.options.options_map['defaultprec'] = ['ftz', 'fp-speculation=safe', 'fp-model precise']
+            self.options.options_map['defaultprec'] = ['fp-speculation=safe', 'fp-model precise']
+            if LooseVersion(self.get_software_version(self.COMPILER_MODULE_NAME)[0]) >= LooseVersion('2022'):
+                self.options.options_map['defaultprec'].insert(0, 'ftz')
             # icx doesn't like -fp-model fast=1; fp-model fast is equivalent
             self.options.options_map['loose'] = ['fp-model fast']
             # fp-model fast=2 gives "warning: overriding '-ffp-model=fast=2' option with '-ffp-model=fast'"

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -54,7 +54,7 @@ from easybuild.tools.run import run_cmd
 
 
 # number of modules included for testing purposes
-TEST_MODULES_COUNT = 90
+TEST_MODULES_COUNT = 91
 
 
 class ModulesTest(EnhancedTestCase):

--- a/test/framework/modules/intel-compilers/2022.1.0
+++ b/test/framework/modules/intel-compilers/2022.1.0
@@ -1,0 +1,41 @@
+#%Module
+proc ModulesHelp { } {
+    puts stderr {
+
+Description
+===========
+Intel C, C++ & Fortran compilers (classic and oneAPI)
+
+
+More information
+================
+ - Homepage: https://software.intel.com/content/www/us/en/develop/tools/oneapi/hpc-toolkit.html
+    }
+}
+
+module-whatis {Description: Intel C, C++ & Fortran compilers (classic and oneAPI)}
+module-whatis {Homepage: https://software.intel.com/content/www/us/en/develop/tools/oneapi/hpc-toolkit.html}
+module-whatis {URL: https://software.intel.com/content/www/us/en/develop/tools/oneapi/hpc-toolkit.html}
+
+set root /tmp/intel-compilers/2022.1.0
+
+conflict intel-compilers
+
+prepend-path	CPATH		$root/tbb/2022.1.0/include
+prepend-path	LD_LIBRARY_PATH		$root/compiler/2022.1.0/linux/lib
+prepend-path	LD_LIBRARY_PATH		$root/compiler/2022.1.0/linux/lib/x64
+prepend-path	LD_LIBRARY_PATH		$root/compiler/2022.1.0/linux/compiler/lib/intel64_lin
+prepend-path	LD_LIBRARY_PATH		$root/tbb/2022.1.0/lib/intel64/gcc4.8
+prepend-path	LIBRARY_PATH		$root/compiler/2022.1.0/linux/lib
+prepend-path	LIBRARY_PATH		$root/compiler/2022.1.0/linux/lib/x64
+prepend-path	LIBRARY_PATH		$root/compiler/2022.1.0/linux/compiler/lib/intel64_lin
+prepend-path	LIBRARY_PATH		$root/tbb/2022.1.0/lib/intel64/gcc4.8
+prepend-path	OCL_ICD_FILENAMES		$root/compiler/2022.1.0/linux/lib/x64/libintelocl.so
+prepend-path	PATH		$root/compiler/2022.1.0/linux/bin
+prepend-path	PATH		$root/compiler/2022.1.0/linux/bin/intel64
+prepend-path	TBBROOT		$root/tbb/2022.1.0
+setenv	EBROOTINTELMINCOMPILERS		"$root"
+setenv	EBVERSIONINTELMINCOMPILERS		"2022.1.0"
+setenv	EBDEVELINTELMINCOMPILERS		"$root/easybuild/Core-intel-compilers-2022.1.0-easybuild-devel"
+
+# Built with EasyBuild version 4.5.0dev

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -705,7 +705,7 @@ class ToolchainTest(EnhancedTestCase):
             tcs = {
                 'gompi': ('2018a', "-march=x86-64 -mtune=generic"),
                 'iccifort': ('2018.1.163', "-xSSE2 -ftz -fp-speculation=safe -fp-model source"),
-                'intel-compilers': ('2021.4.0', "-xSSE2 -ftz -fp-speculation=safe -fp-model precise"),
+                'intel-compilers': ('2021.4.0', "-xSSE2 -fp-speculation=safe -fp-model precise"),
             }
             for tcopt_optarch in [False, True]:
                 for tcname in tcs:
@@ -1953,7 +1953,7 @@ class ToolchainTest(EnhancedTestCase):
             ('CrayIntel', '2015.06-XC'),
             ('GCC', '6.4.0-2.28'),
             ('iccifort', '2018.1.163'),
-            ('intel-compilers', '2021.4.0'),
+            ('intel-compilers', '2022.1.0'),
         ]
 
         # purposely obtain toolchains several times in a row, value for $CFLAGS should not change


### PR DESCRIPTION
`icx -ftz hello.c` gives a warning for 2021 versions:

```
$ icx -ftz hello.c
icx: command line warning #10430: Unsupported command line options encountered
These options as listed are not supported.
For more information, use '-qnextgen-diag'.
option list:
        -ftz
```

So only use it for 2022 where it works.

One ftz test is then changed to 2022, the 2021 test removes ftz.