### PR TITLE
fix broken github tests in options `test.framework.options` by disabling trace output in `download_repo` and `fetch_files_from_pr` functions

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -429,7 +429,8 @@ def change_dir(path):
     return cwd
 
 
-def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False, forced=False, change_into_dir=False):
+def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False, forced=False, change_into_dir=False,
+                 trace=True):
     """
     Extract file at given path to specified directory
     :param fn: path to file to extract
@@ -439,6 +440,7 @@ def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False, forced
     :param overwrite: overwrite existing unpacked file
     :param forced: force extraction in (extended) dry run mode
     :param change_into_dir: change into resulting directorys
+    :param trace: produce trace output for extract command being run
     :return: path to directory (in case of success)
     """
 
@@ -468,7 +470,7 @@ def extract_file(fn, dest, cmd=None, extra_options=None, overwrite=False, forced
     if extra_options:
         cmd = "%s %s" % (cmd, extra_options)
 
-    run.run_cmd(cmd, simple=True, force_in_dry_run=forced)
+    run.run_cmd(cmd, simple=True, force_in_dry_run=forced, trace=trace)
 
     # note: find_base_dir also changes into the base dir!
     base_dir = find_base_dir()
@@ -739,7 +741,7 @@ def det_file_size(http_header):
     return res
 
 
-def download_file(filename, url, path, forced=False):
+def download_file(filename, url, path, forced=False, trace=True):
     """Download a file from the given URL, to the specified path."""
 
     insecure = build_option('insecure_download')
@@ -848,11 +850,13 @@ def download_file(filename, url, path, forced=False):
 
     if downloaded:
         _log.info("Successful download of file %s from url %s to path %s" % (filename, url, path))
-        trace_msg("download succeeded: %s" % url)
+        if trace:
+            trace_msg("download succeeded: %s" % url)
         return path
     else:
         _log.warning("Download of %s to %s failed, done trying" % (url, path))
-        trace_msg("download failed: %s" % url)
+        if trace:
+            trace_msg("download failed: %s" % url)
         return None
 
 

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -243,7 +243,7 @@ class Githubfs(object):
         if not api:
             outfile = tempfile.mkstemp()[1]
             url = '/'.join([GITHUB_RAW, self.githubuser, self.reponame, self.branchname, path])
-            download_file(os.path.basename(path), url, outfile)
+            download_file(os.path.basename(path), url, outfile, trace=False)
             return outfile
         else:
             obj = self.get_path(path).get(ref=self.branchname)[1]
@@ -394,10 +394,10 @@ def download_repo(repo=GITHUB_EASYCONFIGS_REPO, branch=None, account=GITHUB_EB_M
 
     target_path = os.path.join(path, base_name)
     _log.debug("downloading repo %s/%s as archive from %s to %s" % (account, repo, url, target_path))
-    download_file(base_name, url, target_path, forced=True)
+    download_file(base_name, url, target_path, forced=True, trace=False)
     _log.debug("%s downloaded to %s, extracting now" % (base_name, path))
 
-    base_dir = extract_file(target_path, path, forced=True, change_into_dir=False)
+    base_dir = extract_file(target_path, path, forced=True, change_into_dir=False, trace=False)
     extracted_path = os.path.join(base_dir, extracted_dir_name)
 
     # check if extracted_path exists
@@ -499,7 +499,7 @@ def fetch_files_from_pr(pr, path=None, github_user=None, github_account=None, gi
     # determine list of changed files via diff
     diff_fn = os.path.basename(pr_data['diff_url'])
     diff_filepath = os.path.join(path, diff_fn)
-    download_file(diff_fn, pr_data['diff_url'], diff_filepath, forced=True)
+    download_file(diff_fn, pr_data['diff_url'], diff_filepath, forced=True, trace=False)
     diff_txt = read_file(diff_filepath)
     _log.debug("Diff for PR #%s:\n%s", pr, diff_txt)
 
@@ -535,7 +535,7 @@ def fetch_files_from_pr(pr, path=None, github_user=None, github_account=None, gi
             sha = pr_data['head']['sha']
             full_url = URL_SEPARATOR.join([GITHUB_RAW, github_account, github_repo, sha, patched_file])
             _log.info("Downloading %s from %s", fn, full_url)
-            download_file(fn, full_url, path=os.path.join(path, fn), forced=True)
+            download_file(fn, full_url, path=os.path.join(path, fn), forced=True, trace=False)
 
         final_path = path
 


### PR DESCRIPTION
Fix for 3 broken `github` tests in `test/framework/options.py` due to trace output, that only pop up when a GitHub token is available:

* `test_github_xxx_include_easyblocks_from_pr`
* `test_github_preview_pr`
* `test_github_review_pr`

<details>

```
$ python3 -O -m test.framework.options github
Filtered CommandLineOptionsTest tests using 'github', retained 21/135 tests: test_github_copy_ec_from_pr, test_github_empty_pr, test_github_from_pr, test_github_from_pr_listed_ecs, test_github_from_pr_token_log, test_github_from_pr_x, test_github_merge_pr, test_github_new_pr_delete, test_github_new_pr_dependencies, test_github_new_pr_easyblock, test_github_new_pr_from_branch, test_github_new_pr_python, test_github_new_pr_warning_missing_patch, test_github_new_update_pr, test_github_preview_pr, test_github_review_pr, test_github_sync_branch_with_develop, test_github_sync_pr_with_develop, test_github_xxx_include_easyblocks_from_pr, test_new_branch_github, test_update_branch_github
..............FF..F..
======================================================================
FAIL: test_github_preview_pr (__main__.CommandLineOptionsTest)
Test --preview-pr.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Volumes/work/easybuild-framework/test/framework/options.py", line 3922, in test_github_preview_pr
    self.assertTrue(regex.search(txt), "Pattern '%s' not found in: %s" % (regex.pattern, txt))
AssertionError: None is not true : Pattern '^Comparing bzip2-1.0.6\S* with bzip2-1.0.6' not found in:   >> download succeeded: https://github.com/easybuilders/easybuild-easyconfigs/archive/develop.tar.gz
  >> running command:
	[started at: 2023-08-06 20:42:28]
	[working dir: /private/var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-pghjt8mn/eb-nn9pxpne/eb-miclc77z/tmp4pnauht1/easybuilders]
	[output logged in /var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-pghjt8mn/eb-nn9pxpne/eb-miclc77z/easybuild-run_cmd-awx2r9qp.log]
	tar xzf /var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-pghjt8mn/eb-nn9pxpne/eb-miclc77z/tmp4pnauht1/easybuilders/develop.tar.gz
  >> command completed: exit 0, ran in 00h00m02s
Comparing bzip2-1.0.6-GCC-4.9.2.eb with bzip2-1.0.6-GCC-4.9.2.eb
=====
1 + # not really (there's an EB_bzip2 easyblock), but fine for use in unit tests (1/1)
2 + easyblock = 'ConfigureMake' (1/1)
3 + (1/1)

-----

7 - homepage = 'https://sourceware.org/bzip2' (1/1)
7 + homepage = 'http://www.bzip.org/' (1/1)

-----

9 -  compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical (1/1)
  ? -
9 + compresses files to within 10% to 15% of the best available techniques (the PPM family of statistical (1/1)
10 -  compressors), whilst being around twice as fast at compression and six times faster at decompression.""" (1/1)
   ? -
10 + compressors), whilst being around twice as fast at compression and six times faster at decompression.""" (1/1)

-----

15 - source_urls = ['https://sourceware.org/pub/bzip2/'] (1/1)
16 + source_urls = ['http://www.bzip.org/%(version)s'] (1/1)
17 + (1/1)
18 + builddependencies = [('gzip', '1.6')] (1/1)
19 -     '5a823e820b332eca3684416894f58edc125ac3dace9f46e62f98e45362aa8a6d',  # bzip2-1.0.6-pkgconfig.patch (1/1)
19 -     'a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd',  # bzip2-1.0.6.tar.gz (1/1)
19 - ] (1/1)

-----

=====


======================================================================
FAIL: test_github_review_pr (__main__.CommandLineOptionsTest)
Test --review-pr.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Volumes/work/easybuild-framework/test/framework/options.py", line 3943, in test_github_review_pr
    self.assertTrue(regex.search(txt), "Pattern '%s' not found in: %s" % (regex.pattern, txt))
AssertionError: None is not true : Pattern '^Comparing gzip-1.10-\S* with gzip-1.10-' not found in:   >> download succeeded: https://github.com/easybuilders/easybuild-easyconfigs/archive/develop.tar.gz
  >> running command:
	[started at: 2023-08-06 20:42:34]
	[working dir: /private/var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-dtryqzw_/eb-tngdshww/eb-gf_5pbp3/tmp7ovngioj/easybuilders]
	[output logged in /var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-dtryqzw_/eb-tngdshww/eb-gf_5pbp3/easybuild-run_cmd-1lg7ez38.log]
	tar xzf /var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-dtryqzw_/eb-tngdshww/eb-gf_5pbp3/tmp7ovngioj/easybuilders/develop.tar.gz
  >> command completed: exit 0, ran in 00h00m02s
  >> download succeeded: https://github.com/easybuilders/easybuild-easyconfigs/archive/develop.tar.gz
  >> running command:
	[started at: 2023-08-06 20:42:39]
	[working dir: /private/var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-dtryqzw_/eb-tngdshww/eb-gf_5pbp3/tmp57ezz6t5/easybuilders]
	[output logged in /var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-dtryqzw_/eb-tngdshww/eb-gf_5pbp3/easybuild-run_cmd-eyr7etc8.log]
	tar xzf /var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-dtryqzw_/eb-tngdshww/eb-gf_5pbp3/tmp57ezz6t5/easybuilders/develop.tar.gz
  >> command completed: exit 0, ran in 00h00m02s
  >> download succeeded: https://github.com/easybuilders/easybuild-easyconfigs/pull/9921.diff
Comparing gzip-1.10-GCCcore-8.3.0.eb with gzip-1.10-GCCcore-8.3.0.eb
=====
(no diff)
=====


======================================================================
FAIL: test_github_xxx_include_easyblocks_from_pr (__main__.CommandLineOptionsTest)
Test --include-easyblocks-from-pr.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Volumes/work/easybuild-framework/easybuild/base/testing.py", line 91, in assertEqual
    super(TestCase, self).assertEqual(a, b)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/unittest/case.py", line 831, in assertEqual
    assertion_func(first, second, msg=msg)
AssertionError: '  >> download succeeded: https://github.c[752 chars]15\n' != '== easyblock cmakemake.py included from PR #1915\n'
-   >> download succeeded: https://github.com/easybuilders/easybuild-easyblocks/archive/develop.tar.gz
-   >> running command:
- 	[started at: 2023-08-06 20:43:32]
- 	[working dir: /private/var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-w7s2clk2/eb-d75c8ds6/eb-5mny59mp/tmp9dry1337/easybuilders]
- 	[output logged in /var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-w7s2clk2/eb-d75c8ds6/eb-5mny59mp/easybuild-run_cmd-txf_cc6x.log]
- 	tar xzf /var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-w7s2clk2/eb-d75c8ds6/eb-5mny59mp/tmp9dry1337/easybuilders/develop.tar.gz
-   >> command completed: exit 0, ran in < 1s
-   >> download succeeded: https://github.com/easybuilders/easybuild-easyblocks/pull/1915.diff
  == easyblock cmakemake.py included from PR #1915


During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Volumes/work/easybuild-framework/test/framework/options.py", line 3591, in test_github_xxx_include_easyblocks_from_pr
    self.assertEqual(stdout, "== easyblock cmakemake.py included from PR #1915\n")
  File "/Volumes/work/easybuild-framework/easybuild/base/testing.py", line 113, in assertEqual
    raise AssertionError("%s:\nDIFF%s:\n%s" % (msg, limit, ''.join(diff[:self.ASSERT_MAX_DIFF])))
AssertionError: '  >> download succeeded: https://github.c[752 chars]15\n' != '== easyblock cmakemake.py included from PR #1915\n'
-   >> download succeeded: https://github.com/easybuilders/easybuild-easyblocks/archive/develop.tar.gz
-   >> running command:
- 	[started at: 2023-08-06 20:43:32]
- 	[working dir: /private/var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-w7s2clk2/eb-d75c8ds6/eb-5mny59mp/tmp9dry1337/easybuilders]
- 	[output logged in /var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-w7s2clk2/eb-d75c8ds6/eb-5mny59mp/easybuild-run_cmd-txf_cc6x.log]
- 	tar xzf /var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-w7s2clk2/eb-d75c8ds6/eb-5mny59mp/tmp9dry1337/easybuilders/develop.tar.gz
-   >> command completed: exit 0, ran in < 1s
-   >> download succeeded: https://github.com/easybuilders/easybuild-easyblocks/pull/1915.diff
  == easyblock cmakemake.py included from PR #1915
:
DIFF:
-   >> download succeeded: https://github.com/easybuilders/easybuild-easyblocks/archive/develop.tar.gz
-   >> running command:
- 	[started at: 2023-08-06 20:43:32]
- 	[working dir: /private/var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-w7s2clk2/eb-d75c8ds6/eb-5mny59mp/tmp9dry1337/easybuilders]
- 	[output logged in /var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-w7s2clk2/eb-d75c8ds6/eb-5mny59mp/easybuild-run_cmd-txf_cc6x.log]
- 	tar xzf /var/folders/rj/1hpwxbd90j7c2cg560n5g1640000gn/T/eb-3xaumtxm/eb-w7s2clk2/eb-d75c8ds6/eb-5mny59mp/tmp9dry1337/easybuilders/develop.tar.gz
-   >> command completed: exit 0, ran in < 1s
-   >> download succeeded: https://github.com/easybuilders/easybuild-easyblocks/pull/1915.diff


----------------------------------------------------------------------
Ran 21 tests in 556.765s

FAILED (failures=3)
```

</details>