### PR TITLE
use sys.executable to obtain path to `python` command, rather than assuming that `python` command is available in `$PATH`

### DIFF
--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -543,7 +543,7 @@ class RunTest(EnhancedTestCase):
         """Testing use of run_cmd with shell=False to call external scripts"""
         py_test_script = os.path.join(self.test_prefix, 'test.py')
         write_file(py_test_script, '\n'.join([
-            '#!/usr/bin/env python',
+            '#!%s' % sys.executable,
             'print("hello")',
         ]))
         adjust_permissions(py_test_script, stat.S_IXUSR)


### PR DESCRIPTION
fix for failing test when `python` command is not available:

```
$ python3 -O -m test.framework.run test_run_cmd_script
Filtered RunTest tests using 'test_run_cmd_script', retained 1/21 tests: test_run_cmd_script
E
======================================================================
ERROR: test_run_cmd_script (__main__.RunTest)
Testing use of run_cmd with shell=False to call external scripts
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Volumes/work/easybuild-framework/test/framework/run.py", line 551, in test_run_cmd_script
    (out, ec) = run_cmd(py_test_script)
  File "/Volumes/work/easybuild-framework/easybuild/tools/run.py", line 91, in cache_aware_func
    res = func(cmd, *args, **kwargs)
  File "/Volumes/work/easybuild-framework/easybuild/tools/run.py", line 250, in run_cmd
    return complete_cmd(proc, cmd, cwd, start_time, cmd_log, log_ok=log_ok, log_all=log_all, simple=simple,
  File "/Volumes/work/easybuild-framework/easybuild/tools/run.py", line 354, in complete_cmd
    return parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp)
  File "/Volumes/work/easybuild-framework/easybuild/tools/run.py", line 643, in parse_cmd_output
    raise EasyBuildError('cmd "%s" exited with exit code %s and output:\n%s', cmd, ec, stdouterr)
easybuild.tools.build_log.EasyBuildError: 'cmd "/var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-5hxtrldj/eb-b2b3xts0/test.py" exited with exit code 127 and output:\nenv: python: No such file or directory\n'

----------------------------------------------------------------------
Ran 1 test in 0.227s

FAILED (errors=1)
```