### PR TITLE
Avoid warning for non-existing start_dir when set to None

### DIFF
--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -105,17 +105,24 @@ class ExtensionEasyBlock(EasyBlock, Extension):
 
         Uses existing value of self.start_dir if it is set.
         If self.ext_dir (path to extracted source) is set, it is used as the base dir for relative paths.
-        Otherwise (e.g. for non-extracted extensions like Python WHL files) or when the computed start_dir
-        does not exist the start dir is not changed.
+        Otherwise (e.g. for non-extracted extensions like Python WHL files) the current working directory
+        is used as the base dir.
+        When neither start_dir nor ext_dir are set or when the computed start_dir does not exist
+        the start dir is not changed.
         """
         ext_start_dir = self.start_dir
         if self.ext_dir:
             if ext_start_dir:
-                # If start_dir is relative, resolve it using ext_dir as a base
                 ext_start_dir = os.path.join(self.ext_dir, ext_start_dir)
             else:
-                # start_dir is not set -> Use ext_dir
+                # start_dir is not set or empty -> Use ext_dir
                 ext_start_dir = self.ext_dir
+        elif ext_start_dir is not None:
+            # Resolve relative to current dir
+            if ext_start_dir:
+                ext_start_dir = os.path.join(os.getcwd(), ext_start_dir)
+            else:
+                ext_start_dir = os.getcwd()
 
         if ext_start_dir and os.path.isdir(ext_start_dir):
             self.cfg['start_dir'] = ext_start_dir

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -103,30 +103,25 @@ class ExtensionEasyBlock(EasyBlock, Extension):
     def _set_start_dir(self):
         """Set absolute path of self.start_dir similarly to EasyBlock.guess_start_dir
 
-        Uses existing value of self.start_dir if it is set.
+        Uses existing value of self.start_dir defaulting to self.ext_dir.
         If self.ext_dir (path to extracted source) is set, it is used as the base dir for relative paths.
-        Otherwise (e.g. for non-extracted extensions like Python WHL files) the current working directory
-        is used as the base dir.
+        Otherwise otherwise self.builddir is used as the base.
         When neither start_dir nor ext_dir are set or when the computed start_dir does not exist
         the start dir is not changed.
+        The computed start dir will not end in path separators
         """
         ext_start_dir = self.start_dir
         if self.ext_dir:
             if not os.path.isabs(self.ext_dir):
                 raise EasyBuildError("ext_dir must be an absolute path. Is: '%s'", self.ext_dir)
-            if ext_start_dir:
-                ext_start_dir = os.path.join(self.ext_dir, ext_start_dir)
-            else:
-                # start_dir is not set or empty -> Use ext_dir
-                ext_start_dir = self.ext_dir
+            ext_start_dir = os.path.join(self.ext_dir, ext_start_dir or '')
         elif ext_start_dir is not None:
-            # Resolve relative to current dir
-            if ext_start_dir:
-                ext_start_dir = os.path.join(os.getcwd(), ext_start_dir)
-            else:
-                ext_start_dir = os.getcwd()
+            if not os.path.isabs(self.builddir):
+                raise EasyBuildError("builddir must be an absolute path. Is: '%s'", self.builddir)
+            ext_start_dir = os.path.join(self.builddir, ext_start_dir)
 
         if ext_start_dir and os.path.isdir(ext_start_dir):
+            ext_start_dir = ext_start_dir.rstrip(os.sep) or os.sep
             self.cfg['start_dir'] = ext_start_dir
             self.log.debug("Using extension start dir: %s", ext_start_dir)
         elif ext_start_dir is None:

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -108,17 +108,19 @@ class ExtensionEasyBlock(EasyBlock, Extension):
         Otherwise (e.g. for non-extracted extensions like Python WHL files) or when the computed start_dir
         does not exist the start dir is not changed.
         """
-        ext_start_dir = self.start_dir or ''
-
-        if not os.path.isabs(ext_start_dir) and self.ext_dir:
-            # start dir is either empty or a _relative_ path provided by user through self.start_dir
-            # generate absolute path from ext_dir
-            ext_start_dir = os.path.join(self.ext_dir, ext_start_dir)
+        ext_start_dir = self.start_dir
+        if self.ext_dir:
+            if ext_start_dir:
+                # If start_dir is relative, resolve it using ext_dir as a base
+                ext_start_dir = os.path.join(self.ext_dir, ext_start_dir)
+            else:
+                # start_dir is not set -> Use ext_dir
+                ext_start_dir = self.ext_dir
 
         if ext_start_dir and os.path.isdir(ext_start_dir):
             self.cfg['start_dir'] = ext_start_dir
             self.log.debug("Using extension start dir: %s", ext_start_dir)
-        elif self.start_dir is None:
+        elif ext_start_dir is None:
             # This may be on purpose, e.g. for Python WHL files which do not get extracted
             self.log.debug("Start dir is not set.")
         else:

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -106,10 +106,7 @@ class ExtensionEasyBlock(EasyBlock, Extension):
         Uses existing value of self.start_dir if it is already set, an absolute path and exists
         otherwise use self.ext_dir (path to extracted source) as base dir if that is set and exists.
         """
-        ext_start_dir = ''
-
-        if self.start_dir:
-            ext_start_dir = self.start_dir
+        ext_start_dir = self.start_dir or ''
 
         if not os.path.isabs(ext_start_dir) and self.ext_dir:
             # start dir is either empty or a _relative_ path provided by user through self.start_dir
@@ -119,6 +116,9 @@ class ExtensionEasyBlock(EasyBlock, Extension):
         if os.path.isdir(ext_start_dir):
             self.cfg['start_dir'] = ext_start_dir
             self.log.debug("Using extension start dir: %s", ext_start_dir)
+        elif self.start_dir is None:
+            # This may be on purpose, e.g. for Python WHL files which do not get extracted
+            self.log.debug("Start dir is not set.")
         else:
             # non-existing start dir means wrong input from user
             warn_msg = "Provided start dir (%s) for extension %s does not exist: %s" % (self.start_dir, self.name,

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -103,8 +103,10 @@ class ExtensionEasyBlock(EasyBlock, Extension):
     def _set_start_dir(self):
         """Set absolute path of self.start_dir similarly to EasyBlock.guess_start_dir
 
