### PR TITLE
Cancel old GithubAction runs

### DIFF
--- a/.github/workflows/bootstrap_script.yml
+++ b/.github/workflows/bootstrap_script.yml
@@ -1,6 +1,11 @@
 # documentation: https://help.github.com/en/articles/workflow-syntax-for-github-actions
 name: test EasyBuild bootstrap script
 on: [push, pull_request]
+
+concurrency:
+  group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
+  cancel-in-progress: true
+
 jobs:
   setup:
     runs-on: ubuntu-20.04

--- a/.github/workflows/container_tests.yml
+++ b/.github/workflows/container_tests.yml
@@ -1,6 +1,11 @@
 # documentation: https://help.github.com/en/articles/workflow-syntax-for-github-actions
 name: Tests for container support
 on: [push, pull_request]
+
+concurrency:
+  group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
+  cancel-in-progress: true
+
 jobs:
   build:
     # stick to Ubuntu 18.04, where we can still easily install yum via 'apt install'

--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -1,6 +1,11 @@
 # documentation: https://help.github.com/en/articles/workflow-syntax-for-github-actions
 name: Tests for the 'eb' command
 on: [push, pull_request]
+
+concurrency:
+  group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
+  cancel-in-progress: true
+
 jobs:
   test-eb:
     runs-on: ubuntu-20.04

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,5 +1,10 @@
 name: Static Analysis
 on: [push, pull_request]
+
+concurrency:
+  group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
+  cancel-in-progress: true
+
 jobs:
   python-linting:
     runs-on: ubuntu-20.04

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,6 +1,11 @@
 # documentation: https://help.github.com/en/articles/workflow-syntax-for-github-actions
 name: EasyBuild framework unit tests
 on: [push, pull_request]
+
+concurrency:
+  group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
+  cancel-in-progress: true
+
 jobs:
   setup:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Save (free) CPU hours by canceling running actions on the same branch, e.g. after a re-push on a PR