### PR TITLE
fix container tests by using EPEL archive URL for downloading Singularity RPM

### DIFF
--- a/.github/workflows/container_tests.yml
+++ b/.github/workflows/container_tests.yml
@@ -57,8 +57,8 @@ jobs:
         sudo apt install alien
         alien --version
         # determine latest version of Singularity available in EPEL, and download RPM
-        singularity_rpm=$(curl -sL https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/s/ | grep singularity | sed 's/.*singularity/singularity/g' | sed 's/rpm.*/rpm/g')
-        curl -OL https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/s/${singularity_rpm}
+        singularity_rpm=$(curl -sL https://dl.fedoraproject.org/pub/archive/epel/8.5/Everything/x86_64/Packages/s/ | grep singularity | sed 's/.*singularity/singularity/g' | sed 's/rpm.*/rpm/g')
+        curl -OL https://dl.fedoraproject.org/pub/archive/epel/8.5/Everything/x86_64/Packages/s/${singularity_rpm}
         # convert Singularity RPM to Debian package, and install it
         sudo alien -d ${singularity_rpm}
         sudo apt install ./singularity*.deb


### PR DESCRIPTION
Fix for failing container tests, Singularity RPM is no longer available at https://dl.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/s (because they've moved on to Apptainer instead)

```
curl: Remote file name has no length!
curl: try 'curl --help' or 'curl --manual' for more information
Error: Process completed with exit code 23.
```