### PR TITLE
update to v3 of actions/checkout and actions/setup-python in CI workflows

### DIFF
--- a/.github/workflows/bootstrap_script.yml
+++ b/.github/workflows/bootstrap_script.yml
@@ -54,10 +54,10 @@ jobs:
             lc_all: C
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/.github/workflows/container_tests.yml
+++ b/.github/workflows/container_tests.yml
@@ -10,10 +10,10 @@ jobs:
         python: [2.7, 3.6]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -9,10 +9,10 @@ jobs:
         python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,10 +8,10 @@ jobs:
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
         
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -76,10 +76,10 @@ jobs:
             lc_all: C
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{matrix.python}}
         architecture: x64


### PR DESCRIPTION
In response to the following warning popping up when using v2:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-python, actions/setup-python, actions/checkout
```

See also https://github.com/actions/checkout/pull/689