### PR TITLE
use 5.0.x branch for easyblocks + easyconfigs in CI workflows (for now)

### DIFF
--- a/.github/workflows/container_tests.yml
+++ b/.github/workflows/container_tests.yml
@@ -74,7 +74,7 @@ jobs:
           ls dist
           export PREFIX=/tmp/$USER/$GITHUB_SHA
           pip install --prefix $PREFIX dist/easybuild-framework*tar.gz
-          pip install --prefix $PREFIX https://github.com/easybuilders/easybuild-easyblocks/archive/develop.tar.gz
+          pip install --prefix $PREFIX https://github.com/easybuilders/easybuild-easyblocks/archive/5.0.x.tar.gz
 
     - name: run test
       run: |
@@ -95,7 +95,7 @@ jobs:
           echo '%_dbpath %{_var}/lib/rpm' >> $HOME/.rpmmacros
           # build CentOS 7 container image for bzip2 1.0.8 using EasyBuild;
           # see https://docs.easybuild.io/en/latest/Containers.html
-          curl -OL https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/develop/easybuild/easyconfigs/b/bzip2/bzip2-1.0.8.eb
+          curl -OL https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/5.0.x/easybuild/easyconfigs/b/bzip2/bzip2-1.0.8.eb
           export EASYBUILD_CONTAINERPATH=$PWD
           export EASYBUILD_CONTAINER_CONFIG='bootstrap=docker,from=ghcr.io/easybuilders/centos-7.9-python3-amd64'
           eb bzip2-1.0.8.eb --containerize --experimental --container-build-image

--- a/.github/workflows/container_tests_apptainer.yml
+++ b/.github/workflows/container_tests_apptainer.yml
@@ -66,7 +66,7 @@ jobs:
           ls dist
           export PREFIX=/tmp/$USER/$GITHUB_SHA
           pip install --prefix $PREFIX dist/easybuild-framework*tar.gz
-          pip install --prefix $PREFIX https://github.com/easybuilders/easybuild-easyblocks/archive/develop.tar.gz
+          pip install --prefix $PREFIX https://github.com/easybuilders/easybuild-easyblocks/archive/5.0.x.tar.gz
 
     - name: run test
       run: |
@@ -87,7 +87,7 @@ jobs:
           echo '%_dbpath %{_var}/lib/rpm' >> $HOME/.rpmmacros
           # build CentOS 7 container image for bzip2 1.0.8 using EasyBuild;
           # see https://docs.easybuild.io/en/latest/Containers.html
-          curl -OL https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/develop/easybuild/easyconfigs/b/bzip2/bzip2-1.0.8.eb
+          curl -OL https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/5.0.x/easybuild/easyconfigs/b/bzip2/bzip2-1.0.8.eb
           export EASYBUILD_CONTAINERPATH=$PWD
           export EASYBUILD_CONTAINER_CONFIG='bootstrap=docker,from=ghcr.io/easybuilders/centos-7.9-python3-amd64'
           export EASYBUILD_CONTAINER_TYPE='apptainer'

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -25,9 +25,9 @@ jobs:
         run: |
           cd $HOME
           for pkg in easyblocks easyconfigs; do
-              curl -OL https://github.com/easybuilders/easybuild-${pkg}/archive/develop.tar.gz
-              tar xfz develop.tar.gz
-              rm -f develop.tar.gz
+              curl -OL https://github.com/easybuilders/easybuild-${pkg}/archive/5.0.x.tar.gz
+              tar xfz 5.0.x.tar.gz
+              rm -f 5.0.x.tar.gz
           done
 
       - name: Set up environment
@@ -35,7 +35,7 @@ jobs:
         run: |
           # collect environment variables to be set in subsequent steps in script that can be sourced
           echo "export PATH=$PWD:$PATH" > /tmp/eb_env
-          echo "export PYTHONPATH=$PWD:$HOME/easybuild-easyblocks-develop:$HOME/easybuild-easyconfigs-develop" >> /tmp/eb_env
+          echo "export PYTHONPATH=$PWD:$HOME/easybuild-easyblocks-5.0.x:$HOME/easybuild-easyconfigs-5.0.x" >> /tmp/eb_env
 
       - name: Run commands to check test environment
         shell: bash


### PR DESCRIPTION
We'll need to change this back to `develop` once the `5.0.x` branches are collapsed into `develop` after the last EasyBuild 4.x release has been published...