### PR TITLE
fix leaked handles in set_columns, complete_cmd, run_cmd_qa, det_terminal_size functions + tests

### DIFF
--- a/easybuild/base/generaloption.py
+++ b/easybuild/base/generaloption.py
@@ -43,7 +43,7 @@ from optparse import SUPPRESS_HELP as nohelp  # supported in optparse of python 
 
 from easybuild.base.fancylogger import getLogger, setroot, setLogLevel, getDetailsLogLevels
 from easybuild.base.optcomplete import autocomplete, CompleterOption
-from easybuild.tools.py2vs3 import StringIO, configparser, string_type
+from easybuild.tools.py2vs3 import StringIO, configparser, string_type, subprocess_popen_text
 from easybuild.tools.utilities import mk_rst_table, nub, shell_quote
 
 try:
@@ -80,7 +80,9 @@ def set_columns(cols=None):
         stty = '/usr/bin/stty'
         if os.path.exists(stty):
             try:
-                cols = int(os.popen('%s size 2>/dev/null' % stty).read().strip().split(' ')[1])
+                with open(os.devnull, 'w') as devnull:
+                    proc = subprocess_popen_text([stty, "size"], stderr=devnull)
+                    cols = int(proc.communicate()[0].strip().split(' ')[1])
             except (AttributeError, IndexError, OSError, ValueError):
                 # do nothing
                 pass

--- a/easybuild/tools/py2vs3/py2.py
+++ b/easybuild/tools/py2vs3/py2.py
@@ -33,6 +33,7 @@ Implementations for Python 2.
 import ConfigParser as configparser  # noqa
 import json
 import subprocess
+import time
 import urllib2 as std_urllib  # noqa
 from collections import Mapping, OrderedDict  # noqa
 from HTMLParser import HTMLParser  # noqa
@@ -57,6 +58,23 @@ def subprocess_popen_text(cmd, **kwargs):
     """Call subprocess.Popen with specified named arguments."""
     kwargs.setdefault('stderr', subprocess.PIPE)
     return subprocess.Popen(cmd, stdout=subprocess.PIPE, **kwargs)
+
+
+def subprocess_terminate(proc, timeout):
+    """Terminate the subprocess if it hasn't finished after the given timeout"""
+    res = None
+    for pipe in (proc.stdout, proc.stderr, proc.stdin):
+        if pipe:
+            pipe.close()
+    while timeout > 0:
+        res = proc.poll()
+        if res is not None:
+            break
+        delay = min(timeout, 0.1)
+        time.sleep(delay)
+        timeout -= delay
+    if res is None:
+        proc.terminate()
 
 
 def raise_with_traceback(exception_class, message, traceback):

--- a/easybuild/tools/py2vs3/py2.py
+++ b/easybuild/tools/py2vs3/py2.py
@@ -55,7 +55,8 @@ json_loads = json.loads
 
 def subprocess_popen_text(cmd, **kwargs):
     """Call subprocess.Popen with specified named arguments."""
-    return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **kwargs)
+    kwargs.setdefault('stderr', subprocess.PIPE)
+    return subprocess.Popen(cmd, stdout=subprocess.PIPE, **kwargs)
 
 
 def raise_with_traceback(exception_class, message, traceback):

--- a/easybuild/tools/py2vs3/py3.py
+++ b/easybuild/tools/py2vs3/py3.py
@@ -69,7 +69,8 @@ def json_loads(body):
 def subprocess_popen_text(cmd, **kwargs):
     """Call subprocess.Popen in text mode with specified named arguments."""
     # open stdout/stderr in text mode in Popen when using Python 3
-    return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True, **kwargs)
+    kwargs.setdefault('stderr', subprocess.PIPE)
+    return subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True, **kwargs)
 
 
 def raise_with_traceback(exception_class, message, traceback):

--- a/easybuild/tools/py2vs3/py3.py
+++ b/easybuild/tools/py2vs3/py3.py
@@ -73,6 +73,17 @@ def subprocess_popen_text(cmd, **kwargs):
     return subprocess.Popen(cmd, stdout=subprocess.PIPE, universal_newlines=True, **kwargs)
 
 
