### PR TITLE
Add option to silence deprecation warning of ECs and toolchains

### DIFF
--- a/easybuild/base/generaloption.py
+++ b/easybuild/base/generaloption.py
@@ -1149,7 +1149,8 @@ class GeneralOption(object):
                 if len(str(default)) == 0:
                     extra_help.append("default: ''")  # empty string
                 elif typ in ExtOption.TYPE_STRLIST:
-                    extra_help.append("default: %s" % sep.join(default))
+                    if default:
+                        extra_help.append("default: %s" % sep.join(default))
                 else:
                     extra_help.append("default: %s" % default)
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -834,14 +834,16 @@ class EasyConfig(object):
         deprecated = self['deprecated']
         if deprecated:
             if isinstance(deprecated, string_type):
-                depr_msgs.append("easyconfig file '%s' is marked as deprecated:\n%s\n" % (path, deprecated))
+                if 'easyconfig' not in build_option('silence_deprecation_warnings'):
+                    depr_msgs.append("easyconfig file '%s' is marked as deprecated:\n%s\n" % (path, deprecated))
             else:
                 raise EasyBuildError("Wrong type for value of 'deprecated' easyconfig parameter: %s", type(deprecated))
 
         if self.toolchain.is_deprecated():
             # allow use of deprecated toolchains when running unit tests,
             # because test easyconfigs/modules often use old toolchain versions (and updating them is far from trivial)
-            if not build_option('unit_testing_mode'):
+            if (not build_option('unit_testing_mode')
+                    and 'toolchain' not in build_option('silence_deprecation_warnings')):
                 depr_msgs.append("toolchain '%(name)s/%(version)s' is marked as deprecated" % self['toolchain'])
 
         if depr_msgs:

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -595,8 +595,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None):
     eb_go, cfg_settings = set_up_configuration(args=args, logfile=logfile, testing=testing)
     options, orig_paths = eb_go.options, eb_go.args
 
