### PR TITLE
Silence distutils deprecation warnings

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -215,4 +215,4 @@ jobs:
           IGNORE_PATTERNS="no GitHub token available|skipping SvnRepository test|requires Lmod as modules tool|stty: 'standard input': Inappropriate ioctl for device|CryptographyDeprecationWarning: Python 3.[56]|from cryptography.*default_backend|CryptographyDeprecationWarning: Python 2|from cryptography.utils import int_from_bytes|Blowfish|GC3Pie not available, skipping test"
           # '|| true' is needed to avoid that Travis stops the job on non-zero exit of grep (i.e. when there are no matches)
           PRINTED_MSG=$(egrep -v "${IGNORE_PATTERNS}" test_framework_suite.log | grep '\.\n*[A-Za-z]' || true)
-          test "x$PRINTED_MSG" = "x" || (echo "ERROR: Found printed messages in output of test suite\n${PRINTED_MSG}" && exit 1)
+          test "x$PRINTED_MSG" = "x" || (echo "ERROR: Found printed messages in output of test suite" && echo "${PRINTED_MSG}" && exit 1)

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -212,7 +212,7 @@ jobs:
           # run test suite
           python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
           # try and make sure output of running tests is clean (no printed messages/warnings)
-          IGNORE_PATTERNS="no GitHub token available|skipping SvnRepository test|requires Lmod as modules tool|stty: 'standard input': Inappropriate ioctl for device|CryptographyDeprecationWarning: Python 3.[56]|from cryptography.*default_backend|CryptographyDeprecationWarning: Python 2|from cryptography.utils import int_from_bytes|Blowfish|GC3Pie not available, skipping test"
+          IGNORE_PATTERNS="no GitHub token available|skipping SvnRepository test|requires Lmod as modules tool|stty: 'standard input': Inappropriate ioctl for device|CryptographyDeprecationWarning: Python 3.[56]|from cryptography.* import |CryptographyDeprecationWarning: Python 2|Blowfish|GC3Pie not available, skipping test"
           # '|| true' is needed to avoid that Travis stops the job on non-zero exit of grep (i.e. when there are no matches)
           PRINTED_MSG=$(egrep -v "${IGNORE_PATTERNS}" test_framework_suite.log | grep '\.\n*[A-Za-z]' || true)
           test "x$PRINTED_MSG" = "x" || (echo "ERROR: Found printed messages in output of test suite" && echo "${PRINTED_MSG}" && exit 1)

--- a/easybuild/toolchains/iimkl.py
+++ b/easybuild/toolchains/iimkl.py
@@ -32,13 +32,13 @@ Authors:
 * Kenneth Hoste (Ghent University)
 * Bart Oldeman (McGill University, Calcul Quebec, Compute Canada)
 """
-from distutils.version import LooseVersion
 import re
 
 from easybuild.toolchains.iccifort import IccIfort
 from easybuild.toolchains.intel_compilers import IntelCompilersToolchain
 from easybuild.toolchains.fft.intelfftw import IntelFFTW
 from easybuild.toolchains.linalg.intelmkl import IntelMKL
+from easybuild.tools import LooseVersion
 
 
 class Iimkl(IccIfort, IntelCompilersToolchain, IntelMKL, IntelFFTW):

--- a/easybuild/tools/__init__.py
+++ b/easybuild/tools/__init__.py
@@ -36,4 +36,15 @@ Authors:
 """
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
+
+import distutils.version
+import warnings
 from easybuild.tools.loose_version import LooseVersion  # noqa(F401)
+
+
+class StrictVersion(distutils.version.StrictVersion):
+    """Temporary wrapper over distuitls StrictVersion that silences the deprecation warning"""
+    def __init__(self, *args, **kwargs):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=DeprecationWarning)
+            distutils.version.StrictVersion.__init__(self, *args, **kwargs)

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -40,9 +40,9 @@ Authors:
 import os
 import re
 import shlex
-from distutils.version import StrictVersion
 
 from easybuild.base import fancylogger
+from easybuild.tools import StrictVersion
 from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import ERROR, IGNORE, PURGE, UNLOAD, UNSET
 from easybuild.tools.config import EBROOT_ENV_VAR_ACTIONS, LOADED_MODULES_ACTIONS

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -40,6 +40,7 @@ import stat
 import sys
 import tempfile
 import time
+from test.framework.github import requires_github_access
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
 from easybuild.tools import run
@@ -2746,6 +2747,7 @@ class FileToolsTest(EnhancedTestCase):
         regex = re.compile(r'^--- .*/foo\s*\n\+\+\+ .*/bar\s*$', re.M)
         self.assertTrue(regex.search(res), "Pattern '%s' found in: %s" % (regex.pattern, res))
 
+    @requires_github_access()
     def test_get_source_tarball_from_git(self):
         """Test get_source_tarball_from_git function."""
 

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -36,13 +36,13 @@ import tempfile
 import shutil
 import stat
 import sys
-from distutils.version import StrictVersion
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
 
 import easybuild.tools.modules as mod
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig.easyconfig import EasyConfig
+from easybuild.tools import StrictVersion
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.environment import modify_env
 from easybuild.tools.filetools import adjust_permissions, copy_file, copy_dir, mkdir

--- a/test/framework/modulestool.py
+++ b/test/framework/modulestool.py
@@ -34,10 +34,9 @@ import sys
 
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
-from distutils.version import StrictVersion
 
 from easybuild.base import fancylogger
-from easybuild.tools import modules
+from easybuild.tools import modules, StrictVersion
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import read_file, which, write_file
 from easybuild.tools.modules import Lmod

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -36,6 +36,7 @@ import stat
 import sys
 import tempfile
 import textwrap
+import warnings
 from easybuild.tools import LooseVersion
 from unittest import TextTestRunner
 
@@ -6297,12 +6298,15 @@ class CommandLineOptionsTest(EnhancedTestCase):
             else:
                 version_class = LooseVersion
 
-            ver1 = version_class('1.2.3')
-            ver2 = version_class('4.5.6')
-            ver3 = version_class('1.2.3dev')
-            ver4 = version_class('system')
-            ver5 = version_class('rc3')
-            ver6 = version_class('v1802')
+            with warnings.catch_warnings():
+                if use_distutils:
+                    warnings.simplefilter("ignore", category=DeprecationWarning)
+                ver1 = version_class('1.2.3')
+                ver2 = version_class('4.5.6')
+                ver3 = version_class('1.2.3dev')
+                ver4 = version_class('system')
+                ver5 = version_class('rc3')
+                ver6 = version_class('v1802')
 
             # some versions are included multiple times on purpose,
             # to also test comparison between equal LooseVersion instances


### PR DESCRIPTION
Currently CI fails due to deprecation warnings

Once due to a left-over use of  `LooseVersion` and 2nd `StrictVersion`.

I resolved the latter with a wrapper class that suppresses the warning.

See #3963