### PR TITLE
relax major version match regex in `find_related_easyconfigs` using for `--review-pr`

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -472,7 +472,7 @@ def find_related_easyconfigs(path, ec):
     if len(parsed_version) >= 2:
         version_patterns.append(r'%s\.%s\.\w+' % tuple(parsed_version[:2]))  # major/minor version match
     if parsed_version != parsed_version[0]:
-        version_patterns.append(r'%s\.[\d-]+\.\w+' % parsed_version[0])  # major version match
+        version_patterns.append(r'%s\.[\d-]+(\.\w+)*' % parsed_version[0])  # major version match
     version_patterns.append(r'[\w.]+')  # any version
 
     regexes = []


### PR DESCRIPTION
motivated by discussion on slack where `eb --review-pr 19271` is showing only a very old related easyconfig, because it's the only one that has a .patch (as in major.minor.patch) version component