### PR TITLE
Fix trying to generate RPATH wrappers for Clang

### DIFF
--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -988,6 +988,9 @@ class Toolchain(object):
 
         # create wrappers
         for cmd in nub(c_comps + fortran_comps + ['ld', 'ld.gold', 'ld.bfd']):
+            # Not all toolchains have fortran compilers (e.g. Clang), in which case they are 'None'
+            if cmd is None:
+                continue
             orig_cmd = which(cmd)
 
             if orig_cmd:

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -2622,7 +2622,7 @@ class ToolchainTest(EnhancedTestCase):
         fake_clang = os.path.join(self.test_prefix, 'fake', 'clang')
         write_file(fake_clang, '#!/bin/bash\necho "$@"')
         adjust_permissions(fake_clang, stat.S_IXUSR)
-        tc_clang = self.get_toolchain('Clang', version='13.0.1')
+        tc_clang = self.get_toolchain('ClangGCC', version='0.0.0')
         tc_clang.prepare()
 
         # Check that the clang wrapper is indeed in place

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -2617,6 +2617,26 @@ class ToolchainTest(EnhancedTestCase):
         # any other available 'g++' commands should not be a wrapper or our fake g++
         self.assertFalse(any(os.path.samefile(x, fake_gxx) for x in res[2:]))
 
+        # Check that we can create a wrapper for a toolchain for which self.compilers() returns 'None' for the Fortran
+        # compilers (i.e. Clang)
+        fake_clang = os.path.join(self.test_prefix, 'fake', 'clang')
+        write_file(fake_clang, '#!/bin/bash\necho "$@"')
+        adjust_permissions(fake_clang, stat.S_IXUSR)
+        tc_clang = self.get_toolchain('clang', version='13.0.1')
+        tc_clang.prepare()
+
+        # Check that the clang wrapper is indeed in place
+        res = which('clang', retain_all=True)
+        # there should be at least 2 hits: the RPATH wrapper, and our fake 'clang' command (there may be real ones too)
+        self.assertTrue(len(res) >= 2)
+        self.assertTrue(tc_clang.is_rpath_wrapper(res[0]))
+        self.assertEqual(os.path.basename(res[0]), 'clang')
+        self.assertEqual(os.path.basename(os.path.dirname(res[0])), 'clang_wrapper')
+        self.assertFalse(any(tc_clang.is_rpath_wrapper(x) for x in res[1:]))
+        self.assertTrue(os.path.samefile(res[1], fake_clang))
+        # any other available 'clang' commands should not be a wrapper or our fake clang
+        self.assertFalse(any(os.path.samefile(x, fake_clang) for x in res[2:]))
+
         # RPATH wrapper should be robust against Python environment variables & site-packages magic,
         # so we set up a weird environment here to verify that
         # (see https://github.com/easybuilders/easybuild-framework/issues/3421)

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -2622,7 +2622,7 @@ class ToolchainTest(EnhancedTestCase):
         fake_clang = os.path.join(self.test_prefix, 'fake', 'clang')
         write_file(fake_clang, '#!/bin/bash\necho "$@"')
         adjust_permissions(fake_clang, stat.S_IXUSR)
-        tc_clang = self.get_toolchain('clang', version='13.0.1')
+        tc_clang = self.get_toolchain('Clang', version='13.0.1')
         tc_clang.prepare()
 
         # Check that the clang wrapper is indeed in place

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -56,6 +56,7 @@ from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.toolchain.mpi import get_mpi_cmd_template
 from easybuild.tools.toolchain.toolchain import env_vars_external_module
 from easybuild.tools.toolchain.utilities import get_toolchain, search_toolchain
+from easybuild.toolchains.compiler.clang import Clang
 
 easybuild.tools.toolchain.compiler.systemtools.get_compiler_family = lambda: st.POWER
 
@@ -2622,8 +2623,8 @@ class ToolchainTest(EnhancedTestCase):
         fake_clang = os.path.join(self.test_prefix, 'fake', 'clang')
         write_file(fake_clang, '#!/bin/bash\necho "$@"')
         adjust_permissions(fake_clang, stat.S_IXUSR)
-        tc_clang = self.get_toolchain('ClangGCC', version='0.0.0')
-        tc_clang.prepare()
+        tc_clang = Clang(name='Clang', version='1')
+        tc_clang.prepare_rpath_wrappers()
 
         # Check that the clang wrapper is indeed in place
         res = which('clang', retain_all=True)


### PR DESCRIPTION
[This](https://github.com/easybuilders/easybuild-framework/blob/541a645ab9c8e6fc60345e896a0471a2f75f71e8/easybuild/tools/toolchain/toolchain.py#L990) loop is supposed to loop over all compilers for which wrappers need to be created. However, [this line](https://github.com/easybuilders/easybuild-framework/blob/541a645ab9c8e6fc60345e896a0471a2f75f71e8/easybuild/tools/toolchain/toolchain.py#L973) returns (['clang', 'clang++'],[None, None, None]) for the `Clang` toolchain. The subsequent call to `which` happening [here](https://github.com/easybuilders/easybuild-framework/blob/541a645ab9c8e6fc60345e896a0471a2f75f71e8/easybuild/tools/toolchain/toolchain.py#L991) then fails.

This PR fixes that by explicitely checking if `cmd` is `None`. If so, it proceeds to the next loop iteration and doens't try to create an RPATH wrapper for this 'None' command.