### PR TITLE
disable trace output for commands run in `get_source_tarball_from_git`

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2646,7 +2646,7 @@ def get_source_tarball_from_git(filename, targetdir, git_config):
 
     tmpdir = tempfile.mkdtemp()
     cwd = change_dir(tmpdir)
-    run.run_cmd(' '.join(clone_cmd), log_all=True, simple=True, regexp=False)
+    run.run_cmd(' '.join(clone_cmd), log_all=True, simple=True, regexp=False, trace=False)
 
     # If the clone is done into a specified name, change repo_name
     if clone_into:
@@ -2658,14 +2658,14 @@ def get_source_tarball_from_git(filename, targetdir, git_config):
         if recursive:
             checkout_cmd.extend(['&&', 'git', 'submodule', 'update', '--init', '--recursive'])
 
-        run.run_cmd(' '.join(checkout_cmd), log_all=True, simple=True, regexp=False, path=repo_name)
+        run.run_cmd(' '.join(checkout_cmd), log_all=True, simple=True, regexp=False, path=repo_name, trace=False)
 
     elif not build_option('extended_dry_run'):
         # If we wanted to get a tag make sure we actually got a tag and not a branch with the same name
         # This doesn't make sense in dry-run mode as we don't have anything to check
         cmd = 'git describe --exact-match --tags HEAD'
         # Note: Disable logging to also disable the error handling in run_cmd
