### PR TITLE
improve error reporting for failing shell commands (and EasyBuild crashes)

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -87,7 +87,7 @@ from easybuild.tools.hooks import BUILD_STEP, CLEANUP_STEP, CONFIGURE_STEP, EXTE
 from easybuild.tools.hooks import MODULE_STEP, MODULE_WRITE, PACKAGE_STEP, PATCH_STEP, PERMISSIONS_STEP, POSTITER_STEP
 from easybuild.tools.hooks import POSTPROC_STEP, PREPARE_STEP, READY_STEP, SANITYCHECK_STEP, SOURCE_STEP
 from easybuild.tools.hooks import SINGLE_EXTENSION, TEST_STEP, TESTCASES_STEP, load_hooks, run_hook
-from easybuild.tools.run import RunShellCmdError, check_async_cmd, print_run_shell_cmd_error, run_cmd
+from easybuild.tools.run import RunShellCmdError, check_async_cmd, run_cmd
 from easybuild.tools.jenkins import write_to_xml
 from easybuild.tools.module_generator import ModuleGeneratorLua, ModuleGeneratorTcl, module_generator, dependencies_for
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
@@ -4125,7 +4125,7 @@ class EasyBlock(object):
                     try:
                         self.run_step(step_name, step_methods)
                     except RunShellCmdError as err:
-                        print_run_shell_cmd_error(err)
+                        err.print()
                         ec_path = os.path.basename(self.cfg.path)
                         error_msg = f"shell command '{err.cmd_name} ...' failed in {step_name} step for {ec_path}"
                         raise EasyBuildError(error_msg)

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -748,11 +748,11 @@ def prepare_main(args=None, logfile=None, testing=None):
     return init_session_state, eb_go, cfg_settings
 
 
-if __name__ == "__main__":
-    init_session_state, eb_go, cfg_settings = prepare_main()
+def main_with_hooks(args=None):
+    init_session_state, eb_go, cfg_settings = prepare_main(args=args)
     hooks = load_hooks(eb_go.options.hooks)
     try:
-        main(prepared_cfg_data=(init_session_state, eb_go, cfg_settings))
+        main(args=args, prepared_cfg_data=(init_session_state, eb_go, cfg_settings))
     except EasyBuildError as err:
         run_hook(FAIL, hooks, args=[err])
         sys.exit(1)
@@ -763,3 +763,7 @@ if __name__ == "__main__":
         run_hook(CRASH, hooks, args=[err])
         sys.stderr.write("EasyBuild crashed! Please consider reporting a bug, this should not happen...\n\n")
         raise
+
+
+if __name__ == "__main__":
+    main_with_hooks()

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -77,7 +77,6 @@ from easybuild.tools.options import opts_dict_to_eb_opts, set_up_configuration, 
 from easybuild.tools.output import COLOR_GREEN, COLOR_RED, STATUS_BAR, colorize, print_checks, rich_live_cm
 from easybuild.tools.output import start_progress_bar, stop_progress_bar, update_progress_bar
 from easybuild.tools.robot import check_conflicts, dry_run, missing_deps, resolve_dependencies, search_easyconfigs
-from easybuild.tools.run import RunShellCmdError
 from easybuild.tools.package.utilities import check_pkg_support
 from easybuild.tools.parallelbuild import submit_jobs
 from easybuild.tools.repository.repository import init_repository

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -167,7 +167,7 @@ class EasyBuildLog(fancylogger.FancyLogger):
 
     def error(self, msg, *args, **kwargs):
         """Print error message and raise an EasyBuildError."""
-        ebmsg = "EasyBuild crashed with an error %s: " % self.caller_info()
+        ebmsg = "EasyBuild encountered an error %s: " % self.caller_info()
         fancylogger.FancyLogger.error(self, ebmsg + msg, *args, **kwargs)
 
     def devel(self, msg, *args, **kwargs):

--- a/easybuild/tools/hooks.py
+++ b/easybuild/tools/hooks.py
@@ -67,6 +67,7 @@ MODULE_WRITE = 'module_write'
 END = 'end'
 
 CANCEL = 'cancel'
