### PR TITLE
Enable github tokens without interaction.

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -223,6 +223,7 @@ BUILD_OPTIONS_CMDLINE = {
         'github_user',
         'github_org',
         'group',
+        'keyring_github_token',
         'hide_deps',
         'hide_toolchains',
         'http_header_fields_urlpat',

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -2164,7 +2164,12 @@ def check_github():
 
 
 def fetch_github_token(user):
-    """Fetch GitHub token for specified user from keyring."""
+    """Fetch GitHub token for specified user.
+
+    Sources used for the token are, in order:
+      - keyring option (--keyring-github-token or ENV{'EASYBUILD_KEYRING_GITHUB_TOKEN'})
+      - keyring.getpassword(KEYRING_GITHUB_TOKEN, user)
+    """
 
     token, msg = None, None
 
@@ -2175,7 +2180,7 @@ def fetch_github_token(user):
         msg += "required Python module https://pypi.python.org/pypi/keyring is not available."
     else:
         try:
-            token = keyring.get_password(KEYRING_GITHUB_TOKEN, user)
+            token = build_option('keyring_github_token') or keyring.get_password(KEYRING_GITHUB_TOKEN, user)
         except Exception as err:
             _log.warning("Exception occurred when fetching GitHub token: %s", err)
 

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -696,6 +696,7 @@ class EasyBuildOptions(GeneralOption):
             'include-easyblocks-from-pr': ("Include easyblocks from specified PR", 'strlist', 'store', [],
                                            {'metavar': 'PR#'}),
             'install-github-token': ("Install GitHub token (requires --github-user)", None, 'store_true', False),
+            'keyring-github-token': ("Plaintext GitHub token (requires --github-user)", str, 'store', None),
             'close-pr': ("Close pull request", int, 'store', None, {'metavar': 'PR#'}),
             'close-pr-msg': ("Custom close message for pull request closed with --close-pr; ", str, 'store', None),
             'close-pr-reasons': ("Close reason for pull request closed with --close-pr; "


### PR DESCRIPTION
  - Add `--keyring-github-token` as a command line option.
  - This implies we get EASYBUILD_KEYRING_GITHUB_TOKEN for the option as well.
  - This allows for users to load the token into the environment on a session basis.

As an example, one can do:

````shell
function easybuild_github_token_print() {
        python -c 'from keyrings.cryptfile.cryptfile import CryptFileKeyring; print(CryptFileKeyring().get_password("github_token", "terjekv"))'
}

function easybuild_github_token_import() {
        if [ -z "$EASYBUILD_KEYRING_GITHUB_TOKEN" ]; then
                export EASYBUILD_KEYRING_GITHUB_TOKEN=$( easybuild_github_token_print )
        fi
}
````

Which leads to:

````
terjekv@foo:~$ eb --check-github
== Temporary log file in case of crash /tmp/eb-cd2gg12t/easybuild-zwfgp9d4.log

Checking status of GitHub integration...

Making sure we're online...OK

* GitHub user...terjekv => OK
Please enter password for encrypted keyring:
WARNING: signal received (2), cleaning up locks ()...

ERROR: Cancelled by user: keyboard interrupt
[...]
terjekv@foo:~$ easybuild_github_token_import
Please enter password for encrypted keyring:
terjekv@foo:~$ eb --check-github
== Temporary log file in case of crash /tmp/eb-qehdn69c/easybuild-2vxsk85d.log

Checking status of GitHub integration...

Making sure we're online...OK

* GitHub user...terjekv => OK
* GitHub token...ghp..vde (len: 40) => OK (validated)
* git command...OK ("git version 2.31.1; ")
* GitPython module...OK (GitPython version 3.1.30)
[...]
````

This also allows for tokens to be stored in Vault or similar tools.