### PR TITLE
use better test assertions by replacing use of assertFalse/assertTrue

### DIFF
--- a/easybuild/base/testing.py
+++ b/easybuild/base/testing.py
@@ -157,7 +157,7 @@ class TestCase(OrigTestCase):
             call(*args, **kwargs)
             str_kwargs = ['='.join([k, str(v)]) for (k, v) in kwargs.items()]
             str_args = ', '.join(list(map(str, args)) + str_kwargs)
-            self.assertTrue(False, "Expected errors with %s(%s) call should occur" % (call.__name__, str_args))
+            self.fail("Expected errors with %s(%s) call should occur" % (call.__name__, str_args))
         except error as err:
             msg = self.convert_exception_to_str(err)
             if self.is_string(regex):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1559,8 +1559,8 @@ class EasyBlock(object):
                 paths = sum((glob.glob(path) if path else [path] for path in reqs), [])  # sum flattens to list
 
                 # If lib64 is just a symlink to lib we fixup the paths to avoid duplicates
-                lib64_is_symlink = (all(os.path.isdir(path) for path in ['lib', 'lib64'])
-                                    and os.path.samefile('lib', 'lib64'))
+                lib64_is_symlink = (all(os.path.isdir(path) for path in ['lib', 'lib64']) and
+                                    os.path.samefile('lib', 'lib64'))
                 if lib64_is_symlink:
                     fixed_paths = []
                     for path in paths:

--- a/easybuild/tools/configobj.py
+++ b/easybuild/tools/configobj.py
@@ -2034,8 +2034,8 @@ class ConfigObj(Section):
 
         # Turn the list to a string, joined with correct newlines
         newline = self.newlines or os.linesep
-        if (getattr(outfile, 'mode', None) is not None and outfile.mode == 'w'
-                and sys.platform == 'win32' and newline == '\r\n'):
+        if (getattr(outfile, 'mode', None) is not None and outfile.mode == 'w' and
+                sys.platform == 'win32' and newline == '\r\n'):
             # Windows specific hack to avoid writing '\r\r\n'
             newline = '\n'
         output = self._a_to_u(newline).join(out)

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -264,7 +264,7 @@ class BuildLogTest(EnhancedTestCase):
         expected = "\nWARNING: Test log message with a logger involved.\n\n"
         run_check(["Test log message with a logger involved."], expected_stderr=expected, log=logger)
         log_txt = read_file(tmp_logfile)
-        self.assertTrue("WARNING Test log message with a logger involved." in log_txt)
+        self.assertIn("WARNING Test log message with a logger involved.", log_txt)
 
     def test_print_error(self):
         """Test print_error"""

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -151,7 +151,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
         self.assertEqual(install_path(typ='mod'), os.path.join(install, 'modules'))
 
         self.assertEqual(options.installpath, install)
-        self.assertTrue(config_file in options.configfiles)
+        self.assertIn(config_file, options.configfiles)
 
         # check mixed command line/env var configuration
         prefix = os.path.join(self.tmpdir, 'test3')
@@ -362,7 +362,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
             'debug': False,
             'force': True
         })
-        self.assertTrue(not bo['debug'])
+        self.assertFalse(bo['debug'])
         self.assertTrue(bo['force'])
 
         # updating is impossible (methods are not even available)
@@ -618,7 +618,7 @@ class EasyBuildConfigTest(EnhancedTestCase):
             res = get_log_filename('foo', '1.2.3', date='19700101', timestamp='094651', add_salt=True)
             regex = re.compile(os.path.join(tmpdir, r'easybuild-foo-1\.2\.3-19700101\.094651\.[a-zA-Z]{5}\.log$'))
             self.assertTrue(regex.match(res), "Pattern '%s' matches '%s'" % (regex.pattern, res))
-            self.assertTrue(res not in prev_log_filenames)
+            self.assertNotIn(res, prev_log_filenames)
             prev_log_filenames.append(res)
 
     def test_log_file_format(self):

--- a/test/framework/containers.py
+++ b/test/framework/containers.py
@@ -212,7 +212,7 @@ class ContainersTest(EnhancedTestCase):
             self.assertTrue(txt.startswith(expected), "Container recipe starts with '%s':\n\n%s" % (expected, txt))
 
             # no OS packages are installed by default when starting from an existing image
-            self.assertFalse("yum install" in txt)
+            self.assertNotIn("yum install", txt)
 
             for pattern in pip_patterns + post_commands_patterns + [eb_pattern]:
                 regex = re.compile('^' + pattern, re.M)

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -465,7 +465,7 @@ class DocsTest(EnhancedTestCase):
             "====================    ================================================================",
         ])
 
-        self.assertTrue(check_configuremake in ebdoc, "Found '%s' in: %s" % (check_configuremake, ebdoc))
+        self.assertIn(check_configuremake, ebdoc)
         names = []
 
         for mod in modules:
@@ -473,7 +473,7 @@ class DocsTest(EnhancedTestCase):
                 eb_class = getattr(mod, name)
                 # skip imported classes that are not easyblocks
                 if eb_class.__module__.startswith(gen_easyblocks_pkg):
-                    self.assertTrue(name in ebdoc)
+                    self.assertIn(name, ebdoc)
                     names.append(name)
 
         toc = [":ref:`" + n + "`" for n in sorted(set(names))]
@@ -511,7 +511,7 @@ class DocsTest(EnhancedTestCase):
             "installopts         |Extra options for installation",
         ])
 
-        self.assertTrue(check_configuremake in ebdoc, "Found '%s' in: %s" % (check_configuremake, ebdoc))
+        self.assertIn(check_configuremake, ebdoc)
         names = []
 
         for mod in modules:
@@ -519,7 +519,7 @@ class DocsTest(EnhancedTestCase):
                 eb_class = getattr(mod, name)
                 # skip imported classes that are not easyblocks
                 if eb_class.__module__.startswith(gen_easyblocks_pkg):
-                    self.assertTrue(name in ebdoc)
+                    self.assertIn(name, ebdoc)
                     names.append(name)
 
         toc = ["\\[" + n + "\\]\\(#" + n.lower() + "\\)" for n in sorted(set(names))]
@@ -531,7 +531,7 @@ class DocsTest(EnhancedTestCase):
         """Test license_documentation function."""
         lic_docs = avail_easyconfig_licenses(output_format='txt')
         gplv3 = "GPLv3: The GNU General Public License"
-        self.assertTrue(gplv3 in lic_docs, "%s found in: %s" % (gplv3, lic_docs))
+        self.assertIn(gplv3, lic_docs)
 
         lic_docs = avail_easyconfig_licenses(output_format='rst')
         regex = re.compile(r"^``GPLv3``\s*The GNU General Public License", re.M)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2042,6 +2042,7 @@ class EasyBlockTest(EnhancedTestCase):
 
         # Do this before loading the easyblock to check the non-translated output below
         os.environ['LC_ALL'] = 'C'
+        os.environ['LANG'] = 'C'
 
         # this import only works here, since EB_toy is a test easyblock
         from easybuild.easyblocks.toy import EB_toy
@@ -2057,7 +2058,7 @@ class EasyBlockTest(EnhancedTestCase):
         eb.silent = True
         error_pattern = r"Sanity check failed: extensions sanity check failed for 1 extensions: toy\n"
         error_pattern += r"failing sanity check for 'toy' extension: "
-        error_pattern += r'command "thisshouldfail" failed; output:\n/bin/bash: thisshouldfail: command not found'
+        error_pattern += r'command "thisshouldfail" failed; output:\n/bin/bash:.* thisshouldfail: command not found'
         self.assertErrorRegex(EasyBuildError, error_pattern, eb.run_all_steps, True)
 
         # purposely put sanity check command in place that breaks the build,

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -91,7 +91,7 @@ class EasyBlockTest(EnhancedTestCase):
             extra_options.values()
             for key in extra_options.keys():
                 self.assertTrue(isinstance(extra_options[key], list))
-                self.assertTrue(len(extra_options[key]), 3)
+                self.assertEqual(len(extra_options[key]), 3)
 
         name = "pi"
         version = "3.14"
@@ -127,7 +127,7 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(exeb1.cfg['name'], 'foo')
         extra_options = exeb1.extra_options()
         check_extra_options_format(extra_options)
-        self.assertTrue('options' in extra_options)
+        self.assertIn('options', extra_options)
         # Reporting test failure should work also for the extension EB
         self.assertRaises(EasyBuildError, exeb1.report_test_failure, "Fails")
 
@@ -137,7 +137,7 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(exeb2.cfg['version'], '3.14')
         extra_options = exeb2.extra_options()
         check_extra_options_format(extra_options)
-        self.assertTrue('options' in extra_options)
+        self.assertIn('options', extra_options)
         # Reporting test failure should work also for the extension EB
         self.assertRaises(EasyBuildError, exeb2.report_test_failure, "Fails")
 
@@ -149,7 +149,7 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(texeb.cfg['name'], 'bar')
         extra_options = texeb.extra_options()
         check_extra_options_format(extra_options)
-        self.assertTrue('options' in extra_options)
+        self.assertIn('options', extra_options)
         self.assertEqual(extra_options['extra_param'], [None, "help", CUSTOM])
 
         # cleanup
@@ -241,7 +241,7 @@ class EasyBlockTest(EnhancedTestCase):
             self.assertTrue(os.path.samefile(default_symlink, pi_modfile))
         else:
             dot_version_txt = read_file(os.path.join(fake_mod_data[0], 'pi', '.version'))
-            self.assertTrue("set ModulesVersion 3.14" in dot_version_txt)
+            self.assertIn("set ModulesVersion 3.14", dot_version_txt)
 
         eb.clean_up_fake_module(fake_mod_data)
 
@@ -304,7 +304,7 @@ class EasyBlockTest(EnhancedTestCase):
                 r'\s+prepend_path\("MODULEPATH", pathJoin\(%s, %s\)\)' % (home, pj_usermodsdir),
             ])
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % module_syntax)
+            self.fail("Unknown module syntax: %s" % module_syntax)
 
         for regex in regexs:
             regex = re.compile(regex, re.M)
@@ -349,7 +349,7 @@ class EasyBlockTest(EnhancedTestCase):
                     r'\s+prepend_path\("MODULEPATH", pathJoin\(%s, %s\)\)' % (module_envvar, pj_usermodsdir),
                 ])
             else:
-                self.assertTrue(False, "Unknown module syntax: %s" % module_syntax)
+                self.fail("Unknown module syntax: %s" % module_syntax)
 
             for regex in regexs:
                 regex = re.compile(regex, re.M)
@@ -386,7 +386,7 @@ class EasyBlockTest(EnhancedTestCase):
         mkdir(os.path.join(config.install_path(), "existing_dir", usermodsdir_extension), parents=True)
         change_dir(os.path.join(config.install_path(), "existing_dir"))
         self.modtool.run_module('load', 'mytest')
-        self.assertFalse(usermodsdir_extension in os.environ['MODULEPATH'])
+        self.assertNotIn(usermodsdir_extension, os.environ['MODULEPATH'])
         self.modtool.run_module('unload', 'mytest')
         change_dir(cwd)
 
@@ -396,14 +396,14 @@ class EasyBlockTest(EnhancedTestCase):
 
         # Check MODULEPATH when neither directories exist
         self.modtool.run_module('load', 'mytest')
-        self.assertFalse(site_modules in os.environ['MODULEPATH'])
-        self.assertFalse(user_modules in os.environ['MODULEPATH'])
+        self.assertNotIn(site_modules, os.environ['MODULEPATH'])
+        self.assertNotIn(user_modules, os.environ['MODULEPATH'])
         self.modtool.run_module('unload', 'mytest')
         # Now create the directory for site modules
         mkdir(site_modules, parents=True)
         self.modtool.run_module('load', 'mytest')
         self.assertTrue(os.environ['MODULEPATH'].startswith(site_modules))
-        self.assertFalse(user_modules in os.environ['MODULEPATH'])
+        self.assertNotIn(user_modules, os.environ['MODULEPATH'])
         self.modtool.run_module('unload', 'mytest')
         # Now create the directory for user modules
         mkdir(user_modules, parents=True)
@@ -453,14 +453,14 @@ class EasyBlockTest(EnhancedTestCase):
             self.assertTrue(re.search(r'^prepend_path\("CLASSPATH", pathJoin\(root, "bla.jar"\)\)$', guess, re.M))
             self.assertTrue(re.search(r'^prepend_path\("CLASSPATH", pathJoin\(root, "foo.jar"\)\)$', guess, re.M))
             self.assertTrue(re.search(r'^prepend_path\("MANPATH", pathJoin\(root, "share/man"\)\)$', guess, re.M))
-            self.assertTrue('prepend_path("CMAKE_PREFIX_PATH", root)' in guess)
+            self.assertIn('prepend_path("CMAKE_PREFIX_PATH", root)', guess)
             # bin/ is not added to $PATH if it doesn't include files
             self.assertFalse(re.search(r'^prepend_path\("PATH", pathJoin\(root, "bin"\)\)$', guess, re.M))
             self.assertFalse(re.search(r'^prepend_path\("PATH", pathJoin\(root, "sbin"\)\)$', guess, re.M))
             # no include/ subdirectory, so no $CPATH update statement
             self.assertFalse(re.search(r'^prepend_path\("CPATH", .*\)$', guess, re.M))
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         # check that bin is only added to PATH if there are files in there
         write_file(os.path.join(eb.installdir, 'bin', 'test'), 'test')
@@ -473,7 +473,7 @@ class EasyBlockTest(EnhancedTestCase):
             self.assertTrue(re.search(r'^prepend_path\("PATH", pathJoin\(root, "bin"\)\)$', guess, re.M))
             self.assertFalse(re.search(r'^prepend_path\("PATH", pathJoin\(root, "sbin"\)\)$', guess, re.M))
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         # Check that lib64 is only added to CMAKE_LIBRARY_PATH if there are files in there
         # but only if it is not a symlink to lib
@@ -481,7 +481,7 @@ class EasyBlockTest(EnhancedTestCase):
         if get_module_syntax() == 'Tcl':
             self.assertFalse(re.search(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib64$", guess, re.M))
         elif get_module_syntax() == 'Lua':
-            self.assertFalse('prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib64"))' in guess)
+            self.assertNotIn('prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib64"))', guess)
         # -- With files
         write_file(os.path.join(eb.installdir, 'lib64', 'libfoo.so'), 'test')
         with eb.module_generator.start_module_creation():
@@ -489,7 +489,7 @@ class EasyBlockTest(EnhancedTestCase):
         if get_module_syntax() == 'Tcl':
             self.assertTrue(re.search(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib64$", guess, re.M))
         elif get_module_syntax() == 'Lua':
-            self.assertTrue('prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib64"))' in guess)
+            self.assertIn('prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib64"))', guess)
         # -- With files in lib and lib64 symlinks to lib
         write_file(os.path.join(eb.installdir, 'lib', 'libfoo.so'), 'test')
         shutil.rmtree(os.path.join(eb.installdir, 'lib64'))
@@ -499,7 +499,7 @@ class EasyBlockTest(EnhancedTestCase):
         if get_module_syntax() == 'Tcl':
             self.assertFalse(re.search(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib64$", guess, re.M))
         elif get_module_syntax() == 'Lua':
-            self.assertFalse('prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib64"))' in guess)
+            self.assertNotIn('prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib64"))', guess)
 
         # With files in /lib and /lib64 symlinked to /lib there should be exactly 1 entry for (LD_)LIBRARY_PATH
         # pointing to /lib
@@ -521,7 +521,7 @@ class EasyBlockTest(EnhancedTestCase):
         elif get_module_syntax() == 'Lua':
             self.assertTrue(re.match(r'^\nprepend_path\("PATH", pathJoin\(root, "bin"\)\)\n$', txt, re.M))
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         # check for correct behaviour if empty string is specified as one of the values
         # prepend-path statements should be included for both the 'bin' subdir and the install root
@@ -535,7 +535,7 @@ class EasyBlockTest(EnhancedTestCase):
             self.assertTrue(re.search(r'\nprepend_path\("PATH", pathJoin\(root, "bin"\)\)\n', txt, re.M))
             self.assertTrue(re.search(r'\nprepend_path\("PATH", root\)\n', txt, re.M))
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         # check for correct order of prepend statements when providing a list (and that no duplicates are allowed)
         eb.make_module_req_guess = lambda: {'LD_LIBRARY_PATH': ['lib/pathC', 'lib/pathA', 'lib/pathB', 'lib/pathA']}
@@ -561,7 +561,7 @@ class EasyBlockTest(EnhancedTestCase):
                                        r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib/pathA"\)\)\n',
                                        txt, re.M))
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         # If PATH or LD_LIBRARY_PATH contain only folders, do not add an entry
         sub_lib_path = os.path.join('lib', 'path_folders')
@@ -629,7 +629,7 @@ class EasyBlockTest(EnhancedTestCase):
                 r'setenv\("EBDEVELPI", pathJoin\(root, "easybuild/pi-3.14-gompi-2018a-easybuild-devel"\)\)',
             ]))
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         defaulttxt = eb.make_module_extra().strip()
         self.assertTrue(expected_default.match(defaulttxt),
@@ -714,7 +714,7 @@ class EasyBlockTest(EnhancedTestCase):
                 'end',
             ])
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         expected = use_load
         self.assertEqual(eb.make_module_deppaths().strip(), expected)
@@ -776,7 +776,7 @@ class EasyBlockTest(EnhancedTestCase):
                 'end',
             ])
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         expected = tc_load + '\n\n' + fftw_load + '\n\n' + lapack_load
         self.assertEqual(eb.make_module_dep().strip(), expected)
@@ -801,7 +801,7 @@ class EasyBlockTest(EnhancedTestCase):
                 'end',
             ])
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
         expected = tc_load + '\n\n' + fftw_load + '\n\n' + lapack_load
         self.assertEqual(eb.make_module_dep(unload_info=unload_info).strip(), expected)
 
@@ -1134,14 +1134,12 @@ class EasyBlockTest(EnhancedTestCase):
 
         # 'ext1' should be in eb.ext_instances
         eb_exts = [x.name for x in eb.ext_instances]
-        self.assertTrue('ext1' in eb_exts)
+        self.assertIn('ext1', eb_exts)
         # 'EXT-2' should not
-        self.assertFalse('EXT-2' in eb_exts)
-        self.assertFalse('EXT_2' in eb_exts)
-        self.assertFalse('ext-2' in eb_exts)
-        self.assertFalse('ext_2' in eb_exts)
+        self.assertNotIn('EXT-2', eb_exts)
+        self.assertNotIn('ext_2', eb_exts)
         # 'ext3' should not
-        self.assertFalse('ext3' in eb_exts)
+        self.assertNotIn('ext3', eb_exts)
 
         # cleanup
         eb.close_log()
@@ -1223,7 +1221,7 @@ class EasyBlockTest(EnhancedTestCase):
             self.assertTrue(re.search(r'^setenv\("EBVERSION%s", "%s"\)$' % (name.upper(), version), txt, re.M))
 
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         for (key, val) in modextravars.items():
             pushenv = False
@@ -1238,7 +1236,7 @@ class EasyBlockTest(EnhancedTestCase):
             elif get_module_syntax() == 'Lua':
                 regex = re.compile(r'^%s\("%s", "%s"\)$' % (env_setter, key, val), re.M)
             else:
-                self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+                self.fail("Unknown module syntax: %s" % get_module_syntax())
             self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
 
         for (key, vals) in modextrapaths.items():
