### PR TITLE
skip over unset $EB_PYTHON/$EB_INSTALLPYTHON

### DIFF
--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -77,6 +77,10 @@ jobs:
               echo "Looking for pattern \"${pattern}\" in eb_version.out..."
               grep "$pattern" eb_version.out
           done
+          if grep -q "Considering ''" eb_version.out; then
+              echo '`eb` did wrongly consider an empty command'
+              false
+          fi
           # also check when specifying Python command via $EB_PYTHON
           for eb_python in "python${pymajver}" "python${pymajminver}"; do
               export EB_PYTHON="${eb_python}"

--- a/eb
+++ b/eb
@@ -62,6 +62,9 @@ PYTHON=
 #   time, this variable preserves that choice).
 for python_cmd in "${EB_PYTHON}" "${EB_INSTALLPYTHON}" 'python' 'python3' 'python2'; do
 
+    # Only consider non-empty values, i.e. continue if e.g. $EB_PYTHON is not set
+    [ -n "${python_cmd}" ] || continue
+
     verbose "Considering '${python_cmd}'..."
 
     # check whether python* command being considered is available


### PR DESCRIPTION
Check if the current $python_cmd is empty and skip all checks in that case. This avoids useless checks and log output in VERBOSE mode.

Also extend the CI test to catch this issue.