+def subprocess_terminate(proc, timeout):
+    """Terminate the subprocess if it hasn't finished after the given timeout"""
+    try:
+        proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        for pipe in (proc.stdout, proc.stderr, proc.stdin):
+            if pipe:
+                pipe.close()
+        proc.terminate()
+
+
 def raise_with_traceback(exception_class, message, traceback):
     """Raise exception of specified class with given message and traceback."""
     raise exception_class(message).with_traceback(traceback)

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -397,6 +397,8 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
             path = cwd
         dry_run_msg("  running interactive command \"%s\"" % cmd, silent=build_option('silent'))
         dry_run_msg("  (in %s)" % path, silent=build_option('silent'))
+        if cmd_log:
+            cmd_log.close()
         if simple:
             return True
         else:
@@ -442,6 +444,8 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
         if isinstance(answers, string_type):
             answers = [answers]
         elif not isinstance(answers, list):
+            if cmd_log:
+                cmd_log.close()
             raise EasyBuildError("Invalid type for answer on %s, no string or list: %s (%s)",
                                  question, type(answers), answers)
         # list is manipulated when answering matching question, so return a copy
@@ -483,6 +487,8 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
         proc = asyncprocess.Popen(cmd, shell=True, stdout=asyncprocess.PIPE, stderr=asyncprocess.STDOUT,
                                   stdin=asyncprocess.PIPE, close_fds=True, executable='/bin/bash')
     except OSError as err:
+        if cmd_log:
+            cmd_log.close()
         raise EasyBuildError("run_cmd_qa init cmd %s failed:%s", cmd, err)
 
     ec = proc.poll()
@@ -556,6 +562,8 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
             except OSError as err:
                 _log.debug("run_cmd_qa exception caught when killing child process: %s", err)
             _log.debug("run_cmd_qa: full stdouterr: %s", stdout_err)
+            if cmd_log:
+                cmd_log.close()
             raise EasyBuildError("run_cmd_qa: cmd %s : Max nohits %s reached: end of output %s",
                                  cmd, maxhits, stdout_err[-500:])
 
@@ -570,9 +578,11 @@ def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, re
             stdout_err += out
             if cmd_log:
                 cmd_log.write(out)
-                cmd_log.close()
     except IOError as err:
         _log.debug("runqanda cmd %s: remaining data read failed: %s", cmd, err)
