### PR TITLE
EasyBuild 4.6.2 Ubuntu friendly PNS

### DIFF
--- a/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
+++ b/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
@@ -1,0 +1,54 @@
+##
+# Copyright 2015-2022 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+Implementation of the EasyBuild packaging naming scheme
+
+:author: Robert Schmidt (Ottawa Hospital Research Institute)
+:author: Kenneth Hoste (Ghent University)
+"""
+from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
+from easybuild.tools.package.package_naming_scheme.pns import PackageNamingScheme
+from easybuild.tools.version import VERSION as EASYBUILD_VERSION
+
+
+class EasyBuildPNS(PackageNamingScheme):
+    """Class implmenting the default EasyBuild packaging naming scheme."""
+
+    def name(self, ec):
+        """Determine package name"""
+        self.log.debug("Easyconfig dict passed to name() looks like: %s ", ec)
+        return '%s-%s' % (ec['name'], det_full_ec_version(ec))
+
+    def version(self, ec):
+        """Determine package version: EasyBuild version used to build & install."""
+        ebver = str(EASYBUILD_VERSION)
+        if ebver.endswith('dev'):
+            # try and make sure that 'dev' EasyBuild version is not considered newer just because it's longer
+            # (e.g., 2.2.0 vs 2.2.0dev)
+            # cfr. http://rpm.org/ticket/56,
+            # https://debian-handbook.info/browse/stable/sect.manipulating-packages-with-dpkg.html (see box in 5.4.3)
+            ebver.replace('dev', '~dev')
+
+        return '%s-eb' % ebver

--- a/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
+++ b/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
@@ -49,3 +49,5 @@ class EasyBuildDebFriendlyPNS(EasyBuildPNS):
         if not ebver[0].isdigit():  # Make sure to add a 0 to the string if ebver does not start with a number
             ebver = '0'+ebver
         return '%s-eb' % ebver
+
+# -*- coding: utf-8 -*- vim: set fileencoding=utf-8

--- a/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
+++ b/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*- vim: set fileencoding=utf-8
+##
 # Copyright 2015-2022 Ghent University
 #
 # This file is part of EasyBuild,

--- a/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
+++ b/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*- vim: set fileencoding=utf-8
 ##
 # Copyright 2015-2022 Ghent University
 #
@@ -54,5 +55,3 @@ class EasyBuildDebFriendlyPNS(EasyBuildPNS):
         # Postfix `-eb` to ebver instead of prefixing it to comply with
         # https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
         return '%s-eb' % ebver
-
-# -*- coding: utf-8 -*- vim: set fileencoding=utf-8

--- a/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
+++ b/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
@@ -31,6 +31,7 @@ Implementation of the EasyBuild packaging naming scheme
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.package.package_naming_scheme.pns import PackageNamingScheme
 from easybuild.tools.version import VERSION as EASYBUILD_VERSION
+from re import match
 
 
 class EasyBuildPNS(PackageNamingScheme):
@@ -51,4 +52,6 @@ class EasyBuildPNS(PackageNamingScheme):
             # https://debian-handbook.info/browse/stable/sect.manipulating-packages-with-dpkg.html (see box in 5.4.3)
             ebver.replace('dev', '~dev')
 
+        if re.match('\\D', ebver):  # Make sure to add default epoc if ebver does not start with a number
+            ebver = '0:'+ebver
         return '%s-eb' % ebver

--- a/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
+++ b/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
@@ -52,6 +52,6 @@ class EasyBuildPNS(PackageNamingScheme):
             # https://debian-handbook.info/browse/stable/sect.manipulating-packages-with-dpkg.html (see box in 5.4.3)
             ebver.replace('dev', '~dev')
 
-        if re.match('\\D', ebver):  # Make sure to add default epoc if ebver does not start with a number
-            ebver = '0:'+ebver
+        if re.match('\\D', ebver):  # Make sure to add a 0 to the string if ebver does not start with a number
+            ebver = '0'+ebver
         return '%s-eb' % ebver

--- a/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
+++ b/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
@@ -1,4 +1,4 @@
-##
+## -*- coding: utf-8 -*- vim: set fileencoding=utf-8
 # Copyright 2015-2022 Ghent University
 #
 # This file is part of EasyBuild,

--- a/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
+++ b/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
@@ -33,13 +33,8 @@ from easybuild.tools.package.package_naming_scheme.pns import PackageNamingSchem
 from easybuild.tools.version import VERSION as EASYBUILD_VERSION
 
 
-class EasyBuildPNS(PackageNamingScheme):
-    """Class implmenting the default EasyBuild packaging naming scheme."""
-
-    def name(self, ec):
-        """Determine package name"""
-        self.log.debug("Easyconfig dict passed to name() looks like: %s ", ec)
-        return '%s-%s' % (ec['name'], det_full_ec_version(ec))
+class EasyBuildDebFriendlyPNS(EasyBuildPNS):
+    """Class implmenting the Deb friendly EasyBuild packaging naming scheme."""
 
     def version(self, ec):
         """Determine package version: EasyBuild version used to build & install."""

--- a/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
+++ b/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
@@ -31,7 +31,6 @@ Implementation of the EasyBuild packaging naming scheme
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.package.package_naming_scheme.pns import PackageNamingScheme
 from easybuild.tools.version import VERSION as EASYBUILD_VERSION
-from re import match
 
 
 class EasyBuildPNS(PackageNamingScheme):
@@ -52,6 +51,6 @@ class EasyBuildPNS(PackageNamingScheme):
             # https://debian-handbook.info/browse/stable/sect.manipulating-packages-with-dpkg.html (see box in 5.4.3)
             ebver.replace('dev', '~dev')
 
-        if re.match('\\D', ebver):  # Make sure to add a 0 to the string if ebver does not start with a number
+        if not ebver[0].isdigit():  # Make sure to add a 0 to the string if ebver does not start with a number
             ebver = '0'+ebver
         return '%s-eb' % ebver

--- a/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
+++ b/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
@@ -28,8 +28,7 @@ Implementation of the EasyBuild packaging naming scheme
 :author: Robert Schmidt (Ottawa Hospital Research Institute)
 :author: Kenneth Hoste (Ghent University)
 """
