### PR TITLE
Add checksums.json support for Github interface

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -650,7 +650,7 @@ def categorize_files_by_type(paths):
         'files_to_delete': [],
         'patch_files': [],
         'py_files': [],
-        'checksums_files': [],
+        'checksums_json': [],
     }
 
     for path in paths:
@@ -670,7 +670,7 @@ def categorize_files_by_type(paths):
                 raise EasyBuildError('%s is not detected as a valid patch file. Please verify its contents!',
                                      path)
         elif path.endswith('checksums.json'):
-            res['checksums_files'].append(path)
+            res['checksums_json'].append(path)
         else:
             # anything else is considered to be an easyconfig file
             res['easyconfigs'].append(path)

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -35,6 +35,7 @@ alongside the EasyConfig class to represent parsed easyconfig files.
 :author: Toon Willems (Ghent University)
 :author: Fotis Georgatos (Uni.Lu, NTUA)
 :author: Ward Poelmans (Ghent University)
+@author: Maxime Boissonneault (Digital Research Alliance of Canada, Universite Laval)
 """
 import copy
 import fnmatch
@@ -641,7 +642,7 @@ def dump_env_script(easyconfigs):
 
 def categorize_files_by_type(paths):
     """
-    Splits list of filepaths into a 4 separate lists: easyconfigs, files to delete, patch files and
+    Splits list of filepaths into a 5 separate lists: easyconfigs, files to delete, patch files, checksums and
     files with extension .py
     """
     res = {
@@ -649,6 +650,7 @@ def categorize_files_by_type(paths):
         'files_to_delete': [],
         'patch_files': [],
         'py_files': [],
+        'checksums_files': [],
     }
 
     for path in paths:
@@ -667,6 +669,8 @@ def categorize_files_by_type(paths):
             else:
                 raise EasyBuildError('%s is not detected as a valid patch file. Please verify its contents!',
                                      path)
+        elif path.endswith('checksums.json'):
+            res['checksums_files'].append(path)
         else:
             # anything else is considered to be an easyconfig file
             res['easyconfigs'].append(path)

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1845,7 +1845,7 @@ def det_account_branch_for_pr(pr_id, github_user=None, pr_target_repo=None):
 def det_pr_target_repo(paths):
     """Determine target repository for pull request from given cagetorized list of files
 
-    :param paths: paths to categorized lists of files (easyconfigs, files to delete, patches, .py files)
+    :param paths: paths to categorized lists of files (easyconfigs, files to delete, patches, checksums, .py files)
     """
     pr_target_repo = build_option('pr_target_repo')
 
@@ -1855,10 +1855,10 @@ def det_pr_target_repo(paths):
 
         _log.info("Trying to derive target repository based on specified files...")
 
-        easyconfigs, files_to_delete, patch_files, py_files = [paths[key] for key in sorted(paths.keys())]
+        checksums, easyconfigs, files_to_delete, patch_files, py_files = [paths[key] for key in sorted(paths.keys())]
 
         # Python files provided, and no easyconfig files or patches
-        if py_files and not (easyconfigs or patch_files):
+        if py_files and not (easyconfigs or patch_files or checksums):
 
             _log.info("Only Python files provided, no easyconfig files or patches...")
 
@@ -1871,9 +1871,10 @@ def det_pr_target_repo(paths):
                 pr_target_repo = GITHUB_FRAMEWORK_REPO
                 _log.info("Not all Python files are easyblocks, target repository is assumed to be %s", pr_target_repo)
 
-        # if no Python files are provided, only easyconfigs & patches, or if files to delete are .eb files,
+        # if no Python files are provided, only easyconfigs, patches and checksums, or if files to delete are .eb files,
         # then target repo is assumed to be easyconfigs
-        elif easyconfigs or patch_files or (files_to_delete and all(x.endswith('.eb') for x in files_to_delete)):
+        elif (easyconfigs or patch_files or checksums or
+             (files_to_delete and all(x.endswith('.eb') for x in files_to_delete))):
             pr_target_repo = GITHUB_EASYCONFIGS_REPO
             _log.info("Only easyconfig and patch files found, target repository is assumed to be %s", pr_target_repo)
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -28,6 +28,7 @@ Unit tests for easyconfig.py
 @author: Toon Willems (Ghent University)
 @author: Kenneth Hoste (Ghent University)
 @author: Stijn De Weirdt (Ghent University)
+@author: Maxime Boissonneault (Digital Research Alliance of Canada, Universite Laval)
 """
 import copy
 import glob
@@ -3366,7 +3367,8 @@ class EasyConfigTest(EnhancedTestCase):
 
     def test_categorize_files_by_type(self):
         """Test categorize_files_by_type"""
