### PR TITLE
skip GitPython 3.1.28, since it prints 'git' as version which messes up the version check in check_github()

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ keyrings.alt
 
 # GitPython 3.1.15 deprecates Python 3.5
 GitPython==3.1.14; python_version >= '3.0' and python_version < '3.6'
-GitPython; python_version >= '3.6' or python_version <= '3.0'
+# skip GitPython 3.1.28, since it prints 'git' as version which messes up the version check in check_github()
+GitPython!=3.1.28; python_version >= '3.6' or python_version <= '3.0'
 
 # autopep8
 # stick to older autopep8 with Python 2.7, since autopep8 1.7.0 requires pycodestyle>=2.9.1 (which is Python 3 only)


### PR DESCRIPTION
Temporary workaround for hard crash when running `eb --check-github`:

```
Checking status of GitHub integration...

Making sure we're online...OK

* GitHub user...easybuild_test => OK
* GitHub token...(no token found) => FAIL
* git command...OK ("git version 2.37.3; ")
* GitPython module...OK (GitPython version git)

Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/runner/27071ea6b2f01bb01ec8a4fe1b156b7ac26b2654/lib/python3.7/site-packages/easybuild/main.py", line 602, in <module>
    main()
  File "/tmp/runner/27071ea6b2f01bb01ec8a4fe1b156b7ac26b2654/lib/python3.7/site-packages/easybuild/main.py", line 287, in main
    check_github()
  File "/tmp/runner/27071ea6b2f01bb01ec8a4fe1b156b7ac26b2654/lib/python3.7/site-packages/easybuild/tools/github.py", line 2089, in check_github
    if LooseVersion(ver) < LooseVersion(req_ver):
  File "/opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/distutils/version.py", line 52, in __lt__
    c = self._cmp(other)
  File "/opt/hostedtoolcache/Python/3.7.14/x64/lib/python3.7/distutils/version.py", line 337, in _cmp
    if self.version < other.version:
TypeError: '<' not supported between instances of 'str' and 'int'
* push access to easybuild_test/easybuild-easyconfigs repo @ GitHub...
```