+CRASH = 'crash'
 FAIL = 'fail'
 
 RUN_SHELL_CMD = 'run_shell_cmd'
@@ -107,6 +108,7 @@ HOOK_NAMES = [
     POST_PREF + BUILD_AND_INSTALL_LOOP,
     END,
     CANCEL,
+    CRASH,
     FAIL,
     PRE_PREF + RUN_SHELL_CMD,
     POST_PREF + RUN_SHELL_CMD,

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -50,8 +50,7 @@ from datetime import datetime
 
 import easybuild.tools.asyncprocess as asyncprocess
 from easybuild.base import fancylogger
-from easybuild.base.exceptions import LoggedException
-from easybuild.tools.build_log import EasyBuildError, dry_run_msg, print_error, print_msg, time_str_since
+from easybuild.tools.build_log import EasyBuildError, dry_run_msg, print_msg, time_str_since
 from easybuild.tools.config import ERROR, IGNORE, WARN, build_option
 from easybuild.tools.hooks import RUN_SHELL_CMD, load_hooks, run_hook
 from easybuild.tools.utilities import trace_msg
@@ -151,9 +150,6 @@ def raise_run_shell_cmd_error(cmd, exit_code, work_dir, output, stderr):
     # 3) run_cmd_cache decorator
     # 4) actual caller site
     frameinfo = inspect.getouterframes(inspect.currentframe())[3]
-    caller_file_name = frameinfo.filename
-    caller_line_nr = frameinfo.lineno
-    caller_function_name = frameinfo.function
     caller_info = (frameinfo.filename, frameinfo.lineno, frameinfo.function)
 
     raise RunShellCmdError(cmd, exit_code, work_dir, output, stderr, caller_info)
@@ -290,7 +286,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
 
     # return output as a regular string rather than a byte sequence (and non-UTF-8 characters get stripped out)
     output = proc.stdout.decode('utf-8', 'ignore')
-    stderr= proc.stderr.decode('utf-8', 'ignore') if split_stderr else None
+    stderr = proc.stderr.decode('utf-8', 'ignore') if split_stderr else None
 
     res = RunShellCmdResult(cmd=cmd_str, exit_code=proc.returncode, output=output, stderr=stderr, work_dir=work_dir)
 

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -77,7 +77,7 @@ CACHED_COMMANDS = [
 ]
 
 
-RunResult = namedtuple('RunResult', ('cmd', 'exit_code', 'output', 'stderr', 'work_dir'))
+RunShellCmdResult = namedtuple('RunShellCmdResult', ('cmd', 'exit_code', 'output', 'stderr', 'work_dir'))
 
 
 def report_run_shell_cmd_error(cmd, exit_code, work_dir, output, stderr):
@@ -230,7 +230,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
             msg += f"  (in {work_dir})"
             dry_run_msg(msg, silent=silent)
 
-        return RunResult(cmd=cmd_str, exit_code=0, output='', stderr=None, work_dir=work_dir)
+        return RunShellCmdResult(cmd=cmd_str, exit_code=0, output='', stderr=None, work_dir=work_dir)
 
     start_time = datetime.now()
     if not hidden:
@@ -261,9 +261,9 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
 
     # return output as a regular string rather than a byte sequence (and non-UTF-8 characters get stripped out)
     output = proc.stdout.decode('utf-8', 'ignore')
-    stderr_output = proc.stderr.decode('utf-8', 'ignore') if split_stderr else None
+    stderr= proc.stderr.decode('utf-8', 'ignore') if split_stderr else None
 
-    res = RunResult(cmd=cmd_str, exit_code=proc.returncode, output=output, stderr=stderr_output, work_dir=work_dir)
+    res = RunShellCmdResult(cmd=cmd_str, exit_code=proc.returncode, output=output, stderr=stderr, work_dir=work_dir)
 
     if res.exit_code != 0 and fail_on_error:
         report_run_shell_cmd_error(res.cmd, res.exit_code, res.work_dir, output=res.output, stderr=res.stderr)

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -106,7 +106,7 @@ def print_run_shell_cmd_error(err):
     cmd_name = err.cmd.split(' ')[0]
     error_info = [
         '',
-        f"ERROR: Shell command failed!",
+        "ERROR: Shell command failed!",
         pad_4_spaces(f"full command              ->  {err.cmd}"),
         pad_4_spaces(f"exit code                 ->  {err.exit_code}"),
         pad_4_spaces(f"working directory         ->  {err.work_dir}"),

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -139,8 +139,8 @@ class BuildLogTest(EnhancedTestCase):
             r"fancyroot.test_easybuildlog \[WARNING\] :: Deprecated functionality.*onemorewarning.*",
             r"fancyroot.test_easybuildlog \[WARNING\] :: Deprecated functionality.*lastwarning.*",
             r"fancyroot.test_easybuildlog \[WARNING\] :: Deprecated functionality.*thisisnotprinted.*",
-            r"fancyroot.test_easybuildlog \[ERROR\] :: EasyBuild crashed with an error \(at .* in .*\): kaput",
-            r"fancyroot.test_easybuildlog \[ERROR\] :: EasyBuild crashed with an error \(at .* in .*\): err: msg: %s",
+            r"fancyroot.test_easybuildlog \[ERROR\] :: EasyBuild encountered an error \(at .* in .*\): kaput",
+            r"fancyroot.test_easybuildlog \[ERROR\] :: EasyBuild encountered an error \(at .* in .*\): err: msg: %s",
             r"fancyroot.test_easybuildlog \[ERROR\] :: .*EasyBuild encountered an exception \(at .* in .*\): oops",
             '',
         ])
