### PR TITLE
only give read permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/bootstrap_script.yml
+++ b/.github/workflows/bootstrap_script.yml
@@ -2,6 +2,9 @@
 name: test EasyBuild bootstrap script
 on: [push, pull_request]
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 concurrency:
   group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
   cancel-in-progress: true

--- a/.github/workflows/container_tests.yml
+++ b/.github/workflows/container_tests.yml
@@ -2,6 +2,9 @@
 name: Tests for container support
 on: [push, pull_request]
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 concurrency:
   group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
   cancel-in-progress: true

--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -2,6 +2,9 @@
 name: Tests for the 'eb' command
 on: [push, pull_request]
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 concurrency:
   group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
   cancel-in-progress: true

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,6 +1,9 @@
 name: Static Analysis
 on: [push, pull_request]
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 concurrency:
   group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
   cancel-in-progress: true

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -2,6 +2,9 @@
 name: EasyBuild framework unit tests
 on: [push, pull_request]
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 concurrency:
   group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
   cancel-in-progress: true


### PR DESCRIPTION
By default, CI workflows get full permissions (incl. write) to the repo, there's absolutely no need for this in our case.

cfr. https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs