### PR TITLE
Debug bootstrap test on CI

### DIFF
--- a/.github/workflows/bootstrap_script.yml
+++ b/.github/workflows/bootstrap_script.yml
@@ -127,7 +127,11 @@ jobs:
           # test bootstrap script
           export PREFIX=/tmp/$USER/$GITHUB_SHA/eb_bootstrap
           export EASYBUILD_BOOTSTRAP_DEPRECATED=1
-          python easybuild/scripts/bootstrap_eb.py $PREFIX
+          if ! python easybuild/scripts/bootstrap_eb.py $PREFIX; then
+            # Output log file of stage 2 install then fail
+            cat /tmp/eb-*/easybuild-EasyBuild-*.log
+            false
+          fi
           unset EASYBUILD_BOOTSTRAP_DEPRECATED
           # unset $PYTHONPATH to avoid mixing two EasyBuild 'installations' when testing bootstrapped EasyBuild module
           unset PYTHONPATH


### PR DESCRIPTION
The current failure looks like

```
 == FAILED: Installation ended unsuccessfully (build directory: /tmp/tmp1ec454qx/EasyBuild/4.7.1/dummy-dummy): build failed (first 300 chars): cmd " /opt/hostedtoolcache/Python/3.7.16/x64/bin/python -m pip install --prefix=/tmp/runner/200614b91caee792396c8fd6365e015e1bb9145f/eb_bootstrap/software/EasyBuild/4.7.1  --no-deps  --ignore-installed  --no-build-isolation  ." exited with exit code 1 and output:
Processing /tmp/tmp1ec454qx/EasyBuil (took 4 secs)
== Results of the build can be found in the log file(s) /tmp/eb-u9niem1r/easybuild-EasyBuild-4.7.1-20230511.110258.MiSOu.log
```

This isn't helpful so in a first step this prints out the log file in case of error.