### PR TITLE
eliminate duplicate multideps from generated module files

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -666,7 +666,7 @@ class ModuleGenerator(object):
         if multi_deps:
             compatible_modules_txt = '\n'.join([
                 "This module is compatible with the following modules, one of each line is required:",
-            ] + ['* %s' % d for d in multi_deps])
+            ] + ['* %s' % d for d in set(multi_deps)])
             lines.extend(self._generate_section("Compatible modules", compatible_modules_txt))
 
         # Extensions (if any)

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -49,7 +49,7 @@ from easybuild.tools.config import build_option, get_module_syntax, install_path
 from easybuild.tools.filetools import convert_name, mkdir, read_file, remove_file, resolve_path, symlink, write_file
 from easybuild.tools.modules import ROOT_ENV_VAR_NAME_PREFIX, EnvironmentModulesC, Lmod, modules_tool
 from easybuild.tools.py2vs3 import string_type
-from easybuild.tools.utilities import get_subclasses, quote_str
+from easybuild.tools.utilities import get_subclasses, nub, quote_str
 
 
 _log = fancylogger.getLogger('module_generator', fname=False)
@@ -666,7 +666,7 @@ class ModuleGenerator(object):
         if multi_deps:
             compatible_modules_txt = '\n'.join([
                 "This module is compatible with the following modules, one of each line is required:",
-            ] + ['* %s' % d for d in set(multi_deps)])
+            ] + ['* %s' % d for d in nub(multi_deps)])
             lines.extend(self._generate_section("Compatible modules", compatible_modules_txt))
 
         # Extensions (if any)


### PR DESCRIPTION
When combining multi_deps with iterative builds, it generates a list with duplicates, for example: 
``` 
   /cvmfs/soft.computecanada.ca/easybuild/modules/2023/x86-64-v3/Compiler/gcccore/nlopt/2.7.1.lua:
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
help([[
Description
===========
NLopt is a free/open-source library for nonlinear optimization,
 providing a common interface for a number of different free optimization routines
 available online as well as original implementations of various other algorithms.


More information
================
 - Homepage: http://ab-initio.mit.edu/wiki/index.php/NLopt


Compatible modules
==================
This module is compatible with the following modules, one of each line is required:
* python/3.10, python/3.10, python/3.10, python/3.10, python/3.11, python/3.11, python/3.11, python/3.11
]])
``` 

This commit fixes that. 

