### PR TITLE
add eb_bash_completion_local.bash script to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,6 +94,7 @@ implement support for installing particular (groups of) software packages.""",
         'optcomplete.bash',
         'minimal_bash_completion.bash',
         'eb_bash_completion.bash',
+        'eb_bash_completion_local.bash',
         # utility scripts
         'easybuild/scripts/bootstrap_eb.py',
         'easybuild/scripts/install_eb_dep.sh',


### PR DESCRIPTION
This is a follow-up PR of https://github.com/easybuilders/easybuild-framework/pull/3953 where the a script was added to allow bash completion for easyconfigs from local dir but not robot search path. This script was merged, but I didn't add it in `setup.py`.

This option might be useful if you are working on a slow shared filesystem and searching the entire robot search path is too slow.

This bash completion can be enabled with:
```
source $EBROOTEASYBUILD/bin/minimal_bash_completion.bash;
source $EBROOTEASYBUILD/bin/optcomplete.bash;
source $EBROOTEASYBUILD/bin/eb_bash_completion_local.bash;
complete -F _eb eb
```