### PR TITLE
run python in the same process as `eb` wrapper script by using `exec`

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -230,6 +230,11 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     if 'CDPATH' in os.environ:
         del os.environ['CDPATH']
 
+    # When EB is run via `exec` the special bash variable $_ is not set
+    # So emulate this here to allow (module) scripts depending on that to work
+    if '_' not in os.environ:
+        os.environ['_'] = os.path.basename(sys.executable or 'python')
+
     # purposely session state very early, to avoid modules loaded by EasyBuild meddling in
     init_session_state = session_state()
 

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -233,7 +233,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     # When EB is run via `exec` the special bash variable $_ is not set
     # So emulate this here to allow (module) scripts depending on that to work
     if '_' not in os.environ:
-        os.environ['_'] = os.path.basename(sys.executable or 'python')
+        os.environ['_'] = sys.executable
 
     # purposely session state very early, to avoid modules loaded by EasyBuild meddling in
     init_session_state = session_state()

--- a/eb
+++ b/eb
@@ -125,4 +125,4 @@ fi
 export EB_SCRIPT_PATH="${0}"
 
 verbose "${PYTHON} -m ${EASYBUILD_MAIN} ${*}"
-"${PYTHON}" -m "${EASYBUILD_MAIN}" "${@}"
+exec "${PYTHON}" -m "${EASYBUILD_MAIN}" "${@}"


### PR DESCRIPTION
Use `exec` in the `eb` wrapper script to avoid creating a new process.
This allows easier work with e.g. SLURM as signals send to the main process (`eb`) may not be forwarded to Easybuild (python) which results in e.g. stale locks when the process is then later force-killed.