### PR TITLE
fix code style issues reported by recent flake8 linter

### DIFF
--- a/easybuild/base/fancylogger.py
+++ b/easybuild/base/fancylogger.py
@@ -380,9 +380,9 @@ class FancyLogger(logging.getLoggerClass()):
 
         def write_and_flush_stream(hdlr, data=None):
             """Write to stream and flush the handler"""
-            if (not hasattr(hdlr, 'stream')) or hdlr.stream is None:
+            if getattr(hdlr, 'stream', None) is None:
                 # no stream or not initialised.
-                raise("write_and_flush_stream failed. No active stream attribute.")
+                raise ValueError("write_and_flush_stream failed. No active stream attribute.")
             if data is not None:
                 hdlr.stream.write(data)
                 hdlr.flush()

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -973,7 +973,7 @@ class EasyBlock(object):
         if not self.cfg.get('cleanupoldbuild', False):
             uniq_builddir = builddir
             suff = 0
-            while(os.path.isdir(uniq_builddir)):
+            while os.path.isdir(uniq_builddir):
                 uniq_builddir = "%s.%d" % (builddir, suff)
                 suff += 1
             builddir = uniq_builddir

--- a/easybuild/framework/easyconfig/format/version.py
+++ b/easybuild/framework/easyconfig/format/version.py
@@ -117,7 +117,7 @@ class VersionOperator(object):
 
     def is_valid(self):
         """Check if this is a valid VersionOperator. Suffix can be anything."""
-        return not(self.version is None or self.operator is None)
+        return not (self.version is None or self.operator is None)
 
     def set(self, versop_str):
         """

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2870,7 +2870,7 @@ def copy_framework_files(paths, target_dir):
         if framework_topdir in dirnames:
             # construct subdirectory by grabbing last entry in dirnames until we hit 'easybuild-framework' dir
             subdirs = []
-            while(dirnames[-1] != framework_topdir):
+            while dirnames[-1] != framework_topdir:
                 subdirs.insert(0, dirnames.pop())
 
             parent_dir = os.path.join(*subdirs) if subdirs else ''

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -462,7 +462,7 @@ class ModulesTool(object):
         else:
             # filter out tail of paths that already matches tail of target, to avoid unnecessary 'unuse' commands
             idx = 1
-            while(curr_mod_paths[-idx:] == self.mod_paths[-idx:]):
+            while curr_mod_paths[-idx:] == self.mod_paths[-idx:]:
                 idx += 1
             self.log.debug("Not prepending %d last entries of %s", idx - 1, self.mod_paths)
 


### PR DESCRIPTION
Recent flake8 complains about a missing space after keywords:

- C-style `while(condition)` instead of `while condition:`
- `not(condition)` (actually better: `return self.version is not None and self.operator is not None`, but that's personal preference)
- Rewrote the if-condition checking for `stream` attr to remove the `or`
- Missing error class in `raise`. Settled on `ValueError` as the hdlr has a missing or invalid `stream` value