-from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
-from easybuild.tools.package.package_naming_scheme.pns import PackageNamingScheme
+from easybuild.tools.package.package_naming_scheme.easybuild_pns import EasyBuildPNS
 from easybuild.tools.version import VERSION as EASYBUILD_VERSION
 
 

--- a/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
+++ b/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
@@ -23,10 +23,11 @@
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 ##
 """
-Implementation of the EasyBuild packaging naming scheme
+Implementation of the EasyBuild deb friendly packaging naming scheme
 
 :author: Robert Schmidt (Ottawa Hospital Research Institute)
 :author: Kenneth Hoste (Ghent University)
+:author: Martin Budsjö (VolvoCars)
 """
 from easybuild.tools.package.package_naming_scheme.easybuild_pns import EasyBuildPNS
 from easybuild.tools.version import VERSION as EASYBUILD_VERSION

--- a/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
+++ b/easybuild/tools/package/package_naming_scheme/easybuild_deb_friendly_pns.py
@@ -46,8 +46,13 @@ class EasyBuildDebFriendlyPNS(EasyBuildPNS):
             # https://debian-handbook.info/browse/stable/sect.manipulating-packages-with-dpkg.html (see box in 5.4.3)
             ebver.replace('dev', '~dev')
 
-        if not ebver[0].isdigit():  # Make sure to add a 0 to the string if ebver does not start with a number
+        # Make sure to add a `0` to the ebver if it doesn't start with a number
+        if not ebver[0].isdigit():
             ebver = '0'+ebver
+
+        #
+        # Postfix `-eb` to ebver instead of prefixing it to comply with
+        # https://www.debian.org/doc/debian-policy/ch-controlfields.html#version
         return '%s-eb' % ebver
 
 # -*- coding: utf-8 -*- vim: set fileencoding=utf-8

--- a/test/framework/package.py
+++ b/test/framework/package.py
@@ -192,7 +192,7 @@ class PackageTest(EnhancedTestCase):
         elif get_package_naming_scheme() == "EasyBuildDebFriendlyPNS":
             # default: EasyBuild deb friendly package naming scheme, pkg release 1
             self.assertEqual(pns.name(ec), 'OpenMPI-2.1.2-GCC-6.4.0-2.28')