-        Uses existing value of self.start_dir if it is already set, an absolute path and exists
-        otherwise use self.ext_dir (path to extracted source) as base dir if that is set and exists.
+        Uses existing value of self.start_dir if it is set.
+        If self.ext_dir (path to extracted source) is set, it is used as the base dir for relative paths.
+        Otherwise (e.g. for non-extracted extensions like Python WHL files) or when the computed start_dir
+        does not exist the start dir is not changed.
         """
         ext_start_dir = self.start_dir or ''
 
@@ -113,7 +115,7 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             # generate absolute path from ext_dir
             ext_start_dir = os.path.join(self.ext_dir, ext_start_dir)
 
-        if os.path.isdir(ext_start_dir):
+        if ext_start_dir and os.path.isdir(ext_start_dir):
             self.cfg['start_dir'] = ext_start_dir
             self.log.debug("Using extension start dir: %s", ext_start_dir)
         elif self.start_dir is None:

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -112,6 +112,8 @@ class ExtensionEasyBlock(EasyBlock, Extension):
         """
         ext_start_dir = self.start_dir
         if self.ext_dir:
+            if not os.path.isabs(self.ext_dir):
+                raise EasyBuildError("ext_dir must be an absolute path. Is: '%s'", self.ext_dir)
             if ext_start_dir:
                 ext_start_dir = os.path.join(self.ext_dir, ext_start_dir)
             else:

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2181,6 +2181,10 @@ class EasyBlockTest(EnhancedTestCase):
             # extract sources of the extension
             ext = eb.ext_instances[-1]
             ext.run(unpack_src=unpack_src)
+
+            if unpack_src:
+                self.assertTrue(ext.start_dir is None or os.path.isabs(ext.start_dir))
+
             if expected_start_dir is None:
                 self.assertIsNone(ext.start_dir)
             else:

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2244,6 +2244,16 @@ class EasyBlockTest(EnhancedTestCase):
             check_ext_start_dir('.', unpack_src=False)
             self.assertFalse(self.get_stderr())
 
+        # Keep absolute path in start_dir
+        assert os.path.isabs(self.test_prefix)
+        ec['ec']['exts_list'] = [
+            ('barbar', '0.0', {
+                'start_dir': self.test_prefix}),
+        ]
+        with self.mocked_stdout_stderr():
+            check_ext_start_dir(self.test_prefix, unpack_src=False)
+            self.assertFalse(self.get_stderr())
+
         # Support / (absolute path) if explicitely requested
         ec['ec']['exts_list'] = [
             ('barbar', '0.0', {

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2182,13 +2182,14 @@ class EasyBlockTest(EnhancedTestCase):
             ext = eb.ext_instances[-1]
             ext.run(unpack_src=unpack_src)
             if expected_start_dir is None:
-                self.assertIsNone(ext.cfg['start_dir'])
+                self.assertIsNone(ext.start_dir)
             else:
                 if os.path.isabs(expected_start_dir):
                     abs_expected_start_dir = expected_start_dir
                 else:
                     abs_expected_start_dir = os.path.join(eb.builddir, expected_start_dir)
-                self.assertTrue(os.path.samefile(ext.cfg['start_dir'], abs_expected_start_dir))
+                self.assertTrue(os.path.samefile(ext.start_dir, abs_expected_start_dir))
+                self.assertEqual(ext.start_dir, abs_expected_start_dir)
             if unpack_src:
                 self.assertTrue(os.path.samefile(os.getcwd(), abs_expected_start_dir))
             else:
@@ -2234,14 +2235,14 @@ class EasyBlockTest(EnhancedTestCase):
                 'start_dir': '.'}),  # The current path which does exist
         ]
         with self.mocked_stdout_stderr():
-            check_ext_start_dir(cwd, unpack_src=False)
+            check_ext_start_dir(os.path.join(cwd, '.'), unpack_src=False)
             self.assertFalse(self.get_stderr())
         ec['ec']['exts_list'] = [
             ('barbar', '0.0', {
                 'start_dir': '..'}),  # The parent path which also exists
         ]
         with self.mocked_stdout_stderr():
-            check_ext_start_dir(os.path.dirname(cwd), unpack_src=False)
+            check_ext_start_dir(os.path.join(cwd, '..'), unpack_src=False)
             self.assertFalse(self.get_stderr())
 
     def test_prepare_step(self):


### PR DESCRIPTION
Python packages may be installed from WHL files which do not get extracted in which case `self.start_dir, self.ext_dir` are both `None`. This leads to an unhelpful warning:
> WARNING: Provided start dir (None) for extension tensorboard-plugin-wit does not exist:

Check that case and only log a debug message. Also add test for this.

Note that #4196 changed semantics: Prior to this `start_dir` or `ext_dir` where used if set and existing resolved relative to the current directory. After that `start_dir` is resolved relative to `ext_dir` which is usually the same but does not need to.