### PR TITLE
add `fdefault-double-8` to `r8` toolchain compiler option for GCC (to be consistent with Intel)

### DIFF
--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -54,7 +54,7 @@ class Gcc(Compiler):
     }
     COMPILER_UNIQUE_OPTION_MAP = {
         'i8': 'fdefault-integer-8',
-        'r8': 'fdefault-real-8',
+        'r8': ['fdefault-real-8', 'fdefault-double-8'],
         'unroll': 'funroll-loops',
         'f2c': 'ff2c',
         'loop': ['ftree-switch-conversion', 'floop-interchange', 'floop-strip-mine', 'floop-block'],

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -872,7 +872,7 @@ class ToolchainTest(EnhancedTestCase):
                 tc = self.get_toolchain('foss', version='2018a')
                 tc.set_options({opt: enable})
                 tc.prepare()
-                flag = ' '.join('-%s' % x for x in  tc.COMPILER_UNIQUE_OPTION_MAP[opt])
+                flag = ' '.join('-%s' % x for x in tc.COMPILER_UNIQUE_OPTION_MAP[opt])
                 for var in flag_vars:
                     flags = tc.get_variable(var)
                     if enable:

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -872,7 +872,11 @@ class ToolchainTest(EnhancedTestCase):
                 tc = self.get_toolchain('foss', version='2018a')
                 tc.set_options({opt: enable})
                 tc.prepare()
-                flag = ' '.join('-%s' % x for x in tc.COMPILER_UNIQUE_OPTION_MAP[opt])
+                flag = tc.COMPILER_UNIQUE_OPTION_MAP[opt]
+                if isinstance(flag, list):
+                    flag = ' '.join('-%s' % x for x in flag)
+                else:
+                    flag = '-%s' % flag
                 for var in flag_vars:
                     flags = tc.get_variable(var)
                     if enable:


### PR DESCRIPTION
-r8 for intel promotes reals => 64bit, but leaves doubles as 64bit.
-fdefault-real-8 for gfotran promotes reals => 64bit and promotes doubles to 128bit.
-fdefault-real-8 -fdefault-double-8 yields the same effect as intel's -r8

https://github.com/easybuilders/easybuild-framework/issues/4120 contains examples.