### PR TITLE
Support for passing from-pr in an easyconfig-based Easystack file [WIP]

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -426,7 +426,7 @@ class EasyConfig(object):
     """
 
     def __init__(self, path, extra_options=None, build_specs=None, validate=True, hidden=None, rawtxt=None,
-                 auto_convert_value_types=True, local_var_naming_check=None):
+                 auto_convert_value_types=True, local_var_naming_check=None, custom_build_opts=None):
         """
         initialize an easyconfig.
         :param path: path to easyconfig file to be parsed (ignored if rawtxt is specified)
@@ -438,6 +438,7 @@ class EasyConfig(object):
         :param auto_convert_value_types: indicates wether types of easyconfig values should be automatically converted
                                          in case they are wrong
         :param local_var_naming_check: mode to use when checking if local variables use the recommended naming scheme
+        :param custom_build_opts: custom build options passed for this specific EasyConfig in an EasyStack file
         """
         self.template_values = None
         self.enable_templating = True  # a boolean to control templating
@@ -542,6 +543,9 @@ class EasyConfig(object):
         self.set_default_module = False
 
         self.software_license = None
+
+        # Set custom build options from EasyStack file
+        self.custom_build_opts = custom_build_opts
 
     @contextmanager
     def disable_templating(self):
@@ -2038,7 +2042,7 @@ def resolve_template(value, tmpl_dict):
     return value
 
 
-def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, hidden=None):
+def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, hidden=None, custom_build_opts=None):
     """
     Process easyconfig, returning some information for each block
     :param path: path to easyconfig file
@@ -2046,6 +2050,7 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
     :param validate: whether or not to perform validation
     :param parse_only: only parse easyconfig superficially (faster, but results in partial info)
     :param hidden: indicate whether corresponding module file should be installed hidden ('.'-prefixed)
