### PR TITLE
Allow `--review-pr-filter` to override the criteria in `find_related_easyconfigs`

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -472,7 +472,7 @@ def find_related_easyconfigs(path, ec):
     if len(parsed_version) >= 2:
         version_patterns.append(r'%s\.%s\.\w+' % tuple(parsed_version[:2]))  # major/minor version match
     if parsed_version != parsed_version[0]:
-        version_patterns.append(r'%s\.[\d-]+\.\w+' % parsed_version[0])  # major version match
+        version_patterns.append(r'%s\.[\d-]+(\.\w+)*' % parsed_version[0])  # major version match
     version_patterns.append(r'[\w.]+')  # any version
 
     regexes = []

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -653,7 +653,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None, pr
 
     elif options.review_pr:
         print(review_pr(pr=options.review_pr, colored=use_color(options.color), testing=testing,
-                        max_ecs=options.review_pr_max, filter_ecs=options.review_pr_filter))
+                        max_related_ecs=options.review_pr_max, filter_related_ecs=options.review_pr_filter))
 
     elif options.add_pr_labels:
         add_pr_labels(options.add_pr_labels)


### PR DESCRIPTION
following up from https://github.com/easybuilders/easybuild-framework/pull/4385#issuecomment-1822610979

Besides what's described in the title, this PR includes:
- the same commit as in https://github.com/easybuilders/easybuild-framework/pull/4385
- a renaming of internal variables, from `filter_ecs` to `filter_related_ecs`, to avoid confusion with the `filter_ecs` build option
- a bug fix, the pattern specified in `--review-pr-filter` should only apply to the easyconfig basename, not the full path

Marking as draft, needs further discussion