### PR TITLE
use -march=x86-64 -mtune=generic instead of -xSSE2 when using Intel oneAPI compilers

### DIFF
--- a/easybuild/toolchains/compiler/intel_compilers.py
+++ b/easybuild/toolchains/compiler/intel_compilers.py
@@ -43,7 +43,7 @@ class IntelCompilers(IntelIccIfort):
     COMPILER_MODULE_NAME = ['intel-compilers']
     COMPILER_UNIQUE_OPTS = dict(IntelIccIfort.COMPILER_UNIQUE_OPTS)
     COMPILER_UNIQUE_OPTS.update({
-        'oneapi': (False, "Use oneAPI compilers icx/icpx/ifx instead of classic compilers"),
+        'oneapi': (None, "Use oneAPI compilers icx/icpx/ifx instead of classic compilers"),
         'oneapi_c_cxx': (None, "Use oneAPI C/C++ compilers icx/icpx instead of classic Intel C/C++ compilers "
                                "(auto-enabled for Intel compilers version 2022.2.0, or newer)"),
         'oneapi_fortran': (False, "Use oneAPI Fortran compiler ifx instead of classic Intel Fortran compiler"),
@@ -76,7 +76,8 @@ class IntelCompilers(IntelIccIfort):
             if self.options.get('oneapi_c_cxx', None) is None:
                 self.options['oneapi_c_cxx'] = True
 
-        if self.options.get('oneapi', False):
+        oneapi_tcopt = self.options.get('oneapi')
+        if oneapi_tcopt:
             oneapi = True
             self.COMPILER_CXX = 'icpx'
             self.COMPILER_CC = 'icx'
@@ -85,7 +86,7 @@ class IntelCompilers(IntelIccIfort):
             self.COMPILER_FC = 'ifx'
 
         # if both 'oneapi' and 'oneapi_*' are set, the latter are ignored
-        else:
+        elif oneapi_tcopt is None:
             if self.options.get('oneapi_c_cxx', False):
                 oneapi = True
                 self.COMPILER_CC = 'icx'

--- a/easybuild/toolchains/compiler/intel_compilers.py
+++ b/easybuild/toolchains/compiler/intel_compilers.py
@@ -31,6 +31,7 @@ import os
 
 from distutils.version import LooseVersion
 
+import easybuild.tools.systemtools as systemtools
 from easybuild.toolchains.compiler.inteliccifort import IntelIccIfort
 from easybuild.tools.toolchain.compiler import Compiler
 
@@ -108,6 +109,13 @@ class IntelCompilers(IntelIccIfort):
             self.options.options_map['veryloose'] = ['fp-model fast']
             # recommended in porting guide
             self.options.options_map['openmp'] = ['fiopenmp']
+
+            # -xSSE2 is not supported by Intel oneAPI compilers,
+            # so use -march=x86-64 -mtune=generic when using optarch=GENERIC
+            self.COMPILER_GENERIC_OPTION = {
+                (systemtools.X86_64, systemtools.AMD): 'march=x86-64 -mtune=generic',
+                (systemtools.X86_64, systemtools.INTEL): 'march=x86-64 -mtune=generic',
+            }
 
         # skip IntelIccIfort.set_variables (no longer relevant for recent versions)
         Compiler.set_variables(self)

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -709,7 +709,7 @@ class ToolchainTest(EnhancedTestCase):
             tcs = {
                 'gompi': ('2018a', "-march=x86-64 -mtune=generic"),
                 'iccifort': ('2018.1.163', "-xSSE2 -ftz -fp-speculation=safe -fp-model source"),
-                'intel-compilers': ('2021.4.0', "-xSSE2 -fp-speculation=safe -fp-model precise"),
+                'intel-compilers': ('2021.4.0', "-march=x86-64 -mtune=generic -fp-speculation=safe -fp-model precise"),
             }
             for tcopt_optarch in [False, True]:
                 for tcname in tcs:


### PR DESCRIPTION
Required since `xSSE2` is no longer supported by oneAPI compilers:

```
error: unknown target CPU 'SSE2'
note: valid target CPU values are: nocona, core2, penryn, bonnell, atom, silvermont, slm, goldmont, goldmont-plus, tremont, gracemont, nehalem, corei7, westmere, sandybridge, corei7-avx, ivybridge, core-avx-i, haswell, core-avx2, broadwell, common-avx512, skylake, skylake-avx512, skx, cascadelake, cooperlake, cannonlake, icelake-client, rocketlake, icelake-server, tigerlake, sapphirerapids, alderlake, knl, knm, k8, athlon64, athlon-fx, opteron, k8-sse3, athlon64-sse3, opteron-sse3, amdfam10, barcelona, btver1, btver2, bdver1, bdver2, bdver3, bdver4, znver1, znver2, znver3, x86-64, x86-64-v2, x86-64-v3, x86-64-v4
```

tested with HPL in https://github.com/easybuilders/easybuild-easyconfigs/pull/16962 using `eb --from-pr 16962 HPL-2.3-intel-2022b.eb --optarch=GENERIC`