### PR TITLE
use "/usr/bin/env python" in test_run_cmd_script

### DIFF
--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -543,7 +543,7 @@ class RunTest(EnhancedTestCase):
         """Testing use of run_cmd with shell=False to call external scripts"""
         py_test_script = os.path.join(self.test_prefix, 'test.py')
         write_file(py_test_script, '\n'.join([
-            '#!/usr/bin/python',
+            '#!/usr/bin/env python',
             'print("hello")',
         ]))
         adjust_permissions(py_test_script, stat.S_IXUSR)


### PR DESCRIPTION
The system I am running the tests on does not have `/usr/bin/python`, so this test fails.

```
======================================================================
ERROR: test_run_cmd_script (test.framework.run.RunTest)
Testing use of run_cmd with shell=False to call external scripts
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/simon/work/easybuild-framework/test/framework/run.py", line 550, in test_run_cmd_script
    (out, ec) = run_cmd(py_test_script)
  File "/home/simon/work/easybuild-framework/easybuild/tools/run.py", line 90, in cache_aware_func
    res = func(cmd, *args, **kwargs)
  File "/home/simon/work/easybuild-framework/easybuild/tools/run.py", line 250, in run_cmd
    regexp=regexp, stream_output=stream_output, trace=trace)
  File "/home/simon/work/easybuild-framework/easybuild/tools/run.py", line 353, in complete_cmd
    return parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp)
  File "/home/simon/work/easybuild-framework/easybuild/tools/run.py", line 642, in parse_cmd_output
    raise EasyBuildError('cmd "%s" exited with exit code %s and output:\n%s', cmd, ec, stdouterr)
easybuild.tools.build_log.EasyBuildError: 'cmd "/tmp/eb-5s0adni4/eb-i46nvily/eb-fk75l1ha/test.py" exited with exit code 126 and output:\n/bin/bash: /tmp/eb-5s0adni4/eb-i46nvily/eb-fk75l1ha/test.py: /usr/bin/python: bad interpreter: No such file or directory\n'

----------------------------------------------------------------------
```