### PR TITLE
include 'sources' key to entries in list returned by collect_exts_file_info

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -725,6 +725,11 @@ class EasyBlock:
                                 # copy 'path' entry to 'src' for use with extensions
                                 'src': src['path'],
                             })
+                            filename = src['name']
+                        else:
+                            filename = source.get('filename')
+                        if filename is not None:
+                            ext_src['sources'] = [filename]
 
                     else:
 
@@ -738,6 +743,7 @@ class EasyBlock:
                             raise EasyBuildError(error_msg, type(src_fn).__name__, src_fn)
 
                         src_fn = resolve_template(src_fn, template_values)
+                        ext_src['sources'] = [src_fn]
 
                         if fetch_files:
                             src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2350,17 +2350,25 @@ class EasyBlockTest(EnhancedTestCase):
         toy_sources = os.path.join(testdir, 'sandbox', 'sources', 'toy')
         toy_ext_sources = os.path.join(toy_sources, 'extensions')
         toy_ec_file = os.path.join(testdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0-gompi-2018a-test.eb')
-        toy_ec = process_easyconfig(toy_ec_file)[0]
+
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        new_ext_txt = "('baz', '0.0', {'nosource': True}),"  # With nosource option
+        new_ext_txt += "('barbar', '0.0', {'sources': [SOURCE_TAR_GZ]}),"  # With sources containing a list
+        test_ectxt = re.sub(r'\(name, version', new_ext_txt+r"\g<0>", read_file(toy_ec_file))
+        write_file(test_ec, test_ectxt)
+
+        toy_ec = process_easyconfig(test_ec)[0]
         toy_eb = EasyBlock(toy_ec['ec'])
 
         exts_file_info = toy_eb.collect_exts_file_info()
 
         self.assertIsInstance(exts_file_info, list)
-        self.assertEqual(len(exts_file_info), 4)
+        self.assertEqual(len(exts_file_info), 6)
 
         self.assertEqual(exts_file_info[0], {'name': 'ulimit'})
 
         self.assertEqual(exts_file_info[1]['name'], 'bar')
+        self.assertEqual(exts_file_info[1]['sources'], ['bar-0.0.tar.gz'])
         self.assertEqual(exts_file_info[1]['src'], os.path.join(toy_ext_sources, 'bar-0.0.tar.gz'))
         bar_patch1 = 'bar-0.0_fix-silly-typo-in-printf-statement.patch'
         self.assertEqual(exts_file_info[1]['patches'][0]['name'], bar_patch1)
@@ -2370,22 +2378,36 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(exts_file_info[1]['patches'][1]['path'], os.path.join(toy_ext_sources, bar_patch2))
 
         self.assertEqual(exts_file_info[2]['name'], 'barbar')
+        self.assertEqual(exts_file_info[2]['sources'], ['barbar-1.2.tar.gz'])
         self.assertEqual(exts_file_info[2]['src'], os.path.join(toy_ext_sources, 'barbar-1.2.tar.gz'))
         self.assertNotIn('patches', exts_file_info[2])
 
-        self.assertEqual(exts_file_info[3]['name'], 'toy')
-        self.assertEqual(exts_file_info[3]['src'], os.path.join(toy_sources, 'toy-0.0.tar.gz'))
+        self.assertEqual(exts_file_info[3]['name'], 'baz')
+        self.assertNotIn('sources', exts_file_info[3])
+        self.assertNotIn('sources', exts_file_info[3]['options'])
+        self.assertNotIn('src', exts_file_info[3])
         self.assertNotIn('patches', exts_file_info[3])
+
+        self.assertEqual(exts_file_info[4]['name'], 'barbar')
+        self.assertEqual(exts_file_info[4]['sources'], ['barbar-0.0.tar.gz'])
+        self.assertEqual(exts_file_info[4]['src'], os.path.join(toy_ext_sources, 'barbar-0.0.tar.gz'))
+        self.assertNotIn('patches', exts_file_info[4])
+
+        self.assertEqual(exts_file_info[5]['name'], 'toy')
+        self.assertEqual(exts_file_info[5]['sources'], ['toy-0.0.tar.gz'])
+        self.assertEqual(exts_file_info[5]['src'], os.path.join(toy_sources, 'toy-0.0.tar.gz'))
+        self.assertNotIn('patches', exts_file_info[5])
 
         # location of files is missing when fetch_files is set to False
         exts_file_info = toy_eb.collect_exts_file_info(fetch_files=False, verify_checksums=False)
 
         self.assertIsInstance(exts_file_info, list)
-        self.assertEqual(len(exts_file_info), 4)
+        self.assertEqual(len(exts_file_info), 6)
 
         self.assertEqual(exts_file_info[0], {'name': 'ulimit'})
 
         self.assertEqual(exts_file_info[1]['name'], 'bar')
+        self.assertEqual(exts_file_info[1]['sources'], ['bar-0.0.tar.gz'])
         self.assertNotIn('src', exts_file_info[1])
         self.assertEqual(exts_file_info[1]['patches'][0]['name'], bar_patch1)
         self.assertNotIn('path', exts_file_info[1]['patches'][0])
@@ -2393,12 +2415,25 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertNotIn('path', exts_file_info[1]['patches'][1])
 
         self.assertEqual(exts_file_info[2]['name'], 'barbar')
+        self.assertEqual(exts_file_info[2]['sources'], ['barbar-1.2.tar.gz'])
         self.assertNotIn('src', exts_file_info[2])
         self.assertNotIn('patches', exts_file_info[2])
 
-        self.assertEqual(exts_file_info[3]['name'], 'toy')
+        self.assertEqual(exts_file_info[3]['name'], 'baz')
+        self.assertNotIn('sources', exts_file_info[3])
+        self.assertNotIn('sources', exts_file_info[3]['options'])
         self.assertNotIn('src', exts_file_info[3])
         self.assertNotIn('patches', exts_file_info[3])
+
+        self.assertEqual(exts_file_info[4]['name'], 'barbar')
+        self.assertEqual(exts_file_info[4]['sources'], ['barbar-0.0.tar.gz'])
+        self.assertNotIn('src', exts_file_info[4])
+        self.assertNotIn('patches', exts_file_info[4])
+
+        self.assertEqual(exts_file_info[5]['name'], 'toy')
+        self.assertEqual(exts_file_info[5]['sources'], ['toy-0.0.tar.gz'])
+        self.assertNotIn('src', exts_file_info[5])
+        self.assertNotIn('patches', exts_file_info[5])
 
         error_msg = "Can't verify checksums for extension files if they are not being fetched"
         self.assertErrorRegex(EasyBuildError, error_msg, toy_eb.collect_exts_file_info, fetch_files=False)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2451,6 +2451,16 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(exts_file_info[5]['src'], os.path.join(toy_sources, 'toy-0.0.tar.gz'))
         self.assertNotIn('patches', exts_file_info[5])
 
+        self.assertEqual(exts_file_info[4]['name'], 'barbar')
+        self.assertEqual(exts_file_info[4]['sources'], ['barbar-0.0.tar.gz'])
+        self.assertEqual(exts_file_info[4]['src'], os.path.join(toy_ext_sources, 'barbar-0.0.tar.gz'))
+        self.assertNotIn('patches', exts_file_info[4])
+
+        self.assertEqual(exts_file_info[5]['name'], 'toy')
+        self.assertEqual(exts_file_info[5]['sources'], ['toy-0.0.tar.gz'])
+        self.assertEqual(exts_file_info[5]['src'], os.path.join(toy_sources, 'toy-0.0.tar.gz'))
+        self.assertNotIn('patches', exts_file_info[5])
+
         # location of files is missing when fetch_files is set to False
         exts_file_info = toy_eb.collect_exts_file_info(fetch_files=False, verify_checksums=False)
 


### PR DESCRIPTION
The returned dict per extension has a 'patches' key but no 'sources'.
Add this incoorporating `source_tmpl` or the default value.

Add test for that and also for `nosource: True`.