### PR TITLE
don't use deprecated SafeConfigParser when running with Python 3.x

### DIFF
--- a/easybuild/base/generaloption.py
+++ b/easybuild/base/generaloption.py
@@ -45,7 +45,7 @@ from optparse import SUPPRESS_HELP as nohelp  # supported in optparse of python 
 
 from easybuild.base.fancylogger import getLogger, setroot, setLogLevel, getDetailsLogLevels
 from easybuild.base.optcomplete import autocomplete, CompleterOption
-from easybuild.tools.py2vs3 import StringIO, configparser, string_type, subprocess_popen_text
+from easybuild.tools.py2vs3 import StringIO, configparser, ConfigParser, string_type, subprocess_popen_text
 from easybuild.tools.utilities import mk_md_table, mk_rst_table, nub, shell_quote
 
 try:
@@ -898,7 +898,6 @@ class GeneralOption(object):
     CONFIGFILES_INIT = []  # initial list of defaults, overwritten by go_configfiles options
     CONFIGFILES_IGNORE = []
     CONFIGFILES_MAIN_SECTION = 'MAIN'  # sectionname that contains the non-grouped/non-prefixed options
-    CONFIGFILE_PARSER = configparser.SafeConfigParser
     CONFIGFILE_CASESENSITIVE = True
 
     METAVAR_DEFAULT = True  # generate a default metavar
@@ -1274,7 +1273,7 @@ class GeneralOption(object):
                 the 2nd level key,value is the key=value.
                 All section names, keys and values are converted to strings.
         """
-        self.configfile_parser = self.CONFIGFILE_PARSER()
+        self.configfile_parser = ConfigParser()
 
         # make case sensitive
         if self.CONFIGFILE_CASESENSITIVE:

--- a/easybuild/tools/py2vs3/py2.py
+++ b/easybuild/tools/py2vs3/py2.py
@@ -45,6 +45,9 @@ from StringIO import StringIO  # noqa
 from urllib import urlencode  # noqa
 from urllib2 import HTTPError, HTTPSHandler, Request, URLError, build_opener, urlopen  # noqa
 
+# Use the safe version. In Python 3.2+ this is the default already
+ConfigParser = configparser.SafeConfigParser
+
 
 # reload function (built-in in Python 2)
 reload = reload

--- a/easybuild/tools/py2vs3/py3.py
+++ b/easybuild/tools/py2vs3/py3.py
@@ -46,6 +46,7 @@ from io import StringIO  # noqa
 from string import ascii_letters, ascii_lowercase  # noqa
 from urllib.request import HTTPError, HTTPSHandler, Request, URLError, build_opener, urlopen  # noqa
 from urllib.parse import urlencode  # noqa
+from configparser import ConfigParser  # noqa
 
 # reload function (no longer a built-in in Python 3)
 # importlib only works with Python 3.4 & newer


### PR DESCRIPTION
Extracted from #3790