@@ -1250,7 +1248,7 @@ class EasyBlockTest(EnhancedTestCase):
                 elif get_module_syntax() == 'Lua':
                     regex = re.compile(r'^prepend_path\("%s", pathJoin\(root, "%s"\)\)$' % (key, val), re.M)
                 else:
-                    self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+                    self.fail("Unknown module syntax: %s" % get_module_syntax())
                 self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
                 # Check for duplicates
                 num_prepends = len(regex.findall(txt))
@@ -1262,7 +1260,7 @@ class EasyBlockTest(EnhancedTestCase):
             elif get_module_syntax() == 'Lua':
                 regex = re.compile(r'^\s*load\("%s"\)$' % os.path.join(name, ver), re.M)
             else:
-                self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+                self.fail("Unknown module syntax: %s" % get_module_syntax())
             self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
 
         for (name, ver) in [('test', '1.2.3')]:
@@ -1271,7 +1269,7 @@ class EasyBlockTest(EnhancedTestCase):
             elif get_module_syntax() == 'Lua':
                 regex = re.compile(r'^\s*load\("%s/.%s"\)$' % (name, ver), re.M)
             else:
-                self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+                self.fail("Unknown module syntax: %s" % get_module_syntax())
             self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
 
         for (name, ver) in [('OpenMPI', '2.1.2-GCC-6.4.0-2.28')]:
@@ -1280,7 +1278,7 @@ class EasyBlockTest(EnhancedTestCase):
             elif get_module_syntax() == 'Lua':
                 regex = re.compile(r'^\s*load\("%s/.?%s"\)$' % (name, ver), re.M)
             else:
-                self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+                self.fail("Unknown module syntax: %s" % get_module_syntax())
             self.assertFalse(regex.search(txt), "Pattern '%s' *not* found in %s" % (regex.pattern, txt))
 
         os.environ['TEST_PUSHENV'] = '0'
@@ -1637,7 +1635,7 @@ class EasyBlockTest(EnhancedTestCase):
         eb.fetch_patches()
         self.assertEqual(len(eb.patches), 2)
         self.assertEqual(eb.patches[0]['name'], toy_patch)
-        self.assertFalse('level' in eb.patches[0])
+        self.assertNotIn('level', eb.patches[0])
 
         # reset
         eb.patches = []
@@ -1851,11 +1849,11 @@ class EasyBlockTest(EnhancedTestCase):
 
         self.assertEqual(exts_file_info[2]['name'], 'barbar')
         self.assertEqual(exts_file_info[2]['src'], os.path.join(toy_ext_sources, 'barbar-0.0.tar.gz'))
-        self.assertFalse('patches' in exts_file_info[2])
+        self.assertNotIn('patches', exts_file_info[2])
 
         self.assertEqual(exts_file_info[3]['name'], 'toy')
         self.assertEqual(exts_file_info[3]['src'], os.path.join(toy_sources, 'toy-0.0.tar.gz'))
-        self.assertFalse('patches' in exts_file_info[3])
+        self.assertNotIn('patches', exts_file_info[3])
 
         # location of files is missing when fetch_files is set to False
         exts_file_info = toy_eb.collect_exts_file_info(fetch_files=False, verify_checksums=False)
@@ -1866,19 +1864,19 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(exts_file_info[0], {'name': 'ls'})
 
         self.assertEqual(exts_file_info[1]['name'], 'bar')
-        self.assertFalse('src' in exts_file_info[1])
+        self.assertNotIn('src', exts_file_info[1])
         self.assertEqual(exts_file_info[1]['patches'][0]['name'], bar_patch1)
-        self.assertFalse('path' in exts_file_info[1]['patches'][0])
+        self.assertNotIn('path', exts_file_info[1]['patches'][0])
         self.assertEqual(exts_file_info[1]['patches'][1]['name'], bar_patch2)
-        self.assertFalse('path' in exts_file_info[1]['patches'][1])
+        self.assertNotIn('path', exts_file_info[1]['patches'][1])
 
         self.assertEqual(exts_file_info[2]['name'], 'barbar')
-        self.assertFalse('src' in exts_file_info[2])
-        self.assertFalse('patches' in exts_file_info[2])
+        self.assertNotIn('src', exts_file_info[2])
+        self.assertNotIn('patches', exts_file_info[2])
 
         self.assertEqual(exts_file_info[3]['name'], 'toy')
-        self.assertFalse('src' in exts_file_info[3])
-        self.assertFalse('patches' in exts_file_info[3])
+        self.assertNotIn('src', exts_file_info[3])
+        self.assertNotIn('patches', exts_file_info[3])
 
         error_msg = "Can't verify checksums for extension files if they are not being fetched"
         self.assertErrorRegex(EasyBuildError, error_msg, toy_eb.collect_exts_file_info, fetch_files=False)
@@ -1977,13 +1975,13 @@ class EasyBlockTest(EnhancedTestCase):
                 elif get_module_syntax() == 'Lua':
                     self.assertFalse(re.search('load("%s")' % dep, modtxt), failmsg)
                 else:
-                    self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+                    self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         # modpath_extensions_for should spit out correct result, even if modules are loaded
         icc_mod = 'icc/%s' % intel_ver
         impi_mod = 'impi/5.1.2.150'
         self.modtool.load([icc_mod])
-        self.assertTrue(impi_modfile_path in self.modtool.show(impi_mod))
+        self.assertIn(impi_modfile_path, self.modtool.show(impi_mod))
         self.modtool.load([impi_mod])
         expected = {
             icc_mod: [os.path.join(modpath, 'Compiler', 'intel', intel_ver)],
@@ -2019,7 +2017,7 @@ class EasyBlockTest(EnhancedTestCase):
         # verify that patches were applied
         toydir = os.path.join(eb.builddir, 'toy-0.0')
         self.assertEqual(sorted(os.listdir(toydir)), ['toy-extra.txt', 'toy.source'])
-        self.assertTrue("and very proud of it" in read_file(os.path.join(toydir, 'toy.source')))
+        self.assertIn("and very proud of it", read_file(os.path.join(toydir, 'toy.source')))
         self.assertEqual(read_file(os.path.join(toydir, 'toy-extra.txt')), 'moar!\n')
 
         # check again with backup of patched files enabled
@@ -2031,8 +2029,8 @@ class EasyBlockTest(EnhancedTestCase):
         # verify that patches were applied
         toydir = os.path.join(eb.builddir, 'toy-0.0')
         self.assertEqual(sorted(os.listdir(toydir)), ['toy-extra.txt', 'toy.source', 'toy.source.orig'])
-        self.assertTrue("and very proud of it" in read_file(os.path.join(toydir, 'toy.source')))
-        self.assertFalse("and very proud of it" in read_file(os.path.join(toydir, 'toy.source.orig')))
+        self.assertIn("and very proud of it", read_file(os.path.join(toydir, 'toy.source')))
+        self.assertNotIn("and very proud of it", read_file(os.path.join(toydir, 'toy.source.orig')))
         self.assertEqual(read_file(os.path.join(toydir, 'toy-extra.txt')), 'moar!\n')
 
     def test_extensions_sanity_check(self):
@@ -2238,7 +2236,7 @@ class EasyBlockTest(EnhancedTestCase):
         # see also https://github.com/easybuilders/easybuild-framework/issues/2186
         self.setup_hierarchical_modules()
 
-        self.assertTrue('GCC/6.4.0-2.28' in self.modtool.available())
+        self.assertIn('GCC/6.4.0-2.28', self.modtool.available())
 
         self.reset_modulepath([])
         self.assertEqual(os.environ.get('MODULEPATH'), None)
@@ -2369,7 +2367,7 @@ class EasyBlockTest(EnhancedTestCase):
             elif isinstance(ext, tuple):
                 self.assertEqual(ext[2].get('checksums', []), [])
             else:
-                self.assertTrue(False, "Incorrect extension type: %s" % type(ext))
+                self.fail("Incorrect extension type: %s" % type(ext))
 
         # put checksums.json in place next to easyconfig file being used for the tests
         toy_checksums_json = os.path.join(testdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'checksums.json')
@@ -2615,7 +2613,7 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertTrue(all(key.startswith('easybuild.easyblocks') for key in easyblocks))
 
         for modname in ['foo', 'generic.bar', 'toy', 'gcc', 'hpl']:
-            self.assertTrue('easybuild.easyblocks.%s' % modname in easyblocks)
+            self.assertIn('easybuild.easyblocks.%s' % modname, easyblocks)
 
         foo = easyblocks['easybuild.easyblocks.foo']
         self.assertEqual(foo['class'], 'EB_foo')

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1223,7 +1223,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(eb.template_values['javaver'], '11')
         self.assertEqual(eb.template_values['javamajver'], '11')
         self.assertEqual(eb.template_values['javashortver'], '11')
-        self.assertFalse('javaminver' in eb.template_values)
+        self.assertNotIn('javaminver', eb.template_values)
 
         self.assertEqual(eb['modloadmsg'], "Java: 11, 11, 11")
 
@@ -1645,7 +1645,7 @@ class EasyConfigTest(EnhancedTestCase):
         ])
         self.prep()
         ec = EasyConfig(self.eb_file)
-        self.assertFalse('therenosucheasyconfigparameterlikethis' in ec)
+        self.assertNotIn('therenosucheasyconfigparameterlikethis', ec)
         error_regex = "unknown easyconfig parameter"
         self.assertErrorRegex(EasyBuildError, error_regex, lambda k: ec[k], 'therenosucheasyconfigparameterlikethis')
 
@@ -2191,7 +2191,7 @@ class EasyConfigTest(EnhancedTestCase):
             "('GCC', '4.9.2', '', SYSTEM)",
         ]
         for pattern in patterns:
-            self.assertTrue(pattern in dumped_ec_txt, "Pattern '%s' should be found in: %s" % (pattern, dumped_ec_txt))
+            self.assertIn(pattern, dumped_ec_txt)
 
     def test_toolchain_hierarchy_aware_dump(self):
         """Test that EasyConfig's dump() method is aware of the toolchain hierarchy."""
@@ -3157,7 +3157,7 @@ class EasyConfigTest(EnhancedTestCase):
         res = template_constant_dict(ec)
 
         # 'arch' needs to be handled separately, since value depends on system architecture
-        self.assertTrue('arch' in res)
+        self.assertIn('arch', res)
         arch = res.pop('arch')
         self.assertTrue(arch_regex.match(arch), "'%s' matches with pattern '%s'" % (arch, arch_regex.pattern))
 
@@ -3244,7 +3244,7 @@ class EasyConfigTest(EnhancedTestCase):
         dep_names = [x['name'] for x in ec['dependencies']]
         self.assertFalse('CMake' in dep_names, "CMake should not be included in list of dependencies: %s" % dep_names)
 
-        self.assertTrue('arch' in res)
+        self.assertIn('arch', res)
         arch = res.pop('arch')
         self.assertTrue(arch_regex.match(arch), "'%s' matches with pattern '%s'" % (arch, arch_regex.pattern))
 
@@ -3263,7 +3263,7 @@ class EasyConfigTest(EnhancedTestCase):
         dep_names = [x[0] for x in ec['dependencies']]
         self.assertFalse('CMake' in dep_names, "CMake should not be included in list of dependencies: %s" % dep_names)
 
-        self.assertTrue('arch' in res)
+        self.assertIn('arch', res)
         arch = res.pop('arch')
         self.assertTrue(arch_regex.match(arch), "'%s' matches with pattern '%s'" % (arch, arch_regex.pattern))
 
@@ -3280,7 +3280,7 @@ class EasyConfigTest(EnhancedTestCase):
         }
         res = template_constant_dict(ext_dict)
 
-        self.assertTrue('arch' in res)
+        self.assertIn('arch', res)
         arch = res.pop('arch')
         self.assertTrue(arch_regex.match(arch), "'%s' matches with pattern '%s'" % (arch, arch_regex.pattern))
 
@@ -3506,7 +3506,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(versions, [None, ''])
         depr_msg = "WARNING: Deprecated functionality, will no longer work in v5.0: "
         depr_msg += "Use --add-system-to-minimal-toolchains instead of --add-dummy-to-minimal-toolchains"
-        self.assertTrue(depr_msg in stderr)
+        self.assertIn(depr_msg, stderr)
 
         # and GCCcore if existing too
         init_config(build_options={'add_system_to_minimal_toolchains': True})
@@ -3782,7 +3782,7 @@ class EasyConfigTest(EnhancedTestCase):
         ecs = [ec['ec'] for ec in ecs]
 
         res = check_sha256_checksums(ecs)
-        self.assertTrue(len(res) == 1)
+        self.assertEqual(len(res), 1)
         regex = re.compile(r"Non-SHA256 checksum\(s\) found for toy-0.0.tar.gz:.*not_really_a_sha256_checksum")
         self.assertTrue(regex.match(res[0]), "Pattern '%s' found in: %s" % (regex.pattern, res[0]))
 
@@ -3991,8 +3991,8 @@ class EasyConfigTest(EnhancedTestCase):
         ec = EasyConfig(test_ec)
 
         # %(pyver)s and %(pyshortver)s template are not defined when not in iterative mode
-        self.assertFalse('pyver' in ec.template_values)
-        self.assertFalse('pyshortver' in ec.template_values)
+        self.assertNotIn('pyver', ec.template_values)
+        self.assertNotIn('pyshortver', ec.template_values)
 
         # save reference to original list of lists of build dependencies
         builddeps = ec['builddependencies']
@@ -4003,18 +4003,18 @@ class EasyConfigTest(EnhancedTestCase):
         ec['builddependencies'] = builddeps[0]
 
         ec.generate_template_values()
-        self.assertTrue('pyver' in ec.template_values)
+        self.assertIn('pyver', ec.template_values)
         self.assertEqual(ec.template_values['pyver'], '2.7.15')
-        self.assertTrue('pyshortver' in ec.template_values)
+        self.assertIn('pyshortver', ec.template_values)
         self.assertEqual(ec.template_values['pyshortver'], '2.7')
 
         # put next list of build dependencies in place (i.e. Python 3.7.2)
         ec['builddependencies'] = builddeps[1]
 
         ec.generate_template_values()
-        self.assertTrue('pyver' in ec.template_values)
+        self.assertIn('pyver', ec.template_values)
         self.assertEqual(ec.template_values['pyver'], '3.6.6')
-        self.assertTrue('pyshortver' in ec.template_values)
+        self.assertIn('pyshortver', ec.template_values)
         self.assertEqual(ec.template_values['pyshortver'], '3.6')
 
         # check that extensions inherit these template values too
@@ -4074,7 +4074,7 @@ class EasyConfigTest(EnhancedTestCase):
             self.mock_stderr(False)
             self.mock_stdout(False)
             self.assertFalse(stderr)
-            self.assertTrue("test.eb... FIXED!" in stdout)
+            self.assertIn("test.eb... FIXED!", stdout)
 
             # parsing now works
             ec = EasyConfig(test_ec)
@@ -4106,7 +4106,7 @@ class EasyConfigTest(EnhancedTestCase):
                 "Use of 'dummy' toolchain is deprecated, use 'system' toolchain instead",
             ]
             for warning in warnings:
-                self.assertTrue(warning in stderr, "Found warning '%s' in stderr output: %s" % (warning, stderr))
+                self.assertIn(warning, stderr)
 
             init_config(build_options={'local_var_naming_check': 'error', 'silent': True})
 
@@ -4730,7 +4730,7 @@ class EasyConfigTest(EnhancedTestCase):
     def test_ARCH(self):
         """Test ARCH easyconfig constant."""
         arch = easyconfig.constants.EASYCONFIG_CONSTANTS['ARCH'][0]
