### PR TITLE
deprecate support for running EasyBuild with Python 2

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -74,6 +74,7 @@ from easybuild.tools.output import start_progress_bar, stop_progress_bar, update
 from easybuild.tools.robot import check_conflicts, dry_run, missing_deps, resolve_dependencies, search_easyconfigs
 from easybuild.tools.package.utilities import check_pkg_support
 from easybuild.tools.parallelbuild import submit_jobs
+from easybuild.tools.py2vs3 import python2_is_deprecated
 from easybuild.tools.repository.repository import init_repository
 from easybuild.tools.systemtools import check_easybuild_deps
 from easybuild.tools.testing import create_test_report, overall_test_report, regtest, session_state
@@ -574,6 +575,8 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     :param do_build: whether or not to actually perform the build
     :param testing: enable testing mode
     """
+
+    python2_is_deprecated()
 
     register_lock_cleanup_signal_handlers()
 

--- a/easybuild/tools/py2vs3/__init__.py
+++ b/easybuild/tools/py2vs3/__init__.py
@@ -36,3 +36,26 @@ else:
 def create_base_metaclass(base_class_name, metaclass, *bases):
     """Create new class with specified metaclass based on specified base class(es)."""
     return metaclass(base_class_name, bases, {})
+
+
+def python2_is_deprecated():
+    """
+    Print warning when using Python 2, since the support for running EasyBuild with it is deprecated.
+    """
+    if sys.version_info[0] == 2:
+        full_py_ver = '.'.join(str(x) for x in sys.version_info[:3])
+        warning_lines = [
+            "Running EasyBuild with Python v2.x is deprecated, found Python v%s." % full_py_ver,
+            "Support for running EasyBuild with Python v2.x will be removed in EasyBuild v5.0.",
+            '',
+            "It is strongly recommended to start using Python v3.x for running EasyBuild,",
+            "see https://docs.easybuild.io/en/latest/Python-2-3-compatibility.html for more information.",
+        ]
+        max_len = max(len(x) for x in warning_lines)
+        for i in range(len(warning_lines)):
+            line_len = len(warning_lines[i])
+            warning_lines[i] = '!!! ' + warning_lines[i] + ' ' * (max_len - line_len) + ' !!!'
+        max_len = max(len(x) for x in warning_lines)
+        warning_lines.insert(0, '!' * max_len)
+        warning_lines.append('!' * max_len)
+        sys.stderr.write('\n\n' + '\n'.join(warning_lines) + '\n\n\n')


### PR DESCRIPTION
This makes EasyBuild print a big fat deprecation warning when it's being run with Python 2:

```
$ eb --version


!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!! Running EasyBuild with Python v2.x is deprecated, found Python v3.9.6.                      !!!
!!! Support for running EasyBuild with Python v2.x will be removed in EasyBuild v5.0.           !!!
!!!                                                                                             !!!
!!! It is strongly recommended to start using Python v3.x for running EasyBuild,                !!!
!!! see https://docs.easybuild.io/en/latest/Python-2-3-compatibility.html for more information. !!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```