### PR TITLE
always start with empty list for banned/requires libraries to avoid that corresponding build option is updated in-place

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3126,13 +3126,15 @@ class EasyBlock(object):
         self.log.info("Checking for banned/required linked shared libraries...")
 
         # list of libraries that can *not* be linked in any installed binary/library
-        banned_libs = build_option('banned_linked_shared_libs') or []
+        banned_libs = []
+        banned_libs.extend(build_option('banned_linked_shared_libs') or [])
         banned_libs.extend(self.toolchain.banned_linked_shared_libs())
         banned_libs.extend(self.banned_linked_shared_libs())
         banned_libs.extend(self.cfg['banned_linked_shared_libs'])
 
         # list of libraries that *must* be linked in every installed binary/library
-        required_libs = build_option('required_linked_shared_libs') or []
+        required_libs = []
+        required_libs.extend(build_option('required_linked_shared_libs') or [])
         required_libs.extend(self.toolchain.required_linked_shared_libs())
         required_libs.extend(self.required_linked_shared_libs())
         required_libs.extend(self.cfg['required_linked_shared_libs'])


### PR DESCRIPTION
When installing multiple easyconfigs, for which the list of banned libraries is different, we need to ensure that the list used for the installation of the 1st easyconfig doesn't leak to the 2nd easyconfig.

If the `banned_linked_shared_libs` build option value is a list value somehow (for example because of the active EasyBuild configuration, or because `banned_linked_shared_libs` was manipulated through an EasyBuild hook), then we're updating that list in-place with the `.extend` calls.
When the `banned_linked_shared_libs` build option is later requested again, we get the updated list.

This can be avoided by always starting from an empty list, so the reference to the `banned_linked_shared_libs` build option list value is not being reused as a reference across multiple installations.