### PR TITLE
fix regex for extracting glibc version from output of '`ldd --version`' in Gentoo Linux

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -943,6 +943,8 @@ def get_glibc_version():
 
     if os_type == LINUX:
         glibc_ver_str = get_tool_version('ldd')
+        # note: get_tool_version replaces newlines with ';',
+        # hence the use of ';' below after the expected glibc version
         glibc_ver_regex = re.compile(r"^ldd \(.+\) (\d[\d.]+);")
         res = glibc_ver_regex.search(glibc_ver_str)
 

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -943,7 +943,7 @@ def get_glibc_version():
 
     if os_type == LINUX:
         glibc_ver_str = get_tool_version('ldd')
-        glibc_ver_regex = re.compile(r"^ldd \([^)]*\) (\d[\d.]*).*$")
+        glibc_ver_regex = re.compile(r"^ldd \(.+\) (\d[\d.]+);")
         res = glibc_ver_regex.search(glibc_ver_str)
 
         if res is not None:

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -325,7 +325,7 @@ def mocked_run_cmd(cmd, **kwargs):
     """Mocked version of run_cmd, with specified output for known commands."""
     known_cmds = {
         "gcc --version": "gcc (GCC) 5.1.1 20150618 (Red Hat 5.1.1-4)",
-        "ldd --version": "ldd (GNU libc) 2.12",
+        "ldd --version": "ldd (GNU libc) 2.12; ",
         "sysctl -n hw.cpufrequency_max": "2400000000",
         "sysctl -n hw.ncpu": '10',
         "sysctl -n hw.memsize": '8589934592',
@@ -790,6 +790,13 @@ class SystemToolsTest(EnhancedTestCase):
         st.get_os_type = lambda: st.LINUX
         st.run_cmd = mocked_run_cmd
         self.assertEqual(get_glibc_version(), '2.12')
+
+    def test_glibc_version_linux_gentoo(self):
+        """Test getting glibc version (mocked for Linux)."""
+        st.get_os_type = lambda: st.LINUX
+        ldd_version_out = "ldd (Gentoo 2.37-r3 (patchset 5)) 2.37; Copyright (C) 2023 Free Software Foundation, Inc."
+        st.get_tool_version = lambda _: ldd_version_out
+        self.assertEqual(get_glibc_version(), '2.37')
 
     def test_glibc_version_linux_musl_libc(self):
         """Test getting glibc version (mocked for Linux)."""


### PR DESCRIPTION
Without this change, we get `UNKNOWN` in a Gentoo Linux environment:

```
$ eb --show-system-info | grep glibc
  -> glibc version: UNKNOWN
```

That causes trouble with Qt5 for example, because `get_glibc_version` is used in the sanity check, which leads to:

```
  File "/cvmfs/pilot.eessi-hpc.org/versions/2023.06/software/linux/x86_64/generic/software/EasyBuild/4.7.2/lib/python3.11/site-packages/easybuild/easyblocks/q/qt.py", line 203, in sanity_check_step
    if LooseVersion(glibc_version) <= LooseVersion("2.16"):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/pilot.eessi-hpc.org/versions/2023.06/compat/linux/x86_64/usr/lib/python3.11/site-packages/setuptools/_distutils/version.py", line 78, in __le__
    c = self._cmp(other)
        ^^^^^^^^^^^^^^^^
  File "/cvmfs/pilot.eessi-hpc.org/versions/2023.06/compat/linux/x86_64/usr/lib/python3.11/site-packages/setuptools/_distutils/version.py", line 351, in _cmp
    if self.version < other.version:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'str' and 'int'
```

(cfr. https://github.com/EESSI/software-layer/pull/284)

With this change, the glibc version is detected correctly also in Gentoo:

```
[EESSI pilot 2023.06] $ ldd --version
ldd (Gentoo 2.37-r3 (patchset 5)) 2.37
Copyright (C) 2023 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.

[EESSI pilot 2023.06] $ eb --show-system-info | grep glibc
  -> glibc version: 2.37
```