-        self.assertEqual({'easyconfigs': [], 'files_to_delete': [], 'patch_files': [], 'py_files': []},
+        self.assertEqual({'easyconfigs': [], 'files_to_delete': [], 'patch_files': [], 'py_files': [],
+                          'checksums_files': []},
                          categorize_files_by_type([]))
 
         test_dir = os.path.dirname(os.path.abspath(__file__))
@@ -3379,6 +3381,7 @@ class EasyConfigTest(EnhancedTestCase):
         toy_easyblock = os.path.join(easyblocks_dir, 't', 'toy.py')
 
         gzip_ec = os.path.join(test_ecs_dir, 'test_ecs', 'g', 'gzip', 'gzip-1.4.eb')
+        toy_checksums = os.path.join(test_ecs_dir, 'test_ecs', 't', 'toy', 'checksums.json')
         paths = [
             'bzip2-1.0.6.eb',
             toy_easyblock,
@@ -3387,6 +3390,7 @@ class EasyConfigTest(EnhancedTestCase):
             'foo',
             ':toy-0.0-deps.eb',
             configuremake,
+            toy_checksums,
         ]
         res = categorize_files_by_type(paths)
         expected = [
@@ -3398,6 +3402,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(res['files_to_delete'], ['toy-0.0-deps.eb'])
         self.assertEqual(res['patch_files'], [toy_patch])
         self.assertEqual(res['py_files'], [toy_easyblock, configuremake])
+        self.assertEqual(res['checksums_files'], [toy_checksums])
 
         # Error cases
         tmpdir = tempfile.mkdtemp()

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3368,7 +3368,7 @@ class EasyConfigTest(EnhancedTestCase):
     def test_categorize_files_by_type(self):
         """Test categorize_files_by_type"""
         self.assertEqual({'easyconfigs': [], 'files_to_delete': [], 'patch_files': [], 'py_files': [],
-                          'checksums_files': []},
+                          'checksums_json': []},
                          categorize_files_by_type([]))
 
         test_dir = os.path.dirname(os.path.abspath(__file__))
@@ -3402,7 +3402,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(res['files_to_delete'], ['toy-0.0-deps.eb'])
         self.assertEqual(res['patch_files'], [toy_patch])
         self.assertEqual(res['py_files'], [toy_easyblock, configuremake])
-        self.assertEqual(res['checksums_files'], [toy_checksums])
+        self.assertEqual(res['checksums_json'], [toy_checksums])
 
         # Error cases
         tmpdir = tempfile.mkdtemp()

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -990,17 +990,21 @@ class GithubTest(EnhancedTestCase):
 
         test_dir = os.path.dirname(os.path.abspath(__file__))
 
-        # easyconfigs/patches (incl. files to delete) => easyconfigs repo
+        # easyconfigs/patches/checksums (incl. files to delete) => easyconfigs repo
         # this is solely based on filenames, actual files are not opened, except for the patch file which must exist
         toy_patch_fn = 'toy-0.0_fix-silly-typo-in-printf-statement.patch'
         toy_patch = os.path.join(test_dir, 'sandbox', 'sources', 'toy', toy_patch_fn)
         test_cases = [
             ['toy.eb'],
             [toy_patch],
+            ['checksums.json'],
             ['toy.eb', toy_patch],
+            ['toy.eb', toy_patch, 'checksums.json'],
             [':toy.eb'],  # deleting toy.eb
             ['one.eb', 'two.eb'],
+            ['one.eb', 'two.eb', 'checksums.json'],
             ['one.eb', 'two.eb', toy_patch, ':todelete.eb'],
+            ['one.eb', 'two.eb', toy_patch, 'checksums.json', ':todelete.eb'],
         ]
         for test_case in test_cases:
             self.assertEqual(gh.det_pr_target_repo(categorize_files_by_type(test_case)), 'easybuild-easyconfigs')
@@ -1025,8 +1029,8 @@ class GithubTest(EnhancedTestCase):
         py_files.append(github_py)
         self.assertEqual(gh.det_pr_target_repo(categorize_files_by_type(py_files)), 'easybuild-framework')
 
-        # as soon as an easyconfig file or patch files is involved => result is easybuild-easyconfigs repo
-        for fn in ['toy.eb', toy_patch]:
+        # as soon as an easyconfig file, checksums or patch files is involved => result is easybuild-easyconfigs repo
+        for fn in ['toy.eb', toy_patch, 'checksums.json']:
             self.assertEqual(gh.det_pr_target_repo(categorize_files_by_type(py_files + [fn])), 'easybuild-easyconfigs')
 
         # if --pr-target-repo is specified, we always get this value (no guessing anymore)


### PR DESCRIPTION
This uses a workflow very similar to how patches are handled with the github integration, with the difference that instead of copying the patches in place, it merges the `checksums.json` with the existing one if it does exist already