-            self.assertEqual(pns.version(ec), '%s_eb' % EASYBUILD_VERSION)
+            self.assertEqual(pns.version(ec), '%s-eb' % EASYBUILD_VERSION)
             self.assertEqual(pns.release(ec), '1')
 
     def test_package(self):

--- a/test/framework/package.py
+++ b/test/framework/package.py
@@ -36,7 +36,7 @@ from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_
 from unittest import TextTestRunner
 
 from easybuild.framework.easyconfig.easyconfig import EasyConfig
-from easybuild.tools.config import log_path
+from easybuild.tools.config import get_package_naming_scheme, log_path
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, read_file, write_file
 from easybuild.tools.package.utilities import ActivePNS, avail_package_naming_schemes, check_pkg_support, package
@@ -154,7 +154,7 @@ class PackageTest(EnhancedTestCase):
 
     def test_avail_package_naming_schemes(self):
         """Test avail_package_naming_schemes()"""
-        self.assertEqual(sorted(avail_package_naming_schemes().keys()), ['EasyBuildPNS'])
+        self.assertEqual(sorted(avail_package_naming_schemes().keys()), ['EasyBuildDebFriendlyPNS', 'EasyBuildPNS'])
 
     def test_check_pkg_support(self):
         """Test check_pkg_support()."""
@@ -184,10 +184,16 @@ class PackageTest(EnhancedTestCase):
 
         pns = ActivePNS()
 
-        # default: EasyBuild package naming scheme, pkg release 1
-        self.assertEqual(pns.name(ec), 'OpenMPI-2.1.2-GCC-6.4.0-2.28')
-        self.assertEqual(pns.version(ec), 'eb-%s' % EASYBUILD_VERSION)
-        self.assertEqual(pns.release(ec), '1')
+        if get_package_naming_scheme() == "EasyBuildPNS":
+            # default: EasyBuild package naming scheme, pkg release 1
+            self.assertEqual(pns.name(ec), 'OpenMPI-2.1.2-GCC-6.4.0-2.28')
+            self.assertEqual(pns.version(ec), 'eb-%s' % EASYBUILD_VERSION)
+            self.assertEqual(pns.release(ec), '1')
+        elif get_package_naming_scheme() == "EasyBuildDebFriendlyPNS":
+            # default: EasyBuild deb friendly package naming scheme, pkg release 1
+            self.assertEqual(pns.name(ec), 'OpenMPI-2.1.2-GCC-6.4.0-2.28')
+            self.assertEqual(pns.version(ec), '%s_eb' % EASYBUILD_VERSION)
+            self.assertEqual(pns.release(ec), '1')
 
     def test_package(self):
         """Test package function."""

--- a/test/framework/package.py
+++ b/test/framework/package.py
@@ -152,9 +152,11 @@ def mock_fpm(tmpdir):
 class PackageTest(EnhancedTestCase):
     """Tests for packaging support."""
 
+    pnsNames = ['EasyBuildDebFriendlyPNS', 'EasyBuildPNS']
+
     def test_avail_package_naming_schemes(self):
         """Test avail_package_naming_schemes()"""
-        self.assertEqual(sorted(avail_package_naming_schemes().keys()), ['EasyBuildDebFriendlyPNS', 'EasyBuildPNS'])
+        self.assertEqual(sorted(avail_package_naming_schemes().keys()), self.pnsNames)
 
     def test_check_pkg_support(self):
         """Test check_pkg_support()."""
@@ -175,7 +177,7 @@ class PackageTest(EnhancedTestCase):
 
     def test_active_pns(self):
         """Test use of ActivePNS."""
-        for pns_type in ['EasyBuildDebFriendlyPNS', 'EasyBuildPNS']:
+        for pns_type in self.pnsNames:
             os.environ['EASYBUILD_PACKAGE_NAMING_SCHEME'] = pns_type
             init_config(build_options={'silent': True})
 
@@ -186,16 +188,14 @@ class PackageTest(EnhancedTestCase):
 
             pns = ActivePNS()
 
+            self.assertEqual(pns.name(ec), 'OpenMPI-2.1.2-GCC-6.4.0-2.28')
+            self.assertEqual(pns.release(ec), '1')
             if get_package_naming_scheme() == "EasyBuildPNS":
                 # default: EasyBuild package naming scheme, pkg release 1
-                self.assertEqual(pns.name(ec), 'OpenMPI-2.1.2-GCC-6.4.0-2.28')
                 self.assertEqual(pns.version(ec), 'eb-%s' % EASYBUILD_VERSION)
