### PR TITLE
remove crash hook (since it doesn't work)

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -69,7 +69,7 @@ from easybuild.tools.github import check_github, close_pr, find_easybuild_easyco
 from easybuild.tools.github import add_pr_labels, install_github_token, list_prs, merge_pr, new_branch_github, new_pr
 from easybuild.tools.github import new_pr_from_branch
 from easybuild.tools.github import sync_branch_with_develop, sync_pr_with_develop, update_branch, update_pr
-from easybuild.tools.hooks import BUILD_AND_INSTALL_LOOP, PRE_PREF, POST_PREF, CRASH, START, END, CANCEL, FAIL
+from easybuild.tools.hooks import BUILD_AND_INSTALL_LOOP, PRE_PREF, POST_PREF, START, END, CANCEL, FAIL
 from easybuild.tools.hooks import load_hooks, run_hook
 from easybuild.tools.modules import modules_tool
 from easybuild.tools.options import opts_dict_to_eb_opts, set_up_configuration, use_color
@@ -760,6 +760,3 @@ if __name__ == "__main__":
     except KeyboardInterrupt as err:
         run_hook(CANCEL, hooks, args=[err])
         print_error("Cancelled by user: %s" % err)
-    except Exception as err:
-        run_hook(CRASH, hooks, args=[err])
-        print_error("Encountered an unrecoverable error: %s" % err)

--- a/easybuild/tools/hooks.py
+++ b/easybuild/tools/hooks.py
@@ -67,7 +67,6 @@ MODULE_WRITE = 'module_write'
 END = 'end'
 
 CANCEL = 'cancel'
-CRASH = 'crash'
 FAIL = 'fail'
 
 PRE_PREF = 'pre_'
@@ -106,7 +105,6 @@ HOOK_NAMES = [
     POST_PREF + BUILD_AND_INSTALL_LOOP,
     END,
     CANCEL,
-    CRASH,
     FAIL,
 ]
 KNOWN_HOOKS = [h + HOOK_SUFF for h in HOOK_NAMES]

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -722,7 +722,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
             "	post_build_and_install_loop_hook",
             "	end_hook",
             "	cancel_hook",
-            "	crash_hook",
             "	fail_hook",
             '',
         ])


### PR DESCRIPTION
The crash hook was introduced in #4315 by @XavierCS-dev on my request, but I noticed that it's not actually working at all: when adding a `raise RuntimeError` in the `bzip2-1.0.6.eb` easyblock, EasyBuild crashes as expected, but the crash hook or the "`Encountered an unrecoverable error"` message is never printed.

What's more is that I realized that if it would work, it would actually be counter-productive, since we wouldn't be getting a traceback anymore that tells use valuable information about the crash.

So, for now, let's just remove it, and take some more time to figure out how to implement it correctly...