### PR TITLE
deduplicate warnings & errors found in logs and add initial newline + tab in output

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -52,7 +52,7 @@ from easybuild.tools.build_log import EasyBuildError, dry_run_msg, print_msg, ti
 from easybuild.tools.config import ERROR, IGNORE, WARN, build_option
 from easybuild.tools.hooks import RUN_SHELL_CMD, load_hooks, run_hook
 from easybuild.tools.py2vs3 import string_type
-from easybuild.tools.utilities import trace_msg
+from easybuild.tools.utilities import nub, trace_msg
 
 
 _log = fancylogger.getLogger('run', fname=False)
@@ -790,7 +790,7 @@ def extract_errors_from_log(log_txt, reg_exps):
                 elif action == WARN:
                     warnings.append(line)
                 break
-    return warnings, errors
+    return nub(warnings), nub(errors)
 
 
 def check_log_for_errors(log_txt, reg_exps):
@@ -805,8 +805,8 @@ def check_log_for_errors(log_txt, reg_exps):
 
     errors_found_in_log += len(warnings) + len(errors)
     if warnings:
-        _log.warning("Found %s potential error(s) in command output (output: %s)",
+        _log.warning("Found %s potential error(s) in command output:\n\t%s",
                      len(warnings), "\n\t".join(warnings))
     if errors:
-        raise EasyBuildError("Found %s error(s) in command output (output: %s)",
+        raise EasyBuildError("Found %s error(s) in command output:\n\t%s",
                              len(errors), "\n\t".join(errors))

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -705,8 +705,9 @@ class RunTest(EnhancedTestCase):
             "enabling -Werror",
             "the process crashed with 0"
         ])
-        expected_msg = r"Found 2 error\(s\) in command output "\
-                       r"\(output: error found\n\tthe process crashed with 0\)"
+        expected_msg = r"Found 2 error\(s\) in command output:\n"\
+                       r"\terror found\n"\
+                       r"\tthe process crashed with 0"
 
         # String promoted to list
         self.assertErrorRegex(EasyBuildError, expected_msg, check_log_for_errors, input_text,
@@ -718,14 +719,17 @@ class RunTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, expected_msg, check_log_for_errors, input_text,
                               [(r"\b(error|crashed)\b", ERROR)])
 
-        expected_msg = "Found 2 potential error(s) in command output " \
-                       "(output: error found\n\tthe process crashed with 0)"
+        expected_msg = "Found 2 potential error(s) in command output:\n"\
+                       "\terror found\n"\
+                       "\tthe process crashed with 0"
         init_logging(logfile, silent=True)
         check_log_for_errors(input_text, [(r"\b(error|crashed)\b", WARN)])
         stop_logging(logfile)
         self.assertIn(expected_msg, read_file(logfile))
 
-        expected_msg = r"Found 2 error\(s\) in command output \(output: error found\n\ttest failed\)"
+        expected_msg = r"Found 2 error\(s\) in command output:\n"\
+                       r"\terror found\n"\
+                       r"\ttest failed"
         write_file(logfile, '')
         init_logging(logfile, silent=True)
         self.assertErrorRegex(EasyBuildError, expected_msg, check_log_for_errors, input_text, [
@@ -735,7 +739,7 @@ class RunTest(EnhancedTestCase):
             "fail"
         ])
         stop_logging(logfile)
-        expected_msg = "Found 1 potential error(s) in command output (output: the process crashed with 0)"
+        expected_msg = "Found 1 potential error(s) in command output:\n\tthe process crashed with 0"
         self.assertIn(expected_msg, read_file(logfile))
 
     def test_run_cmd_with_hooks(self):


### PR DESCRIPTION
It isn't useful to report duplicate errors multiple times. And e.g. configure may report a wrong option at the start and end. Hence deduplicate it.
Also change the logged warning/error to include a newline & tab in front of each element which makes it nicer to read. E.g.:
```
build failed (first 300 chars): Found 1 error(s) in command output:
	configure: WARNING: unrecognized options: --with-foo, --with-bar (took 2 mins 39 secs)
```