### PR TITLE
rename `run_cache` decorator to `run_shell_cmd_cache`

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -104,10 +104,10 @@ def run_cmd_cache(func):
     return cache_aware_func
 
 
-run_cache = run_cmd_cache
+run_shell_cmd_cache = run_cmd_cache
 
 
-@run_cache
+@run_shell_cmd_cache
 def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=None,
                   hidden=False, in_dry_run=False, verbose_dry_run=False, work_dir=None, shell=True,
                   output_file=False, stream_output=False, asynchronous=False, with_hooks=True,


### PR DESCRIPTION
This should have been included in #4335 ...