### PR TITLE
copy `load_source` function from `easybuild.tools.py2vs3.py3` to `easybuild.tools.filetools` so it can be used `easybuild.tools.hooks`

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -58,6 +58,7 @@ import time
 import zlib
 from functools import partial
 from html.parser import HTMLParser
+from importlib.util import spec_from_file_location, module_from_spec
 import urllib.request as std_urllib
 
 from easybuild.base import fancylogger
@@ -2774,6 +2775,14 @@ def install_fake_vsc():
     sys.path.insert(0, fake_vsc_path)
 
     return fake_vsc_path
+
+
+def load_source(filename, path):
+    """Load file as Python module"""
+    spec = spec_from_file_location(filename, path)
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def get_easyblock_class_name(path):

--- a/easybuild/tools/hooks.py
+++ b/easybuild/tools/hooks.py
@@ -33,9 +33,9 @@ import difflib
 import os
 
 from easybuild.base import fancylogger
-from easybuild.tools.py2vs3 import load_source
 from easybuild.tools.build_log import EasyBuildError, print_msg
 from easybuild.tools.config import build_option
+from easybuild.tools.filetools import load_source
 
 
 _log = fancylogger.getLogger('hooks', fname=False)

--- a/easybuild/tools/py2vs3/py3.py
+++ b/easybuild/tools/py2vs3/py3.py
@@ -66,6 +66,7 @@ from easybuild.tools.run import subprocess_popen_text, subprocess_terminate  # n
 string_type = str
 
 
+# note: also available in easybuild.tools.filetools, should be imported from there!
 def load_source(filename, path):
     """Load file as Python module"""
     spec = spec_from_file_location(filename, path)

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -39,7 +39,9 @@ import shutil
 import stat
 import sys
 import tempfile
+import textwrap
 import time
+import types
 from io import StringIO
 from test.framework.github import requires_github_access
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
@@ -3009,6 +3011,18 @@ class FileToolsTest(EnhancedTestCase):
 
         for name in ['EB_bzip2', 'EB_DL_underscore_POLY_underscore_Classic', 'EB_GCC', 'EB_WRF_minus_Fire']:
             self.assertFalse(ft.is_generic_easyblock(name))
+
+    def test_load_source(self):
+        """Test for load_source function."""
+        txt = textwrap.dedent("""
+        def foobar():
+            pass
+        """)
+        fp = os.path.join(self.test_prefix, 'foobar.py')
+        ft.write_file(fp, txt)
+        foobar = ft.load_source('foobar', fp)
+        self.assertTrue(isinstance(foobar, types.ModuleType))
+        self.assertTrue(isinstance(foobar.foobar, types.FunctionType))
 
     def test_get_easyblock_class_name(self):
         """Test for get_easyblock_class_name function."""


### PR DESCRIPTION
This fixes a problem that was introduced by syncing the `5.0.x` with `develop` after #4280 got merged:

```
ERROR: test_get_easyblock_class_name (test.framework.filetools.FileToolsTest)
Test for get_easyblock_class_name function.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/runner/ec67a2f31722d0b0d37dc7b0811a2a5b4f48dc22/lib/python3.6/site-packages/test/framework/filetools.py", line 3020, in test_get_easyblock_class_name
    self.assertEqual(ft.get_easyblock_class_name(configuremake), 'ConfigureMake')
  File "/tmp/runner/ec67a2f31722d0b0d37dc7b0811a2a5b4f48dc22/lib/python3.6/site-packages/easybuild/tools/filetools.py", line 2782, in get_easyblock_class_name
    mod = load_source(fn, path)
NameError: name 'load_source' is not defined
```

We still need the `load_source` function since it allows avoiding to rely on the (deprecated) `imp` module from the Python stdlib, and since it's also used in `easybuild.tools.filetools` that's a good place to put it.