### PR TITLE
Don't ignore modules tool when using `--fetch`

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -424,9 +424,15 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
     forced = options.force or options.rebuild
     dry_run_mode = options.dry_run or options.dry_run_short or options.missing_modules
 
-    keep_available_modules = forced or dry_run_mode or options.extended_dry_run or pr_options or options.copy_ec
-    keep_available_modules = keep_available_modules or options.inject_checksums or options.sanity_check_only
-    keep_available_modules = keep_available_modules or options.inject_checksums_to_json
+    keep_available_modules = any([
+        forced,
+        dry_run_mode, options.extended_dry_run,
+        pr_options,
+        options.copy_ec,
+        options.fetch,
+        options.sanity_check_only,
+        options.inject_checksums, options.inject_checksums_to_json
+    ])
 
     # skip modules that are already installed unless forced, or unless an option is used that warrants not skipping
     if not keep_available_modules:

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -407,7 +407,7 @@ class EasyBuildOptions(GeneralOption):
             'extra-modules': ("List of extra modules to load after setting up the build environment",
                               'strlist', 'extend', None),
             'fetch': ("Allow downloading sources ignoring OS and modules tool dependencies, "
-                      "implies --stop=fetch, --ignore-osdeps and ignore modules tool", None, 'store_true', False),
+                      "implies --stop=fetch and --ignore-osdeps", None, 'store_true', False),
             'filter-deps': ("List of dependencies that you do *not* want to install with EasyBuild, "
                             "because equivalent OS packages are installed. (e.g. --filter-deps=zlib,ncurses)",
                             'strlist', 'extend', None),
@@ -1187,7 +1187,6 @@ class EasyBuildOptions(GeneralOption):
             self.options.stop = FETCH_STEP
             self.options.ignore_locks = True
             self.options.ignore_osdeps = True
-            self.options.modules_tool = None
 
         # imply --disable-pre-create-installdir with --inject-checksums or --inject-checksums-to-json
         if self.options.inject_checksums or self.options.inject_checksums_to_json:

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5061,7 +5061,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         self.assertTrue(options.options.fetch)
         self.assertEqual(options.options.stop, 'fetch')
-        self.assertEqual(options.options.modules_tool, None)
         self.assertTrue(options.options.ignore_locks)
         self.assertTrue(options.options.ignore_osdeps)
 


### PR DESCRIPTION
The modules tool is required when resolving (at least) external dependencies.

Fixes #4298

I guess the intention was to ignore installed modules for `--fetch` as I had to change the condition for `keep_available_modules` for the test to pass as it would otherwise not fetch for installed modules which I'd guess is not intended.

For that I also changed the `keep_available_modules = keep_available_modules or ...` style to `any([...])` which I think is easier to read and format. The 2 dry-run and inject-checksum options are on the same line on purpose