@@ -168,7 +168,7 @@ class BuildLogTest(EnhancedTestCase):
             r"fancyroot.test_easybuildlog \[WARNING\] :: bleh",
             r"fancyroot.test_easybuildlog \[INFO\] :: 4\+2 = 42",
             r"fancyroot.test_easybuildlog \[DEBUG\] :: this is just a test",
-            r"fancyroot.test_easybuildlog \[ERROR\] :: EasyBuild crashed with an error \(at .* in .*\): foo baz baz",
+            r"fancyroot.test_easybuildlog \[ERROR\] :: EasyBuild encountered an error \(at .* in .*\): foo baz baz",
             '',
         ])
         logtxt_regex = re.compile(r'^%s' % expected_logtxt, re.M)
@@ -223,7 +223,7 @@ class BuildLogTest(EnhancedTestCase):
         info_msg = r"%s \[INFO\] :: fyi" % prefix
         warning_msg = r"%s \[WARNING\] :: this is a warning" % prefix
         deprecated_msg = r"%s \[WARNING\] :: Deprecated functionality, .*: almost kaput; see .*" % prefix
-        error_msg = r"%s \[ERROR\] :: EasyBuild crashed with an error \(at .* in .*\): kaput" % prefix
+        error_msg = r"%s \[ERROR\] :: EasyBuild encountered an error \(at .* in .*\): kaput" % prefix
 
         expected_logtxt = '\n'.join([
             error_msg,

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -737,6 +737,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             "	post_build_and_install_loop_hook",
             "	end_hook",
             "	cancel_hook",
+            "	crash_hook",
             "	fail_hook",
             "	pre_run_shell_cmd_hook",
             "	post_run_shell_cmd_hook",

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -249,7 +249,7 @@ class RunTest(EnhancedTestCase):
         os.close(fd)
 
         regex_start_cmd = re.compile("Running command 'echo hello' in /")
-        regex_cmd_exit = re.compile("Command 'echo hello' exited with exit code [0-9]* and output:")
+        regex_cmd_exit = re.compile("Shell command completed successfully \(see output above\): echo hello")
 
         # command output is always logged
         init_logging(logfile, silent=True)
@@ -258,8 +258,9 @@ class RunTest(EnhancedTestCase):
         stop_logging(logfile)
         self.assertEqual(res.exit_code, 0)
         self.assertEqual(res.output, 'hello\n')
-        self.assertEqual(len(regex_start_cmd.findall(read_file(logfile))), 1)
-        self.assertEqual(len(regex_cmd_exit.findall(read_file(logfile))), 1)
+        logtxt = read_file(logfile)
+        self.assertEqual(len(regex_start_cmd.findall(logtxt)), 1)
+        self.assertEqual(len(regex_cmd_exit.findall(logtxt)), 1)
         write_file(logfile, '')
 
         # with debugging enabled, exit code and output of command should only get logged once

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -249,7 +249,7 @@ class RunTest(EnhancedTestCase):
         os.close(fd)
 
         regex_start_cmd = re.compile("Running command 'echo hello' in /")
-        regex_cmd_exit = re.compile("Shell command completed successfully \(see output above\): echo hello")
+        regex_cmd_exit = re.compile(r"Shell command completed successfully \(see output above\): echo hello")
 
         # command output is always logged
         init_logging(logfile, silent=True)

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -50,8 +50,9 @@ import easybuild.tools.utilities
 from easybuild.tools.build_log import EasyBuildError, init_logging, stop_logging
 from easybuild.tools.config import update_build_option
 from easybuild.tools.filetools import adjust_permissions, change_dir, mkdir, read_file, write_file
-from easybuild.tools.run import check_async_cmd, check_log_for_errors, complete_cmd, get_output_from_process
-from easybuild.tools.run import RunResult, parse_log_for_error, run_shell_cmd, run_cmd, run_cmd_qa, subprocess_terminate
+from easybuild.tools.run import RunShellCmdResult, check_async_cmd, check_log_for_errors, complete_cmd
+from easybuild.tools.run import get_output_from_process, parse_log_for_error, run_shell_cmd, run_cmd, run_cmd_qa
+from easybuild.tools.run import subprocess_terminate
 from easybuild.tools.config import ERROR, IGNORE, WARN
 
 
@@ -863,7 +864,8 @@ class RunTest(EnhancedTestCase):
 
         # inject value into cache to check whether executing command again really returns cached value
         with self.mocked_stdout_stderr():
-            cached_res = RunResult(cmd=cmd, output="123456", exit_code=123, stderr=None, work_dir='/test_ulimit')
+            cached_res = RunShellCmdResult(cmd=cmd, output="123456", exit_code=123, stderr=None,
+                                           work_dir='/test_ulimit')
             run_shell_cmd.update_cache({(cmd, None): cached_res})
             res = run_shell_cmd(cmd)
         self.assertEqual(res.cmd, cmd)
@@ -881,7 +883,7 @@ class RunTest(EnhancedTestCase):
 
         # inject different output for cat with 'foo' as stdin to check whether cached value is used
         with self.mocked_stdout_stderr():
-            cached_res = RunResult(cmd=cmd, output="bar", exit_code=123, stderr=None, work_dir='/test_cat')
+            cached_res = RunShellCmdResult(cmd=cmd, output="bar", exit_code=123, stderr=None, work_dir='/test_cat')
             run_shell_cmd.update_cache({(cmd, 'foo'): cached_res})
             res = run_shell_cmd(cmd, stdin='foo')
         self.assertEqual(res.cmd, cmd)

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -52,7 +52,7 @@ from easybuild.tools.config import update_build_option
 from easybuild.tools.filetools import adjust_permissions, change_dir, mkdir, read_file, write_file
 from easybuild.tools.run import RunShellCmdResult, RunShellCmdError, check_async_cmd, check_log_for_errors
 from easybuild.tools.run import complete_cmd, get_output_from_process, parse_log_for_error
-from easybuild.tools.run import print_run_shell_cmd_error, run_cmd, run_cmd_qa, run_shell_cmd, subprocess_terminate
+from easybuild.tools.run import run_cmd, run_cmd_qa, run_shell_cmd, subprocess_terminate
 from easybuild.tools.config import ERROR, IGNORE, WARN
 
 
@@ -346,7 +346,7 @@ class RunTest(EnhancedTestCase):
                 self.assertEqual(err.caller_info[2], 'test_run_shell_cmd_fail')
 
                 with self.mocked_stdout_stderr() as (_, stderr):
-                    print_run_shell_cmd_error(err)
+                    err.print()
 
                 # check error reporting output
                 stderr = stderr.getvalue()
@@ -381,7 +381,7 @@ class RunTest(EnhancedTestCase):
                 self.assertEqual(err.caller_info[2], 'test_run_shell_cmd_fail')
 
                 with self.mocked_stdout_stderr() as (_, stderr):
-                    print_run_shell_cmd_error(err)
+                    err.print()
 
                 # check error reporting output
                 stderr = stderr.getvalue()

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -40,7 +40,7 @@ from unittest import TextTestRunner
 import easybuild.tools.systemtools as st
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import adjust_permissions, read_file, symlink, which, write_file
-from easybuild.tools.run import RunResult, run_shell_cmd
+from easybuild.tools.run import RunShellCmdResult, run_shell_cmd
 from easybuild.tools.systemtools import CPU_ARCHITECTURES, AARCH32, AARCH64, POWER, X86_64
 from easybuild.tools.systemtools import CPU_FAMILIES, POWER_LE, DARWIN, LINUX, UNKNOWN
 from easybuild.tools.systemtools import CPU_VENDORS, AMD, APM, ARM, CAVIUM, IBM, INTEL
@@ -340,7 +340,7 @@ def mocked_run_shell_cmd(cmd, **kwargs):
         "ulimit -u": '40',
     }
     if cmd in known_cmds:
-        return RunResult(cmd=cmd, exit_code=0, output=known_cmds[cmd], stderr=None, work_dir=os.getcwd())
+        return RunShellCmdResult(cmd=cmd, exit_code=0, output=known_cmds[cmd], stderr=None, work_dir=os.getcwd())
     else:
         return run_shell_cmd(cmd, **kwargs)
 
@@ -774,7 +774,8 @@ class SystemToolsTest(EnhancedTestCase):
         """Test getting gcc version (mocked for Darwin)."""
         st.get_os_type = lambda: st.DARWIN
         out = "Apple LLVM version 7.0.0 (clang-700.1.76)"
-        mocked_run_res = RunResult(cmd="gcc --version", exit_code=0, output=out, stderr=None, work_dir=os.getcwd())
+        cwd = os.getcwd()
+        mocked_run_res = RunShellCmdResult(cmd="gcc --version", exit_code=0, output=out, stderr=None, work_dir=cwd)
         st.run_shell_cmd = lambda *args, **kwargs: mocked_run_res
         self.assertEqual(get_gcc_version(), None)
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -374,8 +374,8 @@ class ToyBuildTest(EnhancedTestCase):
             'verify': False,
             'verbose': False,
         }
