### PR TITLE
fix broken test for `reasons_for_closing`, which fails because commit status of easyconfigs PR is no longer available

### DIFF
--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -345,7 +345,6 @@ class GithubTest(EnhancedTestCase):
         self.assertIsInstance(res, list)
         self.assertEqual(stderr.strip(), "WARNING: Using easyconfigs from closed PR #16080")
         patterns = [
-            "Status of last commit is SUCCESS",
             "Last comment on",
             "No activity since",
             "* c-ares-1.18.1",


### PR DESCRIPTION
This test started failing because the commit status in https://github.com/easybuilders/easybuild-easyconfigs/pull/16080 has been "reset" (GitHub only still provides commit status for sufficiently recent PRs/commits).

We don't care much about the commit status in the test for `reasons_for_closing`, so easiest way to deal with this is to just stop checking the commit status...