### PR TITLE
Modify MPI wrappers for oneAPI

### DIFF
--- a/easybuild/toolchains/compiler/intel_compilers.py
+++ b/easybuild/toolchains/compiler/intel_compilers.py
@@ -69,6 +69,11 @@ class IntelCompilers(IntelIccIfort):
             self.COMPILER_F77 = 'ifx'
             self.COMPILER_F90 = 'ifx'
             self.COMPILER_FC = 'ifx'
+            self.COMPILER_MPICXX = 'mpiicpc -cxx=icpx'
+            self.COMPILER_MPICC = 'mpiicc -cc=icx'
+            self.COMPILER_MPIF77 = 'mpiifort -fc=ifx'
+            self.COMPILER_MPIF90 = 'mpiifort -fc=ifx'
+            self.COMPILER_MPIFC = 'mpiifort -fc=ifx'
             # fp-model source is not supported by icx but is equivalent to precise
             self.options.options_map['defaultprec'] = ['fp-speculation=safe', 'fp-model precise']
             if LooseVersion(self.get_software_version(self.COMPILER_MODULE_NAME)[0]) >= LooseVersion('2022'):

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1431,11 +1431,11 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(os.getenv('F90'), 'ifx')
         self.assertEqual(os.getenv('FC'), 'ifx')
 
-        self.assertEqual(os.getenv('MPICC'), 'mpiicc')
-        self.assertEqual(os.getenv('MPICXX'), 'mpiicpc')
-        self.assertEqual(os.getenv('MPIF77'), 'mpiifort')
-        self.assertEqual(os.getenv('MPIF90'), 'mpiifort')
-        self.assertEqual(os.getenv('MPIFC'), 'mpiifort')
+        self.assertEqual(os.getenv('MPICC'), 'mpiicc -cc=icx')
+        self.assertEqual(os.getenv('MPICXX'), 'mpiicpc -cxx=icpx')
+        self.assertEqual(os.getenv('MPIF77'), 'mpiifort -fc=ifx')
+        self.assertEqual(os.getenv('MPIF90'), 'mpiifort -fc=ifx')
+        self.assertEqual(os.getenv('MPIFC'), 'mpiifort -fc=ifx')
 
     def test_toolchain_verification(self):
         """Test verification of toolchain definition."""


### PR DESCRIPTION
Not sure if this is these are the correct variables, and doubly bad if there's a `which $MPIF90` or similar being run later.