-        err_regex = r"Traceback[\S\s]*toy_buggy.py.*build_step[\S\s]*name 'run_cmd' is not defined"
-        self.assertErrorRegex(EasyBuildError, err_regex, self.run_test_toy_build_with_output, **kwargs)
+        err_regex = r"name 'run_cmd' is not defined"
+        self.assertErrorRegex(NameError, err_regex, self.run_test_toy_build_with_output, **kwargs)
 
     def test_toy_build_formatv2(self):
         """Perform a toy build (format v2)."""
@@ -1435,7 +1435,7 @@ class ToyBuildTest(EnhancedTestCase):
         ])
         write_file(test_ec, test_ec_txt)
 
-        error_pattern = "unzip .*/bar-0.0.tar.gz.* returned non-zero exit status"
+        error_pattern = r"shell command 'unzip \.\.\.' failed in extensions step for test.eb"
         with self.mocked_stdout_stderr():
             # for now, we expect subprocess.CalledProcessError, but eventually 'run' function will
             # do proper error reporting
@@ -2642,7 +2642,7 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec_txt = test_ec_txt + '\nenhance_sanity_check = False'
         write_file(test_ec, test_ec_txt)
 
-        error_pattern = r" Missing mandatory key 'dirs' in sanity_check_paths."
+        error_pattern = r"Missing mandatory key 'dirs' in sanity_check_paths."
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, error_pattern, self._test_toy_build, ec_file=test_ec,
                                   extra_args=eb_args, raise_error=True, verbose=False)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -42,7 +42,7 @@ import tempfile
 import textwrap
 from easybuild.tools import LooseVersion
 from importlib import reload
