### PR TITLE
add support for --summarize-prs (WIP)

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -64,7 +64,7 @@ from easybuild.tools.filetools import adjust_permissions, cleanup, copy_files, d
 from easybuild.tools.filetools import locate_files, read_file, register_lock_cleanup_signal_handlers, write_file
 from easybuild.tools.github import check_github, close_pr, find_easybuild_easyconfig
 from easybuild.tools.github import add_pr_labels, install_github_token, list_prs, merge_pr, new_branch_github, new_pr
-from easybuild.tools.github import new_pr_from_branch
+from easybuild.tools.github import new_pr_from_branch, summarize_prs
 from easybuild.tools.github import sync_branch_with_develop, sync_pr_with_develop, update_branch, update_pr
 from easybuild.tools.hooks import START, END, load_hooks, run_hook
 from easybuild.tools.modules import modules_tool
@@ -644,6 +644,9 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     elif options.list_prs:
         print(list_prs(options.list_prs))
 
+    elif options.summarize_prs:
+        print(summarize_prs(options.summarize_prs))
+
     elif options.merge_pr:
         merge_pr(options.merge_pr)
 
@@ -680,6 +683,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
         options.list_prs,
         options.merge_pr,
         options.review_pr,
+        options.summarize_prs,
         options.terse,
         search_query,
     ]

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -95,6 +95,7 @@ GITHUB_EASYCONFIGS_REPO = 'easybuild-easyconfigs'
 GITHUB_FRAMEWORK_REPO = 'easybuild-framework'
 GITHUB_DEVELOP_BRANCH = 'develop'
 GITHUB_FILE_TYPE = u'file'
+GITHUB_PR_GROUPS = ['author', 'labels']
 GITHUB_PR_STATE_OPEN = 'open'
 GITHUB_PR_STATES = [GITHUB_PR_STATE_OPEN, 'closed', 'all']
 GITHUB_PR_ORDER_CREATED = 'created'
@@ -1414,6 +1415,50 @@ def list_prs(params, per_page=GITHUB_MAX_PER_PAGE, github_user=None):
     lines = []
     for pr in pr_data:
         lines.append("PR #%s: %s" % (pr['number'], pr['title']))
+
+    return '\n'.join(lines)
+
+
+def summarize_prs(params, per_page=GITHUB_MAX_PER_PAGE, github_user=None):
+    """
+    Summarize pull requests according to specified selection/order parameters
+
+    :param params: 4-tuple with selection parameters for PRs (<group>, <state>, <sort>, <direction>),
+                   group is one of GITHUB_PR_GROUPS, for the rest see
+                   see https://developer.github.com/v3/pulls/#parameters
+    """
+    group_by = params[0]
+
+    parameters = {
+        'state': params[1],
+        'sort': params[2],
+        'direction': 'asc',  # params[3],
+        'per_page': per_page,
+    }
+    print_msg("Summarizing PRs with parameters: %s" % ', '.join(k + '=' + str(parameters[k])
+                                                                for k in sorted(parameters)))
+
+    pr_target_account = build_option('pr_target_account')
+    pr_target_repo = build_option('pr_target_repo') or GITHUB_EASYCONFIGS_REPO
+
+    pr_data, _ = fetch_pr_data(None, pr_target_account, pr_target_repo, github_user, **parameters)
+
+    summary = {}
+    for pr in pr_data:
+        if group_by == 'author':
+            groups = [pr['user']['login']]
+        elif group_by == 'labels':
+            groups = [label['name'] for label in pr['labels']]
+        else:
+            groups = [pr[group_by]]
+
+        for group in groups:
+            if group not in summary:
+                summary[group] = 1
+            else:
+                summary[group] += 1
+
+    lines = ["%s: %s" % (key, count) for key, count in sorted(summary.items(), key=lambda kv: kv[1], reverse=True)]
 
     return '\n'.join(lines)
 


### PR DESCRIPTION
This would require pagination (https://github.com/easybuilders/easybuild-framework/pull/2776) to do properly, but as it is it will summarize the oldest 100 open PRs by author or label, e.g.

```bash
$ eb --summarize-prs
== Summarizing PRs with parameters: direction=asc, per_page=100, sort=created, state=open
boegel: 18
jordiblasco: 7
lexming: 6
henkela: 6
verdurin: 5
SimonPinches: 5
mboisson: 4
fizwit: 4
JackPerdue: 3
ekieffer: 3
akesandgren: 3
smoors: 2
Flamefire: 2
rtripath89: 2
orbsmiv: 2
HPC-UniOldenburg: 2
bartoldeman: 2
zao: 1
cmeesters: 1
tardigradus: 1
alirezaghavaminia: 1
edmondac: 1
vanzod: 1
gppezzi: 1
rokzitko: 1
DininduSenanayake: 1
schulkov: 1
seb45tian: 1
jedokaplan: 1
gmatteo: 1
levlafayette: 1
DinaMah: 1
Darkless012: 1
tstrempel: 1
casio888: 1
guacke: 1
rsdmse: 1
timeu: 1
Micket: 1
ghferrari: 1
asoete: 1
```

```bash
$ eb --summarize-prs=labels
== Summarizing PRs with parameters: direction=asc, per_page=100, sort=created, state=open
update: 34
new: 33
enhancement: 6
bug fix: 3
change: 3
code cleanup: 1
python3: 1
```

My motivation was that this may help prioritize which open PRs to work on, e.g. the ones of specific authors when we know they are available to work on request for changes, for instance, or specific types (labels) of PRs.

Also, I guess this is generic enough that there are already ways of getting this information from any github repo and I just don't know about them, but this may allow us to look for other things specific to the easyconfigs repo?

In summary, FWIW.