### PR TITLE
correct uses of :param name: and :return: in docstrings

### DIFF
--- a/easybuild/base/fancylogger.py
+++ b/easybuild/base/fancylogger.py
@@ -826,7 +826,7 @@ def setroot(fancyrecord=FANCYLOG_FANCYRECORD):
     Set a FancyLogger instance as the logging root logger
     with (effective)loglevel of current root FancyLogger
 
-    :param fancyrecord is enabled or not (default FANCYLOG_FANCYRECORD module constant)
+    :param fancyrecord: is enabled or not (default FANCYLOG_FANCYRECORD module constant)
 
     Detecting the loglevel is best-effort, better to set the loglevel after setroot()
     """

--- a/easybuild/base/generaloption.py
+++ b/easybuild/base/generaloption.py
@@ -1228,7 +1228,7 @@ class GeneralOption(object):
         """
         Initialise the configparser to use.
 
-            :params initenv: insert initial environment into the configparser.
+            :param initenv: insert initial environment into the configparser.
                 It is a dict of dicts; the first level key is the section name;
                 the 2nd level key,value is the key=value.
                 All section names, keys and values are converted to strings.

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4338,7 +4338,7 @@ def reproduce_build(app, reprod_dir_root):
     :param app: easyblock class instance
     :param reprod_dir_root: root directory in which to create the 'reprod' directory
 
-    :return reprod_dir: directory containing reproducibility files
+    :return: reprod_dir directory containing reproducibility files
     """
 
     ec_filename = app.cfg.filename()

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -385,7 +385,7 @@ class EasyBlock(object):
         """
         Get checksums for this software that are provided in a checksums.json file
 
-        :param: always_read: always read the checksums.json file, even if it has been read before
+        :param always_read: always read the checksums.json file, even if it has been read before
         """
         if always_read or self.json_checksums is None:
             try:

--- a/easybuild/framework/easyconfig/style.py
+++ b/easybuild/framework/easyconfig/style.py
@@ -108,8 +108,8 @@ def _eb_check_trailing_whitespace(physical_line, lines, line_number, checker_sta
 def check_easyconfigs_style(easyconfigs, verbose=False):
     """
     Check the given list of easyconfigs for style
-    :param: easyconfigs list of file paths to easyconfigs
-    :param: verbose print our statistics and be verbose about the errors and warning
+    :param easyconfigs: list of file paths to easyconfigs
+    :param verbose: print our statistics and be verbose about the errors and warning
     :return: the number of warnings and errors
     """
     # importing autopep8 changes some pep8 functions.

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -49,7 +49,7 @@ def resolve_exts_filter_template(exts_filter, ext):
     Resolve the exts_filter tuple by replacing the template values using the extension
     :param exts_filter: Tuple of (command, input) using template values (ext_name, ext_version, src)
     :param ext: Instance of Extension or dictionary like with 'name' and optionally 'options', 'version', 'source' keys
-    :return (cmd, input) as a tuple of strings
+    :return: (cmd, input) as a tuple of strings
     """
 
     if isinstance(exts_filter, string_type) or len(exts_filter) != 2:

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -132,7 +132,7 @@ class EasyBuildLog(fancylogger.FancyLogger):
         """
         Print deprecation warning or raise an exception, depending on specified version(s)
 
-        :param: msg: deprecation message
+        :param msg: deprecation message
         :param ver: if max_ver is None: threshold for EasyBuild version to determine warning vs exception
                     else: version to check against max_ver to determine warning vs exception
         :param max_ver: version threshold for warning vs exception (compared to 'ver')

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -710,7 +710,7 @@ def extract_errors_from_log(log_txt, reg_exps):
     :param log_txt: String containing the log, will be split into individual lines
     :param reg_exps: List of: regular expressions (as strings) to error on,
                     or tuple of regular expression and action (any of [IGNORE, WARN, ERROR])
-    :return (warnings, errors) as lists of lines containing a match
+    :return: (warnings, errors) as lists of lines containing a match
     """
     actions = (IGNORE, WARN, ERROR)
 

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -1042,7 +1042,7 @@ def locate_solib(libobj):
     Return absolute path to loaded library using dlinfo
     Based on https://stackoverflow.com/a/35683698
 
-    :params libobj: ctypes CDLL object
+    :param libobj: ctypes CDLL object
     """
     # early return if we're not on a Linux system
     if get_os_type() != LINUX:
@@ -1072,7 +1072,7 @@ def find_library_path(lib_filename):
     Search library by file name in the system
     Return absolute path to existing libraries
 
-    :params lib_filename: name of library file
+    :param lib_filename: name of library file
     """
 
     lib_abspath = None


### PR DESCRIPTION
One of the markdown API document generators I am trying:
* blows up on `:param:`
* does not recognise `:params ...`
* blows up on `:param name description` (missing `:` after the parameter name)
* blows up on `:return ...`