### PR TITLE
add encoding comment in nvofbf.py to fix SyntaxError when using Python 2

### DIFF
--- a/easybuild/toolchains/nvofbf.py
+++ b/easybuild/toolchains/nvofbf.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 ##
 # Copyright 2013-2023 Ghent University
 #


### PR DESCRIPTION
(follow-up for #4157)

Without this, `eb --list-toolchains` is broken when running on top of Python 2 (and probably more):

```
$ python2 -m easybuild.main --list-toolchains
Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/arcanine/scratch/gent/vo/000/gvo00002/vsc40023/easybuild/easybuild-framework/easybuild/main.py", line 727, in <module>
    main()
  File "/arcanine/scratch/gent/vo/000/gvo00002/vsc40023/easybuild/easybuild-framework/easybuild/main.py", line 595, in main
    eb_go, cfg_settings = set_up_configuration(args=args, logfile=logfile, testing=testing)
  File "easybuild/tools/options.py", line 1531, in set_up_configuration
    eb_go = parse_options(args=args)
  File "easybuild/tools/options.py", line 1490, in parse_options
    with_include=with_include)
  File "easybuild/tools/options.py", line 249, in __init__
    super(EasyBuildOptions, self).__init__(*args, **kwargs)
  File "easybuild/base/generaloption.py", line 984, in __init__
    self.postprocess()
  File "easybuild/tools/options.py", line 935, in postprocess
    self._postprocess_list_avail()
  File "easybuild/tools/options.py", line 1220, in _postprocess_list_avail
    msg += list_toolchains(self.options.output_format)
  File "easybuild/tools/docs.py", line 1024, in list_toolchains
    _, all_tcs = search_toolchain('')
  File "/arcanine/scratch/gent/vo/000/gvo00002/vsc40023/easybuild/easybuild-framework/easybuild/tools/toolchain/utilities.py", line 68, in search_toolchain
    tc_modules = import_available_modules('easybuild.toolchains')
  File "easybuild/tools/utilities.py", line 152, in import_available_modules
    mod = __import__(modpath, globals(), locals(), [''])
  File "/arcanine/scratch/gent/vo/000/gvo00002/vsc40023/easybuild/easybuild-framework/easybuild/toolchains/nvofbf.py", line 28
SyntaxError: Non-ASCII character '\xc3' in file /arcanine/scratch/gent/vo/000/gvo00002/vsc40023/easybuild/easybuild-framework/easybuild/toolchains/nvofbf.py on line 29, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```

What's weird is that the test suite didn't catch this. It should have been caught by the `test__list_toolchains` test, but somehow that's not the case for the tests being run in GitHub Actions...

```
$ python2 -O -m test.framework.options  test__list_toolchains
Filtered CommandLineOptionsTest tests using 'test__list_toolchains', retained 1/135 tests: test__list_toolchains
E
======================================================================
ERROR: test__list_toolchains (__main__.CommandLineOptionsTest)
Test listing known compiler toolchains.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/arcanine/scratch/gent/vo/000/gvo00002/vsc40023/easybuild/easybuild-framework/test/framework/options.py", line 674, in test__list_toolchains
    self.eb_main(args, logfile=dummylogfn, raise_error=True)
  File "test/framework/utilities.py", line 341, in eb_main
    raise myerr
  File "/arcanine/scratch/gent/vo/000/gvo00002/vsc40023/easybuild/easybuild-framework/easybuild/toolchains/nvofbf.py", line 28
SyntaxError: Non-ASCII character '\xc3' in file /arcanine/scratch/gent/vo/000/gvo00002/vsc40023/easybuild/easybuild-framework/easybuild/toolchains/nvofbf.py on line 29, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details

----------------------------------------------------------------------
Ran 1 test in 0.143s

FAILED (errors=1)
```

(hat tip @migueldiascosta)