### PR TITLE
Use `-qopenmp` instead of `-fiopenmp` for OpenMP in Intel compilers

### DIFF
--- a/easybuild/toolchains/compiler/intel_compilers.py
+++ b/easybuild/toolchains/compiler/intel_compilers.py
@@ -109,8 +109,9 @@ class IntelCompilers(IntelIccIfort):
             self.options.options_map['loose'] = ['fp-model fast']
             # fp-model fast=2 gives "warning: overriding '-ffp-model=fast=2' option with '-ffp-model=fast'"
             self.options.options_map['veryloose'] = ['fp-model fast']
-            # recommended in porting guide
-            self.options.options_map['openmp'] = ['fiopenmp']
+            # recommended in porting guide: qopenmp, unlike fiopenmp, works for both classic and oneapi compilers
+            # https://www.intel.com/content/www/us/en/developer/articles/guide/porting-guide-for-ifort-to-ifx.html
+            self.options.options_map['openmp'] = ['qopenmp']
 
             # -xSSE2 is not supported by Intel oneAPI compilers,
             # so use -march=x86-64 -mtune=generic when using optarch=GENERIC

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -2036,7 +2036,7 @@ class ToolchainTest(EnhancedTestCase):
             'CrayIntel': "-O2 -ftz -fp-speculation=safe -fp-model source -fopenmp -craype-verbose",
             'GCC': "-O2 -ftree-vectorize -test -fno-math-errno -fopenmp",
             'iccifort': "-O2 -test -ftz -fp-speculation=safe -fp-model source -fopenmp",
-            'intel-compilers': "-O2 -test -ftz -fp-speculation=safe -fp-model precise -fiopenmp",
+            'intel-compilers': "-O2 -test -ftz -fp-speculation=safe -fp-model precise -qopenmp",
         }
 
         toolchains = [


### PR DESCRIPTION
Recommended in porting guide: `-qopenmp`, unlike `-fiopenmp`, works for both classic and OneAPI compilers https://www.intel.com/content/www/us/en/developer/articles/guide/porting-guide-for-ifort-to-ifx.html

Fixes #4376