-                self.assertEqual(pns.release(ec), '1')
             elif get_package_naming_scheme() == "EasyBuildDebFriendlyPNS":
                 # default: EasyBuild deb friendly package naming scheme, pkg release 1
-                self.assertEqual(pns.name(ec), 'OpenMPI-2.1.2-GCC-6.4.0-2.28')
                 self.assertEqual(pns.version(ec), '%s-eb' % EASYBUILD_VERSION)
-                self.assertEqual(pns.release(ec), '1')
 
     def test_package(self):
         """Test package function."""

--- a/test/framework/package.py
+++ b/test/framework/package.py
@@ -175,25 +175,27 @@ class PackageTest(EnhancedTestCase):
 
     def test_active_pns(self):
         """Test use of ActivePNS."""
-        init_config(build_options={'silent': True})
+        for pns_type in ['EasyBuildDebFriendlyPNS', 'EasyBuildPNS']:
+            os.environ['EASYBUILD_PACKAGE_NAMING_SCHEME'] = pns_type
+            init_config(build_options={'silent': True})
 
-        topdir = os.path.dirname(os.path.abspath(__file__))
-        test_easyconfigs = os.path.join(topdir, 'easyconfigs', 'test_ecs')
-        test_ec = os.path.join(test_easyconfigs, 'o', 'OpenMPI', 'OpenMPI-2.1.2-GCC-6.4.0-2.28.eb')
-        ec = EasyConfig(test_ec, validate=False)
+            topdir = os.path.dirname(os.path.abspath(__file__))
+            test_easyconfigs = os.path.join(topdir, 'easyconfigs', 'test_ecs')
+            test_ec = os.path.join(test_easyconfigs, 'o', 'OpenMPI', 'OpenMPI-2.1.2-GCC-6.4.0-2.28.eb')
+            ec = EasyConfig(test_ec, validate=False)
 
-        pns = ActivePNS()
+            pns = ActivePNS()
 
-        if get_package_naming_scheme() == "EasyBuildPNS":
-            # default: EasyBuild package naming scheme, pkg release 1
-            self.assertEqual(pns.name(ec), 'OpenMPI-2.1.2-GCC-6.4.0-2.28')
-            self.assertEqual(pns.version(ec), 'eb-%s' % EASYBUILD_VERSION)
-            self.assertEqual(pns.release(ec), '1')
-        elif get_package_naming_scheme() == "EasyBuildDebFriendlyPNS":
-            # default: EasyBuild deb friendly package naming scheme, pkg release 1
-            self.assertEqual(pns.name(ec), 'OpenMPI-2.1.2-GCC-6.4.0-2.28')
-            self.assertEqual(pns.version(ec), '%s-eb' % EASYBUILD_VERSION)
-            self.assertEqual(pns.release(ec), '1')
+            if get_package_naming_scheme() == "EasyBuildPNS":
+                # default: EasyBuild package naming scheme, pkg release 1
+                self.assertEqual(pns.name(ec), 'OpenMPI-2.1.2-GCC-6.4.0-2.28')
+                self.assertEqual(pns.version(ec), 'eb-%s' % EASYBUILD_VERSION)
+                self.assertEqual(pns.release(ec), '1')
+            elif get_package_naming_scheme() == "EasyBuildDebFriendlyPNS":
+                # default: EasyBuild deb friendly package naming scheme, pkg release 1
+                self.assertEqual(pns.name(ec), 'OpenMPI-2.1.2-GCC-6.4.0-2.28')
+                self.assertEqual(pns.version(ec), '%s-eb' % EASYBUILD_VERSION)
+                self.assertEqual(pns.release(ec), '1')
 
     def test_package(self):
         """Test package function."""


### PR DESCRIPTION
Simple new PNS that complies with the deb policy rule: version has to start with a number.

The standard EB PNS generates version strings beginning with `eb_`. This is violating the [Debian package version string policy](https://www.debian.org/doc/debian-policy/ch-controlfields.html#version "Debian package version string policy") requirement of the version string always starting with a number. 
This is a implimentation of a new PNS called EasyBuildDebFriendlyPNS that postfix `eb` to the version string instead of prefixing and also add a `0` to any upstream version string NOT starting with a number

