### PR TITLE
make sure that GitPython version is a proper version before checking minimal required version

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -2086,7 +2086,8 @@ def check_github():
     elif github_user:
         if 'git' in sys.modules:
             ver, req_ver = git.__version__, '1.0'
-            if LooseVersion(ver) < LooseVersion(req_ver):
+            version_regex = re.compile('^[0-9.]+$')
+            if version_regex.match(ver) and LooseVersion(ver) < LooseVersion(req_ver):
                 check_res = "FAIL (GitPython version %s is too old, should be version %s or newer)" % (ver, req_ver)
             elif "Could not read from remote repository" in str(push_err):
                 check_res = "FAIL (GitHub SSH key missing? %s)" % push_err

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ keyrings.alt
 
 # GitPython 3.1.15 deprecates Python 3.5
 GitPython==3.1.14; python_version >= '3.0' and python_version < '3.6'
-# skip GitPython 3.1.28, since it prints 'git' as version which messes up the version check in check_github()
-GitPython!=3.1.28; python_version >= '3.6' or python_version <= '3.0'
+GitPython; python_version >= '3.6' or python_version <= '3.0'
 
 # autopep8
 # stick to older autopep8 with Python 2.7, since autopep8 1.7.0 requires pycodestyle>=2.9.1 (which is Python 3 only)


### PR DESCRIPTION
(includes commit that does workaround from #4090 + rollback of that workaround)

Proper fix for hard crash with `eb --check-github` when GitPython 3.1.28 is installed (see also https://github.com/gitpython-developers/GitPython/issues/1500).