### PR TITLE
add `build_info_msg` easyconfig parameter

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4174,6 +4174,10 @@ def build_and_install_one(ecdict, init_env):
         dry_run_msg('', silent=silent)
     print_msg("processing EasyBuild easyconfig %s" % spec, log=_log, silent=silent)
 
+    if ecdict['ec']['build_info_msg']:
+        msg = "This easyconfig provides the following build information:\n\n%s\n"
+        print_msg(msg % ecdict['ec']['build_info_msg'], log=_log, silent=silent)
+
     if dry_run:
         # print note on interpreting dry run output (argument is reference to location of dry run messages)
         print_dry_run_note('below', silent=silent)

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -228,6 +228,8 @@ DEFAULT_CONFIG = {
     'buildstats': [None, "A list of dicts with build statistics", OTHER],
     'deprecated': [False, "String specifying reason why this easyconfig file is deprecated "
                           "and will be archived in the next major release of EasyBuild", OTHER],
+    'build_info_msg': [None, "String with information to be printed to stdout and logged during the building "
+                             "of the easyconfig", OTHER],
 }
 
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3900,6 +3900,30 @@ class ToyBuildTest(EnhancedTestCase):
             regex = re.compile(pattern, re.M)
             self.assertTrue(regex.search(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
 
+    def test_toy_build_info_msg(self):
+        """
+        Test use of build info message
+        """
+        test_ecs = os.path.join(os.path.dirname(__file__), 'easyconfigs', 'test_ecs')
+        toy_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
+
+        test_ec_txt = read_file(toy_ec)
+        test_ec_txt += '\nbuild_info_msg = "Are you sure you want to install this toy software?"'
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        write_file(test_ec, test_ec_txt)
+
+        with self.mocked_stdout_stderr():
+            self.test_toy_build(ec_file=test_ec, testing=False, verify=False, raise_error=True)
+            stdout = self.get_stdout()
+
+        pattern = '\n'.join([
+            r"== This easyconfig provides the following build information:",
+            r'',
+            r"Are you sure you want to install this toy software\?",
+        ])
+        regex = re.compile(pattern, re.M)
+        self.assertTrue(regex.search(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
+
 
 def suite():
     """ return all the tests in this file """


### PR DESCRIPTION
In some easyconfigs we have comments that document alternative or extras that may be applicable to some people, but these are hidden away from users. Adding this option gives us a way to flag such information during a build.

An example of where I think this would be useful is for the NLTK datasets - see https://github.com/easybuilders/easybuild-easyconfigs/pull/18550