### PR TITLE
add VERSION to easybuild.easyblocks namespace in test sandbox

### DIFF
--- a/test/framework/sandbox/easybuild/easyblocks/__init__.py
+++ b/test/framework/sandbox/easybuild/easyblocks/__init__.py
@@ -1,7 +1,9 @@
 import pkgutil
 
 # Import fake version
-from easybuild.tools.version import VERSION  # noqa: F401
+import easybuild.tools.version
+
+VERSION = easybuild.tools.version.VERSION
 
 subdirs = [chr(x) for x in range(ord('a'), ord('z') + 1)] + ['0']
 for subdir in subdirs:

--- a/test/framework/sandbox/easybuild/easyblocks/__init__.py
+++ b/test/framework/sandbox/easybuild/easyblocks/__init__.py
@@ -1,5 +1,8 @@
 import pkgutil
 
+# Import fake version
+from easybuild.tools.version import VERSION  # noqa: F401
+
 subdirs = [chr(x) for x in range(ord('a'), ord('z') + 1)] + ['0']
 for subdir in subdirs:
     __path__ = pkgutil.extend_path(__path__, '%s.%s' % (__name__, subdir))


### PR DESCRIPTION
Extracted from #3790 and required for some tests (which happen to work now due to unrelated issues)