### PR TITLE
add support for --list-software --output-format=json

### DIFF
--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -39,6 +39,7 @@ Authors:
 import copy
 import inspect
 import os
+import json
 from easybuild.tools import LooseVersion
 
 from easybuild.base import fancylogger
@@ -75,6 +76,7 @@ SIMPLE = 'simple'
 FORMAT_MD = 'md'
 FORMAT_RST = 'rst'
 FORMAT_TXT = 'txt'
+FORMAT_JSON = 'json'
 
 
 def generate_doc(name, params):
@@ -1022,6 +1024,34 @@ def list_software_txt(software, detailed=False):
             lines.append('')
 
     return '\n'.join(lines)
+
+
+def list_software_json(software, detailed=False):
+    """
+    Return overview of supported software in json
+
+    :param software: software information (strucuted like list_software does)
+    :param detailed: whether or not to return detailed information (incl. version, versionsuffix, toolchain info)
+    :return: multi-line string presenting requested info
+    """
+    lines = ['[']
+    for key in sorted(software, key=lambda x: x.lower()):
+        for tmp in software[key]:
+            if detailed:
+                # deep copy here to avoid modifying the original dict
+                x = copy.deepcopy(tmp)
+                x['description'] = x['description'].split('\n')[0].strip()
+            else:
+                x = {}
+            x['name'] = key
+
+            lines.append(json.dumps(x, indent=4) + ",")
+            if detailed:
+                break
+    # remove last comma
+    if len(lines) > 1:
+        lines[-1] = lines[-1][:-1]
+    return '\n'.join(lines) + '\n]'
 
 
 def list_toolchains(output_format=FORMAT_TXT):

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -1074,7 +1074,7 @@ def list_software_json(software, detailed=False):
                 x = {}
             x['name'] = key
 
-            lines.append(json.dumps(x, indent=4, separators=(',', ': ')) + ",")
+            lines.append(json.dumps(x, indent=4, sort_keys=True, separators=(',', ': ')) + ",")
             if not detailed:
                 break
     # remove last line last comma

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -1046,9 +1046,9 @@ def list_software_json(software, detailed=False):
             x['name'] = key
 
             lines.append(json.dumps(x, indent=4) + ",")
-            if detailed:
+            if not detailed:
                 break
-    # remove last comma
+    # remove last line last comma
     if len(lines) > 1:
         lines[-1] = lines[-1][:-1]
     return '\n'.join(lines) + '\n]'

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -117,6 +117,11 @@ def avail_cfgfile_constants(go_cfg_constants, output_format=FORMAT_TXT):
     return generate_doc('avail_cfgfile_constants_%s' % output_format, [go_cfg_constants])
 
 
