### PR TITLE
trim CI test configurations to avoid hitting GitHub rate limits

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -46,15 +46,9 @@ jobs:
           - python: 3.5
             modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Lua
-          - python: 3.5
-            modules_tool: ${{needs.setup.outputs.lmod8}}
-            module_syntax: Tcl
           - python: 3.7
             modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Lua
-          - python: 3.7
-            modules_tool: ${{needs.setup.outputs.lmod8}}
-            module_syntax: Tcl
           - python: 3.8
             modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Lua
@@ -64,15 +58,9 @@ jobs:
           - python: 3.9
             modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Lua
-          - python: 3.9
-            modules_tool: ${{needs.setup.outputs.lmod8}}
-            module_syntax: Tcl
           - python: '3.10'
             modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Lua
-          - python: '3.10'
-            modules_tool: ${{needs.setup.outputs.lmod8}}
-            module_syntax: Tcl
           - python: '3.11'
             modules_tool: ${{needs.setup.outputs.lmod8}}
             module_syntax: Lua


### PR DESCRIPTION
Since we also started testing with #4092, we easily hit the GitHub rate limits due to having too many test configurations, so let's trim things down a bit by excluding less commonly used configurations (like Lmod + Tcl syntax)