### PR TITLE
Only print "default: " for str-list options if it is not empty.

### DIFF
--- a/easybuild/base/generaloption.py
+++ b/easybuild/base/generaloption.py
@@ -1149,7 +1149,8 @@ class GeneralOption(object):
                 if len(str(default)) == 0:
                     extra_help.append("default: ''")  # empty string
                 elif typ in ExtOption.TYPE_STRLIST:
-                    extra_help.append("default: %s" % sep.join(default))
+                    if default:
+                        extra_help.append("default: %s" % sep.join(default))
                 else:
                     extra_help.append("default: %s" % default)
 


### PR DESCRIPTION
This changes `(type comma-separated list; default: )` to `(type comma-separated list)` similar to a default of `None`.

That changes the output of `--help` in the following places (done using `diff` over the output before and after):
>                         Parse (additional) configfiles (type comma-separated list)
>                         Enable dependency resolution, using easyconfigs in specified paths (type pathsep-separated list)
>                         Additional paths to consider by robot for easyconfigs (--robot paths get priority) (type pathsep-separated list)
>                         Additional locations to consider in --search (next to --robot and --robot-paths paths) (type pathsep-separated list)
>                         Location(s) of extra or customized easyblocks (type comma-separated list)
>                         Location(s) of extra or customized module naming schemes (type comma-separated list)
>                         Location(s) of extra or customized toolchains or toolchain components (type comma-separated list)
>     --from-pr=PR#       Obtain easyconfigs from specified PR (type comma-separated list)
>                         Include easyblocks from specified PR (type comma-separated list)
>                         Accept EULA for specified software [DEPRECATED, use --accept-eula-for instead!] (type comma-separated list)
>                         Accept EULA for specified software (type comma-separated list)
>                         Silence specified deprecation warnings out of (python2, Lmod6, easyconfig, toolchain) (type comma-separated list)

BTW: A colon after "type" would probably be nice.