-        (out, ec) = run.run_cmd(cmd, log_ok=False, log_all=False, regexp=False, path=repo_name)
+        (out, ec) = run.run_cmd(cmd, log_ok=False, log_all=False, regexp=False, path=repo_name, trace=False)
         if ec != 0 or tag not in out.splitlines():
             print_warning('Tag %s was not downloaded in the first try due to %s/%s containing a branch'
                           ' with the same name. You might want to alert the maintainers of %s about that issue.',
@@ -2684,14 +2684,14 @@ def get_source_tarball_from_git(filename, targetdir, git_config):
             if recursive:
                 cmds.append('git submodule update --init --recursive')
             for cmd in cmds:
-                run.run_cmd(cmd, log_all=True, simple=True, regexp=False, path=repo_name)
+                run.run_cmd(cmd, log_all=True, simple=True, regexp=False, path=repo_name, trace=False)
 
     # create an archive and delete the git repo directory
     if keep_git_dir:
         tar_cmd = ['tar', 'cfvz', targetpath, repo_name]
     else:
         tar_cmd = ['tar', 'cfvz', targetpath, '--exclude', '.git', repo_name]
-    run.run_cmd(' '.join(tar_cmd), log_all=True, simple=True, regexp=False)
+    run.run_cmd(' '.join(tar_cmd), log_all=True, simple=True, regexp=False, trace=False)
 
     # cleanup (repo_name dir does not exist in dry run mode)
     change_dir(cwd)

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2742,7 +2742,7 @@ class FileToolsTest(EnhancedTestCase):
         self.assertTrue(regex.search(res), "Pattern '%s' found in: %s" % (regex.pattern, res))
 
     @requires_github_access()
-    def test_get_source_tarball_from_git(self):
+    def test_github_get_source_tarball_from_git(self):
         """Test get_source_tarball_from_git function."""
 
         target_dir = os.path.join(self.test_prefix, 'target')
@@ -2775,18 +2775,18 @@ class FileToolsTest(EnhancedTestCase):
         git_repo = {'git_repo': 'git@github.com:easybuilders/testrepository.git'}  # Just to make the below shorter
         expected = '\n'.join([
             r'  running command "git clone --depth 1 --branch tag_for_tests %(git_repo)s"',
-            r"  \(in .*/tmp.*\)",
+            r"  \(in /.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
-            r"  \(in .*/tmp.*\)",
+            r"  \(in /.*\)",
         ]) % git_repo
         run_check()
 
         git_config['clone_into'] = 'test123'
         expected = '\n'.join([
             r'  running command "git clone --depth 1 --branch tag_for_tests %(git_repo)s test123"',
-            r"  \(in .*/tmp.*\)",
+            r"  \(in /.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git test123"',
-            r"  \(in .*/tmp.*\)",
+            r"  \(in /.*\)",
         ]) % git_repo
         run_check()
         del git_config['clone_into']
@@ -2794,18 +2794,18 @@ class FileToolsTest(EnhancedTestCase):
         git_config['recursive'] = True
         expected = '\n'.join([
             r'  running command "git clone --depth 1 --branch tag_for_tests --recursive %(git_repo)s"',
-            r"  \(in .*/tmp.*\)",
+            r"  \(in /.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
-            r"  \(in .*/tmp.*\)",
+            r"  \(in /.*\)",
         ]) % git_repo
         run_check()
 
         git_config['keep_git_dir'] = True
         expected = '\n'.join([
             r'  running command "git clone --branch tag_for_tests --recursive %(git_repo)s"',
-            r"  \(in .*/tmp.*\)",
+            r"  \(in /.*\)",
             r'  running command "tar cfvz .*/target/test.tar.gz testrepository"',
-            r"  \(in .*/tmp.*\)",
+            r"  \(in /.*\)",
         ]) % git_repo
         run_check()
         del git_config['keep_git_dir']
@@ -2814,22 +2814,22 @@ class FileToolsTest(EnhancedTestCase):
         git_config['commit'] = '8456f86'
         expected = '\n'.join([
             r'  running command "git clone --no-checkout %(git_repo)s"',
-            r"  \(in .*/tmp.*\)",
+            r"  \(in /.*\)",
             r'  running command "git checkout 8456f86 && git submodule update --init --recursive"',
             r"  \(in testrepository\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
-            r"  \(in .*/tmp.*\)",
+            r"  \(in /.*\)",
         ]) % git_repo
         run_check()
 
         del git_config['recursive']
         expected = '\n'.join([
             r'  running command "git clone --no-checkout %(git_repo)s"',
-            r"  \(in .*/tmp.*\)",
+            r"  \(in /.*\)",
             r'  running command "git checkout 8456f86"',
             r"  \(in testrepository\)",
             r'  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"',
-            r"  \(in .*/tmp.*\)",
+            r"  \(in /.*\)",
         ]) % git_repo
         run_check()
 
@@ -2851,7 +2851,8 @@ class FileToolsTest(EnhancedTestCase):
             self.assertEqual(os.listdir(target_dir), ['test.tar.gz'])
             # Check that we indeed downloaded the right tag
             extracted_dir = tempfile.mkdtemp(prefix='extracted_dir')
-            extracted_repo_dir = ft.extract_file(test_file, extracted_dir, change_into_dir=False)
+            with self.mocked_stdout_stderr():
+                extracted_repo_dir = ft.extract_file(test_file, extracted_dir, change_into_dir=False)
             self.assertTrue(os.path.isfile(os.path.join(extracted_repo_dir, 'this-is-a-branch.txt')))
             os.remove(test_file)
 
@@ -2865,7 +2866,8 @@ class FileToolsTest(EnhancedTestCase):
             self.assertTrue(os.path.isfile(test_file))
             # Check that we indeed downloaded the tag and not the branch
             extracted_dir = tempfile.mkdtemp(prefix='extracted_dir')
-            extracted_repo_dir = ft.extract_file(test_file, extracted_dir, change_into_dir=False)
+            with self.mocked_stdout_stderr():
+                extracted_repo_dir = ft.extract_file(test_file, extracted_dir, change_into_dir=False)
             self.assertTrue(os.path.isfile(os.path.join(extracted_repo_dir, 'this-is-a-tag.txt')))
 
             del git_config['tag']


### PR DESCRIPTION
This fixes `test_get_source_tarball_from_git` when the test is not skipped sicne a GitHub token is available, which is broken because of the additional trace output (caused by enabling `--trace` by default in #4250):

```
FAIL: test_get_source_tarball_from_git (test.framework.filetools.FileToolsTest)
Test get_source_tarball_from_git function.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/runner/405fb0cc2a0118c1b3f4332611c244409b9d3fa5/lib/python3.6/site-packages/test/framework/filetools.py", line 2782, in test_get_source_tarball_from_git
    run_check()
  File "/tmp/runner/405fb0cc2a0118c1b3f4332611c244409b9d3fa5/lib/python3.6/site-packages/test/framework/filetools.py", line 2765, in run_check
    self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
AssertionError: None is not true : Pattern '  running command "git clone --depth 1 --branch tag_for_tests git@github.com:easybuilders/testrepository.git"
  \(in .*/tmp.*\)
  running command "tar cfvz .*/target/test.tar.gz --exclude .git testrepository"
  \(in .*/tmp.*\)' found in:   >> running command:
	[started at: 2023-08-06 16:53:17]
	[working dir: /tmp/eb-edjcffb7/eb-4r4ias8b/eb-sq9lqq1o/eb-p08iwl5l/eb-yovari1d/tmpp_ixh545]
	[output logged in /tmp/eb-edjcffb7/eb-4r4ias8b/eb-sq9lqq1o/eb-p08iwl5l/eb-yovari1d/easybuild-run_cmd-vtki1hp8.log]
	git clone --depth 1 --branch tag_for_tests git@github.com:easybuilders/testrepository.git
  running command "git clone --depth 1 --branch tag_for_tests git@github.com:easybuilders/testrepository.git"
  (in /tmp/eb-edjcffb7/eb-4r4ias8b/eb-sq9lqq1o/eb-p08iwl5l/eb-yovari1d/tmpp_ixh545)
  >> running command:
	[started at: 2023-08-06 16:53:17]
	[working dir: /tmp/eb-edjcffb7/eb-4r4ias8b/eb-sq9lqq1o/eb-p08iwl5l/eb-yovari1d/tmpp_ixh545]
	[output logged in /tmp/eb-edjcffb7/eb-4r4ias8b/eb-sq9lqq1o/eb-p08iwl5l/eb-yovari1d/easybuild-run_cmd-l1po41__.log]
	tar cfvz /tmp/eb-edjcffb7/eb-4r4ias8b/eb-sq9lqq1o/target/test.tar.gz --exclude .git testrepository
  running command "tar cfvz /tmp/eb-edjcffb7/eb-4r4ias8b/eb-sq9lqq1o/target/test.tar.gz --exclude .git testrepository"
  (in /tmp/eb-edjcffb7/eb-4r4ias8b/eb-sq9lqq1o/eb-p08iwl5l/eb-yovari1d/tmpp_ixh545)
directory /tmp/eb-edjcffb7/eb-4r4ias8b/eb-sq9lqq1o/eb-p08iwl5l/eb-yovari1d/tmpp_ixh545 removed
```