### PR TITLE
print error message in `main_with_hooks` function when `EasyBuildError` was raised

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -754,7 +754,7 @@ def main_with_hooks(args=None):
         main(args=args, prepared_cfg_data=(init_session_state, eb_go, cfg_settings))
     except EasyBuildError as err:
         run_hook(FAIL, hooks, args=[err])
-        sys.exit(1)
+        print_error(err.msg, exit_on_error=True, exit_code=1)
     except KeyboardInterrupt as err:
         run_hook(CANCEL, hooks, args=[err])
         print_error("Cancelled by user: %s" % err)

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -335,8 +335,18 @@ def print_error(msg, *args, **kwargs):
     if args:
         msg = msg % args
 
+    # grab exit code, if specified;
+    # also consider deprecated 'exitCode' option
+    exitCode = kwargs.pop('exitCode', None)
+    exit_code = kwargs.pop('exit_code', exitCode)
+    if exitCode is not None:
+        _init_easybuildlog.deprecated("'exitCode' option in print_error function is replaced with 'exit_code'", '6.0')
+
+    # use 1 as defaut exit code
+    if exit_code is None:
+        exit_code = 1
+
     log = kwargs.pop('log', None)
-    exitCode = kwargs.pop('exitCode', 1)
     opt_parser = kwargs.pop('opt_parser', None)
     exit_on_error = kwargs.pop('exit_on_error', True)
     silent = kwargs.pop('silent', False)
@@ -348,7 +358,7 @@ def print_error(msg, *args, **kwargs):
             if opt_parser:
                 opt_parser.print_shorthelp()
             sys.stderr.write("ERROR: %s\n" % msg)
-        sys.exit(exitCode)
+        sys.exit(exit_code)
     elif log is not None:
         raise EasyBuildError(msg)
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -4104,6 +4104,29 @@ class ToyBuildTest(EnhancedTestCase):
             stderr = stderr.getvalue()
             self.assertTrue(regex.search(stderr), f"Pattern '{regex.pattern}' should be found in {stderr}")
 
+    def test_eb_error(self):
+        """
+        Test whether main function as run by 'eb' command print error messages to stderr.
+        """
+        topdir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+        toy_ec = os.path.join(topdir, 'test', 'framework', 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
+
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        test_ec_txt = read_file(toy_ec)
+        test_ec_txt += "\ndependencies = [('nosuchdep', '1.0')]"
+        write_file(test_ec, test_ec_txt)
+
+        with self.mocked_stdout_stderr() as (_, stderr):
+            cleanup()
+            try:
+                main_with_hooks(args=[test_ec, '--robot', '--force'])
+            except SystemExit:
+                pass
+
+            regex = re.compile("^ERROR: Missing dependencies", re.M)
+            stderr = stderr.getvalue()
+            self.assertTrue(regex.search(stderr), f"Pattern '{regex.pattern}' should be found in {stderr}")
+
 
 def suite():
     """ return all the tests in this file """


### PR DESCRIPTION
also deprecates `exitCode` in `print_error`, replaced with `exit_code` (very small impact, since `exitCode` is not actually used anywhere in framework or easyblocks)