### PR TITLE
make vstring/version variables in LooseVersion read-only

### DIFF
--- a/easybuild/base/fancylogger.py
+++ b/easybuild/base/fancylogger.py
@@ -341,10 +341,7 @@ class FancyLogger(logging.getLoggerClass()):
         loose_cv = LooseVersion(cur_ver)
         loose_mv = LooseVersion(max_ver)
 
-        loose_cv.version = loose_cv.version[:depth]
-        loose_mv.version = loose_mv.version[:depth]
-
-        if loose_cv >= loose_mv:
+        if loose_cv.version[:depth] >= loose_mv.version[:depth]:
             self.raiseException("DEPRECATED (since v%s) functionality used: %s" % (max_ver, msg), exception=exception)
         else:
             deprecation_msg = "Deprecated functionality, will no longer work in v%s: %s" % (max_ver, msg)

--- a/easybuild/tools/loose_version.py
+++ b/easybuild/tools/loose_version.py
@@ -61,14 +61,6 @@ class LooseVersion(object):
 
     def _cmp(self, other):
         """Rich comparison method used by the operators below"""
-        # Comparison of a default/None-version is only equal if the other side is
-        # None or a None-version, otherwise the None-version is "less"
-        if self._vstring is None:
-            if other is None:
-                return 0
-            elif isinstance(other, LooseVersion) and other._vstring is None:
-                return 0
-            return -1
         if isinstance(other, str):
             other = LooseVersion(other)
 

--- a/easybuild/tools/loose_version.py
+++ b/easybuild/tools/loose_version.py
@@ -30,7 +30,7 @@ class LooseVersion(object):
     component_re = re.compile(r'(\d+ | [a-z]+ | \.)', re.VERBOSE)
 
     def __init__(self, vstring=None):
-        self.vstring = vstring
+        self._vstring = vstring
         if vstring:
             components = [x for x in self.component_re.split(vstring)
                           if x and x != '.']
@@ -39,18 +39,36 @@ class LooseVersion(object):
                     components[i] = int(obj)
                 except ValueError:
                     pass
-            self.version = components
+            self._version = components
         else:
-            self.version = None
+            self._version = None
+
+    @property
+    def vstring(self):
+        """Readonly access to the unparsed version(-string)"""
+        return self._vstring
+
+    @property
+    def version(self):
+        """Readonly access to the parsed version (list or None)"""
+        return self._version
 
     def __str__(self):
-        return self.vstring
+        return self._vstring
 
     def __repr__(self):
         return "LooseVersion ('%s')" % str(self)
 
     def _cmp(self, other):
         """Rich comparison method used by the operators below"""
+        # Comparison of a default/None-version is only equal if the other side is
+        # None or a None-version, otherwise the None-version is "less"
+        if self._vstring is None:
+            if other is None:
+                return 0
+            elif isinstance(other, LooseVersion) and other._vstring is None:
+                return 0
+            return -1
         if isinstance(other, str):
             other = LooseVersion(other)
 

--- a/test/framework/utilities_test.py
+++ b/test/framework/utilities_test.py
@@ -158,22 +158,25 @@ class UtilitiesTest(EnhancedTestCase):
             # vstring is the unparsed version
             self.assertEqual(LooseVersion(v1).vstring, v1)
 
+        # Default/None LooseVersion cannot be compared
         none_version = LooseVersion(None)
-        self.assertTrue(none_version == LooseVersion())
-        self.assertTrue(none_version == None)  # noqa: E711
-        self.assertTrue(None == none_version)  # noqa: E711
-        self.assertFalse(none_version == LooseVersion(''))
-        self.assertFalse(none_version == LooseVersion('1'))
-        self.assertTrue(none_version < LooseVersion(''))
-        self.assertTrue(none_version < LooseVersion('0'))
-        self.assertTrue(none_version < LooseVersion('1'))
-
+        self.assertErrorRegex(TypeError, '', lambda c: none_version == LooseVersion('1'))
+        self.assertErrorRegex(TypeError, '', lambda c: none_version < LooseVersion(''))
+        self.assertErrorRegex(TypeError, '', lambda c: none_version < LooseVersion('0'))
+        self.assertErrorRegex(TypeError, '', lambda c: none_version > LooseVersion(''))
+        self.assertErrorRegex(TypeError, '', lambda c: none_version > LooseVersion('0'))
+        self.assertErrorRegex(TypeError, '', lambda c: none_version == '1')
+        self.assertErrorRegex(TypeError, '', lambda c: none_version != '1')
+        self.assertErrorRegex(TypeError, '', lambda c: none_version < '1')
+        self.assertErrorRegex(TypeError, '', lambda c: none_version > '1')
+        # You can check for None .version or .vstring
         self.assertIsNone(none_version.version)
         self.assertIsNone(none_version.vstring)
         # version is the parsed version
         self.assertEqual(LooseVersion('2.5').version, [2, 5])
         self.assertEqual(LooseVersion('2.a.5').version, [2, 'a', 5])
         self.assertEqual(LooseVersion('2.a').version, [2, 'a'])
+        self.assertEqual(LooseVersion('2.a5').version, [2, 'a', 5])
 
 
 def suite():

--- a/test/framework/utilities_test.py
+++ b/test/framework/utilities_test.py
@@ -155,6 +155,25 @@ class UtilitiesTest(EnhancedTestCase):
             self.assertEqual(res, wanted,
                              'cmp(%s, %s) should be %s, got %s' %
                              (v1, v2, wanted, res))
+            # vstring is the unparsed version
+            self.assertEqual(LooseVersion(v1).vstring, v1)
+
+        none_version = LooseVersion(None)
+        self.assertTrue(none_version == LooseVersion())
+        self.assertTrue(none_version == None)  # noqa: E711
+        self.assertTrue(None == none_version)  # noqa: E711
+        self.assertFalse(none_version == LooseVersion(''))
+        self.assertFalse(none_version == LooseVersion('1'))
+        self.assertTrue(none_version < LooseVersion(''))
+        self.assertTrue(none_version < LooseVersion('0'))
+        self.assertTrue(none_version < LooseVersion('1'))
+
+        self.assertIsNone(none_version.version)
+        self.assertIsNone(none_version.vstring)
+        # version is the parsed version
+        self.assertEqual(LooseVersion('2.5').version, [2, 5])
+        self.assertEqual(LooseVersion('2.a.5').version, [2, 'a', 5])
+        self.assertEqual(LooseVersion('2.a').version, [2, 'a'])
 
 
 def suite():


### PR DESCRIPTION
The exposed "public" members `.version` and `.vstring` must not be modified from outside as they belong together. Hence put them into properties.

I was also thinking about the case of `LooseVersion(None)` which can easily happen with `LooseVersion(get_software_version('Bazel'))`. One approach was to compare that equal to `None` or `LooseVersion(None)` and "less" otherwise. But that might be surprising and hence better/safer is `if LooseVersion(...).version is None`

I hence added that to the test suite to show an example and kept my WIP commit in the history if we later decide otherwise.

@boegel This should go into the next release which adds this class.