### PR TITLE
fix use of `locate` in `check_os_dependency`

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -873,9 +873,14 @@ def check_os_dependency(dep):
 
         # try locate if it's available
         if not found and which('locate'):
-            cmd = 'locate --regexp "/%s$"' % dep
-            found = run_cmd(cmd, simple=True, log_all=False, log_ok=False, force_in_dry_run=True, trace=False,
-                            stream_output=False)
+            cmd = 'locate -c --regexp "/%s$"' % dep
+            out, ec = run_cmd(cmd, simple=False, log_all=False, log_ok=False, force_in_dry_run=True, trace=False,
+                              stream_output=False)
+            try:
+                found = (ec == 0 and int(out.strip()) > 0)
+            except ValueError:
+                # Returned something else than an int -> Error
+                found = False
 
     return found
 


### PR DESCRIPTION
`locate` may not set an error exit code when it does not find a dependency so the function may wrongly succeed.
Use the `-c` option to get a number of matches and check that this is more than zero (and an integer) in addition to the exit code.

Fixes #4165