### PR TITLE
add support for start_dir easyconfig template

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -75,6 +75,7 @@ TEMPLATE_NAMES_LOWER = [
 TEMPLATE_NAMES_EASYBLOCK_RUN_STEP = [
     ('builddir', "Build directory"),
     ('installdir', "Installation directory"),
+    ('start_dir', "Directory in which the build process begins"),
 ]
 # software names for which to define <pref>ver and <pref>shortver templates
 TEMPLATE_SOFTWARE_VERSIONS = [

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -119,6 +119,12 @@ class Extension(object):
         for key in TEMPLATE_NAMES_EASYBLOCK_RUN_STEP:
             self.cfg.template_values[key[0]] = str(getattr(self.master, key[0], None))
 
+        # We can't inherit the 'start_dir' value from the parent (which will be set, and will most likely be wrong).
+        # It should be specified for the extension specifically, or be empty (so it is auto-derived).
+        self.cfg['start_dir'] = self.ext.get('options', {}).get('start_dir', None)
+        # Also clear the template
+        del self.cfg.template_values['start_dir']
+
         # list of source/patch files: we use an empty list as default value like in EasyBlock
         self.src = resolve_template(self.ext.get('src', []), self.cfg.template_values)
         self.src_extract_cmd = self.ext.get('extract_cmd', None)

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -84,9 +84,7 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             # name and version properties of EasyBlock are used, so make sure name and version are correct
             self.cfg['name'] = self.ext.get('name', None)
             self.cfg['version'] = self.ext.get('version', None)
-            # We can't inherit the 'start_dir' value from the parent (which will be set, and will most likely be wrong).
-            # It should be specified for the extension specifically, or be empty (so it is auto-derived).
-            self.cfg['start_dir'] = self.ext.get('options', {}).get('start_dir', None)
+
             self.builddir = self.master.builddir
             self.installdir = self.master.installdir
             self.modules_tool = self.master.modules_tool
@@ -122,8 +120,9 @@ class ExtensionEasyBlock(EasyBlock, Extension):
 
         if ext_start_dir and os.path.isdir(ext_start_dir):
             ext_start_dir = ext_start_dir.rstrip(os.sep) or os.sep
-            self.cfg['start_dir'] = ext_start_dir
             self.log.debug("Using extension start dir: %s", ext_start_dir)
+            self.cfg['start_dir'] = ext_start_dir
+            self.cfg.template_values['start_dir'] = ext_start_dir
         elif ext_start_dir is None:
             # This may be on purpose, e.g. for Python WHL files which do not get extracted
             self.log.debug("Start dir is not set.")

--- a/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
@@ -64,7 +64,7 @@ class Toy_Extension(ExtensionEasyBlock):
         Install toy extension.
         """
         if self.src:
-            EB_toy.build_step(self.master, name=self.name, buildopts=self.cfg['buildopts'])
+            EB_toy.build_step(self.master, name=self.name, cfg=self.cfg)
 
             if self.cfg['toy_ext_param']:
                 run_cmd(self.cfg['toy_ext_param'])
@@ -79,7 +79,7 @@ class Toy_Extension(ExtensionEasyBlock):
 
         if self.src:
             super(Toy_Extension, self).run(unpack_src=True)
-            EB_toy.configure_step(self.master, name=self.name)
+            EB_toy.configure_step(self.master, name=self.name, cfg=self.cfg)
 
     def run_async(self):
         """

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -91,26 +91,37 @@ class EB_toy(ExtensionEasyBlock):
 
         return super(EB_toy, self).run_all_steps(*args, **kwargs)
 
-    def configure_step(self, name=None):
+    def configure_step(self, name=None, cfg=None):
         """Configure build of toy."""
         if name is None:
             name = self.name
+        # Allow overwrite from Toy-Extension
+        if cfg is None:
+            cfg = self.cfg
         # make sure Python system dep is handled correctly when specified
-        if self.cfg['allow_system_deps']:
+        if cfg['allow_system_deps']:
             if get_software_root('Python') != 'Python' or get_software_version('Python') != platform.python_version():
                 raise EasyBuildError("Sanity check on allowed Python system dep failed.")
+
+        cmd = ' '.join([
+            cfg['preconfigopts'],
+            'echo "Configured"',
+            cfg['configopts']
+        ])
+        run_cmd(cmd)
 
         if os.path.exists("%s.source" % name):
             os.rename('%s.source' % name, '%s.c' % name)
 
-    def build_step(self, name=None, buildopts=None):
+    def build_step(self, name=None, cfg=None):
         """Build toy."""
-        if buildopts is None:
-            buildopts = self.cfg['buildopts']
+        # Allow overwrite from Toy-Extension
+        if cfg is None:
+            cfg = self.cfg
         if name is None:
             name = self.name
 
-        cmd = compose_toy_build_cmd(self.cfg, name, self.cfg['prebuildopts'], buildopts)
+        cmd = compose_toy_build_cmd(self.cfg, name, cfg['prebuildopts'], cfg['buildopts'])
         run_cmd(cmd)
 
     def install_step(self, name=None):


### PR DESCRIPTION
As #4035 went stale with some issues remaining I tackled this. The test was quite tricky as this template can only be set once the source is extracted.
Hence I wrote the test so that it should be set in the configure and build step of a "regular" EasyConfig and in an extension which is where this will most likely be used.

The extension is very tricky:
- We must not resolve the `start_dir` in the `options` during `__init__` -> Move the relevant code down to the `Extension` class and clear the (new) template too
- The template value is then later set in a method I introduced in #3426 

@jfgrimm Please have a look here.