+def avail_cfgfile_constants_json(go_cfg_constants):
+    """Generate documentation on constants for configuration files in json format"""
+    raise NotImplementedError("JSON output format not supported for avail_cfgfile_constants_json")
+
+
 def avail_cfgfile_constants_txt(go_cfg_constants):
     """Generate documentation on constants for configuration files in txt format"""
     doc = [
@@ -186,6 +191,11 @@ def avail_easyconfig_constants(output_format=FORMAT_TXT):
     return generate_doc('avail_easyconfig_constants_%s' % output_format, [])
 
 
+def avail_easyconfig_constants_json():
+    """Generate easyconfig constant documentation in json format"""
+    raise NotImplementedError("JSON output format not supported for avail_easyconfig_constants_json")
+
+
 def avail_easyconfig_constants_txt():
     """Generate easyconfig constant documentation in txt format"""
     doc = ["Constants that can be used in easyconfigs"]
@@ -242,6 +252,11 @@ def avail_easyconfig_constants_md():
 def avail_easyconfig_licenses(output_format=FORMAT_TXT):
     """Generate the easyconfig licenses documentation"""
     return generate_doc('avail_easyconfig_licenses_%s' % output_format, [])
+
+
+def avail_easyconfig_licenses_json():
+    """Generate easyconfig license documentation in json format"""
+    raise NotImplementedError("JSON output format not supported for avail_easyconfig_licenses_json")
 
 
 def avail_easyconfig_licenses_txt():
@@ -356,6 +371,13 @@ def avail_easyconfig_params_rst(title, grouped_params):
     return '\n'.join(doc)
 
 
+def avail_easyconfig_params_json():
+    """
+    Compose overview of available easyconfig parameters, in json format.
+    """
+    raise NotImplementedError("JSON output format not supported for avail_easyconfig_params_json")
+
+
 def avail_easyconfig_params_txt(title, grouped_params):
     """
     Compose overview of available easyconfig parameters, in plain text format.
@@ -426,6 +448,11 @@ def avail_easyconfig_params(easyblock, output_format=FORMAT_TXT):
 def avail_easyconfig_templates(output_format=FORMAT_TXT):
     """Generate the templating documentation"""
     return generate_doc('avail_easyconfig_templates_%s' % output_format, [])
+
+
+def avail_easyconfig_templates_json():
+    """ Returns template documentation in json text format """
+    raise NotImplementedError("JSON output format not supported for avail_easyconfig_templates")
 
 
 def avail_easyconfig_templates_txt():
@@ -642,6 +669,8 @@ def avail_classes_tree(classes, class_names, locations, detailed, format_strings
 
 
 def list_easyblocks(list_easyblocks=SIMPLE, output_format=FORMAT_TXT):
+    if output_format == FORMAT_JSON:
+        raise NotImplementedError("JSON output format not supported for list_easyblocks")
     format_strings = {
         FORMAT_MD: {
             'det_root_templ': "- **%s** (%s%s)",
@@ -1202,6 +1231,10 @@ def list_toolchains_txt(tcs):
 
     return '\n'.join(doc)
 
+def list_toolchains_json(tcs):
+    """ Returns overview of all toolchains in json format """
+    raise NotImplementedError("JSON output not implemented yet for --list-toolchains")
+
 
 def avail_toolchain_opts(name, output_format=FORMAT_TXT):
     """Show list of known options for given toolchain."""
@@ -1256,6 +1289,11 @@ def avail_toolchain_opts_rst(name, tc_dict):
     return '\n'.join(doc)
 
 
+def avail_toolchain_opts_json(name, tc_dict):
+    """ Returns overview of toolchain options in jsonformat """
+    raise NotImplementedError("JSON output not implemented yet for --avail-toolchain-opts")
+
+
 def avail_toolchain_opts_txt(name, tc_dict):
     """ Returns overview of toolchain options in txt format """
     doc = ["Available options for %s toolchain:" % name]
@@ -1281,6 +1319,11 @@ def get_easyblock_classes(package_name):
 
     return easyblocks
 
+def gen_easyblocks_overview_json(package_name, path_to_examples, common_params=None, doc_functions=None):
+    """
+    Compose overview of all easyblocks in the given package in json format
+    """
+    raise NotImplementedError("JSON output not implemented yet for gen_easyblocks_overview")
 
 def gen_easyblocks_overview_md(package_name, path_to_examples, common_params=None, doc_functions=None):
     """

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -38,8 +38,8 @@ Authors:
 """
 import copy
 import inspect
-import os
 import json
+import os
 from easybuild.tools import LooseVersion
 
 from easybuild.base import fancylogger
@@ -73,10 +73,10 @@ _log = fancylogger.getLogger('tools.docs')
 DETAILED = 'detailed'
 SIMPLE = 'simple'
 
+FORMAT_JSON = 'json'
 FORMAT_MD = 'md'
 FORMAT_RST = 'rst'
 FORMAT_TXT = 'txt'
-FORMAT_JSON = 'json'
 
 
 def generate_doc(name, params):
@@ -1065,22 +1065,26 @@ def list_software_json(software, detailed=False):
     """
     lines = ['[']
     for key in sorted(software, key=lambda x: x.lower()):
-        for tmp in software[key]:
+        for entry in software[key]:
             if detailed:
                 # deep copy here to avoid modifying the original dict
-                x = copy.deepcopy(tmp)
-                x['description'] = ' '.join(x['description'].split('\n')).strip()
+                entry = copy.deepcopy(entry)
+                entry['description'] = ' '.join(entry['description'].split('\n')).strip()
             else:
-                x = {}
-            x['name'] = key
+                entry = {}
+            entry['name'] = key
 
-            lines.append(json.dumps(x, indent=4, sort_keys=True, separators=(',', ': ')) + ",")
+            lines.append(json.dumps(entry, indent=4, sort_keys=True, separators=(',', ': ')) + ",")
             if not detailed:
                 break
-    # remove last line last comma
+
+    # remove trailing comma on last line
     if len(lines) > 1:
-        lines[-1] = lines[-1][:-1]
-    return '\n'.join(lines) + '\n]'
+        lines[-1] = lines[-1].rstrip(',')
+
+    lines.append(']')
+
+    return '\n'.join(lines)
 
 
 def list_toolchains(output_format=FORMAT_TXT):

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -1074,7 +1074,7 @@ def list_software_json(software, detailed=False):
                 x = {}
             x['name'] = key
 
-            lines.append(json.dumps(x, indent=4) + ",")
+            lines.append(json.dumps(x, indent=4, separators=(',', ': ')) + ",")
             if not detailed:
                 break
     # remove last line last comma

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -1231,6 +1231,7 @@ def list_toolchains_txt(tcs):
 
     return '\n'.join(doc)
 
+
 def list_toolchains_json(tcs):
     """ Returns overview of all toolchains in json format """
     raise NotImplementedError("JSON output not implemented yet for --list-toolchains")
@@ -1319,11 +1320,13 @@ def get_easyblock_classes(package_name):
 
     return easyblocks
 
+
 def gen_easyblocks_overview_json(package_name, path_to_examples, common_params=None, doc_functions=None):
     """
     Compose overview of all easyblocks in the given package in json format
     """
     raise NotImplementedError("JSON output not implemented yet for gen_easyblocks_overview")
+
 
 def gen_easyblocks_overview_md(package_name, path_to_examples, common_params=None, doc_functions=None):
     """

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -1040,7 +1040,7 @@ def list_software_json(software, detailed=False):
             if detailed:
                 # deep copy here to avoid modifying the original dict
                 x = copy.deepcopy(tmp)
-                x['description'] = x['description'].split('\n')[0].strip()
+                x['description'] = ' '.join(x['description'].split('\n')).strip()
             else:
                 x = {}
             x['name'] = key

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -469,7 +469,8 @@ class EasyBuildOptions(GeneralOption):
             'mpi-tests': ("Run MPI tests (when relevant)", None, 'store_true', True),
             'optarch': ("Set architecture optimization, overriding native architecture optimizations",
                         None, 'store', None),
-            'output-format': ("Set output format", 'choice', 'store', FORMAT_TXT, [FORMAT_MD, FORMAT_RST, FORMAT_TXT, FORMAT_JSON]),
+            'output-format': ("Set output format", 'choice', 'store', FORMAT_TXT, 
+                              [FORMAT_MD, FORMAT_RST, FORMAT_TXT, FORMAT_JSON]),
             'output-style': ("Control output style; auto implies using Rich if available to produce rich output, "
                              "with fallback to basic colored output",
                              'choice', 'store', OUTPUT_STYLE_AUTO, OUTPUT_STYLES),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -79,7 +79,7 @@ from easybuild.tools.config import OUTPUT_STYLE_AUTO, OUTPUT_STYLES, WARN
 from easybuild.tools.config import get_pretend_installpath, init, init_build_options, mk_full_default_path
 from easybuild.tools.config import BuildOptions, ConfigurationVariables
 from easybuild.tools.configobj import ConfigObj, ConfigObjError
-from easybuild.tools.docs import FORMAT_MD, FORMAT_RST, FORMAT_TXT, FORMAT_JSON
+from easybuild.tools.docs import FORMAT_JSON, FORMAT_MD, FORMAT_RST, FORMAT_TXT
 from easybuild.tools.docs import avail_cfgfile_constants, avail_easyconfig_constants, avail_easyconfig_licenses
 from easybuild.tools.docs import avail_toolchain_opts, avail_easyconfig_params, avail_easyconfig_templates
 from easybuild.tools.docs import list_easyblocks, list_toolchains
@@ -470,7 +470,7 @@ class EasyBuildOptions(GeneralOption):
             'optarch': ("Set architecture optimization, overriding native architecture optimizations",
                         None, 'store', None),
             'output-format': ("Set output format", 'choice', 'store', FORMAT_TXT,
-                              [FORMAT_MD, FORMAT_RST, FORMAT_TXT, FORMAT_JSON]),
+                              [FORMAT_JSON, FORMAT_MD, FORMAT_RST, FORMAT_TXT]),
             'output-style': ("Control output style; auto implies using Rich if available to produce rich output, "
                              "with fallback to basic colored output",
                              'choice', 'store', OUTPUT_STYLE_AUTO, OUTPUT_STYLES),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -79,7 +79,7 @@ from easybuild.tools.config import OUTPUT_STYLE_AUTO, OUTPUT_STYLES, WARN
 from easybuild.tools.config import get_pretend_installpath, init, init_build_options, mk_full_default_path
 from easybuild.tools.config import BuildOptions, ConfigurationVariables
 from easybuild.tools.configobj import ConfigObj, ConfigObjError
-from easybuild.tools.docs import FORMAT_MD, FORMAT_RST, FORMAT_TXT
+from easybuild.tools.docs import FORMAT_MD, FORMAT_RST, FORMAT_TXT, FORMAT_JSON
 from easybuild.tools.docs import avail_cfgfile_constants, avail_easyconfig_constants, avail_easyconfig_licenses
 from easybuild.tools.docs import avail_toolchain_opts, avail_easyconfig_params, avail_easyconfig_templates
 from easybuild.tools.docs import list_easyblocks, list_toolchains
@@ -469,7 +469,7 @@ class EasyBuildOptions(GeneralOption):
             'mpi-tests': ("Run MPI tests (when relevant)", None, 'store_true', True),
             'optarch': ("Set architecture optimization, overriding native architecture optimizations",
                         None, 'store', None),
-            'output-format': ("Set output format", 'choice', 'store', FORMAT_TXT, [FORMAT_MD, FORMAT_RST, FORMAT_TXT]),
+            'output-format': ("Set output format", 'choice', 'store', FORMAT_TXT, [FORMAT_MD, FORMAT_RST, FORMAT_TXT, FORMAT_JSON]),
             'output-style': ("Control output style; auto implies using Rich if available to produce rich output, "
                              "with fallback to basic colored output",
                              'choice', 'store', OUTPUT_STYLE_AUTO, OUTPUT_STYLES),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -469,7 +469,7 @@ class EasyBuildOptions(GeneralOption):
             'mpi-tests': ("Run MPI tests (when relevant)", None, 'store_true', True),
             'optarch': ("Set architecture optimization, overriding native architecture optimizations",
                         None, 'store', None),
-            'output-format': ("Set output format", 'choice', 'store', FORMAT_TXT, 
+            'output-format': ("Set output format", 'choice', 'store', FORMAT_TXT,
                               [FORMAT_MD, FORMAT_RST, FORMAT_TXT, FORMAT_JSON]),
             'output-style': ("Control output style; auto implies using Rich if available to produce rich output, "
                              "with fallback to basic colored output",

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -639,6 +639,9 @@ class DocsTest(EnhancedTestCase):
         regex = re.compile(r"^``GPLv3``\s*|The GNU General Public License", re.M)
         self.assertTrue(regex.search(lic_docs), "%s found in: %s" % (regex.pattern, lic_docs))
 
+        # expect NotImplementedError for JSON output
+        self.assertRaises(NotImplementedError, avail_easyconfig_licenses, output_format='json')
+
     def test_list_easyblocks(self):
         """
         Tests for list_easyblocks function
@@ -666,6 +669,9 @@ class DocsTest(EnhancedTestCase):
 
         txt = list_easyblocks(list_easyblocks='detailed', output_format='md')
         self.assertEqual(txt, LIST_EASYBLOCKS_DETAILED_MD % {'topdir': topdir_easyblocks})
+
+        # expect NotImplementedError for JSON output
+        self.assertRaises(NotImplementedError, list_easyblocks, output_format='json')
 
     def test_list_software(self):
         """Test list_software* functions."""
@@ -791,6 +797,10 @@ class DocsTest(EnhancedTestCase):
             regex = re.compile(pattern, re.M)
             self.assertTrue(regex.search(txt_rst), "Pattern '%s' should be found in: %s" % (regex.pattern, txt_rst))
 
+        # expect NotImplementedError for json output format
+        with self.assertRaises(NotImplementedError):
+            list_toolchains(output_format='json')
+
     def test_avail_cfgfile_constants(self):
         """
         Test avail_cfgfile_constants to generate overview of constants that can be used in a configuration file.
@@ -835,6 +845,10 @@ class DocsTest(EnhancedTestCase):
             regex = re.compile(pattern, re.M)
             self.assertTrue(regex.search(txt_rst), "Pattern '%s' should be found in: %s" % (regex.pattern, txt_rst))
 
+        # expect NotImplementedError for json output format
+        with self.assertRaises(NotImplementedError):
+            avail_cfgfile_constants(option_parser.go_cfg_constants, output_format='json')
+
     def test_avail_easyconfig_constants(self):
         """
         Test avail_easyconfig_constants to generate overview of constants that can be used in easyconfig files.
@@ -877,6 +891,10 @@ class DocsTest(EnhancedTestCase):
         for pattern in rst_patterns:
             regex = re.compile(pattern, re.M)
             self.assertTrue(regex.search(txt_rst), "Pattern '%s' should be found in: %s" % (regex.pattern, txt_rst))
+
+        # expect NotImplementedError for json output format
+        with self.assertRaises(NotImplementedError):
+            avail_easyconfig_constants(output_format='json')
 
     def test_avail_easyconfig_templates(self):
         """
@@ -927,6 +945,10 @@ class DocsTest(EnhancedTestCase):
         for pattern in rst_patterns:
             regex = re.compile(pattern, re.M)
             self.assertTrue(regex.search(txt_rst), "Pattern '%s' should be found in: %s" % (regex.pattern, txt_rst))
+
+        # expect NotImplementedError for json output format
+        with self.assertRaises(NotImplementedError):
+            avail_easyconfig_templates(output_format='json')
 
     def test_avail_toolchain_opts(self):
         """
@@ -1011,6 +1033,12 @@ class DocsTest(EnhancedTestCase):
         for pattern in rst_patterns_intel:
             regex = re.compile(pattern, re.M)
             self.assertTrue(regex.search(txt_rst), "Pattern '%s' should be found in: %s" % (regex.pattern, txt_rst))
+
+        # expect NotImplementedError for json output format
+        with self.assertRaises(NotImplementedError):
+            avail_toolchain_opts('foss', output_format='json')
+        with self.assertRaises(NotImplementedError):
+            avail_toolchain_opts('intel', output_format='json')
 
     def test_mk_table(self):
         """

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -417,8 +417,6 @@ EasyBuild supports 2 different software packages (incl. toolchains, bundles):
 * GCC
 * gzip"""
 
-
-
 LIST_SOFTWARE_DETAILED_MD = """# List of supported software
 
 EasyBuild supports 2 different software packages (incl. toolchains, bundles):

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -462,43 +462,43 @@ LIST_SOFTWARE_SIMPLE_JSON = """[
 
 LIST_SOFTWARE_DETAILED_JSON = """[
 {
-    "toolchain": "system", 
-    "description": "%(gcc_descr)s", 
-    "homepage": "http://gcc.gnu.org/", 
-    "version": "4.6.3", 
-    "versionsuffix": "", 
+    "toolchain": "system",
+    "description": "%(gcc_descr)s",
+    "homepage": "http://gcc.gnu.org/",
+    "version": "4.6.3",
+    "versionsuffix": "",
     "name": "GCC"
 },
 {
-    "toolchain": "GCC/4.6.3", 
-    "description": "%(gzip_descr)s", 
-    "homepage": "http://www.gzip.org/", 
-    "version": "1.4", 
-    "versionsuffix": "", 
+    "toolchain": "GCC/4.6.3",
+    "description": "%(gzip_descr)s",
+    "homepage": "http://www.gzip.org/",
+    "version": "1.4",
+    "versionsuffix": "",
     "name": "gzip"
 },
 {
-    "toolchain": "system", 
-    "description": "%(gzip_descr)s", 
-    "homepage": "http://www.gzip.org/", 
-    "version": "1.4", 
-    "versionsuffix": "", 
+    "toolchain": "system",
+    "description": "%(gzip_descr)s",
+    "homepage": "http://www.gzip.org/",
+    "version": "1.4",
+    "versionsuffix": "",
     "name": "gzip"
 },
 {
-    "toolchain": "foss/2018a", 
-    "description": "%(gzip_descr)s", 
-    "homepage": "http://www.gzip.org/", 
-    "version": "1.5", 
-    "versionsuffix": "", 
+    "toolchain": "foss/2018a",
+    "description": "%(gzip_descr)s",
+    "homepage": "http://www.gzip.org/",
+    "version": "1.5",
+    "versionsuffix": "",
     "name": "gzip"
 },
 {
-    "toolchain": "intel/2018a", 
-    "description": "%(gzip_descr)s", 
-    "homepage": "http://www.gzip.org/", 
-    "version": "1.5", 
-    "versionsuffix": "", 
+    "toolchain": "intel/2018a",
+    "description": "%(gzip_descr)s",
+    "homepage": "http://www.gzip.org/",
+    "version": "1.5",
+    "versionsuffix": "",
     "name": "gzip"
 }
 ]""" % {'gcc_descr': GCC_DESCR, 'gzip_descr': GZIP_DESCR}

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -457,15 +457,6 @@ LIST_SOFTWARE_SIMPLE_JSON = """[
 },
 {
     "name": "gzip"
-},
-{
-    "name": "gzip"
-},
-{
-    "name": "gzip"
-},
-{
-    "name": "gzip"
 }
 ]"""
 
@@ -483,6 +474,30 @@ LIST_SOFTWARE_DETAILED_JSON = """[
     "description": "%(gzip_descr)s",
     "homepage": "http://www.gzip.org/",
     "version": "1.4",
+    "versionsuffix": "",
+    "name": "gzip"
+},
+{
+    "toolchain": "system",
+    "description": "%(gzip_descr)s",
+    "homepage": "http://www.gzip.org/",
+    "version": "1.4",
+    "versionsuffix": "",
+    "name": "gzip"
+},
+{
+    "toolchain": "foss/2018a",
+    "description": "%(gzip_descr)s",
+    "homepage": "http://www.gzip.org/",
+    "version": "1.5",
+    "versionsuffix": "",
+    "name": "gzip"
+},
+{
+    "toolchain": "intel/2018a",
+    "description": "%(gzip_descr)s",
+    "homepage": "http://www.gzip.org/",
+    "version": "1.5",
     "versionsuffix": "",
     "name": "gzip"
 }

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -405,6 +405,91 @@ version|toolchain
 ``1.4``|``GCC/4.6.3``, ``system``
 ``1.5``|``foss/2018a``, ``intel/2018a``""" % {'gcc_descr': GCC_DESCR, 'gzip_descr': GZIP_DESCR}
 
+LIST_SOFTWARE_SIMPLE_MD = """# List of supported software
+
+EasyBuild supports 2 different software packages (incl. toolchains, bundles):
+
+[g](#g)
+
+
+## G
+
+* GCC
+* gzip"""
+
+
+
+LIST_SOFTWARE_DETAILED_MD = """# List of supported software
+
+EasyBuild supports 2 different software packages (incl. toolchains, bundles):
+
+[g](#g)
+
+
+## G
+
+
+[GCC](#gcc) - [gzip](#gzip)
+
+
+### GCC
+
+%(gcc_descr)s
+
+*homepage*: <http://gcc.gnu.org/>
+
+version  |toolchain
+---------|----------
+``4.6.3``|``system``
+
+### gzip
+
+%(gzip_descr)s
+
+*homepage*: <http://www.gzip.org/>
+
+version|toolchain
+-------|-------------------------------
+``1.4``|``GCC/4.6.3``, ``system``
+``1.5``|``foss/2018a``, ``intel/2018a``""" % {'gcc_descr': GCC_DESCR, 'gzip_descr': GZIP_DESCR}
+
+LIST_SOFTWARE_SIMPLE_JSON = """[
+{
+    "name": "GCC"
+},
+{
+    "name": "gzip"
+},
+{
+    "name": "gzip"
+},
+{
+    "name": "gzip"
+},
+{
+    "name": "gzip"
+}
+]"""
+
+LIST_SOFTWARE_DETAILED_JSON = """[
+{
+    "toolchain": "system",
+    "description": "%(gcc_descr)s",
+    "homepage": "http://gcc.gnu.org/",
+    "version": "4.6.3",
+    "versionsuffix": "",
+    "name": "GCC"
+},
+{
+    "toolchain": "GCC/4.6.3",
+    "description": "%(gzip_descr)s",
+    "homepage": "http://www.gzip.org/",
+    "version": "1.4",
+    "versionsuffix": "",
+    "name": "gzip"
+}
+]""" % {'gcc_descr': GCC_DESCR, 'gzip_descr': GZIP_DESCR}
+
 
 class DocsTest(EnhancedTestCase):
 
@@ -586,6 +671,9 @@ class DocsTest(EnhancedTestCase):
 
         self.assertEqual(list_software(output_format='md'), LIST_SOFTWARE_SIMPLE_MD)
         self.assertEqual(list_software(output_format='md', detailed=True), LIST_SOFTWARE_DETAILED_MD)
+
+        self.assertEqual(list_software(output_format='json'), LIST_SOFTWARE_SIMPLE_JSON)
+        self.assertEqual(list_software(output_format='json', detailed=True), LIST_SOFTWARE_DETAILED_JSON)
 
         # GCC/4.6.3 is installed, no gzip module installed
         txt = list_software(output_format='txt', detailed=True, only_installed=True)

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -462,43 +462,43 @@ LIST_SOFTWARE_SIMPLE_JSON = """[
 
 LIST_SOFTWARE_DETAILED_JSON = """[
 {
-    "toolchain": "system",
-    "description": "%(gcc_descr)s",
-    "homepage": "http://gcc.gnu.org/",
-    "version": "4.6.3",
-    "versionsuffix": "",
+    "toolchain": "system", 
+    "description": "%(gcc_descr)s", 
+    "homepage": "http://gcc.gnu.org/", 
+    "version": "4.6.3", 
+    "versionsuffix": "", 
     "name": "GCC"
 },
 {
-    "toolchain": "GCC/4.6.3",
-    "description": "%(gzip_descr)s",
-    "homepage": "http://www.gzip.org/",
-    "version": "1.4",
-    "versionsuffix": "",
+    "toolchain": "GCC/4.6.3", 
+    "description": "%(gzip_descr)s", 
+    "homepage": "http://www.gzip.org/", 
+    "version": "1.4", 
+    "versionsuffix": "", 
     "name": "gzip"
 },
 {
-    "toolchain": "system",
-    "description": "%(gzip_descr)s",
-    "homepage": "http://www.gzip.org/",
-    "version": "1.4",
-    "versionsuffix": "",
+    "toolchain": "system", 
+    "description": "%(gzip_descr)s", 
+    "homepage": "http://www.gzip.org/", 
+    "version": "1.4", 
+    "versionsuffix": "", 
     "name": "gzip"
 },
 {
-    "toolchain": "foss/2018a",
-    "description": "%(gzip_descr)s",
-    "homepage": "http://www.gzip.org/",
-    "version": "1.5",
-    "versionsuffix": "",
+    "toolchain": "foss/2018a", 
+    "description": "%(gzip_descr)s", 
+    "homepage": "http://www.gzip.org/", 
+    "version": "1.5", 
+    "versionsuffix": "", 
     "name": "gzip"
 },
 {
-    "toolchain": "intel/2018a",
-    "description": "%(gzip_descr)s",
-    "homepage": "http://www.gzip.org/",
-    "version": "1.5",
-    "versionsuffix": "",
+    "toolchain": "intel/2018a", 
+    "description": "%(gzip_descr)s", 
+    "homepage": "http://www.gzip.org/", 
+    "version": "1.5", 
+    "versionsuffix": "", 
     "name": "gzip"
 }
 ]""" % {'gcc_descr': GCC_DESCR, 'gzip_descr': GZIP_DESCR}

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -462,44 +462,44 @@ LIST_SOFTWARE_SIMPLE_JSON = """[
 
 LIST_SOFTWARE_DETAILED_JSON = """[
 {
-    "toolchain": "system",
     "description": "%(gcc_descr)s",
     "homepage": "http://gcc.gnu.org/",
-    "version": "4.6.3",
-    "versionsuffix": "",
-    "name": "GCC"
-},
-{
-    "toolchain": "GCC/4.6.3",
-    "description": "%(gzip_descr)s",
-    "homepage": "http://www.gzip.org/",
-    "version": "1.4",
-    "versionsuffix": "",
-    "name": "gzip"
-},
-{
+    "name": "GCC",
     "toolchain": "system",
+    "version": "4.6.3",
+    "versionsuffix": ""
+},
+{
     "description": "%(gzip_descr)s",
     "homepage": "http://www.gzip.org/",
+    "name": "gzip",
+    "toolchain": "GCC/4.6.3",
     "version": "1.4",
-    "versionsuffix": "",
-    "name": "gzip"
+    "versionsuffix": ""
 },
 {
+    "description": "%(gzip_descr)s",
+    "homepage": "http://www.gzip.org/",
+    "name": "gzip",
+    "toolchain": "system",
+    "version": "1.4",
+    "versionsuffix": ""
+},
+{
+    "description": "%(gzip_descr)s",
+    "homepage": "http://www.gzip.org/",
+    "name": "gzip",
     "toolchain": "foss/2018a",
-    "description": "%(gzip_descr)s",
-    "homepage": "http://www.gzip.org/",
     "version": "1.5",
-    "versionsuffix": "",
-    "name": "gzip"
+    "versionsuffix": ""
 },
 {
-    "toolchain": "intel/2018a",
     "description": "%(gzip_descr)s",
     "homepage": "http://www.gzip.org/",
+    "name": "gzip",
+    "toolchain": "intel/2018a",
     "version": "1.5",
-    "versionsuffix": "",
-    "name": "gzip"
+    "versionsuffix": ""
 }
 ]""" % {'gcc_descr': GCC_DESCR, 'gzip_descr': GZIP_DESCR}
 


### PR DESCRIPTION
This could be a first step on getting easybuild on repology as described here:

* https://github.com/repology/repology-updater/issues/705

Next steps would be:

- [ ] handle name collisions
- [ ] serving the json to repology on some server/page (since they don't want to run third party software).

Possibly related:
* https://github.com/easybuilders/easybuild-framework/pull/1644

Please let me know, if the (estimated) effort to get easybuild on repology is worth it. 
The json format might be useful either way.

Cheers,
APN

- [x] eb --avail-cfgfile-constants --output-format json
- [x] eb --avail-easyconfig-constants --output-format json
- [x] eb --avail-easyconfig-licenses --output-format json
- [x] eb --avail-easyconfig-params --output-format json
- [x] eb --avail-easyconfig-templates --output-format json
- [x] eb --avail-toolchain-opts ... --output-format json
- [x] eb --list-easyblocks --output-format json
- [x] eb --list-software --output-format json
- [x] eb --list-toolchains --output-format json
~~- [ ] eb --help json~~
- [x] gen_easyblocks_overview_json