+
+    if cmd_log:
+        cmd_log.close()
 
     if trace:
         trace_msg("interactive command completed: exit %s, ran in %s" % (ec, time_str_since(start_time)))

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -316,21 +316,24 @@ def complete_cmd(proc, cmd, owd, start_time, cmd_log, log_ok=True, log_all=False
 
     stdouterr = output
 
-    ec = proc.poll()
-    while ec is None:
-        # need to read from time to time.
-        # - otherwise the stdout/stderr buffer gets filled and it all stops working
-        output = get_output_from_process(proc, read_size=read_size)
-        if cmd_log:
-            cmd_log.write(output)
-        if stream_output:
-            sys.stdout.write(output)
-        stdouterr += output
+    try:
         ec = proc.poll()
+        while ec is None:
+            # need to read from time to time.
+            # - otherwise the stdout/stderr buffer gets filled and it all stops working
+            output = get_output_from_process(proc, read_size=read_size)
+            if cmd_log:
+                cmd_log.write(output)
+            if stream_output:
+                sys.stdout.write(output)
+            stdouterr += output
+            ec = proc.poll()
 
-    # read remaining data (all of it)
-    output = get_output_from_process(proc)
-    proc.stdout.close()
+        # read remaining data (all of it)
+        output = get_output_from_process(proc)
+    finally:
+        proc.stdout.close()
+
     if cmd_log:
         cmd_log.write(output)
         cmd_log.close()

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -41,6 +41,7 @@ import sys
 import termios
 from ctypes.util import find_library
 from socket import gethostname
+from easybuild.tools.py2vs3 import subprocess_popen_text
 
 # pkg_resources is provided by the setuptools Python package,
 # which we really want to keep as an *optional* dependency
@@ -1183,7 +1184,7 @@ def det_terminal_size():
     except Exception as err:
         _log.warning("First attempt to determine terminal size failed: %s", err)
         try:
-            height, width = [int(x) for x in os.popen("stty size").read().strip().split()]
+            height, width = [int(x) for x in subprocess_popen_text("stty size").communicate()[0].strip().split()]
         except Exception as err:
             _log.warning("Second attempt to determine terminal size failed, going to return defaults: %s", err)
             height, width = 25, 80

--- a/test/framework/asyncprocess.py
+++ b/test/framework/asyncprocess.py
@@ -28,6 +28,7 @@ Unit tests for asyncprocess.py.
 @author: Toon Willems (Ghent University)
 """
 
+import subprocess
 import sys
 import time
 from test.framework.utilities import EnhancedTestCase
@@ -62,6 +63,11 @@ class AsyncProcessTest(EnhancedTestCase):
 
     def tearDown(self):
         """cleanup"""
+        try:
+            # Terminate subprocess
+            self.shell.communicate(timeout=1)
+        except subprocess.TimeoutExpired:
+            pass
         super(AsyncProcessTest, self).tearDown()
 
 

--- a/test/framework/asyncprocess.py
+++ b/test/framework/asyncprocess.py
@@ -28,7 +28,6 @@ Unit tests for asyncprocess.py.
 @author: Toon Willems (Ghent University)
 """
 
-import subprocess
 import sys
 import time
 from test.framework.utilities import EnhancedTestCase
@@ -36,6 +35,7 @@ from unittest import TextTestRunner, TestSuite
 
 import easybuild.tools.asyncprocess as p
 from easybuild.tools.asyncprocess import Popen
+from easybuild.tools.py2vs3 import subprocess_terminate
 
 
 class AsyncProcessTest(EnhancedTestCase):
@@ -63,11 +63,7 @@ class AsyncProcessTest(EnhancedTestCase):
 
     def tearDown(self):
         """cleanup"""
-        try:
-            # Terminate subprocess
-            self.shell.communicate(timeout=1)
-        except subprocess.TimeoutExpired:
-            pass
+        subprocess_terminate(self.shell, timeout=1)
         super(AsyncProcessTest, self).tearDown()
 
 

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -51,6 +51,7 @@ from easybuild.tools.filetools import adjust_permissions, read_file, write_file
 from easybuild.tools.run import check_async_cmd, check_log_for_errors, complete_cmd, get_output_from_process
 from easybuild.tools.run import parse_log_for_error, run_cmd, run_cmd_qa
 from easybuild.tools.config import ERROR, IGNORE, WARN
+from easybuild.tools.py2vs3 import subprocess_terminate
 
 
 class RunTest(EnhancedTestCase):
@@ -84,7 +85,7 @@ class RunTest(EnhancedTestCase):
                 yield proc
             finally:
                 # Make sure to close the process and its pipes
-                proc.communicate(timeout=1)
+                subprocess_terminate(proc, timeout=1)
 
         # get all output at once
         with get_proc("echo hello") as proc:

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -30,6 +30,7 @@ Unit tests for filetools.py
 @author: Kenneth Hoste (Ghent University)
 @author: Stijn De Weirdt (Ghent University)
 """
+import contextlib
 import glob
 import os
 import re
@@ -70,6 +71,7 @@ class RunTest(EnhancedTestCase):
     def test_get_output_from_process(self):
         """Test for get_output_from_process utility function."""
 
+        @contextlib.contextmanager
         def get_proc(cmd, asynchronous=False):
             if asynchronous:
                 proc = asyncprocess.Popen(cmd, shell=True, stdout=asyncprocess.PIPE, stderr=asyncprocess.STDOUT,
@@ -78,56 +80,60 @@ class RunTest(EnhancedTestCase):
                 proc = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
                                         stdin=subprocess.PIPE, close_fds=True, executable='/bin/bash')
 
-            return proc
+            try:
+                yield proc
+            finally:
+                # Make sure to close the process and its pipes
+                proc.communicate(timeout=1)
 
         # get all output at once
-        proc = get_proc("echo hello")
-        out = get_output_from_process(proc)
-        self.assertEqual(out, 'hello\n')
+        with get_proc("echo hello") as proc:
+            out = get_output_from_process(proc)
+            self.assertEqual(out, 'hello\n')
 
         # first get 100 bytes, then get the rest all at once
-        proc = get_proc("echo hello")
-        out = get_output_from_process(proc, read_size=100)
-        self.assertEqual(out, 'hello\n')
-        out = get_output_from_process(proc)
-        self.assertEqual(out, '')
+        with get_proc("echo hello") as proc:
+            out = get_output_from_process(proc, read_size=100)
+            self.assertEqual(out, 'hello\n')
+            out = get_output_from_process(proc)
+            self.assertEqual(out, '')
 
         # get output in small bits, keep trying to get output (which shouldn't fail)
-        proc = get_proc("echo hello")
-        out = get_output_from_process(proc, read_size=1)
-        self.assertEqual(out, 'h')
-        out = get_output_from_process(proc, read_size=3)
-        self.assertEqual(out, 'ell')
-        out = get_output_from_process(proc, read_size=2)
-        self.assertEqual(out, 'o\n')
-        out = get_output_from_process(proc, read_size=1)
-        self.assertEqual(out, '')
-        out = get_output_from_process(proc, read_size=10)
-        self.assertEqual(out, '')
-        out = get_output_from_process(proc)
-        self.assertEqual(out, '')
+        with get_proc("echo hello") as proc:
+            out = get_output_from_process(proc, read_size=1)
+            self.assertEqual(out, 'h')
+            out = get_output_from_process(proc, read_size=3)
+            self.assertEqual(out, 'ell')
+            out = get_output_from_process(proc, read_size=2)
+            self.assertEqual(out, 'o\n')
+            out = get_output_from_process(proc, read_size=1)
+            self.assertEqual(out, '')
+            out = get_output_from_process(proc, read_size=10)
+            self.assertEqual(out, '')
+            out = get_output_from_process(proc)
+            self.assertEqual(out, '')
 
         # can also get output asynchronously (read_size is *ignored* in that case)
         async_cmd = "echo hello; read reply; echo $reply"
 
-        proc = get_proc(async_cmd, asynchronous=True)
-        out = get_output_from_process(proc, asynchronous=True)
-        self.assertEqual(out, 'hello\n')
-        asyncprocess.send_all(proc, 'test123\n')
-        out = get_output_from_process(proc)
-        self.assertEqual(out, 'test123\n')
+        with get_proc(async_cmd, asynchronous=True) as proc:
+            out = get_output_from_process(proc, asynchronous=True)
+            self.assertEqual(out, 'hello\n')
+            asyncprocess.send_all(proc, 'test123\n')
+            out = get_output_from_process(proc)
+            self.assertEqual(out, 'test123\n')
 
-        proc = get_proc(async_cmd, asynchronous=True)
-        out = get_output_from_process(proc, asynchronous=True, read_size=1)
-        # read_size is ignored when getting output asynchronously, we're getting more than 1 byte!
-        self.assertEqual(out, 'hello\n')
-        asyncprocess.send_all(proc, 'test123\n')
-        out = get_output_from_process(proc, read_size=3)
-        self.assertEqual(out, 'tes')
-        out = get_output_from_process(proc, read_size=2)
-        self.assertEqual(out, 't1')
-        out = get_output_from_process(proc)
-        self.assertEqual(out, '23\n')
+        with get_proc(async_cmd, asynchronous=True) as proc:
+            out = get_output_from_process(proc, asynchronous=True, read_size=1)
+            # read_size is ignored when getting output asynchronously, we're getting more than 1 byte!
+            self.assertEqual(out, 'hello\n')
+            asyncprocess.send_all(proc, 'test123\n')
+            out = get_output_from_process(proc, read_size=3)
+            self.assertEqual(out, 'tes')
+            out = get_output_from_process(proc, read_size=2)
+            self.assertEqual(out, 't1')
+            out = get_output_from_process(proc)
+            self.assertEqual(out, '23\n')
 
     def test_run_cmd(self):
         """Basic test for run_cmd function."""

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2154,7 +2154,7 @@ class ToyBuildTest(EnhancedTestCase):
             """# (no modules loaded)""",
             """# (no build environment defined)""",
         ]
-        env_file = open(reprod_dumpenv, "r").read()
+        env_file = read_file(reprod_dumpenv)
         for pattern in patterns:
             self.assertTrue(pattern in env_file)
 
@@ -2270,7 +2270,7 @@ class ToyBuildTest(EnhancedTestCase):
             """module load toy/0.0-one""",
             """# (no build environment defined)""",
         ]
-        env_file = open(reprod_dumpenv, "r").read()
+        env_file = read_file(reprod_dumpenv)
         for pattern in patterns:
             self.assertTrue(pattern in env_file)
 


### PR DESCRIPTION
`os.popen` is used without closing the returned handle.
As this function is deprecated anyway replace it by `subprocess_popen_text`.

Also fix some more leaked handles from opened processes and files, extracted from #3790