### PR TITLE
enforce absolute paths as start dir of extensions

### DIFF
--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -100,18 +100,30 @@ class ExtensionEasyBlock(EasyBlock, Extension):
         self.ext_dir = None  # dir where extension source was unpacked
 
     def _set_start_dir(self):
-        """Set value for self.start_dir
+        """Set absolute path of self.start_dir similarly to EasyBlock.guess_start_dir
 
-        Uses existing value of self.start_dir if it is already set and exists
-        otherwise self.ext_dir (path to extracted source) if that is set and exists, similar to guess_start_dir
+        Uses existing value of self.start_dir if it is already set, an absolute path and exists
+        otherwise use self.ext_dir (path to extracted source) as base dir if that is set and exists.
         """
-        possible_dirs = (self.start_dir, self.ext_dir)
-        for possible_dir in possible_dirs:
-            if possible_dir and os.path.isdir(possible_dir):
-                self.cfg['start_dir'] = possible_dir
-                self.log.debug("Using start_dir: %s", self.start_dir)
+        start_dir = ''
+
+        # Use provided start dir if it is an absolute path
+        if self.start_dir:
+            start_dir = self.start_dir
+            if os.path.isabs(start_dir) and os.path.isdir(start_dir):
+                self.log.info("Using user provided start dir: %s", start_dir)
                 return
-        self.log.debug("Unable to determine start_dir as none of these paths is set and exists: %s", possible_dirs)
+
+        # Generate absolute start dir from ext_dir
+        if self.ext_dir:
+            ext_start_dir = os.path.join(self.ext_dir, start_dir)
+            if os.path.isdir(ext_start_dir):
+                self.cfg['start_dir'] = ext_start_dir
+                self.log.debug("Using start dir: %s", ext_start_dir)
+                return
+
+        tested_dirs = ', '.join([d for d in [start_dir, ext_start_dir] if d])
+        self.log.debug("Unable to determine extension start dir as none of the tentative dirs exist: %s" % tested_dirs)
 
     def run(self, unpack_src=False):
         """Common operations for extensions: unpacking sources, patching, ..."""


### PR DESCRIPTION
Currently, `self.start_dir` in regular packages is always an absolute path. So it can be easily used in easyblocks regardles of `cwd` in the same way as `self.installdir` and `self.builddir`.

However, `self.start_dir` of extensions is either `None` or the path set in `self.cfg['start_dir'] of the extensions, which is commonly a relative path.

This PR updates `ExtensionEasyBlock._set_start_dir` to always define `self.start_dir` as an absolute path. Standardizing its form across packages and extensions.

Breaking changes:
* breaks `RPackages` as it prepends stuff to `self.start_dir`