### PR TITLE
remove support for 32-bit targets

### DIFF
--- a/easybuild/toolchains/compiler/clang.py
+++ b/easybuild/toolchains/compiler/clang.py
@@ -34,7 +34,6 @@ Authors:
 """
 
 import easybuild.tools.systemtools as systemtools
-from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.toolchain.compiler import Compiler
 
 

--- a/easybuild/toolchains/compiler/clang.py
+++ b/easybuild/toolchains/compiler/clang.py
@@ -108,10 +108,3 @@ class Clang(Compiler):
 
     LIB_MULTITHREAD = ['pthread']
     LIB_MATH = ['m']
-
-    def _set_compiler_vars(self):
-        """Set compiler variables."""
-        super(Clang, self)._set_compiler_vars()
-
-        if self.options.get('32bit', None):
-            raise EasyBuildError("_set_compiler_vars: 32bit set, but no support yet for 32bit Clang in EasyBuild")

--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -113,9 +113,6 @@ class Gcc(Compiler):
     def _set_compiler_vars(self):
         super(Gcc, self)._set_compiler_vars()
 
-        if self.options.get('32bit', None):
-            raise EasyBuildError("_set_compiler_vars: 32bit set, but no support yet for 32bit GCC in EasyBuild")
-
         # to get rid of lots of problems with libgfortranbegin
         # or remove the system gcc-gfortran
         # also used in eg LIBBLAS variable

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -124,14 +124,11 @@ class IntelIccIfort(Compiler):
         if LooseVersion(icc_version) < LooseVersion('2011'):
             self.LIB_MULTITHREAD.insert(1, "guide")
 
-        libpaths = ['intel64']
-        if self.options.get('32bit', None):
-            libpaths.append('ia32')
-        libpaths = ['lib/%s' % x for x in libpaths]
+        libpath = 'lib/intel64'
         if LooseVersion(icc_version) > LooseVersion('2011.4') and LooseVersion(icc_version) < LooseVersion('2013_sp1'):
-            libpaths = ['compiler/%s' % x for x in libpaths]
+            libpath = 'compiler/%s' % libpath
 
-        self.variables.append_subdirs("LDFLAGS", icc_root, subdirs=libpaths)
+        self.variables.append_subdirs("LDFLAGS", icc_root, subdirs=[libpath])
 
     def set_variables(self):
         """Set the variables."""

--- a/easybuild/toolchains/fcc.py
+++ b/easybuild/toolchains/fcc.py
@@ -45,9 +45,7 @@ class FCC(FujitsuCompiler):
             names should be a list of strings containing the name of the dependency
         """
         cpp_paths = ['include']
-        ld_paths = ['lib']
-        if not self.options.get('32bit', None):
-            ld_paths.insert(0, 'lib64')
+        ld_paths = ['lib64', 'lib']
 
         if cpp is not None:
             for p in cpp:

--- a/easybuild/toolchains/linalg/acml.py
+++ b/easybuild/toolchains/linalg/acml.py
@@ -73,8 +73,6 @@ class Acml(LinAlg):
 
     def _set_blas_variables(self):
         """Fix the map a bit"""
-        if self.options.get('32bit', None):
-            raise EasyBuildError("_set_blas_variables: 32bit ACML not (yet) supported")
         try:
             for root in self.get_software_root(self.BLAS_MODULE_NAME):
                 subdirs = self.ACML_SUBDIRS_MAP[self.COMPILER_FAMILY]

--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -132,9 +132,6 @@ class IntelMKL(LinAlg):
             raise EasyBuildError("_set_blas_variables: interface_mt unsupported combination with compiler family %s",
                                  self.COMPILER_FAMILY)
 
-        if self.options.get('32bit', None):
-            # 32bit
-            self.BLAS_LIB_MAP.update({"lp64": ''})
         if self.options.get('i8', None):
             # ilp64/i8
             self.BLAS_LIB_MAP.update({"lp64": '_ilp64'})
@@ -145,26 +142,19 @@ class IntelMKL(LinAlg):
         found_version = self.get_software_version(self.BLAS_MODULE_NAME)[0]
         ver = LooseVersion(found_version)
         if ver < LooseVersion('10.3'):
-            if self.options.get('32bit', None):
-                self.BLAS_LIB_DIR = ['lib/32']
-            else:
-                self.BLAS_LIB_DIR = ['lib/em64t']
+            self.BLAS_LIB_DIR = ['lib/em64t']
             self.BLAS_INCLUDE_DIR = ['include']
         else:
-            if self.options.get('32bit', None):
-                raise EasyBuildError("_set_blas_variables: 32-bit libraries not supported yet for IMKL v%s (> v10.3)",
-                                     found_version)
+            if ver >= LooseVersion('2021'):
+                basedir = os.path.join('mkl', found_version)
             else:
-                if ver >= LooseVersion('2021'):
-                    basedir = os.path.join('mkl', found_version)
-                else:
-                    basedir = 'mkl'
+                basedir = 'mkl'
 