-        self.assertTrue(arch in KNOWN_ARCH_CONSTANTS, "Unexpected value for ARCH constant: %s" % arch)
+        self.assertIn(arch, KNOWN_ARCH_CONSTANTS, "Unexpected value for ARCH constant: %s" % arch)
 
     def test_easyconfigs_caches(self):
         """

--- a/test/framework/easyconfigparser.py
+++ b/test/framework/easyconfigparser.py
@@ -64,8 +64,8 @@ class EasyConfigParserTest(EnhancedTestCase):
         ec['sources'].append(fn)
 
         ec_bis = ecp.get_config_dict()
-        self.assertTrue(fn in ec['sources'])
-        self.assertFalse(fn in ec_bis['sources'])
+        self.assertIn(fn, ec['sources'])
+        self.assertNotIn(fn, ec_bis['sources'])
 
     def test_v20(self):
         """Test parsing of easyconfig in format v2."""
@@ -79,9 +79,9 @@ class EasyConfigParserTest(EnhancedTestCase):
         formatter = ecp._formatter
         self.assertEqual(formatter.VERSION, EasyVersion('2.0'))
 
-        self.assertTrue('name' in formatter.pyheader_localvars)
-        self.assertFalse('version' in formatter.pyheader_localvars)
-        self.assertFalse('toolchain' in formatter.pyheader_localvars)
+        self.assertIn('name', formatter.pyheader_localvars)
+        self.assertNotIn('version', formatter.pyheader_localvars)
+        self.assertNotIn('toolchain', formatter.pyheader_localvars)
 
         # this should be ok: ie the default values
         ec = ecp.get_config_dict()
@@ -94,8 +94,8 @@ class EasyConfigParserTest(EnhancedTestCase):
         ec['sources'].append(fn)
 
         ec_bis = ecp.get_config_dict()
-        self.assertTrue(fn in ec['sources'])
-        self.assertFalse(fn in ec_bis['sources'])
+        self.assertIn(fn, ec['sources'])
+        self.assertNotIn(fn, ec_bis['sources'])
 
         # restore
         easybuild.tools.build_log.EXPERIMENTAL = orig_experimental
@@ -112,9 +112,9 @@ class EasyConfigParserTest(EnhancedTestCase):
         formatter = ecp._formatter
         self.assertEqual(formatter.VERSION, EasyVersion('2.0'))
 
-        self.assertTrue('name' in formatter.pyheader_localvars)
-        self.assertFalse('version' in formatter.pyheader_localvars)
-        self.assertFalse('toolchain' in formatter.pyheader_localvars)
+        self.assertIn('name', formatter.pyheader_localvars)
+        self.assertNotIn('version', formatter.pyheader_localvars)
+        self.assertNotIn('toolchain', formatter.pyheader_localvars)
 
         # restore
         easybuild.tools.build_log.EXPERIMENTAL = orig_experimental

--- a/test/framework/environment.py
+++ b/test/framework/environment.py
@@ -121,9 +121,9 @@ class EnvironmentTest(EnhancedTestCase):
 
         res = env.unset_env_vars(['HOME', 'NO_SUCH_ENV_VAR', 'TEST_ENV_VAR'])
 
-        self.assertFalse('HOME' in os.environ)
-        self.assertFalse('NO_SUCH_ENV_VAR' in os.environ)
-        self.assertFalse('TEST_ENV_VAR' in os.environ)
+        self.assertNotIn('HOME', os.environ)
+        self.assertNotIn('NO_SUCH_ENV_VAR', os.environ)
+        self.assertNotIn('TEST_ENV_VAR', os.environ)
 
         expected = {
             'HOME': home,

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -218,7 +218,7 @@ class FileToolsTest(EnhancedTestCase):
         self.assertTrue(len(txt.split('\n')) == len(perl_lines) + 4)
         self.assertTrue(txt.startswith(perl_lines[0] + "\n\nuse IO::Handle qw();\nSTDOUT->autoflush(1);"))
         for line in perl_lines[1:]:
-            self.assertTrue(line in txt)
+            self.assertIn(line, txt)
         os.remove(fp)
         os.remove("%s.eb.orig" % fp)
 
@@ -512,7 +512,7 @@ class FileToolsTest(EnhancedTestCase):
         if ft.HAVE_REQUESTS:
             res = ft.download_file(fn, url, target)
             self.assertTrue(res and os.path.exists(res))
-            self.assertTrue("https://easybuilders.github.io/easybuild" in ft.read_file(res))
+            self.assertIn("https://easybuilders.github.io/easybuild", ft.read_file(res))
 
         # without requests being available, error is raised
         ft.HAVE_REQUESTS = False
@@ -528,7 +528,7 @@ class FileToolsTest(EnhancedTestCase):
         if ft.HAVE_REQUESTS:
             res = ft.download_file(fn, url, target)
             self.assertTrue(res and os.path.exists(res))
-            self.assertTrue("https://easybuilders.github.io/easybuild" in ft.read_file(res))
+            self.assertIn("https://easybuilders.github.io/easybuild", ft.read_file(res))
 
         # without requests being available, error is raised
         ft.HAVE_REQUESTS = False
@@ -569,7 +569,7 @@ class FileToolsTest(EnhancedTestCase):
         stderr = self.get_stderr()
         self.mock_stderr(False)
 
-        self.assertTrue("WARNING: Not checking server certificates while downloading toy-0.0.eb" in stderr)
+        self.assertIn("WARNING: Not checking server certificates while downloading toy-0.0.eb", stderr)
         self.assertTrue(os.path.exists(res))
         self.assertTrue(ft.read_file(res).startswith("name = 'toy'"))
 
@@ -606,9 +606,9 @@ class FileToolsTest(EnhancedTestCase):
             stderr = self.get_stderr()
             self.mock_stderr(False)
 
-            self.assertTrue("WARNING: Not checking server certificates while downloading README.rst" in stderr)
+            self.assertIn("WARNING: Not checking server certificates while downloading README.rst", stderr)
             self.assertTrue(os.path.exists(res))
-            self.assertTrue("https://easybuilders.github.io/easybuild" in ft.read_file(res))
+            self.assertIn("https://easybuilders.github.io/easybuild", ft.read_file(res))
 
     def test_mkdir(self):
         """Test mkdir function."""
@@ -1051,10 +1051,10 @@ class FileToolsTest(EnhancedTestCase):
         ft.copy_file(fp, fp2)
         res = ft.back_up_file(fp2)
         self.assertTrue(fp2.endswith('.lua'))
-        self.assertTrue('.lua' in os.path.basename(res))
+        self.assertIn('.lua', os.path.basename(res))
 
         res = ft.back_up_file(fp2, strip_fn='.lua')
-        self.assertFalse('.lua' in os.path.basename(res))
+        self.assertNotIn('.lua', os.path.basename(res))
         # strip_fn should not remove the first a in 'a.lua'
         expected = os.path.basename(fp) + 'a.bak_'
         res_fn = os.path.basename(res)
@@ -1420,13 +1420,13 @@ class FileToolsTest(EnhancedTestCase):
         with self.log_to_testlogfile():
             ft.apply_regex_substitutions(testfile, regex_subs_no_match, on_missing_match=run.WARN)
         logtxt = ft.read_file(self.logfile)
-        self.assertTrue('WARNING ' + error_pat in logtxt)
+        self.assertIn('WARNING ' + error_pat, logtxt)
 
         # Ignore
         with self.log_to_testlogfile():
             ft.apply_regex_substitutions(testfile, regex_subs_no_match, on_missing_match=run.IGNORE)
         logtxt = ft.read_file(self.logfile)
-        self.assertTrue('INFO ' + error_pat in logtxt)
+        self.assertIn('INFO ' + error_pat, logtxt)
 
         # clean error on non-existing file
         error_pat = "Failed to patch .*/nosuchfile.txt: .*No such file or directory"
@@ -1605,7 +1605,7 @@ class FileToolsTest(EnhancedTestCase):
         prefix = 'https://pypi.python.org/packages'
         for entry in res:
             self.assertTrue(entry.startswith(prefix), "'%s' should start with '%s'" % (entry, prefix))
-            self.assertTrue('ipython' in entry, "Pattern 'ipython' should be found in '%s'" % entry)
+            self.assertIn('ipython', entry)
 
     def test_derive_alt_pypi_url(self):
         """Test derive_alt_pypi_url() function."""
@@ -1653,7 +1653,7 @@ class FileToolsTest(EnhancedTestCase):
         expected_warning = "Use of patch file with filename that doesn't end with correct extension: foo.txt "
         expected_warning += "(should be any of: .patch, .patch.bz2, .patch.gz, .patch.xz)"
         fail_msg = "Warning '%s' should appear in stderr output: %s" % (expected_warning, stderr)
-        self.assertTrue(expected_warning in stderr, fail_msg)
+        self.assertIn(expected_warning, stderr, fail_msg)
 
         # deprecation warning is treated as an error in context of unit test suite
         expected_error = expected_warning.replace('(', '\\(').replace(')', '\\)')
@@ -1687,10 +1687,10 @@ class FileToolsTest(EnhancedTestCase):
             backup_file = src_file + '.orig'
             patched = ft.read_file(src_file)
             pattern = "I'm a toy, and very proud of it"
-            self.assertTrue(pattern in patched)
+            self.assertIn(pattern, patched)
             if with_backup:
                 self.assertTrue(os.path.exists(backup_file))
-                self.assertTrue(pattern not in ft.read_file(backup_file))
+                self.assertNotIn(pattern, ft.read_file(backup_file))
                 # Restore file to original after first(!) iteration
                 ft.move_file(backup_file, src_file)
             else:
@@ -1701,7 +1701,7 @@ class FileToolsTest(EnhancedTestCase):
         self.assertTrue(ft.apply_patch(toy_patch_gz, path))
         patched_gz = ft.read_file(os.path.join(path, 'toy-0.0', 'toy.source'))
         pattern = "I'm a toy, and very very proud of it"
-        self.assertTrue(pattern in patched_gz)
+        self.assertIn(pattern, patched_gz)
 
         # trying the patch again should fail
         self.assertErrorRegex(EasyBuildError, "Couldn't apply patch file", ft.apply_patch, toy_patch, path)
@@ -1737,10 +1737,10 @@ class FileToolsTest(EnhancedTestCase):
 
         # test applying of patch with git
         toy_source_path = os.path.join(self.test_prefix, 'toy-0.0', 'toy.source')
-        self.assertFalse("I'm a toy, and very proud of it" in ft.read_file(toy_source_path))
+        self.assertNotIn("I'm a toy, and very proud of it", ft.read_file(toy_source_path))
 
         ft.apply_patch(toy_patch, self.test_prefix, use_git=True)
-        self.assertTrue("I'm a toy, and very proud of it" in ft.read_file(toy_source_path))
+        self.assertIn("I'm a toy, and very proud of it", ft.read_file(toy_source_path))
 
         # construct patch that only adds a new file,
         # this shouldn't break applying a patch with git even when no level is specified
@@ -1761,7 +1761,7 @@ class FileToolsTest(EnhancedTestCase):
         ft.remove_dir(path)
         path = ft.extract_file(toy_tar_gz, self.test_prefix, change_into_dir=False)
 
-        self.assertFalse("I'm a toy, and very proud of it" in ft.read_file(toy_source_path))
+        self.assertNotIn("I'm a toy, and very proud of it", ft.read_file(toy_source_path))
 
         # mock stderr to catch deprecation warning caused by setting 'use_git_am'
         self.allow_deprecated_behaviour()
@@ -1769,8 +1769,8 @@ class FileToolsTest(EnhancedTestCase):
         ft.apply_patch(toy_patch, self.test_prefix, use_git_am=True)
         stderr = self.get_stderr()
         self.mock_stderr(False)
-        self.assertTrue("I'm a toy, and very proud of it" in ft.read_file(toy_source_path))
-        self.assertTrue("'use_git_am' named argument in apply_patch function has been renamed to 'use_git'" in stderr)
+        self.assertIn("I'm a toy, and very proud of it", ft.read_file(toy_source_path))
+        self.assertIn("'use_git_am' named argument in apply_patch function has been renamed to 'use_git'", stderr)
 
     def test_copy_file(self):
         """Test copy_file function."""
@@ -2395,7 +2395,7 @@ class FileToolsTest(EnhancedTestCase):
                 os.path.join('s', 'ScaLAPACK', 'ScaLAPACK-2.0.2-gompi-2018a-OpenBLAS-0.2.20.eb'),
             ]
             for fn in expected:
-                self.assertTrue(fn in index)
+                self.assertIn(fn, index)
 
             for fp in index:
                 self.assertTrue(fp.endswith('.eb') or os.path.basename(fp) == 'checksums.json')
@@ -2438,7 +2438,7 @@ class FileToolsTest(EnhancedTestCase):
 
         self.assertEqual(len(index), 26)
         for fn in expected:
-            self.assertTrue(fn in index, "%s should be found in %s" % (fn, sorted(index)))
+            self.assertIn(fn, index)
 
         # dump_index will not overwrite existing index without force
         error_pattern = "File exists, not overwriting it without --force"
@@ -2468,7 +2468,7 @@ class FileToolsTest(EnhancedTestCase):
 
         self.assertEqual(len(index), 26)
         for fn in expected:
-            self.assertTrue(fn in index, "%s should be found in %s" % (fn, sorted(index)))
+            self.assertIn(fn, index)
 
         ft.remove_file(index_fp)
 
@@ -2949,7 +2949,7 @@ class FileToolsTest(EnhancedTestCase):
         self.mock_stdout(True)
         try:
             import vsc  # noqa
-            self.assertTrue(False, "'import vsc' results in an error")
+            self.fail("'import vsc' results in an error")
         except SystemExit:
             pass
 
@@ -2975,7 +2975,7 @@ class FileToolsTest(EnhancedTestCase):
         self.mock_stdout(True)
         try:
             from test_fake_vsc import import_vsc  # noqa
-            self.assertTrue(False, "'import vsc' results in an error")
+            self.fail("'import vsc' results in an error")
         except SystemExit:
             pass
         stderr = self.get_stderr()
@@ -3266,7 +3266,7 @@ class FileToolsTest(EnhancedTestCase):
 
         # files specified via absolute path don't have to be found
         res = ft.locate_files([one], [])
-        self.assertTrue(len(res) == 1)
+        self.assertEqual(len(res), 1)
         self.assertTrue(os.path.samefile(res[0], one))
 
         # note: don't compare file paths directly but use os.path.samefile instead,

--- a/test/framework/general.py
+++ b/test/framework/general.py
@@ -129,7 +129,7 @@ class GeneralTest(EnhancedTestCase):
         res = import_available_modules('easybuild.tools.repository')
         self.assertEqual(len(res), 5)
         # don't check all, since some required specific Python packages to be installed...
-        self.assertTrue(easybuild.tools.repository.filerepo in res)
+        self.assertIn(easybuild.tools.repository.filerepo, res)
 
         # replicate situation where import_available_modules failed when running in directory where modules are located
         # cfr. https://github.com/easybuilders/easybuild-framework/issues/2659

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -175,7 +175,7 @@ class GithubTest(EnhancedTestCase):
         stdout = self.get_stdout()
         self.mock_stdout(False)
         self.mock_stderr(False)
-        self.assertTrue("Could not determine any missing labels for PR #11262" in stdout)
+        self.assertIn("Could not determine any missing labels for PR #11262", stdout)
 
         self.mock_stdout(True)
         self.mock_stderr(True)
@@ -183,7 +183,7 @@ class GithubTest(EnhancedTestCase):
         stdout = self.get_stdout()
         self.mock_stdout(False)
         self.mock_stderr(False)
-        self.assertTrue("PR #8006 should be labelled 'update'" in stdout)
+        self.assertIn("PR #8006 should be labelled 'update'", stdout)
 
     def test_github_fetch_pr_data(self):
         """Test fetch_pr_data function."""
@@ -267,7 +267,7 @@ class GithubTest(EnhancedTestCase):
             "* QEMU-2.4.0",
         ]
         for pattern in patterns:
-            self.assertTrue(pattern in stdout, "Pattern '%s' found in: %s" % (pattern, stdout))
+            self.assertIn(pattern, stdout)
 
     def test_github_close_pr(self):
         """Test close_pr function."""
@@ -295,7 +295,7 @@ class GithubTest(EnhancedTestCase):
             "[DRY RUN] Closed easybuilders/testrepository PR #2",
         ]
         for pattern in patterns:
-            self.assertTrue(pattern in stdout, "Pattern '%s' found in: %s" % (pattern, stdout))
+            self.assertIn(pattern, stdout)
 
         retest_msg = VALID_CLOSE_PR_REASONS['retest']
 
@@ -312,7 +312,7 @@ class GithubTest(EnhancedTestCase):
             "[DRY RUN] Reopened easybuilders/testrepository PR #2",
         ]
         for pattern in patterns:
-            self.assertTrue(pattern in stdout, "Pattern '%s' found in: %s" % (pattern, stdout))
+            self.assertIn(pattern, stdout)
 
     def test_github_fetch_easyblocks_from_pr(self):
         """Test fetch_easyblocks_from_pr function."""
@@ -427,7 +427,7 @@ class GithubTest(EnhancedTestCase):
 
         # github_account value is None (results in using default 'easybuilders')
         cache_key = (7159, None, 'easybuild-easyconfigs', self.test_prefix)
-        self.assertTrue(cache_key in gh.fetch_files_from_pr._cache.keys())
+        self.assertIn(cache_key, gh.fetch_files_from_pr._cache.keys())
 
         cache_entry = gh.fetch_files_from_pr._cache[cache_key]
         self.assertEqual(sorted([os.path.basename(f) for f in cache_entry]), sorted(pr7159_filenames))
@@ -503,7 +503,7 @@ class GithubTest(EnhancedTestCase):
         path = gh.download_repo(repo=repo, branch=branch, account=account, path=self.test_prefix,
                                 github_user=GITHUB_TEST_ACCOUNT)
         self.assertTrue(os.path.samefile(path, repodir))
-        self.assertTrue('easybuild' in os.listdir(repodir))
+        self.assertIn('easybuild', os.listdir(repodir))
         self.assertTrue(re.match('^[0-9a-f]{40}$', read_file(shafile)))
         self.assertTrue(os.path.exists(os.path.join(repodir, 'easybuild', 'easyblocks', '__init__.py')))
 
@@ -593,7 +593,7 @@ class GithubTest(EnhancedTestCase):
         txt = self.get_stdout()
         self.mock_stdout(False)
 
-        self.assertTrue(ec == 'toy')
+        self.assertEqual(ec, 'toy')
         reg = re.compile(r'[1-9]+ of [1-9]+ easyconfigs checked')
         self.assertTrue(re.search(reg, txt))
 
@@ -667,7 +667,7 @@ class GithubTest(EnhancedTestCase):
             self.mock_stderr(False)
             self.assertEqual(res, expected_result)
             self.assertEqual(stdout, expected_stdout)
-            self.assertTrue(expected_warning in stderr, "Found '%s' in: %s" % (expected_warning, stderr))
+            self.assertIn(expected_warning, stderr)
             return stderr
 
         pr_data = {
@@ -920,12 +920,12 @@ class GithubTest(EnhancedTestCase):
         status, headers = client.head()
         self.assertEqual(status, 200)
         self.assertTrue(headers)
-        self.assertTrue('X-GitHub-Media-Type' in headers)
+        self.assertIn('X-GitHub-Media-Type', headers)
 
         httperror_hit = False
         try:
             status, body = client.user.emails.post(body='test@example.com')
-            self.assertTrue(False, 'posting to unauthorized endpoint did not throw a http error')
+            self.fail('posting to unauthorized endpoint did not throw a http error')
         except HTTPError:
             httperror_hit = True
         self.assertTrue(httperror_hit, "expected HTTPError not encountered")
@@ -933,7 +933,7 @@ class GithubTest(EnhancedTestCase):
         httperror_hit = False
         try:
             status, body = client.user.emails.delete(body='test@example.com')
-            self.assertTrue(False, 'deleting to unauthorized endpoint did not throw a http error')
+            self.fail('deleting to unauthorized endpoint did not throw a http error')
         except HTTPError:
             httperror_hit = True
         self.assertTrue(httperror_hit, "expected HTTPError not encountered")
@@ -1165,10 +1165,10 @@ class GithubTest(EnhancedTestCase):
             "EASYBUILD_DEBUG=1",
         ]
         for pattern in patterns:
-            self.assertTrue(pattern in res['full'], "Pattern '%s' found in: %s" % (pattern, res['full']))
+            self.assertIn(pattern, res['full'])
 
         for pattern in patterns[:2]:
-            self.assertTrue(pattern in res['full'], "Pattern '%s' found in: %s" % (pattern, res['overview']))
+            self.assertIn(pattern, res['full'])
 
         # mock create_gist function, we don't want to actually create a gist every time we run this test...
         def fake_create_gist(*args, **kwargs):
@@ -1183,12 +1183,12 @@ class GithubTest(EnhancedTestCase):
             "https://github.com/easybuilders/easybuild-easyconfigs/pull/123",
         ])
         for pattern in patterns:
-            self.assertTrue(pattern in res['full'], "Pattern '%s' found in: %s" % (pattern, res['full']))
+            self.assertIn(pattern, res['full'])
 
         for pattern in patterns[:3]:
-            self.assertTrue(pattern in res['full'], "Pattern '%s' found in: %s" % (pattern, res['overview']))
+            self.assertIn(pattern, res['full'])
 
-        self.assertTrue("**SUCCESS** _test.eb_" in res['overview'])
+        self.assertIn("**SUCCESS** _test.eb_", res['overview'])
 
     def test_is_patch_for(self):
         """Test for is_patch_for function."""

--- a/test/framework/lib.py
+++ b/test/framework/lib.py
@@ -72,9 +72,9 @@ class EasyBuildLibTest(TestCase):
         if BuildOptions in BuildOptions._instances:
             del BuildOptions._instances[BuildOptions]
 
-        self.assertFalse(BuildOptions in BuildOptions._instances)
+        self.assertNotIn(BuildOptions, BuildOptions._instances)
         set_up_configuration(silent=True)
-        self.assertTrue(BuildOptions in BuildOptions._instances)
+        self.assertIn(BuildOptions, BuildOptions._instances)
 
     def test_run_cmd(self):
         """Test use of run_cmd function in the context of using EasyBuild framework as a library."""
@@ -119,7 +119,7 @@ class EasyBuildLibTest(TestCase):
 
         modtool = modules_tool()
         modtool.use(test_mods_path)
-        self.assertTrue('GCC/6.4.0-2.28' in modtool.available())
+        self.assertIn('GCC/6.4.0-2.28', modtool.available())
         modtool.load(['GCC/6.4.0-2.28'])
         self.assertEqual(modtool.list(), [{'default': None, 'mod_name': 'GCC/6.4.0-2.28'}])
 

--- a/test/framework/license.py
+++ b/test/framework/license.py
@@ -44,7 +44,7 @@ class LicenseTest(EnhancedTestCase):
         lics = what_licenses()
         commonlicenses = ['LicenseVeryRestrictive', 'LicenseGPLv2', 'LicenseGPLv3']
         for lic in commonlicenses:
-            self.assertTrue(lic in lics, "%s found in %s" % (lic, lics.keys()))
+            self.assertIn(lic, lics)
 
     def test_default_license(self):
         """Verify that the default License class is very restrictive"""

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -223,7 +223,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
         self.modtool.load([module_name])
         full_module_name = module_name + '/' + version_one
 
-        self.assertTrue(full_module_name in self.modtool.loaded_modules())
+        self.assertIn(full_module_name, self.modtool.loaded_modules())
         self.modtool.purge()
 
         # setting bar version as default
@@ -231,7 +231,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
         self.modtool.load([module_name])
         full_module_name = module_name + '/' + version_two
 
-        self.assertTrue(full_module_name in self.modtool.loaded_modules())
+        self.assertIn(full_module_name, self.modtool.loaded_modules())
         self.modtool.purge()
 
     def test_is_loaded(self):
@@ -970,7 +970,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
         self.modtool.load([module_name])
         full_module_name = module_name + '/' + version_one
 
-        self.assertTrue(full_module_name in self.modtool.loaded_modules())
+        self.assertIn(full_module_name, self.modtool.loaded_modules())
         self.assertEqual(os.getenv(test_envvar), test_flags)
         self.modtool.purge()
 
@@ -1065,7 +1065,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
             self.assertEqual(if_else_cond, expected)
 
         else:
-            self.assertTrue(False, "Unknown module syntax")
+            self.fail("Unknown module syntax")
 
     def test_load_msg(self):
         """Test including a load message in the module file."""
@@ -1242,18 +1242,18 @@ class ModuleGeneratorTest(EnhancedTestCase):
     def test_mod_name_validation(self):
         """Test module naming validation."""
         # module name must be a string
-        self.assertTrue(not is_valid_module_name(('foo', 'bar')))
-        self.assertTrue(not is_valid_module_name(['foo', 'bar']))
-        self.assertTrue(not is_valid_module_name(123))
+        self.assertFalse(is_valid_module_name(('foo', 'bar')))
+        self.assertFalse(is_valid_module_name(['foo', 'bar']))
+        self.assertFalse(is_valid_module_name(123))
 
         # module name must be relative
-        self.assertTrue(not is_valid_module_name('/foo/bar'))
+        self.assertFalse(is_valid_module_name('/foo/bar'))
 
         # module name must only contain valid characters
-        self.assertTrue(not is_valid_module_name('foo\x0bbar'))
-        self.assertTrue(not is_valid_module_name('foo\x0cbar'))
-        self.assertTrue(not is_valid_module_name('foo\rbar'))
-        self.assertTrue(not is_valid_module_name('foo\0bar'))
+        self.assertFalse(is_valid_module_name('foo\x0bbar'))
+        self.assertFalse(is_valid_module_name('foo\x0cbar'))
+        self.assertFalse(is_valid_module_name('foo\rbar'))
+        self.assertFalse(is_valid_module_name('foo\0bar'))
 
         # valid module name must be accepted
         self.assertTrue(is_valid_module_name('gzip/foss-2018a-suffix'))

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -110,7 +110,7 @@ class ModulesTest(EnhancedTestCase):
         modify_env(os.environ, self.orig_environ, verbose=False)
         self.reset_modulepath([os.path.join(testdir, 'modules')])
 
-        self.assertFalse('EBROOTGCC' in os.environ)
+        self.assertNotIn('EBROOTGCC', os.environ)
         self.modtool.run_module(['load', 'GCC/6.4.0-2.28'])
         self.assertEqual(os.environ['EBROOTGCC'], '/prefix/software/GCC/6.4.0-2.28')
 
@@ -170,7 +170,7 @@ class ModulesTest(EnhancedTestCase):
             self.assertTrue(regex.search(out), "Pattern '%s' should be found in: %s" % (regex.pattern, out))
 
         # OpenBLAS module did *not* get loaded
-        self.assertFalse('EBROOTOPENBLAS' in os.environ)
+        self.assertNotIn('EBROOTOPENBLAS', os.environ)
         res = self.modtool.list()
         expected = ['GCC/6.4.0-2.28', 'OpenMPI/2.1.2-GCC-6.4.0-2.28', 'hwloc/1.11.8-GCC-6.4.0-2.28']
         self.assertEqual(sorted([x['mod_name'] for x in res]), expected)
@@ -215,9 +215,9 @@ class ModulesTest(EnhancedTestCase):
         if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('5.7.5'):
             # with recent versions of Lmod, also the hidden modules are included in the output of 'avail'
             self.assertEqual(len(ms), TEST_MODULES_COUNT + 3)
-            self.assertTrue('bzip2/.1.0.6' in ms)
-            self.assertTrue('toy/.0.0-deps' in ms)
-            self.assertTrue('OpenMPI/.2.1.2-GCC-6.4.0-2.28' in ms)
+            self.assertIn('bzip2/.1.0.6', ms)
+            self.assertIn('toy/.0.0-deps', ms)
+            self.assertIn('OpenMPI/.2.1.2-GCC-6.4.0-2.28', ms)
         else:
             self.assertEqual(len(ms), TEST_MODULES_COUNT)
 
@@ -292,11 +292,11 @@ class ModulesTest(EnhancedTestCase):
         write_file(os.path.join(java_mod_dir, '.modulerc'), modulerc_tcl_txt)
 
         avail_mods = self.modtool.available()
-        self.assertTrue('Java/1.8.0_181' in avail_mods)
+        self.assertIn('Java/1.8.0_181', avail_mods)
         if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.0'):
-            self.assertTrue('Java/1.8' in avail_mods)
-            self.assertTrue('Java/site_default' in avail_mods)
-            self.assertTrue('JavaAlias' in avail_mods)
+            self.assertIn('Java/1.8', avail_mods)
+            self.assertIn('Java/site_default', avail_mods)
+            self.assertIn('JavaAlias', avail_mods)
             self.assertEqual(self.modtool.exist(['JavaAlias']), [True])
 
         self.assertEqual(self.modtool.exist(['Java/1.8', 'Java/1.8.0_181']), [True, True])
@@ -344,7 +344,7 @@ class ModulesTest(EnhancedTestCase):
         mkdir(os.path.join(self.test_prefix, 'Core'))
         shutil.move(java_mod_dir, os.path.join(self.test_prefix, 'Core', 'Java'))
 
-        self.assertTrue('Core/Java/1.8.0_181' in self.modtool.available())
+        self.assertIn('Core/Java/1.8.0_181', self.modtool.available())
         self.assertEqual(self.modtool.exist(['Core/Java/1.8.0_181']), [True])
         # there's a workaround to ensure that module wrappers/aliases are recognized when they're
         # being checked with the full module name (see https://github.com/TACC/Lmod/issues/446);
@@ -366,8 +366,8 @@ class ModulesTest(EnhancedTestCase):
                        ]))
 
             avail_mods = self.modtool.available()
-            self.assertTrue('Java/1.8.0_181' in avail_mods)
-            self.assertTrue('Java/1.8' in avail_mods)
+            self.assertIn('Java/1.8.0_181', avail_mods)
+            self.assertIn('Java/1.8', avail_mods)
             self.assertEqual(self.modtool.exist(['Java/1.8', 'Java/1.8.0_181']), [True, True])
 
             # check for an alias with a different version suffix than the base module
@@ -379,7 +379,7 @@ class ModulesTest(EnhancedTestCase):
 
             # back to HMNS setup
             shutil.move(java_mod_dir, os.path.join(self.test_prefix, 'Core', 'Java'))
-            self.assertTrue('Core/Java/1.8.0_181' in self.modtool.available())
+            self.assertIn('Core/Java/1.8.0_181', self.modtool.available())
             self.assertEqual(self.modtool.exist(['Core/Java/1.8.0_181']), [True])
             self.assertEqual(self.modtool.exist(['Core/Java/1.8']), [True])
             self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
@@ -410,7 +410,7 @@ class ModulesTest(EnhancedTestCase):
 
         for m in ms:
             self.modtool.load([m])
-            self.assertTrue(m in self.modtool.loaded_modules())
+            self.assertIn(m, self.modtool.loaded_modules())
             self.modtool.purge()
 
         # trying to load a module not on the top level of a hierarchy should fail
@@ -431,7 +431,7 @@ class ModulesTest(EnhancedTestCase):
 
         # GCC should be loaded, but should not be listed last (OpenMPI was loaded last)
         loaded_modules = self.modtool.loaded_modules()
-        self.assertTrue('GCC/6.4.0-2.28' in loaded_modules)
+        self.assertIn('GCC/6.4.0-2.28', loaded_modules)
         self.assertFalse(loaded_modules[-1] == 'GCC/6.4.0-2.28')
 
         # if GCC is loaded again, $EBROOTGCC should be set again, and GCC should be listed last
@@ -444,7 +444,7 @@ class ModulesTest(EnhancedTestCase):
 
         if isinstance(self.modtool, Lmod):
             # order of loaded modules only changes with Lmod
-            self.assertTrue(self.modtool.loaded_modules()[-1] == 'GCC/6.4.0-2.28')
+            self.assertEqual(self.modtool.loaded_modules()[-1], 'GCC/6.4.0-2.28')
 
         # set things up for checking that GCC does *not* get reloaded when requested
         if 'EBROOTGCC' in os.environ:
@@ -452,12 +452,12 @@ class ModulesTest(EnhancedTestCase):
         self.modtool.load(['OpenMPI/2.1.2-GCC-6.4.0-2.28'])
         if isinstance(self.modtool, Lmod):
             # order of loaded modules only changes with Lmod
-            self.assertTrue(self.modtool.loaded_modules()[-1] == 'OpenMPI/2.1.2-GCC-6.4.0-2.28')
+            self.assertEqual(self.modtool.loaded_modules()[-1], 'OpenMPI/2.1.2-GCC-6.4.0-2.28')
 
         # reloading can be disabled using allow_reload=False
         self.modtool.load(['GCC/6.4.0-2.28'], allow_reload=False)
         self.assertEqual(os.environ.get('EBROOTGCC'), None)
-        self.assertFalse(loaded_modules[-1] == 'GCC/6.4.0-2.28')
+        self.assertNotEqual(loaded_modules[-1], 'GCC/6.4.0-2.28')
 
     def test_show(self):
         """Test for ModulesTool.show method."""
@@ -638,13 +638,13 @@ class ModulesTest(EnhancedTestCase):
         ms = self.modtool.available()
 
         self.modtool.load([ms[0]])
-        self.assertTrue(len(self.modtool.loaded_modules()) > 0)
+        self.assertGreater(len(self.modtool.loaded_modules()), 0)
 
         self.modtool.purge()
-        self.assertTrue(len(self.modtool.loaded_modules()) == 0)
+        self.assertEqual(len(self.modtool.loaded_modules()), 0)
 
         self.modtool.purge()
-        self.assertTrue(len(self.modtool.loaded_modules()) == 0)
+        self.assertEqual(len(self.modtool.loaded_modules()), 0)
 
     def test_get_software_root_version_libdir(self):
         """Test get_software_X functions."""
@@ -1119,18 +1119,18 @@ class ModulesTest(EnhancedTestCase):
         # fetch cache entry
         avail_cache_key = list(mod.MODULE_AVAIL_CACHE.keys())[0]
         cached_res = mod.MODULE_AVAIL_CACHE[avail_cache_key]
-        self.assertTrue(cached_res == res)
+        self.assertEqual(cached_res, res)
 
         # running avail again results in getting cached result, exactly the same result as before
         # depending on the modules tool being used, it may not be the same list instance, because of post-processing
-        self.assertTrue(self.modtool.available() == res)
+        self.assertEqual(self.modtool.available(), res)
 
         # run 'show', should be all cached
         show_res_gcc = self.modtool.show('GCC/6.4.0-2.28')
         show_res_fftw = self.modtool.show('FFTW')
         self.assertEqual(len(mod.MODULE_SHOW_CACHE), 2)
-        self.assertTrue(show_res_gcc in mod.MODULE_SHOW_CACHE.values())
-        self.assertTrue(show_res_fftw in mod.MODULE_SHOW_CACHE.values())
+        self.assertIn(show_res_gcc, mod.MODULE_SHOW_CACHE.values())
+        self.assertIn(show_res_fftw, mod.MODULE_SHOW_CACHE.values())
         self.assertTrue(self.modtool.show('GCC/6.4.0-2.28') is show_res_gcc)
         self.assertTrue(self.modtool.show('FFTW') is show_res_fftw)
 
@@ -1158,7 +1158,7 @@ class ModulesTest(EnhancedTestCase):
             ])
             write_file(os.path.join(self.test_prefix, subdir, 'test'), modtxt)
 
-        self.assertFalse(test_dir1 in os.environ.get('MODULEPATH', ''))
+        self.assertNotIn(test_dir1, os.environ.get('MODULEPATH', ''))
         self.modtool.use(test_dir1)
         self.assertTrue(os.environ['MODULEPATH'].startswith('%s:' % test_dir1))
         self.modtool.use(test_dir2)
@@ -1177,21 +1177,21 @@ class ModulesTest(EnhancedTestCase):
         self.modtool.unload(['test'])
 
         self.modtool.unuse(test_dir3)
-        self.assertFalse(test_dir3 in os.environ.get('MODULEPATH', ''))
+        self.assertNotIn(test_dir3, os.environ.get('MODULEPATH', ''))
 
         self.modtool.load(['test'])
         self.assertEqual(os.getenv('TEST123'), 'two')
         self.modtool.unload(['test'])
 
         self.modtool.unuse(test_dir2)
-        self.assertFalse(test_dir2 in os.environ.get('MODULEPATH', ''))
+        self.assertNotIn(test_dir2, os.environ.get('MODULEPATH', ''))
 
         self.modtool.load(['test'])
         self.assertEqual(os.getenv('TEST123'), 'one')
         self.modtool.unload(['test'])
 
         self.modtool.unuse(test_dir1)
-        self.assertFalse(test_dir1 in os.environ.get('MODULEPATH', ''))
+        self.assertNotIn(test_dir1, os.environ.get('MODULEPATH', ''))
 
         # also test use with high priority
         self.modtool.use(test_dir2, priority=10000)
@@ -1228,7 +1228,7 @@ class ModulesTest(EnhancedTestCase):
             self.modtool.use(test_dir1)
             self.assertEqual(os.environ['MODULEPATH'], test_dir1)
             self.modtool.unuse(test_dir1)
-            self.assertFalse('MODULEPATH' in os.environ)
+            self.assertNotIn('MODULEPATH', os.environ)
             os.environ['MODULEPATH'] = old_module_path  # Restore
 
     def test_add_and_remove_module_path(self):
@@ -1299,16 +1299,16 @@ class ModulesTest(EnhancedTestCase):
         # cfr. https://github.com/easybuilders/easybuild-framework/issues/1756,
         # https://bugzilla.redhat.com/show_bug.cgi?id=1326075
         modules_dir = os.path.abspath(os.path.join(self.test_prefix, 'modules'))
-        self.assertFalse(modules_dir in os.environ['MODULEPATH'])
+        self.assertNotIn(modules_dir, os.environ['MODULEPATH'])
 
         mkdir(modules_dir, parents=True)
         self.modtool.use(modules_dir)
         modulepath = os.environ['MODULEPATH']
-        self.assertTrue(modules_dir in modulepath)
+        self.assertIn(modules_dir, modulepath)
 
         out, _ = run_cmd("bash -c 'echo MODULEPATH: $MODULEPATH'", simple=False)
         self.assertEqual(out.strip(), "MODULEPATH: %s" % modulepath)
-        self.assertTrue(modules_dir in out)
+        self.assertIn(modules_dir, out)
 
     def test_load_in_hierarchy(self):
         """Test whether loading a module in a module hierarchy results in loading the correct module."""
@@ -1455,7 +1455,7 @@ class ModulesTest(EnhancedTestCase):
         stderr = check_loaded_modules()
         warning_msg = "WARNING: Found defined $EBROOT* environment variables without matching loaded module: "
         warning_msg = "$EBROOTSOFTWAREWITHOUTAMATCHINGMODULE\n"
-        self.assertTrue(warning_msg in stderr)
+        self.assertIn(warning_msg, stderr)
 
         build_options.update({'check_ebroot_env_vars': 'error'})
         init_config(build_options=build_options)

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -1038,6 +1038,7 @@ class ModulesTest(EnhancedTestCase):
 
         # GCC/4.6.3 is *not* an available Core module
         os.environ['LC_ALL'] = 'C'
+        os.environ['LANG'] = 'C'
         self.assertErrorRegex(EasyBuildError, load_err_msg, self.modtool.load, ['GCC/4.6.3'])
 
         # GCC/6.4.0-2.28 is one of the available Core modules

--- a/test/framework/modulestool.py
+++ b/test/framework/modulestool.py
@@ -91,10 +91,10 @@ class ModulesToolTest(EnhancedTestCase):
         try:
             bmmt = BrokenMockModulesTool(mod_paths=[], testing=True)
             # should never get here
-            self.assertTrue(False, 'BrokenMockModulesTool should fail')
+            self.fail('BrokenMockModulesTool should fail')
         except EasyBuildError as err:
             err_msg = "command is not available"
-            self.assertTrue(err_msg in str(err), "'%s' found in: %s" % (err_msg, err))
+            self.assertIn(err_msg, str(err))
 
         os.environ[BrokenMockModulesTool.COMMAND_ENVIRONMENT] = MockModulesTool.COMMAND
         os.environ['module'] = "() { /bin/echo $*\n}"

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -492,8 +492,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
         stdout = self.get_stdout()
         self.mock_stdout(False)
 
-        self.assertTrue("Auto-enabling streaming output" in stdout)
-        self.assertTrue("== (streaming) output for command 'gcc toy.c -o toy':" in stdout)
+        self.assertIn("Auto-enabling streaming output", stdout)
+        self.assertIn("== (streaming) output for command 'gcc toy.c -o toy':", stdout)
 
         if os.path.exists(dummylogfn):
             os.remove(dummylogfn)
@@ -1284,7 +1284,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertTrue(regex.search(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
 
         self.assertEqual(os.listdir(test_target_dir), [ec_filename])
-        self.assertTrue("name = 'bat'" in read_file(os.path.join(test_target_dir, ec_filename)))
+        self.assertIn("name = 'bat'", read_file(os.path.join(test_target_dir, ec_filename)))
         remove_dir(test_target_dir)
 
         # test copying of a single easyconfig file from a PR to a non-existing path
@@ -1296,7 +1296,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertTrue(regex.search(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
 
         self.assertTrue(os.path.exists(bat_ec))
-        self.assertTrue("name = 'bat'" in read_file(bat_ec))
+        self.assertIn("name = 'bat'", read_file(bat_ec))
 
         change_dir(cwd)
         remove_dir(test_working_dir)
@@ -1323,7 +1323,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertTrue(regex.search(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
 
         self.assertEqual(os.listdir(test_working_dir), [ec_filename])
-        self.assertTrue("name = 'bat'" in read_file(os.path.join(test_working_dir, ec_filename)))
+        self.assertIn("name = 'bat'", read_file(os.path.join(test_working_dir, ec_filename)))
 
         # also test copying of patch file to current directory (without specifying target location)
         change_dir(test_working_dir)
@@ -1347,7 +1347,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         regex = re.compile(r'.*/%s copied to %s' % (ec_pr11521, test_ec))
         self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
         self.assertTrue(os.path.exists(test_ec))
-        self.assertTrue("name = 'ExifTool'" in read_file(test_ec))
+        self.assertIn("name = 'ExifTool'", read_file(test_ec))
         remove_file(test_ec)
 
     def test_dry_run(self):
@@ -1407,7 +1407,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                 self.mock_stderr(False)
                 self.mock_stdout(False)
                 self.assertFalse(stderr)
-                self.assertTrue(expected in stdout, "Pattern '%s' found in: %s" % (expected, stdout))
+                self.assertIn(expected, stdout)
 
     def test_dry_run_short(self):
         """Test dry run (short format)."""
@@ -1609,7 +1609,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         warning_stub = "\nWARNING: There may be newer version(s) of dep 'OpenBLAS' available with a different " \
                        "versionsuffix to '-LAPACK-3.4.2'"
         self.mock_stderr(False)
-        self.assertTrue(warning_stub in errtxt)
+        self.assertIn(warning_stub, errtxt)
         patterns = [
             # toolchain got updated
             r"^ \* \[x\] .*/test_ecs/g/GCC/GCC-6.4.0-2.28.eb \(module: GCC/6.4.0-2.28\)$",
@@ -1832,9 +1832,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
             stderr = self.get_stderr()
             self.mock_stdout(False)
             self.mock_stderr(False)
-            self.assertFalse(self.github_token in outtxt)
-            self.assertFalse(self.github_token in stdout)
-            self.assertFalse(self.github_token in stderr)
+            self.assertNotIn(self.github_token, outtxt)
+            self.assertNotIn(self.github_token, stdout)
+            self.assertNotIn(self.github_token, stderr)
 
         except URLError as err:
             print("Ignoring URLError '%s' in test_from_pr" % err)
@@ -1980,7 +1980,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                 'setenv("SITE_SPECIFIC_FOOTER_ENV_VAR", "bar")',
             ])
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         # dump header/footer text to file
         handle, modules_footer = tempfile.mkstemp(prefix='modules-footer-')
@@ -2158,10 +2158,10 @@ class CommandLineOptionsTest(EnhancedTestCase):
         try:
             log.experimental('x')
             # sanity check, should never be reached if it works.
-            self.assertTrue(False, "Experimental logging should be disabled by setting --disable-experimental option")
+            self.fail("Experimental logging should be disabled by setting --disable-experimental option")
         except easybuild.tools.build_log.EasyBuildError as err:
             # check error message
-            self.assertTrue('Experimental functionality.' in str(err))
+            self.assertIn('Experimental functionality.', str(err))
 
         # toggle experimental
         EasyBuildOptions(
@@ -2170,7 +2170,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         try:
             log.experimental('x')
         except easybuild.tools.build_log.EasyBuildError as err:
-            self.assertTrue(False, "Experimental logging should be allowed by the --experimental option: %s" % err)
+            self.fail("Experimental logging should be allowed by the --experimental option: %s" % err)
 
         # set it back
         easybuild.tools.build_log.EXPERIMENTAL = orig_value
@@ -2199,7 +2199,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             stderr = self.get_stderr()
             self.mock_stderr(False)
         except easybuild.tools.build_log.EasyBuildError as err:
-            self.assertTrue(False, "Deprecated logging should work: %s" % err)
+            self.fail("Deprecated logging should work: %s" % err)
 
         stderr_regex = re.compile("^\nWARNING: Deprecated functionality, will no longer work in")
         self.assertTrue(stderr_regex.search(stderr), "Pattern '%s' found in: %s" % (stderr_regex.pattern, stderr))
@@ -2211,9 +2211,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         try:
             log.deprecated('x', str(orig_value))
             # not supposed to get here
-            self.assertTrue(False, 'Deprecated logging should throw EasyBuildError')
+            self.fail('Deprecated logging should throw EasyBuildError')
         except easybuild.tools.build_log.EasyBuildError as err2:
-            self.assertTrue('DEPRECATED' in str(err2))
+            self.assertIn('DEPRECATED', str(err2))
 
         # force higher version by prefixing it with 1, which should result in deprecation errors
         EasyBuildOptions(
@@ -2222,9 +2222,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         try:
             log.deprecated('x', str(orig_value))
             # not supposed to get here
-            self.assertTrue(False, 'Deprecated logging should throw EasyBuildError')
+            self.fail('Deprecated logging should throw EasyBuildError')
         except easybuild.tools.build_log.EasyBuildError as err3:
-            self.assertTrue('DEPRECATED' in str(err3))
+            self.assertIn('DEPRECATED', str(err3))
 
         # set it back
         easybuild.tools.build_log.CURRENT_VERSION = orig_value
@@ -2370,7 +2370,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.eb_main(args + [copied_ec], verbose=True, raise_error=True)
         outtxt = self.get_stdout()
         errtxt = self.get_stderr()
-        self.assertTrue(r'toy-0.0-tweaked.eb copied to ' + copied_ec in outtxt)
+        self.assertIn(r'toy-0.0-tweaked.eb copied to ' + copied_ec, outtxt)
         self.assertFalse(errtxt)
         self.mock_stdout(False)
         self.mock_stderr(False)
@@ -2383,7 +2383,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                      verbose=True, raise_error=True)
         outtxt = self.get_stdout()
         errtxt = self.get_stderr()
-        self.assertTrue(r'1 file(s) copied to ' + tweaked_ecs_dir in outtxt)
+        self.assertIn(r'1 file(s) copied to ' + tweaked_ecs_dir, outtxt)
         self.assertFalse(errtxt)
         self.mock_stdout(False)
         self.mock_stderr(False)
@@ -3034,7 +3034,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             self.assertErrorRegex(SystemExit, '.*', self.eb_main, args, raise_error=True, raise_systemexit=True)
             stderr = self.get_stderr()
             self.mock_stderr(False)
-            self.assertTrue("error: no such option: -X" in stderr)
+            self.assertIn("error: no such option: -X", stderr)
 
     def test_missing_cfgfile(self):
         """Test behaviour when non-existing config file is specified."""
@@ -3103,7 +3103,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         else:
             homecfgfile_str += " => not found"
         expected = expected_tmpl % ('(not set)', '(not set)', homecfgfile_str, '{/etc}')
-        self.assertTrue(expected in logtxt)
+        self.assertIn(expected, logtxt)
 
         # to predict the full output, we need to take control over $HOME and $XDG_CONFIG_DIRS
         os.environ['HOME'] = self.test_prefix
@@ -3127,7 +3127,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         logtxt = read_file(self.logfile)
         expected = expected_tmpl % ('(not set)', xdg_config_dirs, "%s => found" % homecfgfile, '{%s}' % xdg_config_dirs,
                                     '(no matches)', 1, homecfgfile)
-        self.assertTrue(expected in logtxt)
+        self.assertIn(expected, logtxt)
 
         xdg_config_home = os.path.join(self.test_prefix, 'home')
         os.environ['XDG_CONFIG_HOME'] = xdg_config_home
@@ -3153,7 +3153,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
                                     "%s => found" % os.path.join(xdg_config_home, 'easybuild', 'config.cfg'),
                                     '{' + ', '.join(xdg_config_dirs) + '}',
                                     ', '.join(cfgfiles[:-1]), 4, ', '.join(cfgfiles))
-        self.assertTrue(expected in logtxt)
+        self.assertIn(expected, logtxt)
 
         del os.environ['XDG_CONFIG_DIRS']
         del os.environ['XDG_CONFIG_HOME']
@@ -3796,7 +3796,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         txt = self.get_stdout()
         self.mock_stdout(False)
         self.mock_stderr(False)
-        self.assertTrue("This PR should be labelled with 'update'" in txt)
+        self.assertIn("This PR should be labelled with 'update'", txt)
 
         # test --review-pr-max
         self.mock_stdout(True)
@@ -3811,7 +3811,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         txt = self.get_stdout()
         self.mock_stdout(False)
         self.mock_stderr(False)
-        self.assertTrue("2016.04" not in txt)
+        self.assertNotIn("2016.04", txt)
 
         # test --review-pr-filter
         self.mock_stdout(True)
@@ -3826,7 +3826,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         txt = self.get_stdout()
         self.mock_stdout(False)
         self.mock_stderr(False)
-        self.assertTrue("2016.04" not in txt)
+        self.assertNotIn("2016.04", txt)
 
     def test_set_tmpdir(self):
         """Test set_tmpdir config function."""
@@ -4225,7 +4225,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         if len(dirs) == 1:
             git_working_dir = dirs[0]
         else:
-            self.assertTrue(False, "Failed to find temporary git working dir: %s" % dirs)
+            self.fail("Failed to find temporary git working dir: %s" % dirs)
 
         remote = 'git@github.com:%s/easybuild-easyconfigs.git' % GITHUB_TEST_ACCOUNT
         regexs = [
@@ -4264,7 +4264,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             unstaged_file_full = os.path.join(res[0], unstaged_file)
             self.assertFalse(os.path.exists(unstaged_file_full), "%s not found in %s" % (unstaged_file, res[0]))
         else:
-            self.assertTrue(False, "Found copy of easybuild-easyconfigs working copy")
+            self.fail("Found copy of easybuild-easyconfigs working copy")
 
         # add required commit message, try again
         args.append('--pr-commit-msg=just a test')
@@ -4752,7 +4752,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '',
             "Review OK, merging pull request!",
         ])
-        self.assertTrue(expected_stdout in stdout)
+        self.assertIn(expected_stdout, stdout)
 
     def test_github_empty_pr(self):
         """Test use of --new-pr (dry run only) with no changes"""
@@ -5033,7 +5033,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         # just a selection
         for mod in ['cray-libsci/13.2.0', 'cray-netcdf/4.3.2', 'fftw/3.3.4.3']:
-            self.assertTrue(mod in metadata)
+            self.assertIn(mod, metadata)
 
         netcdf = {
             'name': ['netCDF', 'netCDF-Fortran'],
@@ -5057,7 +5057,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         # default metadata is overruled, and not available anymore
         for mod in ['cray-libsci/13.2.0', 'cray-netcdf/4.3.2', 'fftw/3.3.4.3']:
-            self.assertFalse(mod in metadata)
+            self.assertNotIn(mod, metadata)
 
         foobar1 = {
             'name': ['foo', 'bar'],
@@ -5195,7 +5195,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args = ['--list-prs', 'closed,updated,asc']
         txt, _ = self._run_mock_eb(args, testing=False)
         expected = "Listing PRs with parameters: direction=asc, per_page=100, sort=updated, state=closed"
-        self.assertTrue(expected in txt)
+        self.assertIn(expected, txt)
 
     def test_list_software(self):
         """Test --list-software and --list-installed-software."""
@@ -5518,7 +5518,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # filename of provided easyconfig doesn't matter by default
         self.eb_main(args, logfile=dummylogfn, raise_error=True)
         logtxt = read_file(self.logfile)
-        self.assertTrue('module: toy/0.0' in logtxt)
+        self.assertIn('module: toy/0.0', logtxt)
 
         write_file(self.logfile, '')
 
@@ -5534,7 +5534,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args[0] = toy_ec
         self.eb_main(args, logfile=dummylogfn, raise_error=True)
         logtxt = read_file(self.logfile)
-        self.assertTrue('module: toy/0.0' in logtxt)
+        self.assertIn('module: toy/0.0', logtxt)
 
     def test_set_default_module(self):
         """Test use of --set-default-module"""
@@ -5557,9 +5557,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
             toy_dot_version = os.path.join(toy_mod_dir, '.version')
             self.assertTrue(os.path.exists(toy_dot_version))
             toy_dot_version_txt = read_file(toy_dot_version)
-            self.assertTrue("set ModulesVersion 0.0-deps" in toy_dot_version_txt)
+            self.assertIn("set ModulesVersion 0.0-deps", toy_dot_version_txt)
         else:
-            self.assertTrue(False, "Uknown module syntax: %s" % get_module_syntax())
+            self.fail("Uknown module syntax: %s" % get_module_syntax())
 
         # make sure default is also set for moduleclass symlink
         toy_mod_symlink_dir = os.path.join(self.test_installpath, 'modules', 'tools', 'toy')
@@ -5583,7 +5583,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             modfile_path = os.path.join(toy_mod_dir, '0.0-deps')
             self.assertTrue(os.path.samefile(os.readlink(mod_symlink), modfile_path))
         else:
-            self.assertTrue(False, "Uknown module syntax: %s" % get_module_syntax())
+            self.fail("Uknown module syntax: %s" % get_module_syntax())
 
     def test_set_default_module_robot(self):
         """Test use of --set-default-module --robot."""
@@ -5635,9 +5635,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
             self.assertEqual(sorted(os.listdir(test_mod_dir)), ['.version', '1.0'])
             self.assertEqual(sorted(os.listdir(testdep_mod_dir)), ['3.14'])
             dot_version_file = os.path.join(test_mod_dir, '.version')
-            self.assertTrue("set ModulesVersion 1.0" in read_file(dot_version_file))
+            self.assertIn("set ModulesVersion 1.0", read_file(dot_version_file))
         else:
-            self.assertTrue(False, "Uknown module syntax: %s" % get_module_syntax())
+            self.fail("Uknown module syntax: %s" % get_module_syntax())
 
     def test_inject_checksums(self):
         """Test for --inject-checksums"""
@@ -5662,7 +5662,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertFalse(os.path.exists(os.path.join(self.test_installpath, 'software', 'toy')))
 
         # SHA256 is default type of checksums used
-        self.assertTrue("injecting sha256 checksums in" in stdout)
+        self.assertIn("injecting sha256 checksums in", stdout)
         self.assertEqual(stderr, '')
 
         args.append('--force')
@@ -5699,7 +5699,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         # some checks on 'raw' easyconfig contents
         # single-line checksum for barbar extension since there's only one
-        self.assertTrue("'checksums': ['d5bd9908cdefbe2d29c6f8d5b45b2aaed9fd904b5e6397418bb5094fbdb3d838']," in ec_txt)
+        self.assertIn("'checksums': ['d5bd9908cdefbe2d29c6f8d5b45b2aaed9fd904b5e6397418bb5094fbdb3d838'],", ec_txt)
 
         # single-line checksum entry for bar source tarball
         regex = re.compile("^[ ]*{'bar-0.0.tar.gz': '%s'},$" % bar_tar_gz_sha256, re.M)
@@ -5724,7 +5724,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             self.assertTrue(regex.search(ec_txt), "Pattern '%s' found in: %s" % (regex.pattern, ec_txt))
 
         # name/version of toy should NOT be hardcoded in exts_list, 'name'/'version' parameters should be used
-        self.assertTrue('    (name, version, {' in ec_txt)
+        self.assertIn('    (name, version, {', ec_txt)
 
         # make sure checksums are only there once...
         # exactly one definition of 'checksums' easyconfig parameter
@@ -5766,7 +5766,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertEqual(len(ec_backups), 1)
         self.assertEqual(read_file(toy_ec), read_file(ec_backups[0]))
 
-        self.assertTrue("injecting sha256 checksums in" in stdout)
+        self.assertIn("injecting sha256 checksums in", stdout)
         self.assertEqual(stderr, warning_msg)
 
         remove_file(ec_backups[0])
@@ -5796,7 +5796,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # get rid of existing checksums
         regex = re.compile(r'^checksums(?:.|\n)*?\]\s*$', re.M)
         toy_ec_txt = regex.sub('', toy_ec_txt)
-        self.assertFalse('checksums = ' in toy_ec_txt)
+        self.assertNotIn('checksums = ', toy_ec_txt)
 
         write_file(test_ec, toy_ec_txt)
         args = [test_ec, '--inject-checksums=md5']
@@ -5869,7 +5869,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.mock_stderr(False)
 
         self.assertEqual(stdout, '')
-        self.assertTrue("option --inject-checksums: invalid choice" in stderr)
+        self.assertIn("option --inject-checksums: invalid choice", stderr)
 
     def test_inject_checksums_to_json(self):
         """Test --inject-checksums-to-json."""
@@ -5954,7 +5954,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # because of missing checksum for source of 'bar' extension
         regex = re.compile("^.*'checksums':.*$", re.M)
         test_ec_txt = regex.sub('', read_file(test_ec))
-        self.assertFalse("'checksums':" in test_ec_txt)
+        self.assertNotIn("'checksums':", test_ec_txt)
         write_file(test_ec, test_ec_txt)
         error_pattern = r"Missing checksum for bar-0\.0\.tar\.gz"
         self.assertErrorRegex(EasyBuildError, error_pattern, self.eb_main, args, do_build=True, raise_error=True)
@@ -5964,7 +5964,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         for param in ['checksums', 'exts_list']:
             regex = re.compile(r'^%s(?:.|\n)*?\]\s*$' % param, re.M)
             test_ec_txt = regex.sub('', test_ec_txt)
-            self.assertFalse('%s = ' % param in test_ec_txt)
+            self.assertNotIn('%s = ' % param, test_ec_txt)
 
         write_file(test_ec, test_ec_txt)
         error_pattern = "Missing checksum for toy-0.0.tar.gz"
@@ -6059,7 +6059,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertEqual(len(tmp_logs), 1)
 
         logtxt = read_file(os.path.join(tmp_logdir, tmp_logs[0]))
-        self.assertTrue("COMPLETED: Installation ended successfully" in logtxt)
+        self.assertIn("COMPLETED: Installation ended successfully", logtxt)
 
     def test_sanity_check_only(self):
         """Test use of --sanity-check-only."""
@@ -6082,7 +6082,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         # sanity check fails if software was not installed yet
         outtxt, error_thrown = self.eb_main([test_ec, '--sanity-check-only'], do_build=True, return_error=True)
-        self.assertTrue("Sanity check failed" in str(error_thrown))
+        self.assertIn("Sanity check failed", str(error_thrown))
 
         # actually install, then try --sanity-check-only again;
         # need to use --force to install toy because module already exists (but installation doesn't)
@@ -6113,8 +6113,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
         for skip in skipped:
             self.assertTrue("== %s [skipped]" % skip)
 
-        self.assertTrue("== sanity checking..." in stdout)
-        self.assertTrue("COMPLETED: Installation ended successfully" in stdout)
+        self.assertIn("== sanity checking...", stdout)
+        self.assertIn("COMPLETED: Installation ended successfully", stdout)
         msgs = [
             "  >> file 'bin/barbar' found: OK",
             "  >> file 'bin/toy' found: OK",
@@ -6124,7 +6124,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             "ls -l lib/libbarbar.a",  # sanity check for extension barbar (via exts_filter)
         ]
         for msg in msgs:
-            self.assertTrue(msg in stdout, "'%s' found in: %s" % (msg, stdout))
+            self.assertIn(msg, stdout)
 
         ebroottoy = os.path.join(self.test_installpath, 'software', 'toy', '0.0')
 
@@ -6145,7 +6145,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         # failing sanity check for extension can be bypassed via --skip-extensions
         outtxt = self.eb_main(args + ['--skip-extensions'], do_build=True, raise_error=True)
-        self.assertTrue("Sanity check for toy successful" in outtxt)
+        self.assertIn("Sanity check for toy successful", outtxt)
 
         # restore fail, we want a passing sanity check for the next check
         move_file(libbarbar + '.moved', libbarbar)
@@ -6176,11 +6176,11 @@ class CommandLineOptionsTest(EnhancedTestCase):
         toy_eb = os.path.join(test_ebs, 't', 'toy.py')
         toy_eb_txt = read_file(toy_eb)
 
-        self.assertFalse('self.build_in_installdir = True' in toy_eb_txt)
+        self.assertNotIn('self.build_in_installdir = True', toy_eb_txt)
 
         regex = re.compile(r'^(\s+)(super\(EB_toy, self\).__init__.*)\n', re.M)
         toy_eb_txt = regex.sub(r'\1\2\n\1self.build_in_installdir = True', toy_eb_txt)
-        self.assertTrue('self.build_in_installdir = True' in toy_eb_txt)
+        self.assertIn('self.build_in_installdir = True', toy_eb_txt)
 
         toy_eb = os.path.join(self.test_prefix, 'toy.py')
         write_file(toy_eb, toy_eb_txt)
@@ -6455,7 +6455,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.eb_main(args + ['--accept-eula=foo,toy,bar'], do_build=True, raise_error=True)
         stderr = self.get_stderr()
         self.mock_stderr(False)
-        self.assertTrue("Use accept-eula-for configuration setting rather than accept-eula" in stderr)
+        self.assertIn("Use accept-eula-for configuration setting rather than accept-eula", stderr)
 
         remove_dir(self.test_installpath)
         self.assertFalse(os.path.exists(toy_modfile))
@@ -6468,7 +6468,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.mock_stderr(False)
 
         self.assertTrue(os.path.exists(toy_modfile))
-        self.assertTrue("Use accept-eula-for configuration setting rather than accept-eula" in stderr)
+        self.assertIn("Use accept-eula-for configuration setting rather than accept-eula", stderr)
 
         remove_dir(self.test_installpath)
         self.assertFalse(os.path.exists(toy_modfile))
@@ -6704,7 +6704,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertFalse(build_option('debug'))
         self.assertFalse(build_option('hidden'))
         # tests may be configured to run with Tcl module syntax
-        self.assertTrue(get_module_syntax() in ('Lua', 'Tcl'))
+        self.assertIn(get_module_syntax(), ('Lua', 'Tcl'))
 
         # start with a clean slate, reset all configuration done by setUp method that prepares each test
         cleanup()
@@ -6749,7 +6749,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         stderr = self.get_stderr()
         self.mock_stderr(False)
 
-        self.assertTrue("WARNING: set_up_configuration is about to call init() and init_build_options()" in stderr)
+        self.assertIn("WARNING: set_up_configuration is about to call init() and init_build_options()", stderr)
 
         # 'hidden' option is enabled, but corresponding build option is still set to False!
         self.assertTrue(eb_go.options.hidden)
@@ -6777,8 +6777,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertFalse(BuildOptions()['debug'])
 
         # tests may be configured to run with Tcl module syntax
-        self.assertTrue(ConfigurationVariables()['module_syntax'] in ('Lua', 'Tcl'))
-        self.assertTrue(get_module_syntax() in ('Lua', 'Tcl'))
+        self.assertIn(ConfigurationVariables()['module_syntax'], ('Lua', 'Tcl'))
+        self.assertIn(get_module_syntax(), ('Lua', 'Tcl'))
 
     def test_opts_dict_to_eb_opts(self):
         """Tests for opts_dict_to_eb_opts."""

--- a/test/framework/parallelbuild.py
+++ b/test/framework/parallelbuild.py
@@ -167,18 +167,18 @@ class ParallelBuildTest(EnhancedTestCase):
         self.assertEqual(len(jobs[1].deps), 0)
 
         # only dependency for toy/0.0-deps is intel/2018a (dep marked as external module is filtered out)
-        self.assertTrue('toy-0.0-deps.eb' in jobs[2].script)
+        self.assertIn('toy-0.0-deps.eb', jobs[2].script)
         self.assertEqual(len(jobs[2].deps), 1)
-        self.assertTrue('intel-2018a.eb' in jobs[2].deps[0].script)
+        self.assertIn('intel-2018a.eb', jobs[2].deps[0].script)
 
         # dependencies for gzip/1.4-GCC-4.6.3: GCC/4.6.3 (toolchain) + toy/.0.0-deps
-        self.assertTrue('gzip-1.4-GCC-4.6.3.eb' in jobs[3].script)
+        self.assertIn('gzip-1.4-GCC-4.6.3.eb', jobs[3].script)
         self.assertEqual(len(jobs[3].deps), 2)
         regex = re.compile(r'toy-0.0-deps\.eb.* --hidden')
         script_txt = jobs[3].deps[0].script
         fail_msg = "Pattern '%s' should be found in: %s" % (regex.pattern, script_txt)
         self.assertTrue(regex.search(script_txt), fail_msg)
-        self.assertTrue('GCC-4.6.3.eb' in jobs[3].deps[1].script)
+        self.assertIn('GCC-4.6.3.eb', jobs[3].deps[1].script)
 
         # also test use of --pre-create-installdir
         ec_file = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')

--- a/test/framework/repository.py
+++ b/test/framework/repository.py
@@ -173,7 +173,7 @@ class RepositoryTest(EnhancedTestCase):
             self.assertTrue(os.path.exists(path))
             ectxt = read_file(path)
             self.assertTrue(ectxt.startswith("# Built with EasyBuild version"))
-            self.assertTrue("# Build statistics" in ectxt)
+            self.assertIn("# Build statistics", ectxt)
             ecdict = EasyConfigParser(path).get_config_dict()
             self.assertEqual(ecdict['buildstats'], expected_buildstats)
 

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -202,15 +202,15 @@ class RobotTest(EnhancedTestCase):
         res = resolve_dependencies([deepcopy(easyconfig_moredeps)], self.modtool)
         self.assertEqual(len(res), 2)
         full_mod_names = [ec['full_mod_name'] for ec in res]
-        self.assertFalse('toy/.0.0-deps' in full_mod_names)
+        self.assertNotIn('toy/.0.0-deps', full_mod_names)
 
         res = resolve_dependencies([deepcopy(easyconfig_moredeps)], self.modtool, retain_all_deps=True)
         self.assertEqual(len(res), 4)  # hidden dep toy/.0.0-deps (+1) depends on (fake) intel/2018a (+1)
         self.assertEqual('gzip/1.4', res[0]['full_mod_name'])
         self.assertEqual('foo/1.2.3', res[-1]['full_mod_name'])
         full_mod_names = [ec['full_mod_name'] for ec in res]
-        self.assertTrue('toy/.0.0-deps' in full_mod_names)
-        self.assertTrue('intel/2018a' in full_mod_names)
+        self.assertIn('toy/.0.0-deps', full_mod_names)
+        self.assertIn('intel/2018a', full_mod_names)
 
         # here we have included a dependency in the easyconfig list
         easyconfig['full_mod_name'] = 'gzip/1.4'
@@ -482,7 +482,7 @@ class RobotTest(EnhancedTestCase):
         self.assertEqual(len(res), 10)
         mods = [x['full_mod_name'] for x in res]
         self.assertEqual(mods, all_mods_ordered)
-        self.assertTrue('SQLite/3.8.10.2-GCC-6.4.0-2.28' in mods)
+        self.assertIn('SQLite/3.8.10.2-GCC-6.4.0-2.28', mods)
 
         # test taking into account existing modules
         # with an SQLite module with foss/2018a in place, this toolchain should be used rather than GCC/6.4.0-2.28
@@ -497,8 +497,8 @@ class RobotTest(EnhancedTestCase):
         res = resolve_dependencies([bar], self.modtool, retain_all_deps=True)
         self.assertEqual(len(res), 10)
         mods = [x['full_mod_name'] for x in res]
-        self.assertTrue('SQLite/3.8.10.2-foss-2018a' in mods)
-        self.assertFalse('SQLite/3.8.10.2-GCC-6.4.0-2.28' in mods)
+        self.assertIn('SQLite/3.8.10.2-foss-2018a', mods)
+        self.assertNotIn('SQLite/3.8.10.2-GCC-6.4.0-2.28', mods)
 
         # Check whether having 2 version of system toolchain is ok
         # Clear easyconfig and toolchain caches
@@ -543,8 +543,8 @@ class RobotTest(EnhancedTestCase):
         res = resolve_dependencies([bar], self.modtool, retain_all_deps=True)
         self.assertEqual(len(res), 11)
         mods = [x['full_mod_name'] for x in res]
-        self.assertTrue('impi/5.1.2.150' in mods)
-        self.assertTrue('gzip/1.4' in mods)
+        self.assertIn('impi/5.1.2.150', mods)
+        self.assertIn('gzip/1.4', mods)
 
     def test_resolve_dependencies_missing(self):
         """Test handling of missing dependencies in resolve_dependencies function."""
@@ -1109,10 +1109,10 @@ class RobotTest(EnhancedTestCase):
         res = resolve_dependencies(easyconfigs, self.modtool, retain_all_deps=True)
         specs = [ec['spec'] for ec in res]
         # Check it picks up the tweaked OpenMPI
-        self.assertTrue(tweaked_openmpi in specs)
+        self.assertIn(tweaked_openmpi, specs)
         # Check it picks up the untweaked dependency of the tweaked OpenMPI
         untweaked_hwloc = os.path.join(test_easyconfigs, 'h', 'hwloc', 'hwloc-1.11.8-GCC-6.4.0-2.28.eb')
-        self.assertTrue(untweaked_hwloc in specs)
+        self.assertIn(untweaked_hwloc, specs)
 
     def test_robot_find_subtoolchain_for_dep(self):
         """Test robot_find_subtoolchain_for_dep."""
@@ -1392,7 +1392,7 @@ class RobotTest(EnhancedTestCase):
         self.mock_stderr(False)
 
         self.assertTrue(conflicts)
-        self.assertTrue("Conflict found for dependencies of foss-2018a: GCC-4.6.4 vs GCC-6.4.0-2.28" in stderr)
+        self.assertIn("Conflict found for dependencies of foss-2018a: GCC-4.6.4 vs GCC-6.4.0-2.28", stderr)
 
         # conflicts between specified easyconfigs are also detected
 
@@ -1407,7 +1407,7 @@ class RobotTest(EnhancedTestCase):
         self.mock_stderr(False)
 
         self.assertTrue(conflicts)
-        self.assertTrue("Conflict between (dependencies of) easyconfigs: GCC-4.9.3-2.25 vs GCC-6.4.0-2.28" in stderr)
+        self.assertIn("Conflict between (dependencies of) easyconfigs: GCC-4.9.3-2.25 vs GCC-6.4.0-2.28", stderr)
 
         # indirect conflict on dependencies
         ecs, _ = parse_easyconfigs([
@@ -1420,7 +1420,7 @@ class RobotTest(EnhancedTestCase):
         self.mock_stderr(False)
 
         self.assertTrue(conflicts)
-        self.assertTrue("Conflict between (dependencies of) easyconfigs: GCC-4.9.2 vs GCC-6.4.0-2.28" in stderr)
+        self.assertIn("Conflict between (dependencies of) easyconfigs: GCC-4.9.2 vs GCC-6.4.0-2.28", stderr)
 
         # test use of check_inter_ec_conflicts
         self.assertFalse(check_conflicts(ecs, self.modtool, check_inter_ec_conflicts=False), "No conflicts found")

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -721,7 +721,7 @@ class RunTest(EnhancedTestCase):
         init_logging(logfile, silent=True)
         check_log_for_errors(input_text, [(r"\b(error|crashed)\b", WARN)])
         stop_logging(logfile)
-        self.assertTrue(expected_msg in read_file(logfile))
+        self.assertIn(expected_msg, read_file(logfile))
 
         expected_msg = r"Found 2 error\(s\) in command output \(output: error found\n\ttest failed\)"
         write_file(logfile, '')
@@ -734,7 +734,7 @@ class RunTest(EnhancedTestCase):
         ])
         stop_logging(logfile)
         expected_msg = "Found 1 potential error(s) in command output (output: the process crashed with 0)"
-        self.assertTrue(expected_msg in read_file(logfile))
+        self.assertIn(expected_msg, read_file(logfile))
 
 
 def suite():

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -556,7 +556,7 @@ class SystemToolsTest(EnhancedTestCase):
     def test_cpu_architecture_native(self):
         """Test getting the CPU architecture."""
         arch = get_cpu_architecture()
-        self.assertTrue(arch in CPU_ARCHITECTURES)
+        self.assertIn(arch, CPU_ARCHITECTURES)
 
     def test_cpu_architecture(self):
         """Test getting the CPU architecture (mocked)."""
@@ -601,7 +601,7 @@ class SystemToolsTest(EnhancedTestCase):
     def test_cpu_vendor_native(self):
         """Test getting CPU vendor."""
         cpu_vendor = get_cpu_vendor()
-        self.assertTrue(cpu_vendor in CPU_VENDORS)
+        self.assertIn(cpu_vendor, CPU_VENDORS)
 
     def test_cpu_vendor_linux(self):
         """Test getting CPU vendor (mocked for Linux)."""
@@ -694,12 +694,12 @@ class SystemToolsTest(EnhancedTestCase):
     def test_os_type(self):
         """Test getting OS type."""
         os_type = get_os_type()
-        self.assertTrue(os_type in [DARWIN, LINUX])
+        self.assertIn(os_type, [DARWIN, LINUX])
 
     def test_shared_lib_ext_native(self):
         """Test getting extension for shared libraries."""
         ext = get_shared_lib_ext()
-        self.assertTrue(ext in ['dylib', 'so'])
+        self.assertIn(ext, ['dylib', 'so'])
 
     def test_shared_lib_ext_linux(self):
         """Test getting extension for shared libraries (mocked for Linux)."""
@@ -889,7 +889,7 @@ class SystemToolsTest(EnhancedTestCase):
         self.mock_stderr(False)
         self.assertFalse(stderr)
 
-        self.assertTrue(py_maj_ver in [2, 3])
+        self.assertIn(py_maj_ver, [2, 3])
         if py_maj_ver == 2:
             self.assertTrue(py_min_ver == 7)
         else:

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -95,7 +95,7 @@ class ToolchainTest(EnhancedTestCase):
         ec_file = find_full_path(os.path.join(test_ecs, 'g', 'gzip', 'gzip-1.4.eb'))
         ec = EasyConfig(ec_file, validate=False)
         tc = ec.toolchain
-        self.assertTrue('debug' in tc.options)
+        self.assertIn('debug', tc.options)
 
     def test_unknown_toolchain(self):
         """Test search_toolchain function for not available toolchains."""
@@ -168,7 +168,7 @@ class ToolchainTest(EnhancedTestCase):
             stderr = self.get_stderr()
             self.mock_stderr(False)
             self.assertTrue(tc.is_system_toolchain())
-            self.assertTrue(dummy_depr_warning in stderr, "Found '%s' in: %s" % (dummy_depr_warning, stderr))
+            self.assertIn(dummy_depr_warning, stderr)
 
     def test_toolchain_prepare_sysroot(self):
         """Test build environment setup done by Toolchain.prepare in case --sysroot is specified."""
@@ -294,7 +294,7 @@ class ToolchainTest(EnhancedTestCase):
         for key, prev_val, new_val in [('CC', 'foo', 'gcc'), ('CXX', 'bar', 'g++')]:
             warning_msg = "WARNING: $%s was defined as '%s', " % (key, prev_val)
             warning_msg += "but is now set to '%s' in minimal build environment" % new_val
-            self.assertTrue(warning_msg in stderr)
+            self.assertIn(warning_msg, stderr)
 
         self.assertEqual(os.getenv('CC'), 'gcc')
         self.assertEqual(os.getenv('CXX'), 'g++')
@@ -334,7 +334,7 @@ class ToolchainTest(EnhancedTestCase):
 
         warning_msg = "WARNING: 'nosuchcommand' command not found in $PATH, "
         warning_msg += "not setting $CC in minimal build environment"
-        self.assertTrue(warning_msg in stderr)
+        self.assertIn(warning_msg, stderr)
         self.assertEqual(stdout, '')
 
         self.assertEqual(os.getenv('CC'), None)
@@ -557,7 +557,7 @@ class ToolchainTest(EnhancedTestCase):
         tc.prepare()
         for var in flag_vars:
             flags = tc.get_variable(var)
-            self.assertTrue(tc.COMPILER_SHARED_OPTION_MAP['defaultopt'] in flags)
+            self.assertIn(tc.COMPILER_SHARED_OPTION_MAP['defaultopt'], flags)
 
         # check other optimization flags
         for opt in ['noopt', 'lowopt', 'opt']:
@@ -568,9 +568,9 @@ class ToolchainTest(EnhancedTestCase):
                 for var in flag_vars:
                     flags = tc.get_variable(var)
                     if enable:
-                        self.assertTrue(tc.COMPILER_SHARED_OPTION_MAP[opt] in flags)
+                        self.assertIn(tc.COMPILER_SHARED_OPTION_MAP[opt], flags)
                     else:
-                        self.assertTrue(tc.COMPILER_SHARED_OPTION_MAP[opt] in flags)
+                        self.assertIn(tc.COMPILER_SHARED_OPTION_MAP[opt], flags)
                 self.modtool.purge()
 
     def test_optimization_flags_combos(self):
@@ -586,7 +586,7 @@ class ToolchainTest(EnhancedTestCase):
         for var in flag_vars:
             flags = tc.get_variable(var)
             flag = '-%s' % tc.COMPILER_SHARED_OPTION_MAP['lowopt']
-            self.assertTrue(flag in flags)
+            self.assertIn(flag, flags)
         self.modtool.purge()
 
         tc = self.get_toolchain('foss', version='2018a')
@@ -595,7 +595,7 @@ class ToolchainTest(EnhancedTestCase):
         for var in flag_vars:
             flags = tc.get_variable(var)
             flag = '-%s' % tc.COMPILER_SHARED_OPTION_MAP['noopt']
-            self.assertTrue(flag in flags)
+            self.assertIn(flag, flags)
         self.modtool.purge()
 
         tc = self.get_toolchain('foss', version='2018a')
@@ -604,7 +604,7 @@ class ToolchainTest(EnhancedTestCase):
         for var in flag_vars:
             flags = tc.get_variable(var)
             flag = '-%s' % tc.COMPILER_SHARED_OPTION_MAP['noopt']
-            self.assertTrue(flag in flags)
+            self.assertIn(flag, flags)
 
     def test_misc_flags_shared(self):
         """Test whether shared compiler flags are set correctly."""
@@ -622,9 +622,9 @@ class ToolchainTest(EnhancedTestCase):
                 for var in flag_vars:
                     flags = tc.get_variable(var).split()
                     if enable:
-                        self.assertTrue(flag in flags, "%s: True means %s in %s" % (opt, flag, flags))
+                        self.assertIn(flag, flags, "%s: True means %s in %s" % (opt, flag, flags))
                     else:
-                        self.assertTrue(flag not in flags, "%s: False means no %s in %s" % (opt, flag, flags))
+                        self.assertNotIn(flag, flags, "%s: False means no %s in %s" % (opt, flag, flags))
                 self.modtool.purge()
 
         value = '--see-if-this-propagates'
@@ -643,10 +643,10 @@ class ToolchainTest(EnhancedTestCase):
         tc.prepare()
         self.assertTrue(tc.get_variable('CXXFLAGS').endswith(' ' + value))
         for var in flag_vars:
-            self.assertTrue(value not in tc.get_variable(var))
+            self.assertNotIn(value, tc.get_variable(var))
             # https://github.com/easybuilders/easybuild-framework/pull/3571
             # catch variable resued inside loop
-            self.assertTrue("-o -n -l -y" not in tc.get_variable(var))
+            self.assertNotIn("-o -n -l -y", tc.get_variable(var))
         self.modtool.purge()
 
     def test_misc_flags_unique(self):
@@ -671,9 +671,9 @@ class ToolchainTest(EnhancedTestCase):
                     for key, value in option.items():
                         flag = "-%s" % value
                         if enable == key:
-                            self.assertTrue(flag in flags, "%s: %s means %s in %s" % (opt, enable, flag, flags))
+                            self.assertIn(flag, flags, "%s: %s means %s in %s" % (opt, enable, flag, flags))
                         else:
-                            self.assertTrue(flag not in flags, "%s: %s means no %s in %s" % (opt, enable, flag, flags))
+                            self.assertNotIn(flag, flags, "%s: %s means no %s in %s" % (opt, enable, flag, flags))
                 self.modtool.purge()
 
     def test_override_optarch(self):
@@ -695,9 +695,9 @@ class ToolchainTest(EnhancedTestCase):
                 for var in flag_vars:
                     flags = tc.get_variable(var)
                     if enable:
-                        self.assertTrue(flag in flags, "optarch: True means %s in %s" % (flag, flags))
+                        self.assertIn(flag, flags, "optarch: True means %s in %s" % (flag, flags))
                     else:
-                        self.assertFalse(flag in flags, "optarch: False means no %s in %s" % (flag, flags))
+                        self.assertNotIn(flag, flags, "optarch: False means no %s in %s" % (flag, flags))
                 self.modtool.purge()
 
     def test_optarch_generic(self):
@@ -739,10 +739,10 @@ class ToolchainTest(EnhancedTestCase):
                         tup = (key, tcversion, tcopts, generic_flags, val)
                         if generic:
                             error_msg = "(%s, %s, %s) '%s' flags should be found in: '%s'"
-                            self.assertTrue(generic_flags in val, error_msg % tup)
+                            self.assertIn(generic_flags, val, error_msg % tup)
                         else:
                             error_msg = "(%s, %s, %s) '%s' flags should not be found in: '%s'"
-                            self.assertFalse(generic_flags in val, error_msg % tup)
+                            self.assertNotIn(generic_flags, val, error_msg % tup)
 
                     modules.modules_tool().purge()
 
@@ -756,14 +756,14 @@ class ToolchainTest(EnhancedTestCase):
         tc.set_options({})
         tc.prepare()
         self.assertEqual(tc.options.options_map['optarch'], 'mcpu=cortex-a53')
-        self.assertTrue('-mcpu=cortex-a53' in os.environ['CFLAGS'])
+        self.assertIn('-mcpu=cortex-a53', os.environ['CFLAGS'])
         self.modtool.purge()
 
         tc = self.get_toolchain("GCCcore", version="6.2.0")
         tc.set_options({})
         tc.prepare()
         self.assertEqual(tc.options.options_map['optarch'], 'mcpu=native')
-        self.assertTrue('-mcpu=native' in os.environ['CFLAGS'])
+        self.assertIn('-mcpu=native', os.environ['CFLAGS'])
         self.modtool.purge()
 
         st.get_cpu_model = lambda: 'ARM Cortex-A53 + Cortex-A72'
@@ -771,7 +771,7 @@ class ToolchainTest(EnhancedTestCase):
         tc.set_options({})
         tc.prepare()
         self.assertEqual(tc.options.options_map['optarch'], 'mcpu=cortex-a72.cortex-a53')
-        self.assertTrue('-mcpu=cortex-a72.cortex-a53' in os.environ['CFLAGS'])
+        self.assertIn('-mcpu=cortex-a72.cortex-a53', os.environ['CFLAGS'])
         self.modtool.purge()
 
     def test_compiler_dependent_optarch(self):
@@ -852,13 +852,13 @@ class ToolchainTest(EnhancedTestCase):
                 # Check that the correct flags are there
                 if enable and flags != '':
                     error_msg = "optarch: True means '%s' in '%s'" % (flags, set_flags)
-                    self.assertTrue(flags in set_flags, "optarch: True means '%s' in '%s'")
+                    self.assertIn(flags, set_flags, "optarch: True means '%s' in '%s'")
 
                 # Check that there aren't any unexpected flags
                 else:
                     for blacklisted_flag in blacklist:
                         error_msg = "optarch: False means no '%s' in '%s'" % (blacklisted_flag, set_flags)
-                        self.assertFalse(blacklisted_flag in set_flags, error_msg)
+                        self.assertNotIn(blacklisted_flag, set_flags, error_msg)
 
             self.modtool.purge()
 
@@ -900,9 +900,9 @@ class ToolchainTest(EnhancedTestCase):
                 for var in flag_vars:
                     flags = tc.get_variable(var)
                     if enable:
-                        self.assertTrue(flag in flags, "%s: True means %s in %s" % (opt, flag, flags))
+                        self.assertIn(flag, flags, "%s: True means %s in %s" % (opt, flag, flags))
                     else:
-                        self.assertTrue(flag not in flags, "%s: False means no %s in %s" % (opt, flag, flags))
+                        self.assertNotIn(flag, flags, "%s: False means no %s in %s" % (opt, flag, flags))
                 self.modtool.purge()
 
     def test_precision_flags(self):
@@ -1261,7 +1261,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(tc.comp_family(prefix='CUDA'), "CUDA")
 
         # check CUDA runtime lib
-        self.assertTrue("-lrt -lcudart" in tc.get_variable('LIBS'))
+        self.assertIn("-lrt -lcudart", tc.get_variable('LIBS'))
 
     def setup_sandbox_for_foss_fftw(self, moddir, fftwver='3.3.7'):
         """Set up sandbox for foss FFTW and FFTW.MPI"""
@@ -1377,12 +1377,12 @@ class ToolchainTest(EnhancedTestCase):
 
         for flag in ['-mt_mpi', '-fopenmp']:
             for var in ['CFLAGS', 'CXXFLAGS', 'FCFLAGS', 'FFLAGS', 'F90FLAGS']:
-                self.assertTrue(flag in tc.get_variable(var))
+                self.assertIn(flag, tc.get_variable(var))
 
         # -openmp is deprecated for new Intel compiler versions
-        self.assertFalse('-openmp' in tc.get_variable('CFLAGS'))
-        self.assertFalse('-openmp' in tc.get_variable('CXXFLAGS'))
-        self.assertFalse('-openmp' in tc.get_variable('FFLAGS'))
+        self.assertNotIn('-openmp', tc.get_variable('CFLAGS'))
+        self.assertNotIn('-openmp', tc.get_variable('CXXFLAGS'))
+        self.assertNotIn('-openmp', tc.get_variable('FFLAGS'))
 
         self.assertEqual(tc.get_variable('CC'), 'mpiicc')
         self.assertEqual(tc.get_variable('CXX'), 'mpiicpc')
@@ -1405,7 +1405,7 @@ class ToolchainTest(EnhancedTestCase):
         tc.prepare()
         self.assertEqual(tc.get_variable('MPIFC'), 'mpiifort')
         for var in ['CFLAGS', 'CXXFLAGS', 'FCFLAGS', 'FFLAGS', 'F90FLAGS']:
-            self.assertTrue('-openmp' in tc.get_variable(var))
+            self.assertIn('-openmp', tc.get_variable(var))
 
         # with compiler-only toolchain the $MPI* variables are not defined
         mpi_vars = ('MPICC', 'MPICXX', 'MPIF77', 'MPIF90', 'MPIFC')
@@ -1731,7 +1731,7 @@ class ToolchainTest(EnhancedTestCase):
         self.assertTrue([m['mod_name'] for m in self.modtool.list()], mods)
         self.assertTrue(os.environ['EBROOTTOY'].endswith('software/toy/0.0'))
         self.assertEqual(os.environ['EBVERSIONTOY'], '0.0')
-        self.assertFalse('EBROOTFOOBAR' in os.environ)
+        self.assertNotIn('EBROOTFOOBAR', os.environ)
 
         # with metadata
         deps[1] = {
@@ -1749,7 +1749,7 @@ class ToolchainTest(EnhancedTestCase):
         os.environ['FOOBAR_PREFIX'] = '/foo/bar'
         tc.prepare(deps=deps)
         mods = ['GCC/6.4.0-2.28', 'hwloc/1.11.8-GCC-6.4.0-2.28', 'OpenMPI/2.1.2-GCC-6.4.0-2.28', 'toy/0.0']
-        self.assertTrue([m['mod_name'] for m in self.modtool.list()], mods)
+        self.assertEqual(sorted(m['mod_name'] for m in self.modtool.list()), sorted(mods))
         self.assertEqual(os.environ['EBROOTTOY'], '/foo/bar')
         self.assertEqual(os.environ['EBVERSIONTOY'], '1.2.3')
         self.assertEqual(os.environ['EBROOTFOOBAR'], '/foo/bar')
@@ -1890,25 +1890,25 @@ class ToolchainTest(EnhancedTestCase):
         self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_intel4)
         self.assertEqual(os.environ.get('LIBFFT', "(not set)"), libfft_intel4)
         self.assertEqual(os.environ.get('LIBFFT_MT', "(not set)"), libfft_mt_intel4)
-        self.assertTrue(libscalack_intel4 in os.environ['LIBSCALAPACK'])
+        self.assertIn(libscalack_intel4, os.environ['LIBSCALAPACK'])
         self.modtool.purge()
 
         tc = self.get_toolchain('intel', version='2012a')
         tc.prepare()
         self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_intel3)
-        self.assertTrue(libscalack_intel3 in os.environ['LIBSCALAPACK'])
+        self.assertIn(libscalack_intel3, os.environ['LIBSCALAPACK'])
         self.modtool.purge()
 
         tc = self.get_toolchain('intel', version='2018a')
         tc.prepare()
         self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_intel4)
-        self.assertTrue(libscalack_intel4 in os.environ['LIBSCALAPACK'])
+        self.assertIn(libscalack_intel4, os.environ['LIBSCALAPACK'])
         self.modtool.purge()
 
         tc = self.get_toolchain('intel', version='2012a')
         tc.prepare()
         self.assertEqual(os.environ.get('LIBBLAS_MT', "(not set)"), libblas_mt_intel3)
-        self.assertTrue(libscalack_intel3 in os.environ['LIBSCALAPACK'])
+        self.assertIn(libscalack_intel3, os.environ['LIBSCALAPACK'])
         self.modtool.purge()
 
         libscalack_intel4 = libscalack_intel4.replace('_lp64', '_ilp64')
@@ -1916,7 +1916,7 @@ class ToolchainTest(EnhancedTestCase):
         opts = {'i8': True}
         tc.set_options(opts)
         tc.prepare()
-        self.assertTrue(libscalack_intel4 in os.environ['LIBSCALAPACK'])
+        self.assertIn(libscalack_intel4, os.environ['LIBSCALAPACK'])
         self.modtool.purge()
 
         tc = self.get_toolchain('fosscuda', version='2018a')
@@ -2892,7 +2892,7 @@ class ToolchainTest(EnhancedTestCase):
         # new $TMPDIR should be /tmp/xxxxxx
         tmpdir = os.environ.get('TMPDIR')
         self.assertTrue(tmpdir.startswith('/tmp'))
-        self.assertTrue(len(tmpdir) in (11, 13))
+        self.assertIn(len(tmpdir), (11, 13))
 
         # also test cleanup method to ensure short $TMPDIR is cleaned up properly
         self.assertTrue(os.path.exists(tmpdir))

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1700,7 +1700,7 @@ class ToolchainTest(EnhancedTestCase):
         ]
         tc.prepare(deps=deps)
         mods = ['GCC/6.4.0-2.28', 'hwloc/1.11.8-GCC-6.4.0-2.28', 'OpenMPI/2.1.2-GCC-6.4.0-2.28']
-        self.assertTrue([m['mod_name'] for m in self.modtool.list()], mods)
+        self.assertEqual(sorted(m['mod_name'] for m in self.modtool.list()), sorted(mods))
 
     def test_prepare_deps_external(self):
         """Test preparing for a toolchain when dependencies and external modules are involved."""
@@ -1728,7 +1728,7 @@ class ToolchainTest(EnhancedTestCase):
         tc = self.get_toolchain('GCC', version='6.4.0-2.28')
         tc.prepare(deps=deps)
         mods = ['GCC/6.4.0-2.28', 'hwloc/1.11.8-GCC-6.4.0-2.28', 'OpenMPI/2.1.2-GCC-6.4.0-2.28', 'toy/0.0']
-        self.assertTrue([m['mod_name'] for m in self.modtool.list()], mods)
+        self.assertEqual(sorted(m['mod_name'] for m in self.modtool.list()), sorted(mods))
         self.assertTrue(os.environ['EBROOTTOY'].endswith('software/toy/0.0'))
         self.assertEqual(os.environ['EBVERSIONTOY'], '0.0')
         self.assertNotIn('EBROOTFOOBAR', os.environ)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -327,7 +327,7 @@ class ToyBuildTest(EnhancedTestCase):
             regex = re.compile(mod_load_msg, re.M)
             self.assertTrue(regex.search(toy_module_txt), "Pattern '%s' found in: %s" % (regex.pattern, toy_module_txt))
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         # newline between "I AM toy v0.0" (modloadmsg) and "oh hai!" (mod*footer) is added automatically
         expected = "\nTHANKS FOR LOADING ME\nI AM toy v0.0\n"
@@ -774,7 +774,7 @@ class ToyBuildTest(EnhancedTestCase):
                     regex = re.compile(pattern % group_name, re.M)
                     self.assertTrue(regex.search(outtxt), "Pattern '%s' found in: %s" % (regex.pattern, outtxt))
             else:
-                self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+                self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         write_file(test_ec, read_file(toy_ec) + "\ngroup = ('%s', 'custom message', 'extra item')\n" % group_name)
         self.assertErrorRegex(SystemExit, '.*', self.eb_main, args, do_build=True,
@@ -832,7 +832,7 @@ class ToyBuildTest(EnhancedTestCase):
         elif get_module_syntax() == 'Lua':
             load_regex_template = r'load\("%s/.*"\)'
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         modtxt = read_file(toy_module_path)
         for dep in ['foss', 'GCC', 'OpenMPI']:
@@ -883,7 +883,7 @@ class ToyBuildTest(EnhancedTestCase):
             regex = re.compile(r'^prepend_path\("MODULEPATH", "%s"\)' % fullmodpath_extension, re.M)
             self.assertTrue(regex.search(modtxt), "Pattern '%s' found in %s" % (regex.pattern, modtxt))
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
         os.remove(toy_module_path)
 
         # ... unless they shouldn't be
@@ -898,7 +898,7 @@ class ToyBuildTest(EnhancedTestCase):
             regex = re.compile(r'^prepend_path\("MODULEPATH", "%s"\)' % fullmodpath_extension, re.M)
             self.assertFalse(regex.search(modtxt), "Pattern '%s' found in %s" % (regex.pattern, modtxt))
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
         os.remove(toy_module_path)
 
         # test module path with system/system build
@@ -941,7 +941,7 @@ class ToyBuildTest(EnhancedTestCase):
             regex = re.compile(r'^prepend_path\("MODULEPATH", "%s"\)' % fullmodpath_extension, re.M)
             self.assertTrue(regex.search(modtxt), "Pattern '%s' found in %s" % (regex.pattern, modtxt))
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
         os.remove(toy_module_path)
 
         # building a toolchain module should also work
@@ -1556,7 +1556,7 @@ class ToyBuildTest(EnhancedTestCase):
                 r'puts stderr "oh hai\!"$',
             ])
         else:
-            self.assertTrue(False, "Unknown module syntax: %s" % get_module_syntax())
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         mod_txt_regex = re.compile(mod_txt_regex_pattern)
         msg = "Pattern '%s' matches with: %s" % (mod_txt_regex.pattern, toy_mod_txt)
@@ -2028,7 +2028,7 @@ class ToyBuildTest(EnhancedTestCase):
             self.assertEqual(len(hidden_toy_mod_backups), backups_hidden)
 
             first_toy_lua_mod_backup = (toy_mod_backups or hidden_toy_mod_backups)[0]
-            self.assertTrue('.bak_' in os.path.basename(first_toy_lua_mod_backup))
+            self.assertIn('.bak_', os.path.basename(first_toy_lua_mod_backup))
 
             # check messages in stdout/stderr
             regex = re.compile("^== backup of existing module file stored at %s" % toy_mod_bak, re.M)
@@ -2162,7 +2162,7 @@ class ToyBuildTest(EnhancedTestCase):
         ]
         env_file = read_file(reprod_dumpenv)
         for pattern in patterns:
-            self.assertTrue(pattern in env_file)
+            self.assertIn(pattern, env_file)
 
         # Check that the toytoy easyblock is recorded in the reprod easyconfig
         ec = EasyConfig(reprod_ec)
@@ -2170,7 +2170,7 @@ class ToyBuildTest(EnhancedTestCase):
 
         # make sure start_dir is not recorded in the dumped easyconfig, this does not appear in the original easyconfig
         # and is representative of values that are (typically) set by the easyblock steps (which are also dumped)
-        self.assertFalse('start_dir' in ec.parser.get_config_dict())
+        self.assertNotIn('start_dir', ec.parser.get_config_dict())
 
         # Check for child easyblock existence
         child_easyblock = os.path.join(reprod_dir, 'easyblocks', 'toytoy.py')
@@ -2278,7 +2278,7 @@ class ToyBuildTest(EnhancedTestCase):
         ]
         env_file = read_file(reprod_dumpenv)
         for pattern in patterns:
-            self.assertTrue(pattern in env_file)
+            self.assertIn(pattern, env_file)
 
     def test_toy_sanity_check_commands(self):
         """Test toy build with extra sanity check commands."""
@@ -2418,7 +2418,7 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec_txt = regex.sub('', toy_ec_txt)
         write_file(test_ec, test_ec_txt)
 
-        self.assertFalse('sanity_check_' in test_ec_txt)
+        self.assertNotIn('sanity_check_', test_ec_txt)
 
         # create custom easyblock for toy that has a custom sanity_check_step
         toy_easyblock = os.path.join(test_dir, 'sandbox', 'easybuild', 'easyblocks', 't', 'toy.py')
@@ -2667,8 +2667,8 @@ class ToyBuildTest(EnhancedTestCase):
         # by default, /lib and /usr are included in RPATH filter,
         # together with temporary directory and build directory
         rpath_filter_paths = grab_gcc_rpath_wrapper_args()['filter_paths'].split(',')
-        self.assertTrue('/lib.*' in rpath_filter_paths)
-        self.assertTrue('/usr.*' in rpath_filter_paths)
+        self.assertIn('/lib.*', rpath_filter_paths)
+        self.assertIn('/usr.*', rpath_filter_paths)
         self.assertTrue(any(p.startswith(os.getenv('TMPDIR')) for p in rpath_filter_paths))
         self.assertTrue(any(p.startswith(self.test_buildpath) for p in rpath_filter_paths))
 
@@ -2700,8 +2700,8 @@ class ToyBuildTest(EnhancedTestCase):
 
         # check whether rpath filter was set correctly
         rpath_filter_paths = grab_gcc_rpath_wrapper_args()['filter_paths'].split(',')
-        self.assertTrue('/test.*' in rpath_filter_paths)
-        self.assertTrue('/foo/bar.*' in rpath_filter_paths)
+        self.assertIn('/test.*', rpath_filter_paths)
+        self.assertIn('/foo/bar.*', rpath_filter_paths)
         self.assertTrue(any(p.startswith(os.getenv('TMPDIR')) for p in rpath_filter_paths))
         self.assertTrue(any(p.startswith(self.test_buildpath) for p in rpath_filter_paths))
 
@@ -3009,7 +3009,7 @@ class ToyBuildTest(EnhancedTestCase):
                 '}',
             ])
 
-        self.assertTrue(expected in toy_mod_txt, "Pattern '%s' should be found in: %s" % (expected, toy_mod_txt))
+        self.assertIn(expected, toy_mod_txt)
 
         # also check relevant parts of "module help" and whatis bits
         expected_descr = '\n'.join([
@@ -3019,7 +3019,7 @@ class ToyBuildTest(EnhancedTestCase):
             "* GCC/4.6.3 (default), GCC/7.3.0-2.30",
         ])
         error_msg_descr = "Pattern '%s' should be found in: %s" % (expected_descr, toy_mod_txt)
-        self.assertTrue(expected_descr in toy_mod_txt, error_msg_descr)
+        self.assertIn(expected_descr, toy_mod_txt, error_msg_descr)
 
         if get_module_syntax() == 'Lua':
             expected_whatis = "whatis([==[Compatible modules: GCC/4.6.3 (default), GCC/7.3.0-2.30]==])"
@@ -3027,22 +3027,22 @@ class ToyBuildTest(EnhancedTestCase):
             expected_whatis = "module-whatis {Compatible modules: GCC/4.6.3 (default), GCC/7.3.0-2.30}"
 
         error_msg_whatis = "Pattern '%s' should be found in: %s" % (expected_whatis, toy_mod_txt)
-        self.assertTrue(expected_whatis in toy_mod_txt, error_msg_whatis)
+        self.assertIn(expected_whatis, toy_mod_txt, error_msg_whatis)
 
         def check_toy_load(depends_on=False):
             # by default, toy/0.0 should load GCC/4.6.3 (first listed GCC version in multi_deps)
             self.modtool.load(['toy/0.0'])
             loaded_mod_names = [x['mod_name'] for x in self.modtool.list()]
-            self.assertTrue('toy/0.0' in loaded_mod_names)
-            self.assertTrue('GCC/4.6.3' in loaded_mod_names)
-            self.assertFalse('GCC/7.3.0-2.30' in loaded_mod_names)
+            self.assertIn('toy/0.0', loaded_mod_names)
+            self.assertIn('GCC/4.6.3', loaded_mod_names)
+            self.assertNotIn('GCC/7.3.0-2.30', loaded_mod_names)
 
             if depends_on:
                 # check behaviour when unloading toy (should also unload GCC/4.6.3)
                 self.modtool.unload(['toy/0.0'])
                 loaded_mod_names = [x['mod_name'] for x in self.modtool.list()]
-                self.assertFalse('toy/0.0' in loaded_mod_names)
-                self.assertFalse('GCC/4.6.3' in loaded_mod_names)
+                self.assertNotIn('toy/0.0', loaded_mod_names)
+                self.assertNotIn('GCC/4.6.3', loaded_mod_names)
             else:
                 # just undo (don't use 'purge', make cause problems in test environment), to prepare for next test
                 self.modtool.unload(['toy/0.0', 'GCC/4.6.3'])
@@ -3050,20 +3050,20 @@ class ToyBuildTest(EnhancedTestCase):
             # if GCC/7.3.0-2.30 is loaded first, then GCC/4.6.3 is not loaded by loading toy/0.0
             self.modtool.load(['GCC/7.3.0-2.30'])
             loaded_mod_names = [x['mod_name'] for x in self.modtool.list()]
-            self.assertTrue('GCC/7.3.0-2.30' in loaded_mod_names)
+            self.assertIn('GCC/7.3.0-2.30', loaded_mod_names)
 
             self.modtool.load(['toy/0.0'])
             loaded_mod_names = [x['mod_name'] for x in self.modtool.list()]
-            self.assertTrue('toy/0.0' in loaded_mod_names)
-            self.assertTrue('GCC/7.3.0-2.30' in loaded_mod_names)
-            self.assertFalse('GCC/4.6.3' in loaded_mod_names)
+            self.assertIn('toy/0.0', loaded_mod_names)
+            self.assertIn('GCC/7.3.0-2.30', loaded_mod_names)
+            self.assertNotIn('GCC/4.6.3', loaded_mod_names)
 
             if depends_on:
                 # check behaviour when unloading toy (should *not* unload GCC/7.3.0-2.30)
                 self.modtool.unload(['toy/0.0'])
                 loaded_mod_names = [x['mod_name'] for x in self.modtool.list()]
-                self.assertFalse('toy/0.0' in loaded_mod_names)
-                self.assertTrue('GCC/7.3.0-2.30' in loaded_mod_names)
+                self.assertNotIn('toy/0.0', loaded_mod_names)
+                self.assertIn('GCC/7.3.0-2.30', loaded_mod_names)
             else:
                 # just undo
                 self.modtool.unload(['toy/0.0', 'GCC/7.3.0-2.30'])
@@ -3071,20 +3071,20 @@ class ToyBuildTest(EnhancedTestCase):
             # having GCC/4.6.3 loaded already is also fine
             self.modtool.load(['GCC/4.6.3'])
             loaded_mod_names = [x['mod_name'] for x in self.modtool.list()]
-            self.assertTrue('GCC/4.6.3' in loaded_mod_names)
+            self.assertIn('GCC/4.6.3', loaded_mod_names)
 
             self.modtool.load(['toy/0.0'])
             loaded_mod_names = [x['mod_name'] for x in self.modtool.list()]
-            self.assertTrue('toy/0.0' in loaded_mod_names)
-            self.assertTrue('GCC/4.6.3' in loaded_mod_names)
-            self.assertFalse('GCC/7.3.0-2.30' in loaded_mod_names)
+            self.assertIn('toy/0.0', loaded_mod_names)
+            self.assertIn('GCC/4.6.3', loaded_mod_names)
+            self.assertNotIn('GCC/7.3.0-2.30', loaded_mod_names)
 
             if depends_on:
                 # check behaviour when unloading toy (should *not* unload GCC/4.6.3)
                 self.modtool.unload(['toy/0.0'])
                 loaded_mod_names = [x['mod_name'] for x in self.modtool.list()]
-                self.assertFalse('toy/0.0' in loaded_mod_names)
-                self.assertTrue('GCC/4.6.3' in loaded_mod_names)
+                self.assertNotIn('toy/0.0', loaded_mod_names)
+                self.assertIn('GCC/4.6.3', loaded_mod_names)
             else:
                 # just undo
                 self.modtool.unload(['toy/0.0', 'GCC/4.6.3'])
@@ -3098,13 +3098,13 @@ class ToyBuildTest(EnhancedTestCase):
         self.test_toy_build(ec_file=test_ec)
         toy_mod_txt = read_file(toy_mod_file)
 
-        self.assertFalse(expected in toy_mod_txt, "Pattern '%s' should not be found in: %s" % (expected, toy_mod_txt))
+        self.assertNotIn(expected, toy_mod_txt)
 
         self.modtool.load(['toy/0.0'])
         loaded_mod_names = [x['mod_name'] for x in self.modtool.list()]
-        self.assertTrue('toy/0.0' in loaded_mod_names)
-        self.assertFalse('GCC/4.6.3' in loaded_mod_names)
-        self.assertFalse('GCC/7.3.0-2.30' in loaded_mod_names)
+        self.assertIn('toy/0.0', loaded_mod_names)
+        self.assertNotIn('GCC/4.6.3', loaded_mod_names)
+        self.assertNotIn('GCC/7.3.0-2.30', loaded_mod_names)
 
         # also check relevant parts of "module help" and whatis bits (no '(default)' here!)
         expected_descr_no_default = '\n'.join([
@@ -3114,7 +3114,7 @@ class ToyBuildTest(EnhancedTestCase):
             "* GCC/4.6.3, GCC/7.3.0-2.30",
         ])
         error_msg_descr = "Pattern '%s' should be found in: %s" % (expected_descr_no_default, toy_mod_txt)
-        self.assertTrue(expected_descr_no_default in toy_mod_txt, error_msg_descr)
+        self.assertIn(expected_descr_no_default, toy_mod_txt, error_msg_descr)
 
         if get_module_syntax() == 'Lua':
             expected_whatis_no_default = "whatis([==[Compatible modules: GCC/4.6.3, GCC/7.3.0-2.30]==])"
@@ -3122,7 +3122,7 @@ class ToyBuildTest(EnhancedTestCase):
             expected_whatis_no_default = "module-whatis {Compatible modules: GCC/4.6.3, GCC/7.3.0-2.30}"
 
         error_msg_whatis = "Pattern '%s' should be found in: %s" % (expected_whatis_no_default, toy_mod_txt)
-        self.assertTrue(expected_whatis_no_default in toy_mod_txt, error_msg_whatis)
+        self.assertIn(expected_whatis_no_default, toy_mod_txt, error_msg_whatis)
 
         # restore original environment to continue testing with a clean slate
         modify_env(os.environ, self.orig_environ, verbose=False)
@@ -3159,11 +3159,11 @@ class ToyBuildTest(EnhancedTestCase):
                     '}',
                 ])
 
-            self.assertTrue(expected in toy_mod_txt, "Pattern '%s' should be found in: %s" % (expected, toy_mod_txt))
+            self.assertIn(expected, toy_mod_txt)
             error_msg_descr = "Pattern '%s' should be found in: %s" % (expected_descr, toy_mod_txt)
-            self.assertTrue(expected_descr in toy_mod_txt, error_msg_descr)
+            self.assertIn(expected_descr, toy_mod_txt, error_msg_descr)
             error_msg_whatis = "Pattern '%s' should be found in: %s" % (expected_whatis, toy_mod_txt)
-            self.assertTrue(expected_whatis in toy_mod_txt, error_msg_whatis)
+            self.assertIn(expected_whatis, toy_mod_txt, error_msg_whatis)
 
             check_toy_load(depends_on=True)
 
@@ -3488,13 +3488,13 @@ class ToyBuildTest(EnhancedTestCase):
                 self.mock_stdout(False)
 
                 if any('--wait-on-lock=' in x for x in all_args):
-                    self.assertTrue("Use of --wait-on-lock is deprecated" in stderr)
+                    self.assertIn("Use of --wait-on-lock is deprecated", stderr)
                 else:
                     self.assertEqual(stderr, '')
 
                 wait_matches = wait_regex.findall(stdout)
                 # we can't rely on an exact number of 'waiting' messages, so let's go with a range...
-                self.assertTrue(len(wait_matches) in range(2, 5))
+                self.assertIn(len(wait_matches), range(2, 5))
 
                 self.assertTrue(ok_regex.search(stdout), "Pattern '%s' found in: %s" % (ok_regex.pattern, stdout))
 
@@ -3511,7 +3511,7 @@ class ToyBuildTest(EnhancedTestCase):
         self.mock_stdout(False)
 
         wait_matches = wait_regex.findall(stdout)
-        self.assertTrue(len(wait_matches) in range(2, 5))
+        self.assertIn(len(wait_matches), range(2, 5))
 
         # when there is no lock in place, --wait-on-lock* has no impact
         remove_dir(toy_lock_path)
@@ -3611,7 +3611,7 @@ class ToyBuildTest(EnhancedTestCase):
 
         # the tilde character included here is a Unicode tilde character, not a regular ASCII tilde (~)
         descr = "This description includes a unicode tilde character: ∼, for your entertainment."
-        self.assertFalse('~' in descr)
+        self.assertNotIn('~', descr)
 
         regex = re.compile(r'^description\s*=.*', re.M)
         test_ec_txt = regex.sub(r'description = "%s"' % descr, toy_ec_txt)
@@ -3652,7 +3652,7 @@ class ToyBuildTest(EnhancedTestCase):
 
         self.assertTrue(os.path.exists(lib_path))
         self.assertFalse(os.path.exists(lib64_path))
-        self.assertFalse('lib64' in os.listdir(toy_installdir))
+        self.assertNotIn('lib64', os.listdir(toy_installdir))
         self.assertTrue(os.path.isdir(lib_path))
         self.assertFalse(os.path.islink(lib_path))
 
@@ -3695,7 +3695,7 @@ class ToyBuildTest(EnhancedTestCase):
 
         self.assertTrue(os.path.exists(lib64_path))
         self.assertFalse(os.path.exists(lib_path))
-        self.assertFalse('lib' in os.listdir(toy_installdir))
+        self.assertNotIn('lib', os.listdir(toy_installdir))
         self.assertTrue(os.path.isdir(lib64_path))
         self.assertFalse(os.path.islink(lib64_path))
 
@@ -3784,7 +3784,7 @@ class ToyBuildTest(EnhancedTestCase):
         args = ['--ignore-test-failure']
         stdout, stderr = self.run_test_toy_build_with_output(extra_args=args, verify=False, testing=False)
 
-        self.assertTrue("Build succeeded (with --ignore-test-failure) for 1 out of 1" in stdout)
+        self.assertIn("Build succeeded (with --ignore-test-failure) for 1 out of 1", stdout)
         self.assertFalse(stderr)
 
     def test_toy_post_install_patches(self):

--- a/test/framework/tweak.py
+++ b/test/framework/tweak.py
@@ -85,7 +85,7 @@ class TweakTest(EnhancedTestCase):
         ecs_basename = [os.path.basename(ec) for ec in ecs]
         for gccver in gccvers:
             gcc_ec = 'GCC-%s.eb' % gccver
-            self.assertTrue(gcc_ec in ecs_basename, "%s is included in %s" % (gcc_ec, ecs_basename))
+            self.assertIn(gcc_ec, ecs_basename)
 
     def test_obtain_ec_for(self):
         """Test obtain_ec_for function."""
@@ -156,7 +156,7 @@ class TweakTest(EnhancedTestCase):
         self.assertEqual(tweaked_toy_ec_parsed['version'], '1.2.3')
         for key in [k for k in toy_ec_parsed.keys() if k not in ['checksums', 'version']]:
             val = toy_ec_parsed[key]
-            self.assertTrue(key in tweaked_toy_ec_parsed, "Parameter '%s' not defined in tweaked easyconfig file" % key)
+            self.assertIn(key, tweaked_toy_ec_parsed, "Parameter '%s' not defined in tweaked easyconfig file" % key)
             tweaked_val = tweaked_toy_ec_parsed.get(key)
             self.assertEqual(val, tweaked_val, "Different value for %s parameter: %s vs %s" % (key, val, tweaked_val))
 
@@ -436,11 +436,12 @@ class TweakTest(EnhancedTestCase):
         tweaked_dict = tweaked_ec['ec'].asdict()
         # First check the mapped toolchain
         key, value = 'toolchain', iccifort_binutils_tc
-        self.assertTrue(key in tweaked_dict and value == tweaked_dict[key])
+        self.assertIn(key, tweaked_dict)
+        self.assertEqual(value, tweaked_dict[key])
         # Also check that binutils has been mapped
         for key, value in {'name': 'binutils', 'version': '2.25', 'versionsuffix': ''}.items():
-            self.assertTrue(key in tweaked_dict['builddependencies'][0] and
-                            value == tweaked_dict['builddependencies'][0][key])
+            self.assertIn(key, tweaked_dict['builddependencies'][0])
+            self.assertEqual(tweaked_dict['builddependencies'][0][key], value)
 
         # Now test the case where we try to update the dependencies
         init_config(build_options=build_options)
@@ -450,15 +451,16 @@ class TweakTest(EnhancedTestCase):
         tweaked_dict = tweaked_ec['ec'].asdict()
         # First check the mapped toolchain
         key, value = 'toolchain', iccifort_binutils_tc
-        self.assertTrue(key in tweaked_dict and value == tweaked_dict[key])
+        self.assertIn(key, tweaked_dict)
+        self.assertEqual(value, tweaked_dict[key])
         # Also check that binutils has been mapped
         for key, value in {'name': 'binutils', 'version': '2.25', 'versionsuffix': ''}.items():
-            self.assertTrue(
-                key in tweaked_dict['builddependencies'][0] and value == tweaked_dict['builddependencies'][0][key]
-            )
+            self.assertIn(key, tweaked_dict['builddependencies'][0])
+            self.assertEqual(tweaked_dict['builddependencies'][0][key], value)
         # Also check that the gzip dependency was upgraded
         for key, value in {'name': 'gzip', 'version': '1.6', 'versionsuffix': ''}.items():
-            self.assertTrue(key in tweaked_dict['dependencies'][0] and value == tweaked_dict['dependencies'][0][key])
+            self.assertIn(key, tweaked_dict['dependencies'][0])
+            self.assertEqual(tweaked_dict['dependencies'][0][key], value)
 
         # Make sure there are checksums for our next test
         self.assertTrue(tweaked_dict['checksums'])
@@ -475,19 +477,21 @@ class TweakTest(EnhancedTestCase):
         tweaked_dict = tweaked_ec['ec'].asdict()
         # First check the mapped toolchain
         key, value = 'toolchain', iccifort_binutils_tc
-        self.assertTrue(key in tweaked_dict and value == tweaked_dict[key])
+        self.assertIn(key, tweaked_dict)
+        self.assertEqual(tweaked_dict[key], value)
         # Also check that binutils has been mapped
         for key, value in {'name': 'binutils', 'version': '2.25', 'versionsuffix': ''}.items():
-            self.assertTrue(
-                key in tweaked_dict['builddependencies'][0] and value == tweaked_dict['builddependencies'][0][key]
-            )
+            self.assertIn(key, tweaked_dict['builddependencies'][0])
+            self.assertEqual(tweaked_dict['builddependencies'][0][key], value)
         # Also check that the gzip dependency was upgraded
         for key, value in {'name': 'gzip', 'version': '1.6', 'versionsuffix': ''}.items():
-            self.assertTrue(key in tweaked_dict['dependencies'][0] and value == tweaked_dict['dependencies'][0][key])
+            self.assertIn(key, tweaked_dict['dependencies'][0])
+            self.assertEqual(tweaked_dict['dependencies'][0][key], value)
 
         # Finally check that the version was upgraded
         key, value = 'version', new_version
-        self.assertTrue(key in tweaked_dict and value == tweaked_dict[key])
+        self.assertIn(key, tweaked_dict)
+        self.assertEqual(tweaked_dict[key], value)
         # and that the checksum was removed
         self.assertFalse(tweaked_dict['checksums'])
 
@@ -513,7 +517,7 @@ class TweakTest(EnhancedTestCase):
             if isinstance(extension, tuple) and extension[0] == 'toy':
                 self.assertEqual(extension[1], new_version)
                 # Make sure checksum has been purged
-                self.assertFalse('checksums' in extension[2])
+                self.assertNotIn('checksums', extension[2])
                 hit_extension += 1
         self.assertEqual(hit_extension, 1, "Should only have updated one extension")
 

--- a/test/framework/yeb.py
+++ b/test/framework/yeb.py
@@ -122,8 +122,8 @@ class YebTest(EnhancedTestCase):
         ecdict['sources'].append(fn)
 
         ecdict_bis = ec.parser.get_config_dict()
-        self.assertTrue(fn in ecdict['sources'])
-        self.assertFalse(fn in ecdict_bis['sources'])
+        self.assertIn(fn, ecdict['sources'])
+        self.assertNotIn(fn, ecdict_bis['sources'])
 
     def test_is_yeb_format(self):
         """ Test is_yeb_format function """


### PR DESCRIPTION
Replace `self.assertTrue(False, ...` and similar by appropriate assert functions. This avoids redundancy and potential mistakes and improves error reporting.

I checked that all functions are available in Python 2.7 and 3.1+

Especially the `assertTrue(False` were annoying as the error message started with "Assertion failed: False is not True"

Most of the `assert[Not]In` replace the need to duplicate the arguments in the message which sometimes got forgotten.

Mostly done by a RegEx search&replace so should be save.

I also fixed a bug in the test:
```
mods = ['GCC/6.4.0-2.28', 'hwloc/1.11.8-GCC-6.4.0-2.28', 'OpenMPI/2.1.2-GCC-6.4.0-2.28']
self.assertTrue([m['mod_name'] for m in self.modtool.list()], mods)
```
Here `assertEqual` was intended as shown by the 2nd parameter. Another reason why we should try to avoid the generic `assertTrue/False` tests