### PR TITLE
restore initial environment before processing each easystack item

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -62,6 +62,7 @@ from easybuild.framework.easyconfig.tweak import obtain_ec_for, tweak
 from easybuild.tools.config import find_last_log, get_repository, get_repositorypath, build_option
 from easybuild.tools.containers.common import containerize
 from easybuild.tools.docs import list_software
+from easybuild.tools.environment import restore_env
 from easybuild.tools.filetools import adjust_permissions, cleanup, copy_files, dump_index, load_index
 from easybuild.tools.filetools import locate_files, read_file, register_lock_cleanup_signal_handlers, write_file
 from easybuild.tools.github import check_github, close_pr, find_easybuild_easyconfig
@@ -186,6 +187,10 @@ def build_and_install_software(ecs, init_session_state, exit_on_failure=True):
         update_progress_bar(STATUS_BAR, label=status_label)
 
     stop_progress_bar(STATUS_BAR)
+
+    # restore original environment for any next software builds
+    _log.info("Resetting environment")
+    restore_env(init_env)
 
     return res
 


### PR DESCRIPTION
Closes #4194 by explicitly restoring the environment at the end of `build_and_install_software`. This should prevent that the dependencies of a previous (set of) installation(s) are still loaded for the next one, e.g. when using an easystack file. Also added a test that verifies this.

Test output before applying the patch to `main.py`:
```
$ python3 -O -m test.framework.easystack
.......F..
======================================================================
FAIL: test_easystack_restore_env_after_each_build (__main__.EasyStackTest)
Test that the build environment is reset for each easystack item
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/bob/ebdev/easybuild-framework/test/framework/easystack.py", line 148, in test_easystack_restore_env_after_each_build
    self.assertFalse(regex.search(stdout), "Pattern '%s' should not be found in: %s" % (regex.pattern, stdout))
AssertionError: <re.Match object; span=(166129, 166280), match="WARNING Loaded modules detected: ['EasyBuild-deve> is not false : Pattern 'WARNING Loaded modules detected: \[.*gompi/2018.*\]\n' should not be found in:
<LOTS OF OUTPUT>
== 2023-02-10 13:46:59,710 easyblock.py:2248 WARNING Loaded modules detected: ['EasyBuild-develop', 'GCC/6.4.0-2.28', 'hwloc/1.11.8-GCC-6.4.0-2.28', 'OpenMPI/2.1.2-GCC-6.4.0-2.28', 'gompi/2018a']
<LOTS OF OUTPUT>
----------------------------------------------------------------------
Ran 10 tests in 2.169s

FAILED (failures=1)
```

After applying the patch:
```
$ python3 -O -m test.framework.easystack
..........
----------------------------------------------------------------------
Ran 10 tests in 2.096s

OK
```