-                self.BLAS_LIB_DIR = [os.path.join(basedir, 'lib', 'intel64')]
-                if ver >= LooseVersion('10.3.4') and ver < LooseVersion('11.1'):
-                    self.BLAS_LIB_DIR.append(os.path.join('compiler', 'lib', 'intel64'))
-                elif ver < LooseVersion('2021'):
-                    self.BLAS_LIB_DIR.append(os.path.join('lib', 'intel64'))
+            self.BLAS_LIB_DIR = [os.path.join(basedir, 'lib', 'intel64')]
+            if ver >= LooseVersion('10.3.4') and ver < LooseVersion('11.1'):
+                self.BLAS_LIB_DIR.append(os.path.join('compiler', 'lib', 'intel64'))
+            elif ver < LooseVersion('2021'):
+                self.BLAS_LIB_DIR.append(os.path.join('lib', 'intel64'))
 
             self.BLAS_INCLUDE_DIR = [os.path.join(basedir, 'include')]
 
@@ -198,11 +188,7 @@ class IntelMKL(LinAlg):
             self.SCALAPACK_LIB.append("mkl_solver%(lp64)s_sequential")
             self.SCALAPACK_LIB_MT.append("mkl_solver%(lp64)s")
 
-        if self.options.get('32bit', None):
-            # 32 bit
-            self.SCALAPACK_LIB_MAP.update({"lp64_sc": '_core'})
-
-        elif self.options.get('i8', None):
+        if self.options.get('i8', None):
             # ilp64/i8
             self.SCALAPACK_LIB_MAP.update({"lp64_sc": '_ilp64'})
 

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -89,7 +89,6 @@ class Compiler(Toolchain):
         'cstd': (None, "Specify C standard"),
         'shared': (False, "Build shared library"),
         'static': (False, "Build static library"),
-        '32bit': (False, "Compile 32bit target"),  # LA, FFTW
         'openmp': (False, "Enable OpenMP"),
         'vectorize': (None, "Enable compiler auto-vectorization, default except for noopt and lowopt"),
         'packed-linker-options': (False, "Pack the linker options as comma separated list"),  # ScaLAPACK mainly
@@ -104,7 +103,6 @@ class Compiler(Toolchain):
     COMPILER_UNIQUE_OPTION_MAP = None
     COMPILER_SHARED_OPTION_MAP = {
         DEFAULT_OPT_LEVEL: 'O2',
-        '32bit': 'm32',
         'cstd': 'std=%(value)s',
         'debug': 'g',
         'lowopt': 'O1',
@@ -189,10 +187,6 @@ class Compiler(Toolchain):
 
     def _set_compiler_vars(self):
         """Set the compiler variables"""
-        is32bit = self.options.get('32bit', None)
-        if is32bit:
-            self.log.debug("_set_compiler_vars: 32bit set: changing compiler definitions")
-
         comp_var_tmpl_dict = {}
 
         # always include empty infix first for non-prefixed compilers (e.g., GCC, Intel, ...)
@@ -214,8 +208,6 @@ class Compiler(Toolchain):
                         self.log.warning("_set_compiler_vars: %s compiler variable %s undefined", infix, var)
 
                 self.variables[pref_var] = value
-                if is32bit:
-                    self.variables.nappend_el(pref_var, self.options.option('32bit'))
 
                 # update dictionary to complete compiler variable template
                 # to produce e.g. 'nvcc -ccbin=icpc' from 'nvcc -ccbin=%(CXX_base)'

--- a/easybuild/tools/toolchain/mpi.py
+++ b/easybuild/tools/toolchain/mpi.py
@@ -193,10 +193,6 @@ class Mpi(Toolchain):
 
     def _set_mpi_compiler_variables(self):
         """Set the MPI compiler variables"""
-        is32bit = self.options.get('32bit', None)
-        if is32bit:
-            self.log.debug("_set_mpi_compiler_variables: 32bit set: changing compiler definitions")
-
         for var_tuple in COMPILER_VARIABLES:
             c_var = var_tuple[0]  # [1] is the description
             var = MPI_COMPILER_TEMPLATE % {'c_var': c_var}
@@ -213,9 +209,6 @@ class Mpi(Toolchain):
             }
 
             self.variables.nappend_el(var, self.options.option('_opt_%s' % var, templatedict=templatedict))
-
-            if is32bit:
-                self.variables.nappend_el(var, self.options.option('32bit'))
 
             if self.options.get('usempi', None):
                 var_seq = SEQ_COMPILER_TEMPLATE % {'c_var': c_var}
@@ -238,9 +231,7 @@ class Mpi(Toolchain):
 
         lib_dir = ['lib']
         incl_dir = ['include']
-        suffix = None
-        if not self.options.get('32bit', None):
-            suffix = '64'
+        suffix = '64'
 
         # take into account that MPI_MODULE_NAME could be None (see Cray toolchains)
         for root in self.get_software_root(self.MPI_MODULE_NAME or []):

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -1058,9 +1058,7 @@ class Toolchain(object):
             names should be a list of strings containing the name of the dependency
         """
         cpp_paths = ['include']
-        ld_paths = ['lib']
-        if not self.options.get('32bit', None):
-            ld_paths.insert(0, 'lib64')
+        ld_paths = ['lib64', 'lib']
 
         if cpp is not None:
             for p in cpp:


### PR DESCRIPTION
This was only ever supported for imkl < 11.0 and related Intel compilers around 2012, which have been deprecated a long time ago.