-from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
+from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, cleanup
 from test.framework.package import mock_fpm
 from unittest import TextTestRunner
 
@@ -50,6 +50,7 @@ import easybuild.tools.hooks  # so we can reset cached hooks
 import easybuild.tools.module_naming_scheme  # required to dynamically load test module naming scheme(s)
 from easybuild.framework.easyconfig.easyconfig import EasyConfig
 from easybuild.framework.easyconfig.parser import EasyConfigParser
+from easybuild.main import main_with_hooks
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import get_module_syntax, get_repositorypath
 from easybuild.tools.environment import modify_env
@@ -57,7 +58,7 @@ from easybuild.tools.filetools import adjust_permissions, change_dir, copy_file,
 from easybuild.tools.filetools import read_file, remove_dir, remove_file, which, write_file
 from easybuild.tools.module_generator import ModuleGeneratorTcl
 from easybuild.tools.modules import Lmod
-from easybuild.tools.run import run_cmd
+from easybuild.tools.run import RunShellCmdError, run_cmd, run_shell_cmd
 from easybuild.tools.utilities import nub
 from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.version import VERSION as EASYBUILD_VERSION
@@ -4067,6 +4068,41 @@ class ToyBuildTest(EnhancedTestCase):
         ])
         regex = re.compile(pattern, re.M)
         self.assertTrue(regex.search(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
+
+    def test_eb_crash(self):
+        """
+        Test behaviour when EasyBuild crashes, for example due to a buggy hook
+        """
+        hooks_file = os.path.join(self.test_prefix, 'my_hooks.py')
+        hooks_file_txt = textwrap.dedent("""
+            def pre_configure_hook(self, *args, **kwargs):
+                no_such_thing
+        """)
+        write_file(hooks_file, hooks_file_txt)
+
+        topdir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        toy_eb = os.path.join(topdir, 'test', 'framework', 'sandbox', 'easybuild', 'easyblocks', 't', 'toy.py')
+        toy_ec = os.path.join(topdir, 'test', 'framework', 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
+
+        args = [
+            toy_ec,
+            f'--hooks={hooks_file}',
+            f'--force',
+            f'--installpath={self.test_prefix}',
+            f'--include-easyblocks={toy_eb}',
+        ]
+
+        with self.mocked_stdout_stderr() as (_, stderr):
+            cleanup()
+            try:
+                main_with_hooks(args=args)
+                self.assertFalse("This should never be reached, main function should have crashed!")
+            except NameError as err:
+                self.assertEqual(str(err), "name 'no_such_thing' is not defined")
+
+            regex = re.compile(r"EasyBuild crashed! Please consider reporting a bug, this should not happen")
+            stderr = stderr.getvalue()
+            self.assertTrue(regex.search(stderr), f"Pattern '{regex.pattern}' should be found in {stderr}")
 
 
 def suite():

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -4087,7 +4087,7 @@ class ToyBuildTest(EnhancedTestCase):
         args = [
             toy_ec,
             f'--hooks={hooks_file}',
-            f'--force',
+            '--force',
             f'--installpath={self.test_prefix}',
             f'--include-easyblocks={toy_eb}',
         ]

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -58,7 +58,7 @@ from easybuild.tools.filetools import adjust_permissions, change_dir, copy_file,
 from easybuild.tools.filetools import read_file, remove_dir, remove_file, which, write_file
 from easybuild.tools.module_generator import ModuleGeneratorTcl
 from easybuild.tools.modules import Lmod
-from easybuild.tools.run import RunShellCmdError, run_cmd, run_shell_cmd
+from easybuild.tools.run import run_cmd
 from easybuild.tools.utilities import nub
 from easybuild.tools.systemtools import get_shared_lib_ext
 from easybuild.tools.version import VERSION as EASYBUILD_VERSION


### PR DESCRIPTION
First step towards vastly better error reporting for failing shell commands.

Example output:

```
== building...
  >> running command:
        [started at: 2023-10-07 18:35:19]
        [working dir: /tmp/kehoste/bzip2/1.0.6/system-system/bzip2-1.0.6]
        [output logged in /tmp/eb-gig4d62n/easybuild-run-seeh08kw.log]
        make  -j 8 CC=gcc CFLAGS='-Wall -Winline -O3 -fPIC -g $(BIGFILES)'

ERROR: Shell command failed!
    full command              ->  make  -j 8 CC=gcc CFLAGS='-Wall -Winline -O3 -fPIC -g $(BIGFILES)'
    exit code                 ->  123
    working directory         ->  /tmp/kehoste/bzip2/1.0.6/system-system/bzip2-1.0.6
    output (stdout + stderr)  ->  /tmp/eb-gig4d62n/shell-cmd-error-03bewi0y/make.out
    called from               ->  'build_step' function in /Users/kehoste/work/easybuild-easyblocks/easybuild/easyblocks/generic/configuremake.py (line 355)

== ... (took 1 secs)
== FAILED: Installation ended unsuccessfully: shell command 'make ...' failed in build step for bzip2-1.0.6.eb (took 1 secs)
== Results of the build can be found in the log file(s) /tmp/eb-gig4d62n/easybuild-bzip2-1.0.6-20231007.183519.HtNIq.log
```

compared to the more messy (and partially duplicate) output with potentially very long lines and a feeble attempt at reducing the size of the output by cutting it down to just the first 300 characters of command output that EasyBuild 4.x produces:

```
== building...
  >> running command:
        [started at: 2023-10-07 15:57:38]
        [working dir: /tmp/kehoste/bzip2/1.0.6/system-system/bzip2-1.0.6]
        [output logged in /tmp/eb-uqgwnvww/easybuild-run_cmd-safmezzg.log]
        make  -j 8 CC=gcc CFLAGS='-Wall -Winline -O3 -fPIC -g $(BIGFILES)'
  >> command completed: exit 123, ran in < 1s
== ... (took < 1 sec)
== FAILED: Installation ended unsuccessfully (build directory: /tmp/kehoste/bzip2/1.0.6/system-system): build failed (first 300 chars): cmd " make  -j 8 CC=gcc CFLAGS='-Wall -Winline -O3 -fPIC -g
$(BIGFILES)'; exit 123" exited with exit code 123 and output:
gcc -Wall -Winline -O3 -fPIC -g -D_FILE_OFFSET_BITS=64 -c huffman.c
gcc -Wall -Winline -O3 -fPIC -g -D_FILE_OFFSET_BITS=64 -c crctable.c
gcc -Wall -Winline -O3 -fPIC -g -D_FILE_O (took 1 secs)
== Results of the build can be found in the log file(s) /tmp/eb-uqgwnvww/easybuild-bzip2-1.0.6-20231007.155738.nfQZD.log

ERROR: Build of /Users/kehoste/work/easybuild-easyconfigs/easybuild/easyconfigs/b/bzip2/bzip2-1.0.6.eb failed (err: 'build failed (first 300 chars): cmd " make  -j 8 CC=gcc CFLAGS=\'-Wall -Winline -O3 -fPIC -g $(BIGFILES)\'; exit 123" exited with exit code 123 and output:\ngcc -Wall -Winline -O3 -fPIC -g -D_FILE_OFFSET_BITS=64 -c huffman.c\ngcc -Wall -Winline -O3 -fPIC -g -D_FILE_OFFSET_BITS=64 -c crctable.c\ngcc -Wall -Winline -O3 -fPIC -g -D_FILE_O')
```

Next steps (in follow-up PRs) could be:

* Try and extract first error message from command output, and include that in printed output (leaving the door open to use context-specific patterns when trying to extract errors, so we can define functions like `run_make_cmd` and `run_pip_cmd` in easyblocks);
* Leverage `rich` to produce colored output by default (`ERROR` in red, etc.);
* Generate script that can be sourced to jump back into the environment and working directory of the failed command, to make debugging easier;