### PR TITLE
drop load storm safe guard for Environment Modules v4.2.4+

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -915,8 +915,13 @@ class ModuleGeneratorTcl(ModuleGenerator):
 
         cond_tmpl = None
 
+        # Environment Modules v4+ safely handles automatic module load by not reloading already
+        # loaded module. No safe guard test is required and it should even be avoided to get the
+        # module dependency correctly tracked.
+        safe_auto_load = self.modules_tool.supports_safe_auto_load
+
         if recursive_unload is None:
-            recursive_unload = build_option('recursive_mod_unload') or depends_on
+            recursive_unload = build_option('recursive_mod_unload') or depends_on or safe_auto_load
 
         if recursive_unload:
             # wrapping the 'module load' statement with an 'is-loaded or mode == unload'
@@ -927,7 +932,7 @@ class ModuleGeneratorTcl(ModuleGenerator):
             # see also http://lmod.readthedocs.io/en/latest/210_load_storms.html
             cond_tmpl = "[ module-info mode remove ] || %s"
 
-        if depends_on:
+        if depends_on or safe_auto_load:
             if multi_dep_mods and len(multi_dep_mods) > 1:
                 parent_mod_name = os.path.dirname(mod_name)
                 guard = self.is_loaded(multi_dep_mods[1:])

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -215,6 +215,7 @@ class ModulesTool(object):
         self.supports_depends_on = False
         self.supports_tcl_getenv = False
         self.supports_tcl_check_group = False
+        self.supports_safe_auto_load = False
 
     def __str__(self):
         """String representation of this ModulesTool instance."""
@@ -1325,6 +1326,7 @@ class EnvironmentModules(EnvironmentModulesTcl):
     DEPR_VERSION = '4.0.0'  # needs to be set as EnvironmentModules inherits from EnvironmentModulesTcl
     MAX_VERSION = None
     REQ_VERSION_TCL_CHECK_GROUP = '4.6.0'
+    REQ_VERSION_SAFE_AUTO_LOAD = '4.2.4'
     VERSION_REGEXP = r'^Modules\s+Release\s+(?P<version>\d[^+\s]*)(\+\S*)?\s'
 
     SHOW_HIDDEN_OPTION = '--all'
@@ -1354,6 +1356,7 @@ class EnvironmentModules(EnvironmentModulesTcl):
         version = LooseVersion(self.version)
         self.supports_tcl_getenv = version >= LooseVersion(self.REQ_VERSION_TCL_GETENV)
         self.supports_tcl_check_group = version >= LooseVersion(self.REQ_VERSION_TCL_CHECK_GROUP)
+        self.supports_safe_auto_load = version >= LooseVersion(self.REQ_VERSION_SAFE_AUTO_LOAD)
 
     def check_module_function(self, allow_mismatch=False, regex=None):
         """Check whether selected module tool matches 'module' function definition."""


### PR DESCRIPTION
Environment Modules v4+ safely handles automatic module load by not reloading already loaded module. Same goes when unloading module: already unloaded dependency will not be evaluated again.

As a result, no safe guard test is required and it should even be avoided to get the module dependency correctly tracked.

If module dependency declaration is skipped, no relation binds the loaded modules. Thus unloading the dependency will not lead to the auto unload of the dependent module. Without "is-loaded" safe guard, dependency is always declared and loaded environment is kept consistent by auto_handling mechanism [1]

A new ModuleTool property named "supports_safe_auto_load" is introduced. When enabled, module load safe guard code is not generated like if depends_on is enabled.

"supports_safe_auto_load" is enabled for EnviromentModules 4.2.4+. Prior v4 versions were not handling safely module load of module parent name if already loaded module were not corresponding to the default version.

[1] https://modules.readthedocs.io/en/latest/module.html#envvar-MODULES_AUTO_HANDLING