### PR TITLE
Don't fail `mkdir` if path gets created while processing it

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1923,7 +1923,7 @@ def mkdir(path, parents=False, set_gid=None, sticky=None):
                 os.mkdir(path)
         except FileExistsError as err:
             if os.path.exists(path):
-                # This may happen if a parallel build creates the directory after we checked for its existance
+                # This may happen if a parallel build creates the directory after we checked for its existence
                 _log.debug("Directory creation aborted as it seems it was already created: %s", err)
             else:
                 raise EasyBuildError("Failed to create directory %s: %s", path, err)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1921,6 +1921,12 @@ def mkdir(path, parents=False, set_gid=None, sticky=None):
                 os.makedirs(path)
             else:
                 os.mkdir(path)
+        except FileExistsError as err:
+            if os.path.exists(path):
+                # This may happen if a parallel build creates the directory after we checked for its existance
+                _log.debug("Directory creation aborted as it seems it was already created: %s", err)
+            else:
+                raise EasyBuildError("Failed to create directory %s: %s", path, err)
         except OSError as err:
             raise EasyBuildError("Failed to create directory %s: %s", path, err)
 


### PR DESCRIPTION
This may happen if a parallel build creates e.g. the sources-directory

Reported in [Slack](https://easybuild.slack.com/archives/C34UA1HT7/p1689951724004299?thread_ts=1689951680.526819&cid=C34UA1HT7)

> I'm now seeing this error when I try to run a CI job (which runs EB to test installing some software)
> ```
> HASH=$(git rev-parse HEAD) eb ci-plans/files/ligka_ci_actor.eb -f ${EB_OPTS} ${EB_HTTP_OPTS}
> ERROR: Build of /home/ITER/haywart/src/ligka/ci-plans/files/ligka_ci_actor.eb failed (err: "build failed (first 300 chars): Failed to create directory /home/ITER/haywart/src/ligka/sources/generic/eb_v4.8.0/ConfigureMake: [Errno 17] File exists: '/home/ITER/haywart/src/ligka/sources/generic/eb_v4.8.0/ConfigureMake'")
> ```

Note that our `mkdir` is documented referring to `mkdir -p` which also doesn't fail if the directory exists.