### PR TITLE
take into account that `VERBOSE_VERSION` imported from `easybuild.easyblocks` is now a string value

### DIFF
--- a/easybuild/tools/version.py
+++ b/easybuild/tools/version.py
@@ -92,7 +92,7 @@ except Exception:
 
 def this_is_easybuild():
     """Standard starting message"""
-    top_version = max(FRAMEWORK_VERSION, EASYBLOCKS_VERSION)
+    top_version = max(FRAMEWORK_VERSION, LooseVersion(EASYBLOCKS_VERSION))
     msg = "This is EasyBuild %s (framework: %s, easyblocks: %s) on host %s."
     msg = msg % (top_version, FRAMEWORK_VERSION, EASYBLOCKS_VERSION, gethostname())
 


### PR DESCRIPTION
required because of changes in `easybuild/easyblocks/__init__.py` in https://github.com/easybuilders/easybuild-easyblocks/pull/3018