### PR TITLE
respect start dir defined in extensions

### DIFF
--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -121,7 +121,7 @@ class ExtensionEasyBlock(EasyBlock, Extension):
         for possible_dir in possible_start_dirs:
             if os.path.isdir(possible_dir):
                 self.cfg['start_dir'] = possible_dir
-                self.log.info("Using start_dir: %s", possible_dir)
+                self.log.debug("Using start_dir: %s", possible_dir)
                 return
 
             self.log.debug("Tentative start dir not found: %s" % possible_dir)


### PR DESCRIPTION
Currently extensions ignore `start_dir` because `ExtensionEasyBlock._set_start_dir` forcefully overwrites `self.cfg['start_dir']` of the extension.

This PR enables extensions to define a `start_dir`. The resulting start dir will be on of the following by preference from top to bottom:
1. if `self.cfg['start_dir']` is an absolute path and exists it will be used as is
2. combine `self.start_dir` with `self.cfg['start_dir']`
3. combine `self.ext_dir` with `self.cfg['start_dir']`

Motivation: Some Julia packages are distributed in a subfolder of other Julia packages. For instance, SnoopPrecompile and SnoopCompileCore are found inside [SnoopCompile](https://github.com/timholy/SnoopCompile.jl)