### PR TITLE
initial implementation of `run` function to replace `run_cmd` + `run_cmd_qa`

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -141,8 +141,8 @@ def run(cmd, fail_on_error=True, split_stderr=False, stdin=None,
     _log.info(f"Running command '{cmd_msg}' in {work_dir}")
     proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=shell)
 
-    # return output as a regular string (UTF-8 characters get stripped out)
-    output = proc.stdout.decode('ascii', 'ignore')
+    # return output as a regular string rather than a byte sequence (and non-UTF-8 characters get stripped out)
+    output = proc.stdout.decode('utf-8', 'ignore')
 
     res = RunResult(output=output, exit_code=proc.returncode, stderr=None)
     _log.info(f"Command '{cmd_msg}' exited with exit code {res.exit_code} and output:\n%{res.output}")

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -161,16 +161,24 @@ def run(cmd, fail_on_error=True, split_stderr=False, stdin=None,
 def cmd_trace_msg(cmd, start_time, work_dir, stdin, cmd_out_fp):
     """
     Helper function to construct and print trace message for command being run
+
+    :param cmd: command being run
+    :param start_time: datetime object indicating when command was started
+    :param work_dir: path of working directory in which command is run
+    :param stdin: stdin input value for command
+    :param cmd_out_fp: path to output log file for command
     """
+    start_time = start_time.strftime('%Y-%m-%d %H:%M:%S')
+
     lines = [
         "running command:",
-        "\t[started at: %s]" % start_time.strftime('%Y-%m-%d %H:%M:%S'),
-        "\t[working dir: %s]" % work_dir,
+        f"\t[started at: {start_time}]",
+        f"\t[working dir: {work_dir}]",
     ]
     if stdin:
-        lines.append("\t[input: %s]" % stdin)
+        lines.append(f"\t[input: {stdin}]")
     if cmd_out_fp:
-        lines.append("\t[output logged in %s]" % cmd_out_fp)
+        lines.append(f"\t[output logged in {cmd_out_fp}]")
 
     lines.append('\t' + cmd)
 

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -104,7 +104,7 @@ def run(cmd, fail_on_error=True, split_stderr=False, stdin=None,
     """
 
     # temporarily raise a NotImplementedError until all options are implemented
-    if any((not fail_on_error, split_stderr, stdin, in_dry_run, work_dir, output_file, stream_output, asynchronous)):
+    if any((not fail_on_error, split_stderr, in_dry_run, work_dir, output_file, stream_output, asynchronous)):
         raise NotImplementedError
 
     if qa_patterns or qa_wait_patterns:
@@ -138,8 +138,12 @@ def run(cmd, fail_on_error=True, split_stderr=False, stdin=None,
     if not hidden:
         cmd_trace_msg(cmd_msg, start_time, work_dir, stdin, cmd_out_fp)
 
+    if stdin:
+        # 'input' value fed to subprocess.run must be a byte sequence
+        stdin = stdin.encode()
+
     _log.info(f"Running command '{cmd_msg}' in {work_dir}")
-    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=shell)
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, input=stdin, shell=shell)
 
     # return output as a regular string rather than a byte sequence (and non-UTF-8 characters get stripped out)
     output = proc.stdout.decode('utf-8', 'ignore')

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -115,7 +115,7 @@ def run(cmd, fail_on_error=True, split_stderr=False, stdin=None,
     elif isinstance(cmd, list):
         cmd_msg = ' '.join(cmd)
     else:
-        raise EasyBuildError("Unknown command type ('%s'): %s", type(cmd), cmd)
+        raise EasyBuildError(f"Unknown command type ('{type(cmd)}'): {cmd}")
 
     silent = build_option('silent')
 
@@ -128,8 +128,8 @@ def run(cmd, fail_on_error=True, split_stderr=False, stdin=None,
     # early exit in 'dry run' mode, after printing the command that would be run (unless 'hidden' is enabled)
     if build_option('extended_dry_run'):
         if not hidden:
-            msg = "  running command \"%s\"\n" % cmd_msg
-            msg += "  (in %s)" % work_dir
+            msg = f"  running command \"%{cmd_msg}s\"\n"
+            msg += f"  (in %{work_dir})"
             dry_run_msg(msg, silent=silent)
 
         return RunResult(output='', exit_code=0, stderr=None)
@@ -138,15 +138,18 @@ def run(cmd, fail_on_error=True, split_stderr=False, stdin=None,
     if not hidden:
         cmd_trace_msg(cmd_msg, start_time, work_dir, stdin, cmd_out_fp)
 
+    _log.info(f"Running command '{cmd_msg}' in {work_dir}")
     proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=shell)
 
     # return output as a regular string (UTF-8 characters get stripped out)
     output = proc.stdout.decode('ascii', 'ignore')
 
     res = RunResult(output=output, exit_code=proc.returncode, stderr=None)
+    _log.info(f"Command '{cmd_msg}' exited with exit code {res.exit_code} and output:\n%{res.output}")
 
     if not hidden:
-        trace_msg("command completed: exit %s, ran in %s" % (res.exit_code, time_str_since(start_time)))
+        time_since_start = time_str_since(start_time)
+        trace_msg(f"command completed: exit {res.exit_code}, ran in {time_since_start}")
 
     return res
 

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -173,6 +173,7 @@ class RunTest(EnhancedTestCase):
         # this is constructed to reproduce errors like:
         # UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe2
         # UnicodeEncodeError: 'ascii' codec can't encode character u'\u2018'
+        # (such errors are ignored by the 'run' implementation)
         for text in [b"foo \xe2 bar", b"foo \u2018 bar"]:
             test_file = os.path.join(self.test_prefix, 'foo.txt')
             write_file(test_file, text)

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -162,7 +162,8 @@ class RunTest(EnhancedTestCase):
     def test_run_basic(self):
         """Basic test for run function."""
 
-        res = run("echo hello")
+        with self.mocked_stdout_stderr():
+            res = run("echo hello")
         self.assertEqual(res.output, "hello\n")
         # no reason echo hello could fail
         self.assertEqual(res.exit_code, 0)
@@ -177,7 +178,8 @@ class RunTest(EnhancedTestCase):
             write_file(test_file, text)
             cmd = "cat %s" % test_file
 
-            res = run(cmd)
+            with self.mocked_stdout_stderr():
+                res = run(cmd)
             self.assertEqual(res.exit_code, 0)
             self.assertTrue(res.output.startswith('foo ') and res.output.endswith(' bar'))
             self.assertEqual(type(res.output), str)
@@ -242,7 +244,8 @@ class RunTest(EnhancedTestCase):
 
         # command output is always logged
         init_logging(logfile, silent=True)
-        res = run("echo hello")
+        with self.mocked_stdout_stderr():
+            res = run("echo hello")
         stop_logging(logfile)
         self.assertEqual(res.exit_code, 0)
         self.assertEqual(res.output, 'hello\n')
@@ -254,8 +257,11 @@ class RunTest(EnhancedTestCase):
         setLogLevelDebug()
 
         init_logging(logfile, silent=True)
-        self.assertTrue(run("echo hello"))
+        with self.mocked_stdout_stderr():
+            res = run("echo hello")
         stop_logging(logfile)
+        self.assertEqual(res.exit_code, 0)
+        self.assertEqual(res.output, 'hello\n')
         self.assertEqual(len(regex_start_cmd.findall(read_file(logfile))), 1)
         self.assertEqual(len(regex_cmd_exit.findall(read_file(logfile))), 1)
         write_file(logfile, '')

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -400,7 +400,7 @@ class RunTest(EnhancedTestCase):
 
         pattern = [
             r"^  >> running command:",
-            r"\t\[started at: .*\]",
+            r"\t\[started at: [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\]",
             r"\t\[working dir: .*\]",
             r"\techo hello",
             r"  >> command completed: exit 0, ran in .*",


### PR DESCRIPTION
cfr. #4252

Marked as draft because:

* need to check which other tests can be copied to also cover `run` with the current implementation;
* should switch from `run_cmd` to `run` where possible;

