### PR TITLE
change openmp flag to be a string for intel_compilers

### DIFF
--- a/easybuild/toolchains/compiler/intel_compilers.py
+++ b/easybuild/toolchains/compiler/intel_compilers.py
@@ -110,7 +110,7 @@ class IntelCompilers(IntelIccIfort):
             # fp-model fast=2 gives "warning: overriding '-ffp-model=fast=2' option with '-ffp-model=fast'"
             self.options.options_map['veryloose'] = ['fp-model fast']
             # recommended in porting guide
-            self.options.options_map['openmp'] = ['fiopenmp']
+            self.options.options_map['openmp'] = 'fiopenmp'
 
             # -xSSE2 is not supported by Intel oneAPI compilers,
             # so use -march=x86-64 -mtune=generic when using optarch=GENERIC


### PR DESCRIPTION
In https://github.com/easybuilders/easybuild-easyconfigs/pull/17707#issuecomment-1601094327 we are seeing `-['fiopenmp']` in the flags.

https://github.com/easybuilders/easybuild-easyblocks/blob/4fbf1443d22628f490e1f943a0a370c1e3e32e12/easybuild/easyblocks/q/quantumespresso.py uses `self.toolchain.get_flag('openmp')`, but
```py
    def get_flag(self, name):
        """Get compiler flag for a certain option."""
        return "-%s" % self.options.option(name)
```
Which is causing the issue:
```
>>> openmp_flag = ['fiopenmp']
>>> "-%s" % openmp_flag
"-['fiopenmp']"
```

There is a more complete change where we redo the whole toolchain and flags setup. However, that would be large change and this bugfix will be sufficient for now.