### PR TITLE
use SYSTEM constant for dependency that uses system toolchain in dumped easyconfig

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -50,7 +50,7 @@ from contextlib import contextmanager
 import easybuild.tools.filetools as filetools
 from easybuild.base import fancylogger
 from easybuild.framework.easyconfig import MANDATORY
-from easybuild.framework.easyconfig.constants import EXTERNAL_MODULE_MARKER
+from easybuild.framework.easyconfig.constants import EASYCONFIG_CONSTANTS, EXTERNAL_MODULE_MARKER
 from easybuild.framework.easyconfig.default import DEFAULT_CONFIG
 from easybuild.framework.easyconfig.format.convert import Dependency
 from easybuild.framework.easyconfig.format.format import DEPENDENCY_PARAMETERS
@@ -1589,7 +1589,7 @@ class EasyConfig(object):
 
         # (true) boolean value simply indicates that a system toolchain is used
         elif isinstance(tc_spec, bool) and tc_spec:
-            tc = {'name': SYSTEM_TOOLCHAIN_NAME, 'version': ''}
+            tc = EASYCONFIG_CONSTANTS['SYSTEM'][0]
 
         # two-element list/tuple value indicates custom toolchain specification
         elif isinstance(tc_spec, (list, tuple,)):

--- a/easybuild/framework/easyconfig/format/one.py
+++ b/easybuild/framework/easyconfig/format/one.py
@@ -76,16 +76,19 @@ def dump_dependency(dep, toolchain, toolchain_hierarchy=None):
     else:
         # minimal spec: (name, version)
         tup = (dep['name'], dep['version'])
+        res = None
         if all(dep['toolchain'] != subtoolchain for subtoolchain in toolchain_hierarchy):
             if dep[SYSTEM_TOOLCHAIN_NAME]:
-                tup += (dep['versionsuffix'], True)
+                # use SYSTEM constant to indicate that system toolchain should be used for this dependency
+                res = re.sub(r'\)$', ', SYSTEM)', str(tup + (dep['versionsuffix'],)))
             else:
                 tup += (dep['versionsuffix'], (dep['toolchain']['name'], dep['toolchain']['version']))
 
         elif dep['versionsuffix']:
             tup += (dep['versionsuffix'],)
 
-        res = str(tup)
+        if res is None:
+            res = str(tup)
     return res
 
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -2110,6 +2110,7 @@ class EasyConfigTest(EnhancedTestCase):
 
             dependencies = [
                 ('toy', '0.0', '', True),
+                ('GCC', '4.9.2', '', SYSTEM),
             ]
 
             moduleclass = 'tools'
@@ -2122,7 +2123,12 @@ class EasyConfigTest(EnhancedTestCase):
         dumped_ec = os.path.join(self.test_prefix, 'dumped.eb')
         ec.dump(dumped_ec)
         dumped_ec_txt = read_file(dumped_ec)
-        self.assertTrue("('toy', '0.0', '', SYSTEM)" in dumped_ec_txt)
+        patterns = [
+            "('toy', '0.0', '', SYSTEM)",
+            "('GCC', '4.9.2', '', SYSTEM)",
+        ]
+        for pattern in patterns:
+            self.assertTrue(pattern in dumped_ec_txt, "Pattern '%s' should be found in: %s" % (pattern, dumped_ec_txt))
 
     def test_toolchain_hierarchy_aware_dump(self):
         """Test that EasyConfig's dump() method is aware of the toolchain hierarchy."""

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -2094,6 +2094,36 @@ class EasyConfigTest(EnhancedTestCase):
                 if param in ec:
                     self.assertEqual(ec[param], dumped_ec[param])
 
+        ec_txt = textwrap.dedent("""
+            easyblock = 'EB_toy'
+
+            name = 'foo'
+            version = '0.0.1'
+
+            toolchain = {'name': 'GCC', 'version': '4.6.3'}
+
+            homepage = 'http://foo.com/'
+            description = "foo description"
+
+            sources = [SOURCE_TAR_GZ]
+            source_urls = ["http://example.com"]
+
+            dependencies = [
+                ('toy', '0.0', '', True),
+            ]
+
+            moduleclass = 'tools'
+        """)
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        write_file(test_ec, ec_txt)
+        ec = EasyConfig(test_ec)
+
+        # verify whether SYSTEM constant is used for dependency that uses system toolchain in dumped easyconfig
+        dumped_ec = os.path.join(self.test_prefix, 'dumped.eb')
+        ec.dump(dumped_ec)
+        dumped_ec_txt = read_file(dumped_ec)
+        self.assertTrue("('toy', '0.0', '', SYSTEM)" in dumped_ec_txt)
+
     def test_toolchain_hierarchy_aware_dump(self):
         """Test that EasyConfig's dump() method is aware of the toolchain hierarchy."""
         test_ecs_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')


### PR DESCRIPTION
Currently, we usually using `True` as 4th value in a dependency specification if the system toolchain should be used, for example:

```python
dependencies = [('CUDA', '11.4.1', '', True)]
```

A more intuitive alternative, which has actually been silently supported already for a long time, is to use the `SYSTEM` constant instead (since EasyBuild v4.0.0, see #2877):

```python
dependencies = [('CUDA', '11.4.1', '', SYSTEM]
```

This translates to the following under the covers:

```python
dependencies = [('CUDA', '11.4.1', '', {'name': 'system', 'version': 'system'}]
```

Directly specifying the toolchain to use for a dependency through the classic `name`/`version` dict value has been supported for ages (at least since EasyBuild v2.7.0, but also before already); the `SYSTEM` constant just makes this (significantly) less ugly.

This practice currently isn't adopted in the central easyconfigs repository though, mainly because the easyconfigs test suite in which we check whether the values of easyconfig parameters for the original easyconfig and for the easyconfig file that's obtained by dumping the parsed easyconfig are equal.
This check fails when using the `SYSTEM` constant in a dependency specification as shown above, because the dumped easyconfig will use the more cryptic `True` value instead.

With the changes in this PR, we will be able to use `SYSTEM` rather than `True` to indicate that the system toolchain should be used for a dependency for easyconfigs being contributed to the central easyconfigs repository...

Note that this will need a change in the easyconfigs test suite analogous to the workaround that @ocaisa added to https://github.com/easybuilders/easybuild-easyconfigs/pull/15900 though, since the check on the toolchain part of a dependency will fail if `True` is still being used instead of the `SYSTEM` constant (which we should keep supporting for now, we can consider deprecating that later, and start requiring that new PRs use `SYSTEM` rather than `True` at some point).