### PR TITLE
Adapt module function check for Environment Modules v4+

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -71,6 +71,7 @@ CACHED_COMMANDS = [
     "sysctl -n machdep.cpu.brand_string",  # used in get_cpu_model (OS X)
     "sysctl -n machdep.cpu.vendor",  # used in get_cpu_vendor (OS X)
     "type module",  # used in ModulesTool.check_module_function
+    "type _module_raw",  # used in EnvironmentModules.check_module_function
     "ulimit -u",  # used in det_parallelism
 ]
 


### PR DESCRIPTION
Default check_module_function tests that module command is called from module shell function. With EnvironmentModules v4+, module command is usually called from the _module_raw shell function.

This commit adds a specific version of check_module_function for EnvironmentModules class. Module command is first checked within _module_raw shell function definition. If not found, default test (that checks module function) is run.

Adapt "test_module_mismatch" unit test to specifically check module command definition with EnvironmentModules.

Fixes #4368