-    silence_deprecation_warnings = build_option('silence_deprecation_warnings') or []
-    if 'python2' not in silence_deprecation_warnings:
+    if 'python2' not in build_option('silence_deprecation_warnings'):
         python2_is_deprecated()
 
     global _log

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -254,7 +254,6 @@ BUILD_OPTIONS_CMDLINE = {
         'rpath_filter',
         'rpath_override_dirs',
         'required_linked_shared_libs',
-        'silence_deprecation_warnings',
         'skip',
         'stop',
         'subdir_user_modules',
@@ -335,6 +334,7 @@ BUILD_OPTIONS_CMDLINE = {
         'include_easyblocks_from_pr',
         'robot',
         'search_paths',
+        'silence_deprecation_warnings',
     ],
     WARN: [
         'check_ebroot_env_vars',

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -274,9 +274,7 @@ class ModulesTool(object):
                     depr_msg = "Support for %s version < %s is deprecated, " % (self.NAME, self.DEPR_VERSION)
                     depr_msg += "found version %s" % self.version
 
-                    silence_deprecation_warnings = build_option('silence_deprecation_warnings') or []
-
-                    if self.version.startswith('6') and 'Lmod6' in silence_deprecation_warnings:
+                    if self.version.startswith('6') and 'Lmod6' in build_option('silence_deprecation_warnings'):
                         self.log.warning(depr_msg)
                     else:
                         self.log.deprecated(depr_msg, '5.0')

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -339,6 +339,8 @@ class EasyBuildOptions(GeneralOption):
         # override options
         descr = ("Override options", "Override default EasyBuild behavior.")
 
+        all_deprecations = ('python2', 'Lmod6', 'easyconfig', 'toolchain')
+
         opts = OrderedDict({
             'accept-eula': ("Accept EULA for specified software [DEPRECATED, use --accept-eula-for instead!]",
                             'strlist', 'store', []),
@@ -494,7 +496,9 @@ class EasyBuildOptions(GeneralOption):
             'set-default-module': ("Set the generated module as default", None, 'store_true', False),
             'set-gid-bit': ("Set group ID bit on newly created directories", None, 'store_true', False),
             'show-progress-bar': ("Show progress bar in terminal output", None, 'store_true', True),
-            'silence-deprecation-warnings': ("Silence specified deprecation warnings", 'strlist', 'extend', None),
+            'silence-deprecation-warnings': (
+                "Silence specified deprecation warnings out of (%s)" % ', '.join(all_deprecations),
+                'strlist', 'extend', []),
             'skip-extensions': ("Skip installation of extensions", None, 'store_true', False),
             'skip-test-cases': ("Skip running test cases", None, 'store_true', False, 't'),
             'skip-test-step': ("Skip running the test step (e.g. unit tests)", None, 'store_true', False),
@@ -906,6 +910,10 @@ class EasyBuildOptions(GeneralOption):
         # override current version of EasyBuild with version specified to --deprecated
         if self.options.deprecated:
             build_log.CURRENT_VERSION = LooseVersion(self.options.deprecated)
+
+        # Convert this to an empty list if not set to simplify usage
+        if self.options.silence_deprecation_warnings is None:
+            self.options.silence_deprecation_warnings = []
 
         # log to specified value of --unittest-file
         if self.options.unittest_file:

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -911,10 +911,6 @@ class EasyBuildOptions(GeneralOption):
         if self.options.deprecated:
             build_log.CURRENT_VERSION = LooseVersion(self.options.deprecated)
 
-        # Convert this to an empty list if not set to simplify usage
-        if self.options.silence_deprecation_warnings is None:
-            self.options.silence_deprecation_warnings = []
-
         # log to specified value of --unittest-file
         if self.options.unittest_file:
             fancylogger.logToFile(self.options.unittest_file, max_bytes=0)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3803,7 +3803,7 @@ class EasyConfigTest(EnhancedTestCase):
             self.assertFalse(self.get_stdout())
 
     def test_deprecated_toolchain(self):
-        """Test use of deprecatd toolchain"""
+        """Test use of deprecated toolchain"""
         topdir = os.path.dirname(os.path.abspath(__file__))
         deprecated_toolchain_ec = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0-gompi-2018a.eb')
         init_config(build_options={'silence_deprecation_warnings': [], 'unit_testing_mode': False})

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3795,6 +3795,26 @@ class EasyConfigTest(EnhancedTestCase):
 
         error_pattern = r"easyconfig file '.*/test.eb' is marked as deprecated:\nthis is just a test\n \(see also"
         self.assertErrorRegex(EasyBuildError, error_pattern, EasyConfig, test_ec)
+        with self.mocked_stdout_stderr():
+            # But this can be silenced
+            init_config(build_options={'silence_deprecation_warnings': ['easyconfig']})
+            EasyConfig(test_ec)
+            self.assertFalse(self.get_stderr())
+            self.assertFalse(self.get_stdout())
+
+    def test_deprecated_toolchain(self):
+        """Test use of deprecatd toolchain"""
+        topdir = os.path.dirname(os.path.abspath(__file__))
+        deprecated_toolchain_ec = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0-gompi-2018a.eb')
+        init_config(build_options={'silence_deprecation_warnings': [], 'unit_testing_mode': False})
+        error_pattern = r"toolchain 'gompi/2018a' is marked as deprecated \(see also"
+        self.assertErrorRegex(EasyBuildError, error_pattern, EasyConfig, deprecated_toolchain_ec)
+        with self.mocked_stdout_stderr():
+            # But this can be silenced
+            init_config(build_options={'silence_deprecation_warnings': ['toolchain'], 'unit_testing_mode': False})
+            EasyConfig(deprecated_toolchain_ec)
+            self.assertFalse(self.get_stderr())
+            self.assertFalse(self.get_stdout())
 
     def test_filename(self):
         """Test filename method of EasyConfig class."""


### PR DESCRIPTION
We have the `silence_deprecation_warnings` option but that didn't support the warnings caused by deprecated ECs and toolchains.

Add this and enhance the error message.

While at it also make the build_option return an empty list instead of `None` so we can grep the code for any usage like `if 'foo' in build_option('silence_deprecation_warnings'):`