### PR TITLE
also run unit tests with Python 3.11

### DIFF
--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
+        python: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
       fail-fast: false
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
         
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -68,6 +68,12 @@ jobs:
           - python: '3.10'
             modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Tcl
+          - python: '3.11'
+            modules_tool: ${{needs.setup.outputs.lmod8}}
+            module_syntax: Lua
+          - python: '3.11'
+            modules_tool: ${{needs.setup.outputs.lmod8}}
+            module_syntax: Tcl
           # There may be encoding errors in Python 3 which are hidden when an UTF-8 encoding is set
           # Hence run the tests (again) with LC_ALL=C and Python 3.6 (or any < 3.7)
           - python: 3.6

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -206,7 +206,7 @@ jobs:
           # run test suite
           python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
           # try and make sure output of running tests is clean (no printed messages/warnings)
-          IGNORE_PATTERNS="no GitHub token available|skipping SvnRepository test|requires Lmod as modules tool|stty: 'standard input': Inappropriate ioctl for device|CryptographyDeprecationWarning: Python 3.[56]|from cryptography.*default_backend|CryptographyDeprecationWarning: Python 2|from cryptography.utils import int_from_bytes|Blowfish"
+          IGNORE_PATTERNS="no GitHub token available|skipping SvnRepository test|requires Lmod as modules tool|stty: 'standard input': Inappropriate ioctl for device|CryptographyDeprecationWarning: Python 3.[56]|from cryptography.*default_backend|CryptographyDeprecationWarning: Python 2|from cryptography.utils import int_from_bytes|Blowfish|GC3Pie not available, skipping test"
           # '|| true' is needed to avoid that Travis stops the job on non-zero exit of grep (i.e. when there are no matches)
           PRINTED_MSG=$(egrep -v "${IGNORE_PATTERNS}" test_framework_suite.log | grep '\.\n*[A-Za-z]' || true)
           test "x$PRINTED_MSG" = "x" || (echo "ERROR: Found printed messages in output of test suite\n${PRINTED_MSG}" && exit 1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ archspec
 
 # cryptography 3.4.0 no longer supports Python 2.7
 cryptography==3.3.2; python_version == '2.7'
-cryptography; python_version >= '3.5'
+# cryptography; python_version >= '3.5'
 
 # rich is only supported for Python 3.6+
 rich; python_version >= '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ flake8
 
 # 2.6.7 uses invalid Python 2 syntax
 GC3Pie!=2.6.7; python_version < '3.0'
-GC3Pie; python_version >= '3.0'
+GC3Pie; python_version >= '3.0' and python_version < '3.11'
 python-graph-dot
 python-hglib
 requests
@@ -31,7 +31,7 @@ archspec
 
 # cryptography 3.4.0 no longer supports Python 2.7
 cryptography==3.3.2; python_version == '2.7'
-# cryptography; python_version >= '3.5'
+cryptography; python_version >= '3.5' and python_version < '3.11'
 
 # rich is only supported for Python 3.6+
 rich; python_version >= '3.6'


### PR DESCRIPTION
WIP because there's no final release of Python 3.11 yet, and some (indirect) dependencies (like `pycrypto`) seem to still have a problem with it...