+    :param custom_build_opts: custom build options passed for this EasyConfig through an EasyStack file
     """
     blocks = retrieve_blocks_in_spec(path, build_option('only_blocks'))
 
@@ -2066,7 +2071,8 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
 
         # create easyconfig
         try:
-            ec = EasyConfig(spec, build_specs=build_specs, validate=validate, hidden=hidden)
+            ec = EasyConfig(spec, build_specs=build_specs, validate=validate,
+                            hidden=hidden, custom_build_opts=custom_build_opts)
         except EasyBuildError as err:
             raise EasyBuildError("Failed to process easyconfig %s: %s", spec, err.msg)
 

--- a/easybuild/framework/easystack.py
+++ b/easybuild/framework/easystack.py
@@ -69,6 +69,8 @@ class EasyStack(object):
         self.robot = False
         self.software_list = []
         self.easyconfigs = []  # A list of easyconfig names. May or may not include .eb extension
+        # A dict where keys are easyconfig names, values are dictionary of options that should be applied for that easyconfig
+        self.ec_opts = {}
 
     def compose_ec_filenames(self):
         """Returns a list of all easyconfig names"""
@@ -171,7 +173,11 @@ class EasyStackParser(object):
                 if len(easyconfig) == 1:
                     # Get single key from dictionary 'easyconfig'
                     easyconf_name = list(easyconfig.keys())[0]
+                    # Add easyconfig name to the list
                     easystack.easyconfigs.append(easyconf_name)
+                    # Add options to the ec_opts dict
+                    if 'options' in easyconfig[easyconf_name].keys():
+                        easystack.ec_opts[easyconf_name] = easyconfig[easyconf_name]['options']
                 else:
                     dict_keys = ', '.join(easyconfig.keys())
                     msg = "Failed to parse easystack file: expected a dictionary with one key (the EasyConfig name). "
@@ -307,12 +313,16 @@ def parse_easystack(filepath):
 
     easyconfig_names = easystack.compose_ec_filenames()
 
-    general_options = easystack.get_general_options()
+    # Disabled general options for now. We weren't using them, and first want support for EasyConfig-specific options.
+    # Then, we need a method to resolve conflicts (specific options should win)
+    # general_options = easystack.get_general_options()
 
     _log.debug("EasyStack parsed. Proceeding to install these Easyconfigs: %s" % ', '.join(sorted(easyconfig_names)))
-    if len(general_options) != 0:
-        _log.debug("General options for installation are: \n%s" % str(general_options))
-    else:
-        _log.debug("No general options were specified in easystack")
+    _log.debug("Using EasyConfig specific options based on the following dict:")
+    _log.debug(easystack.ec_opts)
+    # if len(general_options) != 0:
+    #    _log.debug("General options for installation are: \n%s" % str(general_options))
+    # else:
+    #    _log.debug("No general options were specified in easystack")
 
-    return easyconfig_names, general_options
+    return easyconfig_names, easystack.ec_opts

--- a/easybuild/framework/easystack.py
+++ b/easybuild/framework/easystack.py
@@ -183,7 +183,7 @@ class EasyStackParser(object):
                     msg = "Failed to parse easystack file: expected a dictionary with one key (the EasyConfig name). "
                     msg += "Instead found keys: %s" % dict_keys
                     raise EasyBuildError(msg)
- 
+
         return easystack
 
     @staticmethod

--- a/easybuild/framework/easystack.py
+++ b/easybuild/framework/easystack.py
@@ -88,8 +88,10 @@ class EasyStack(object):
 
         # entries specified via 'easyconfigs' top-level key
         for ec in self.easyconfigs:
-            ec_filenames.append(ec + '.eb')
-
+            if not ec.endswith('.eb'):
+                ec_filenames.append(ec + '.eb')
+            else:
+                ec_filenames.append(ec)
         return ec_filenames
 
     # flags applicable to all sw (i.e. robot)

--- a/easybuild/framework/easystack.py
+++ b/easybuild/framework/easystack.py
@@ -68,7 +68,7 @@ class EasyStack(object):
         self.easybuild_version = None
         self.robot = False
         self.software_list = []
-        self.easyconfigs = [] # A list of easyconfig names. May or may not include .eb extension
+        self.easyconfigs = []  # A list of easyconfig names. May or may not include .eb extension
 
     def compose_ec_filenames(self):
         """Returns a list of all easyconfig names"""

--- a/easybuild/framework/easystack.py
+++ b/easybuild/framework/easystack.py
@@ -69,7 +69,7 @@ class EasyStack(object):
         self.robot = False
         self.software_list = []
         self.easyconfigs = []  # A list of easyconfig names. May or may not include .eb extension
-        # A dict where keys are easyconfig names, values are dictionary of options that should be 
+        # A dict where keys are easyconfig names, values are dictionary of options that should be
         # applied for that easyconfig
         self.ec_opts = {}
 

--- a/easybuild/framework/easystack.py
+++ b/easybuild/framework/easystack.py
@@ -131,10 +131,20 @@ class EasyStackParser(object):
 
         easystack_data = None
         top_keys = ('easyconfigs', 'software')
+        keys_found = []
         for key in top_keys:
             if key in easystack_raw:
-                easystack_data = easystack_raw[key]
-                break
+                keys_found.append(key)
+        # For now, we don't support mixing multiple top_keys, so check that only one was defined
+        if len(keys_found) > 1:
+            keys_string = ', '.join(keys_found)
+            msg = "Specifying multiple top level keys (%s) in one EasyStack file is not supported." % keys_string
+            raise EasyBuildError(msg)
+        elif len(keys_found) == 0:
+            raise EasyBuildError("An EasyStack file needs to contain at least one of the keys: %s" % (top_keys,))
+        else:
+            key = keys_found[0]
+            easystack_data = easystack_raw[key]
 
         if easystack_data is None:
             msg = "Not a valid EasyStack YAML file: no 'easyconfigs' or 'software' top-level key found"

--- a/easybuild/framework/easystack.py
+++ b/easybuild/framework/easystack.py
@@ -177,7 +177,7 @@ class EasyStackParser(object):
                     msg = "Failed to parse easystack file: expected a dictionary with one key (the EasyConfig name). "
                     msg += "Instead found keys: %s" % dict_keys
                     raise EasyBuildError(msg)
-        
+ 
         return easystack
 
     @staticmethod

--- a/easybuild/framework/easystack.py
+++ b/easybuild/framework/easystack.py
@@ -69,7 +69,8 @@ class EasyStack(object):
         self.robot = False
         self.software_list = []
         self.easyconfigs = []  # A list of easyconfig names. May or may not include .eb extension
-        # A dict where keys are easyconfig names, values are dictionary of options that should be applied for that easyconfig
+        # A dict where keys are easyconfig names, values are dictionary of options that should be 
+        # applied for that easyconfig
         self.ec_opts = {}
 
     def compose_ec_filenames(self):

--- a/easybuild/framework/easystack.py
+++ b/easybuild/framework/easystack.py
@@ -141,19 +141,16 @@ class EasyStackParser(object):
             msg = "Specifying multiple top level keys (%s) in one EasyStack file is not supported." % keys_string
             raise EasyBuildError(msg)
         elif len(keys_found) == 0:
-            raise EasyBuildError("An EasyStack file needs to contain at least one of the keys: %s" % (top_keys,))
+            msg = "Not a valid EasyStack YAML file: no 'easyconfigs' or 'software' top-level key found"
+            raise EasyBuildError(msg)
         else:
             key = keys_found[0]
             easystack_data = easystack_raw[key]
 
-        if easystack_data is None:
-            msg = "Not a valid EasyStack YAML file: no 'easyconfigs' or 'software' top-level key found"
-            raise EasyBuildError(msg)
-        else:
-            parse_method_name = 'parse_by_' + key
-            parse_method = getattr(EasyStackParser, 'parse_by_%s' % key, None)
-            if parse_method is None:
-                raise EasyBuildError("Easystack parse method '%s' not found!", parse_method_name)
+        parse_method_name = 'parse_by_' + key
+        parse_method = getattr(EasyStackParser, 'parse_by_%s' % key, None)
+        if parse_method is None:
+            raise EasyBuildError("Easystack parse method '%s' not found!", parse_method_name)
 
         # assign general easystack attributes
         easybuild_version = easystack_raw.get('easybuild_version', None)

--- a/easybuild/framework/easystack.py
+++ b/easybuild/framework/easystack.py
@@ -64,13 +64,11 @@ def check_value(value, context):
 class EasyStack(object):
     """One class instance per easystack. General options + list of all SoftwareSpecs instances"""
 
-    def __init__(self, easyconfigs=None):
+    def __init__(self):
         self.easybuild_version = None
         self.robot = False
         self.software_list = []
-        self.easyconfigs = []
-        if easyconfigs is not None:
-            self.easyconfigs.extend(easyconfigs)
+        self.easyconfigs = [] # A list of easyconfig names. May or may not include .eb extension
 
     def compose_ec_filenames(self):
         """Returns a list of all easyconfig names"""
@@ -163,8 +161,23 @@ class EasyStackParser(object):
         """
         Parse easystack file with 'easyconfigs' as top-level key.
         """
-        easystack = EasyStack(easyconfigs=easyconfigs)
 
+        easystack = EasyStack()
+
+        for easyconfig in easyconfigs:
+            if isinstance(easyconfig, str):
+                easystack.easyconfigs.append(easyconfig)
+            elif isinstance(easyconfig, dict):
+                if len(easyconfig) == 1:
+                    # Get single key from dictionary 'easyconfig'
+                    easyconf_name = list(easyconfig.keys())[0]
+                    easystack.easyconfigs.append(easyconf_name)
+                else:
+                    dict_keys = ', '.join(easyconfig.keys())
+                    msg = "Failed to parse easystack file: expected a dictionary with one key (the EasyConfig name). "
+                    msg += "Instead found keys: %s" % dict_keys
+                    raise EasyBuildError(msg)
+        
         return easystack
 
     @staticmethod

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -261,8 +261,6 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     if options.easystack:
         # TODO add general_options (i.e. robot) to build options
         orig_paths, opts_per_ec = parse_easystack(options.easystack)
-        print(f"opts_per_ec:")
-        print(opts_per_ec)
         if opts_per_ec:
             print_warning("Specifying options in easystack files is not supported yet. They are parsed, but ignored.")
 
@@ -377,7 +375,6 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
 
     # determine paths to easyconfigs
     determined_paths = det_easyconfig_paths(categorized_paths['easyconfigs'], opts_per_ec)
-    print(f"determined_paths: {determined_paths}")
 
     # only copy easyconfigs here if we're not using --try-* (that's handled below)
     copy_ec = options.copy_ec and not tweaked_ecs_paths

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -43,7 +43,7 @@ import traceback
 
 # IMPORTANT this has to be the first easybuild import as it customises the logging
 #  expect missing log output when this not the case!
-from easybuild.tools.build_log import EasyBuildError, print_error, print_msg, stop_logging
+from easybuild.tools.build_log import EasyBuildError, print_error, print_msg, stop_logging, print_warning
 
 from easybuild.framework.easyblock import build_and_install_one, inject_checksums
 from easybuild.framework.easyconfig import EASYCONFIGS_PKG_SUBDIR
@@ -261,7 +261,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
         # TODO add general_options (i.e. robot) to build options
         orig_paths, general_options = parse_easystack(options.easystack)
         if general_options:
-            raise EasyBuildError("Specifying general configuration options in easystack file is not supported yet.")
+            print_warning("Specifying options in easystack files is not supported yet. They are parsed, but ignored.")
 
     # check whether packaging is supported when it's being used
     if options.package:

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -257,10 +257,13 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
         print_msg(last_log, log=_log, prefix=False)
 
     # if easystack is provided with the command, commands with arguments from it will be executed
+    opts_per_ec = {}
     if options.easystack:
         # TODO add general_options (i.e. robot) to build options
-        orig_paths, general_options = parse_easystack(options.easystack)
-        if general_options:
+        orig_paths, opts_per_ec = parse_easystack(options.easystack)
+        print(f"opts_per_ec:")
+        print(opts_per_ec)
+        if opts_per_ec:
             print_warning("Specifying options in easystack files is not supported yet. They are parsed, but ignored.")
 
     # check whether packaging is supported when it's being used
@@ -373,7 +376,8 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     no_ec_opts = [options.aggregate_regtest, options.regtest, pr_options, search_query]
 
     # determine paths to easyconfigs
-    determined_paths = det_easyconfig_paths(categorized_paths['easyconfigs'])
+    determined_paths = det_easyconfig_paths(categorized_paths['easyconfigs'], opts_per_ec)
+    print(f"determined_paths: {determined_paths}")
 
     # only copy easyconfigs here if we're not using --try-* (that's handled below)
     copy_ec = options.copy_ec and not tweaked_ecs_paths

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -422,7 +422,8 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
             sys.exit(31)  # exit -> 3x1t -> 31
 
     # read easyconfig files
-    easyconfigs, generated_ecs = parse_easyconfigs(paths, validate=not options.inject_checksums, opts_per_ec = opts_per_ec)
+    easyconfigs, generated_ecs = parse_easyconfigs(paths, validate=not options.inject_checksums,
+                                                   opts_per_ec=opts_per_ec)
 
     # handle --check-contrib & --check-style options
     if run_contrib_style_checks([ec['ec'] for ec in easyconfigs], options.check_contrib, options.check_style):

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -55,7 +55,6 @@ from easybuild.framework.easyconfig.tools import categorize_files_by_type, dep_g
 from easybuild.framework.easyconfig.tools import det_easyconfig_paths, dump_env_script, get_paths_for
 from easybuild.framework.easyconfig.tools import parse_easyconfigs, review_pr, run_contrib_checks, skip_available
 from easybuild.framework.easyconfig.tweak import obtain_ec_for, tweak
-from easybuild.tools.build_log import print_warning
 from easybuild.tools.config import find_last_log, get_repository, get_repositorypath, build_option
 from easybuild.tools.containers.common import containerize
 from easybuild.tools.docs import list_software

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -425,7 +425,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
             sys.exit(31)  # exit -> 3x1t -> 31
 
     # read easyconfig files
-    easyconfigs, generated_ecs = parse_easyconfigs(paths, validate=not options.inject_checksums)
+    easyconfigs, generated_ecs = parse_easyconfigs(paths, validate=not options.inject_checksums, opts_per_ec = opts_per_ec)
 
     # handle --check-contrib & --check-style options
     if run_contrib_style_checks([ec['ec'] for ec in easyconfigs], options.check_contrib, options.check_style):

--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -458,9 +458,11 @@ def resolve_dependencies(easyconfigs, modtool, retain_all_deps=False, raise_erro
                         for ec in processed_ecs:
                             if ec not in easyconfigs + additional:
                                 # Make dependency inherit custom build opts
-                                if (ec['ec'].custom_build_opts is None) and (entry['ec'].custom_build_opts is not None) :
+                                if (ec['ec'].custom_build_opts is None) and (entry['ec'].custom_build_opts is not None):
                                     ec['ec'].custom_build_opts = entry['ec'].custom_build_opts
-                                    _log.debug("Copied custom build opts (%s) from %s to %s" % (str(custom_build_opts), entry['ec'], ec['ec']))
+                                    msg = "Copied custom build opts (%s) " % str(custom_build_opts)
+                                    msg += "from %s to %s" % (entry['ec'], ec['ec'])
+                                    _log.debug(msg)
                                 additional.append(ec)
                                 _log.debug("Added %s as dependency of %s" % (ec, entry))
                 else:

--- a/test/framework/easystack.py
+++ b/test/framework/easystack.py
@@ -102,7 +102,7 @@ class EasyStackTest(EnhancedTestCase):
         self.assertEqual(opts, {})
 
     def test_easystack_easyconfig_opts(self):
-        """Teast an easystack file using the 'easyconfigs' key, where additonal options are defined for some easyconfigs"""
+        """Test an easystack file using the 'easyconfigs' key, with additonal options for some easyconfigs"""
         topdir = os.path.dirname(os.path.abspath(__file__))
         test_easystack = os.path.join(topdir, 'easystacks', 'test_easystack_easyconfigs_opts.yaml')
 

--- a/test/framework/easystack.py
+++ b/test/framework/easystack.py
@@ -86,6 +86,21 @@ class EasyStackTest(EnhancedTestCase):
         self.assertEqual(sorted(ec_fns), sorted(expected))
         self.assertEqual(opts, {})
 
+    def test_easystack_easyconfigs_with_eb_ext(self):
+        """Test for easystack file using 'easyconfigs' key, where eb extension is included in the easystack file"""
+        topdir = os.path.dirname(os.path.abspath(__file__))
+        test_easystack = os.path.join(topdir, 'easystacks', 'test_easystack_easyconfigs_with_eb_ext.yaml')
+
+        ec_fns, opts = parse_easystack(test_easystack)
+        expected = [
+            'binutils-2.25-GCCcore-4.9.3.eb',
+            'binutils-2.26-GCCcore-4.9.3.eb',
+            'foss-2018a.eb',
+            'toy-0.0-gompi-2018a-test.eb',
+        ]
+        self.assertEqual(sorted(ec_fns), sorted(expected))
+        self.assertEqual(opts, {})
+
     def test_parse_fail(self):
         """Test for clean error when easystack file fails to parse."""
         test_yml = os.path.join(self.test_prefix, 'test.yml')

--- a/test/framework/easystack.py
+++ b/test/framework/easystack.py
@@ -101,6 +101,25 @@ class EasyStackTest(EnhancedTestCase):
         self.assertEqual(sorted(ec_fns), sorted(expected))
         self.assertEqual(opts, {})
 
+    def test_easystack_easyconfig_opts(self):
+        """Teast an easystack file using the 'easyconfigs' key, where additonal options are defined for some easyconfigs"""
+        topdir = os.path.dirname(os.path.abspath(__file__))
+        test_easystack = os.path.join(topdir, 'easystacks', 'test_easystack_easyconfigs_opts.yaml')
+
+        ec_fns, opts = parse_easystack(test_easystack)
+        expected = [
+            'binutils-2.25-GCCcore-4.9.3.eb',
+            'binutils-2.26-GCCcore-4.9.3.eb',
+            'foss-2018a.eb',
+            'toy-0.0-gompi-2018a-test.eb',
+        ]
+        expected_opts = {
+            'binutils-2.25-GCCcore-4.9.3.eb': {'debug': True},
+            'foss-2018a.eb': {'robot': True},
+        }
+        self.assertEqual(sorted(ec_fns), sorted(expected))
+        self.assertEqual(opts, expected_opts)
+
     def test_parse_fail(self):
         """Test for clean error when easystack file fails to parse."""
         test_yml = os.path.join(self.test_prefix, 'test.yml')

--- a/test/framework/easystack.py
+++ b/test/framework/easystack.py
@@ -56,6 +56,36 @@ class EasyStackTest(EnhancedTestCase):
         easybuild.tools.build_log.EXPERIMENTAL = self.orig_experimental
         super(EasyStackTest, self).tearDown()
 
+    def test_easystack_basic(self):
+        """Test for basic easystack file."""
+        topdir = os.path.dirname(os.path.abspath(__file__))
+        test_easystack = os.path.join(topdir, 'easystacks', 'test_easystack_basic.yaml')
+
+        ec_fns, opts = parse_easystack(test_easystack)
+        expected = [
+            'binutils-2.25-GCCcore-4.9.3.eb',
+            'binutils-2.26-GCCcore-4.9.3.eb',
+            'foss-2018a.eb',
+            'toy-0.0-gompi-2018a-test.eb',
+        ]
+        self.assertEqual(sorted(ec_fns), sorted(expected))
+        self.assertEqual(opts, {})
+
+    def test_easystack_easyconfigs(self):
+        """Test for easystack file using 'easyconfigs' key."""
+        topdir = os.path.dirname(os.path.abspath(__file__))
+        test_easystack = os.path.join(topdir, 'easystacks', 'test_easystack_easyconfigs.yaml')
+
+        ec_fns, opts = parse_easystack(test_easystack)
+        expected = [
+            'binutils-2.25-GCCcore-4.9.3.eb',
+            'binutils-2.26-GCCcore-4.9.3.eb',
+            'foss-2018a.eb',
+            'toy-0.0-gompi-2018a-test.eb',
+        ]
+        self.assertEqual(sorted(ec_fns), sorted(expected))
+        self.assertEqual(opts, {})
+
     def test_parse_fail(self):
         """Test for clean error when easystack file fails to parse."""
         test_yml = os.path.join(self.test_prefix, 'test.yml')
@@ -120,15 +150,17 @@ class EasyStackTest(EnhancedTestCase):
         versions = ('1.2.3', '1.2.30', '2021a', '1.2.3')
         for version in versions:
             write_file(test_easystack, tmpl_easystack_txt + ' ' + version)
-            ec_fns, _ = parse_easystack(test_easystack)
+            ec_fns, opts = parse_easystack(test_easystack)
             self.assertEqual(ec_fns, ['foo-%s.eb' % version])
+            self.assertEqual(opts, {})
 
         # multiple versions as a list
         test_easystack_txt = tmpl_easystack_txt + " [1.2.3, 3.2.1]"
         write_file(test_easystack, test_easystack_txt)
-        ec_fns, _ = parse_easystack(test_easystack)
+        ec_fns, opts = parse_easystack(test_easystack)
         expected = ['foo-1.2.3.eb', 'foo-3.2.1.eb']
         self.assertEqual(sorted(ec_fns), sorted(expected))
+        self.assertEqual(opts, {})
 
         # multiple versions listed with more info
         test_easystack_txt = '\n'.join([
@@ -139,9 +171,10 @@ class EasyStackTest(EnhancedTestCase):
             "                 versionsuffix: -foo",
         ])
         write_file(test_easystack, test_easystack_txt)
-        ec_fns, _ = parse_easystack(test_easystack)
+        ec_fns, opts = parse_easystack(test_easystack)
         expected = ['foo-1.2.3.eb', 'foo-2021a.eb', 'foo-3.2.1-foo.eb']
         self.assertEqual(sorted(ec_fns), sorted(expected))
+        self.assertEqual(opts, {})
 
         # versions that get interpreted by YAML as float or int, single quotes required
         for version in ('1.2', '123', '3.50', '100', '2.44_01'):
@@ -152,8 +185,9 @@ class EasyStackTest(EnhancedTestCase):
 
             # all is fine when wrapping the value in single quotes
             write_file(test_easystack, tmpl_easystack_txt + " '" + version + "'")
-            ec_fns, _ = parse_easystack(test_easystack)
+            ec_fns, opts = parse_easystack(test_easystack)
             self.assertEqual(ec_fns, ['foo-%s.eb' % version])
+            self.assertEqual(opts, {})
 
             # one rotten apple in the basket is enough
             test_easystack_txt = tmpl_easystack_txt + " [1.2.3, %s, 3.2.1]" % version
@@ -179,9 +213,10 @@ class EasyStackTest(EnhancedTestCase):
                 "                 versionsuffix: -foo",
             ])
             write_file(test_easystack, test_easystack_txt)
-            ec_fns, _ = parse_easystack(test_easystack)
+            ec_fns, opts = parse_easystack(test_easystack)
             expected = ['foo-1.2.3.eb', 'foo-%s.eb' % version, 'foo-3.2.1-foo.eb']
             self.assertEqual(sorted(ec_fns), sorted(expected))
+            self.assertEqual(opts, {})
 
         # also check toolchain version that could be interpreted as a non-string value...
         test_easystack_txt = '\n'.join([
@@ -192,9 +227,10 @@ class EasyStackTest(EnhancedTestCase):
             "        versions: [1.2.3, '2.3']",
         ])
         write_file(test_easystack, test_easystack_txt)
-        ec_fns, _ = parse_easystack(test_easystack)
+        ec_fns, opts = parse_easystack(test_easystack)
         expected = ['test-1.2.3-intel-2021.03.eb', 'test-2.3-intel-2021.03.eb']
         self.assertEqual(sorted(ec_fns), sorted(expected))
+        self.assertEqual(opts, {})
 
 
 def suite():

--- a/test/framework/easystacks/test_easystack_easyconfig_opts.yaml
+++ b/test/framework/easystacks/test_easystack_easyconfig_opts.yaml
@@ -1,0 +1,11 @@
+easyconfigs:
+    - binutils-2.25-GCCcore-4.9.3:
+        options: {
+          'debug': True,
+        }
+    - binutils-2.26-GCCcore-4.9.3
+    - foss-2018a:
+        options: {
+          'robot': True,
+        }
+    - toy-0.0-gompi-2018a-test

--- a/test/framework/easystacks/test_easystack_easyconfigs.yaml
+++ b/test/framework/easystacks/test_easystack_easyconfigs.yaml
@@ -1,0 +1,5 @@
+easyconfigs:
+    - binutils-2.25-GCCcore-4.9.3
+    - binutils-2.26-GCCcore-4.9.3
+    - foss-2018a
+    - toy-0.0-gompi-2018a-test

--- a/test/framework/easystacks/test_easystack_easyconfigs_with_eb_ext.yaml
+++ b/test/framework/easystacks/test_easystack_easyconfigs_with_eb_ext.yaml
@@ -1,0 +1,5 @@
+easyconfigs:
+    - binutils-2.25-GCCcore-4.9.3.eb
+    - binutils-2.26-GCCcore-4.9.3.eb
+    - foss-2018a.eb
+    - toy-0.0-gompi-2018a-test.eb


### PR DESCRIPTION
Note that this PR builds on top of https://github.com/easybuilders/easybuild-framework/pull/4021 (because we need option parsing for EasyStack files, before we can do anything with the options...). Thus, that part might still change.

At this point in time, the behavior of this PR on the following example:

```
robot: true
easyconfigs:
  - ncurses-6.3-GCCcore-11.3.0.eb
  - expecttest-0.1.3-GCCcore-11.3.0.eb:
      options: {
        'from_pr': [15922,15923],
      }
  - FFmpeg-5.0.1-GCCcore-11.3.0.eb:
      options: {
        'from_pr': [15918],
      }
```

Is:

```
eb_github -D --easystack easystack_flat_ebs_from_pr.yaml -r --debug
== Temporary log file in case of crash /scratch/casparl/eb-xdu4273p/easybuild-uyvbixfc.log

WARNING: Specifying options in easystack files is not supported yet. They are parsed, but ignored.


WARNING: Using easyconfigs from closed PR #15923

Dry run: printing build status of easyconfigs and dependencies
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/m/M4/M4-1.4.19.eb (module: M4/1.4.19)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/b/Bison/Bison-3.8.2.eb (module: Bison/3.8.2)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/f/flex/flex-2.6.4.eb (module: flex/2.6.4)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/z/zlib/zlib-1.2.12.eb (module: zlib/1.2.12)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/b/binutils/binutils-2.38.eb (module: binutils/2.38)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/g/GCCcore/GCCcore-11.3.0.eb (module: GCCcore/11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/z/zlib/zlib-1.2.12-GCCcore-11.3.0.eb (module: zlib/1.2.12-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/h/help2man/help2man-1.49.2-GCCcore-11.3.0.eb (module: help2man/1.49.2-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/m/M4/M4-1.4.19-GCCcore-11.3.0.eb (module: M4/1.4.19-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/b/Bison/Bison-3.8.2-GCCcore-11.3.0.eb (module: Bison/3.8.2-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/f/flex/flex-2.6.4-GCCcore-11.3.0.eb (module: flex/2.6.4-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/b/binutils/binutils-2.38-GCCcore-11.3.0.eb (module: binutils/2.38-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/p/pkgconf/pkgconf-1.8.0-GCCcore-11.3.0.eb (module: pkgconf/1.8.0-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/n/NASM/NASM-2.15.05-GCCcore-11.3.0.eb (module: NASM/2.15.05-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/b/bzip2/bzip2-1.0.8-GCCcore-11.3.0.eb (module: bzip2/1.0.8-GCCcore-11.3.0)
 * [x] /scratch/casparl/eb-xdu4273p/files_pr15918/x/x264/x264-20220620-GCCcore-11.3.0.eb (module: x264/20220620-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/e/expat/expat-2.4.8-GCCcore-11.3.0.eb (module: expat/2.4.8-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/n/ncurses/ncurses-6.3-GCCcore-11.3.0.eb (module: ncurses/6.3-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/u/UnZip/UnZip-6.0-GCCcore-11.3.0.eb (module: UnZip/6.0-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/l/libreadline/libreadline-8.1.2-GCCcore-11.3.0.eb (module: libreadline/8.1.2-GCCcore-11.3.0)
 * [x] /scratch/casparl/eb-xdu4273p/files_pr15918/y/Yasm/Yasm-1.3.0-GCCcore-11.3.0.eb (module: Yasm/1.3.0-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/t/Tcl/Tcl-8.6.12-GCCcore-11.3.0.eb (module: Tcl/8.6.12-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/p/pkgconf/pkgconf-1.8.0.eb (module: pkgconf/1.8.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/s/SQLite/SQLite-3.38.3-GCCcore-11.3.0.eb (module: SQLite/3.38.3-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/o/OpenSSL/OpenSSL-1.1.eb (module: OpenSSL/1.1)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/c/cURL/cURL-7.83.0-GCCcore-11.3.0.eb (module: cURL/7.83.0-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/l/libffi/libffi-3.4.2-GCCcore-11.3.0.eb (module: libffi/3.4.2-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/l/libtool/libtool-2.4.7-GCCcore-11.3.0.eb (module: libtool/2.4.7-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/g/groff/groff-1.22.4-GCCcore-11.3.0.eb (module: groff/1.22.4-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/d/DB/DB-18.1.40-GCCcore-11.3.0.eb (module: DB/18.1.40-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/l/libpng/libpng-1.6.37-GCCcore-11.3.0.eb (module: libpng/1.6.37-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/n/ncurses/ncurses-6.2.eb (module: ncurses/6.2)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/p/Perl/Perl-5.34.1-GCCcore-11.3.0.eb (module: Perl/5.34.1-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/i/intltool/intltool-0.51.0-GCCcore-11.3.0.eb (module: intltool/0.51.0-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/g/gettext/gettext-0.21.eb (module: gettext/0.21)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/a/Autoconf/Autoconf-2.71-GCCcore-11.3.0.eb (module: Autoconf/2.71-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/x/XZ/XZ-5.2.5-GCCcore-11.3.0.eb (module: XZ/5.2.5-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/a/Automake/Automake-1.16.5-GCCcore-11.3.0.eb (module: Automake/1.16.5-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/l/libxml2/libxml2-2.9.13-GCCcore-11.3.0.eb (module: libxml2/2.9.13-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/p/Python/Python-3.10.4-GCCcore-11.3.0-bare.eb (module: Python/3.10.4-GCCcore-11.3.0-bare)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/a/Autotools/Autotools-20220317-GCCcore-11.3.0.eb (module: Autotools/20220317-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/l/libarchive/libarchive-3.6.1-GCCcore-11.3.0.eb (module: libarchive/3.6.1-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/g/gettext/gettext-0.21-GCCcore-11.3.0.eb (module: gettext/0.21-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/g/GMP/GMP-6.2.1-GCCcore-11.3.0.eb (module: GMP/6.2.1-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/g/git/git-2.36.0-GCCcore-11.3.0-nodocs.eb (module: git/2.36.0-GCCcore-11.3.0-nodocs)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/c/CMake/CMake-3.23.1-GCCcore-11.3.0.eb (module: CMake/3.23.1-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/l/LAME/LAME-3.100-GCCcore-11.3.0.eb (module: LAME/3.100-GCCcore-11.3.0)
 * [x] /scratch/casparl/eb-xdu4273p/files_pr15918/x/x265/x265-3.5-GCCcore-11.3.0.eb (module: x265/3.5-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/r/Rust/Rust-1.60.0-GCCcore-11.3.0.eb (module: Rust/1.60.0-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/p/Python/Python-3.10.4-GCCcore-11.3.0.eb (module: Python/3.10.4-GCCcore-11.3.0)
 * [x] /scratch/casparl/eb-xdu4273p/files_pr15922/e/expecttest/expecttest-0.1.3-GCCcore-11.3.0.eb (module: expecttest/0.1.3-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/f/FriBidi/FriBidi-1.0.12-GCCcore-11.3.0.eb (module: FriBidi/1.0.12-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/n/Ninja/Ninja-1.10.2-GCCcore-11.3.0.eb (module: Ninja/1.10.2-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/b/Brotli/Brotli-1.0.9-GCCcore-11.3.0.eb (module: Brotli/1.0.9-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/g/gperf/gperf-3.1-GCCcore-11.3.0.eb (module: gperf/3.1-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/f/freetype/freetype-2.12.1-GCCcore-11.3.0.eb (module: freetype/2.12.1-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/m/Meson/Meson-0.62.1-GCCcore-11.3.0.eb (module: Meson/0.62.1-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/x/xorg-macros/xorg-macros-1.19.3-GCCcore-11.3.0.eb (module: xorg-macros/1.19.3-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/u/util-linux/util-linux-2.38-GCCcore-11.3.0.eb (module: util-linux/2.38-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/f/fontconfig/fontconfig-2.14.0-GCCcore-11.3.0.eb (module: fontconfig/2.14.0-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/l/libpciaccess/libpciaccess-0.16-GCCcore-11.3.0.eb (module: libpciaccess/0.16-GCCcore-11.3.0)
 * [x] /home/casparl/.local/easybuild/Debian10/2022/software/EasyBuild/4.6.0-dev/easybuild/easyconfigs/x/X11/X11-20220504-GCCcore-11.3.0.eb (module: X11/20220504-GCCcore-11.3.0)
 * [x] /scratch/casparl/eb-xdu4273p/files_pr15918/f/FFmpeg/FFmpeg-5.0.1-GCCcore-11.3.0.eb (module: FFmpeg/5.0.1-GCCcore-11.3.0)
```

In this, `Yasm`, is a dependency of `x265`, which is a dependency of `FFmpeg`. As we can see, all are properly resolved from the right tempdir `.../files_pr15918/...`. Essentially, this is as expected.

In terms of the 'challenges' discussed [in issue #4050](https://github.com/easybuilders/easybuild-framework/issues/4050#issue-1325770178), behaviour would/should now be that for

```yaml
# my_easystack.yaml
easyconfigs:
  - A.eb
    options: {
      'from_pr': 1235,
    }
  - B.eb
```
With `C.eb` being a dependency of both `A.eb` and `B.eb`, this should resolve `C.eb` to the version from `from_pr`.