### PR TITLE
add support for `%(sysroot)s` template value

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -204,7 +204,6 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
     template_values['arch'] = platform.uname()[4]
 
     # set 'sysroot' template based on 'sysroot' configuration option, using empty string as fallback
- value
     template_values['sysroot'] = build_option('sysroot') or ''
 
     # step 1: add TEMPLATE_NAMES_EASYCONFIG

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -203,12 +203,9 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
     # set 'arch' for system architecture based on 'machine' (4th) element of platform.uname() return value
     template_values['arch'] = platform.uname()[4]
 
-    # set 'sysroot' based on sysroot build option
-    sysroot = build_option('sysroot')
-    if sysroot is None:
-        template_values['sysroot'] = ""
-    else:
-        template_values['sysroot'] = sysroot
+    # set 'sysroot' template based on 'sysroot' configuration option, using empty string as fallback
+ value
+    template_values['sysroot'] = build_option('sysroot') or ''
 
     # step 1: add TEMPLATE_NAMES_EASYCONFIG
     for name in TEMPLATE_NAMES_EASYCONFIG:

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -205,7 +205,7 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
 
     # set 'sysroot' based on sysroot build option
     sysroot = build_option('sysroot')
-    if sysroot == None:
+    if sysroot is None:
         template_values['sysroot'] = ""
     else:
         template_values['sysroot'] = sysroot

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -90,6 +90,8 @@ TEMPLATE_SOFTWARE_VERSIONS = [
 # template values which are only generated dynamically
 TEMPLATE_NAMES_DYNAMIC = [
     ('arch', "System architecture (e.g. x86_64, aarch64, ppc64le, ...)"),
+    ('sysroot', "Location root directory of system, prefix for standard paths like /usr/lib and /usr/include"
+     "as specify by the --sysroot configuration option"),
     ('mpi_cmd_prefix', "Prefix command for running MPI programs (with default number of ranks)"),
     ('cuda_compute_capabilities', "Comma-separated list of CUDA compute capabilities, as specified via "
      "--cuda-compute-capabilities configuration option or via cuda_compute_capabilities easyconfig parameter"),
@@ -200,6 +202,13 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
 
     # set 'arch' for system architecture based on 'machine' (4th) element of platform.uname() return value
     template_values['arch'] = platform.uname()[4]
+
+    # set 'sysroot' based on sysroot build option
+    sysroot = build_option('sysroot')
+    if sysroot == None:
+        template_values['sysroot'] = ""
+    else:
+        template_values['sysroot'] = sysroot
 
     # step 1: add TEMPLATE_NAMES_EASYCONFIG
     for name in TEMPLATE_NAMES_EASYCONFIG:

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3344,6 +3344,7 @@ class EasyConfigTest(EnhancedTestCase):
             'pyminver': '7',
             'pyshortver': '3.7',
             'pyver': '3.7.2',
+            'sysroot': '',
             'version': '0.01',
             'version_major': '0',
             'version_major_minor': '0.01',

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1346,6 +1346,76 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertIn('start_dir in extension configure is %s &&' % ext_start_dir, logtxt)
         self.assertIn('start_dir in extension build is %s &&' % ext_start_dir, logtxt)
 
+    def test_sysroot_template_empty(self):
+        """Test the %(sysroot)s template whenever --sysroot is unset (i.e. None)"""
+
+        self.contents = textwrap.dedent("""
+            name = 'toy'
+            version = '0.0'
+
+            homepage = 'https://easybuilders.github.io/easybuild'
+            description = 'Toy C program, 100% toy.'
+
+            toolchain = SYSTEM
+
+            sources = [SOURCE_TAR_GZ]
+
+            preconfigopts = 'echo sysroot in configure is %(sysroot)s && '
+            prebuildopts = 'echo sysroot in build is %(sysroot)s && '
+            preinstallopts = 'echo sysroot in install is %(sysroot)s && '
+
+            moduleclass = 'tools'
+        """)
+        self.prep()
+        ec = EasyConfig(self.eb_file)
+        from easybuild.easyblocks.toy import EB_toy
+        eb = EB_toy(ec)
+        # Check behaviour when sysroot is not set (i.e. None)
+        eb.cfg['sysroot'] = None  # Should we define this explicitely? Or rely on this to be the default?
+        eb.cfg['stop'] = 'extensions'
+        with self.mocked_stdout_stderr():
+            eb.run_all_steps(False)
+        logtxt = read_file(eb.logfile)
+        sysroot = ""
+        self.assertIn('sysroot in configure is %s/ &&' % sysroot, logtxt)
+        self.assertIn('sysroot in build is %s/ &&' % sysroot, logtxt)
+        self.assertIn('sysroot in install is %s/ &&' % sysroot, logtxt)
+
+    def test_sysroot_template_non_empty(self):
+        """Test the %(sysroot)s template whenever --sysroot is unset (i.e. None)"""
+
+        self.contents = textwrap.dedent("""
+            name = 'toy'
+            version = '0.0'
+
+            homepage = 'https://easybuilders.github.io/easybuild'
+            description = 'Toy C program, 100% toy.'
+
+            toolchain = SYSTEM
+
+            sources = [SOURCE_TAR_GZ]
+
+            preconfigopts = 'echo sysroot in configure is %(sysroot)s && '
+            prebuildopts = 'echo sysroot in build is %(sysroot)s && '
+            preinstallopts = 'echo sysroot in install is %(sysroot)s && '
+
+            moduleclass = 'tools'
+        """)
+        self.prep()
+        ec = EasyConfig(self.eb_file)
+        from easybuild.easyblocks.toy import EB_toy
+        eb = EB_toy(ec)
+        # Check behaviour when sysroot is not set (i.e. None)
+        eb.cfg['sysroot'] = '/tmp'  # This should be a path that exists, otherwise EasyBuild complains
+        eb.cfg['stop'] = 'extensions'
+        with self.mocked_stdout_stderr():
+            eb.run_all_steps(False)
+        logtxt = read_file(eb.logfile)
+        sysroot = ""
+        self.assertIn('sysroot in configure is %s/ &&' % sysroot, logtxt)
+        self.assertIn('sysroot in build is %s/ &&' % sysroot, logtxt)
+        self.assertIn('sysroot in install is %s/ &&' % sysroot, logtxt)
+
     def test_constant_doc(self):
         """test constant documentation"""
         doc = avail_easyconfig_constants()

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1367,16 +1367,12 @@ class EasyConfigTest(EnhancedTestCase):
 
         # Validate the value of the sysroot template if sysroot is unset (i.e. the build option is None)
         # As a test, we'll set the sysroot to self.test_prefix, as it has to be a directory that is guaranteed to exist
-        old_sysroot = build_option('sysroot')
         update_build_option('sysroot', self.test_prefix)
 
         ec = EasyConfig(test_ec)
         self.assertEqual(ec['configopts'], "--some-opt=%s/" % self.test_prefix)
         self.assertEqual(ec['buildopts'], "--some-opt=%s/" % self.test_prefix)
         self.assertEqual(ec['installopts'], "--some-opt=%s/" % self.test_prefix)
-
-        # Restore original value for sysroot build option
-        update_build_option('sysroot', old_sysroot)
 
     def test_constant_doc(self):
         """test constant documentation"""
@@ -3266,6 +3262,7 @@ class EasyConfigTest(EnhancedTestCase):
             'nameletter': 'g',
             'nameletterlower': 'g',
             'parallel': None,
+            'sysroot': '',
             'toolchain_name': 'foss',
             'toolchain_version': '2018a',
             'version': '1.5',

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1367,12 +1367,16 @@ class EasyConfigTest(EnhancedTestCase):
 
         # Validate the value of the sysroot template if sysroot is unset (i.e. the build option is None)
         # As a test, we'll set the sysroot to self.test_prefix, as it has to be a directory that is guaranteed to exist
+        old_sysroot = build_option('sysroot')
         update_build_option('sysroot', self.test_prefix)
 
         ec = EasyConfig(test_ec)
         self.assertEqual(ec['configopts'], "--some-opt=%s/" % self.test_prefix)
         self.assertEqual(ec['buildopts'], "--some-opt=%s/" % self.test_prefix)
         self.assertEqual(ec['installopts'], "--some-opt=%s/" % self.test_prefix)
+
+        # Restore original value for sysroot build option
+        update_build_option('sysroot', old_sysroot)
 
     def test_constant_doc(self):
         """test constant documentation"""

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3409,6 +3409,7 @@ class EasyConfigTest(EnhancedTestCase):
             'namelower': 'foo',
             'nameletter': 'f',
             'nameletterlower': 'f',
+            'sysroot': '',
             'version': '1.2.3',
             'version_major': '1',
             'version_major_minor': '1.2',

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1351,7 +1351,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         test_easyconfigs = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'easyconfigs', 'test_ecs')
         toy_ec = os.path.join(test_easyconfigs, 't', 'toy', 'toy-0.0.eb')
- 
+
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         test_ec_txt = read_file(toy_ec)
         test_ec_txt += '\nconfigopts = "--some-opt=%(sysroot)s/"'


### PR DESCRIPTION
This improves sysroot support. For example this code line in [wget](https://github.com/easybuilders/easybuild-easyconfigs/blob/3f0b0151205bb4497a28e3c494db80e144bbbe48/easybuild/easyconfigs/w/wget/wget-1.21.3-GCCcore-11.3.0.eb#L41) can be generalized using sysroot template.
From
`preconfigopts = "export PKG_CONFIG_PATH=/usr/lib64/pkgconfig:/usr/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig && "`
to
`preconfigopts = "export PKG_CONFIG_PATH=%(sysroot)s/usr/lib64/pkgconfig:%(sysroot)s/usr/lib/pkgconfig:%(sysroot)s/usr/lib/x86_64-linux-gnu/pkgconfig && " `

This works for both cases when --sysroot is passed and when it's not (i.e. when it defaults to None).
