### PR TITLE
detect Fortran .mod files in GCCcore installations

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3303,6 +3303,19 @@ class EasyBlock(object):
 
         return fail_msg
 
+    def sanity_check_mod_files(self):
+        """
+        Check installation for Fortran .mod files
+        """
+        self.log.debug("Check for .mod files in install directory")
+        mod_files = glob.glob(os.path.join(self.installdir, '**', '*.mod'), recursive=True)
+
+        fail_msg = None
+        if mod_files:
+            fail_msg = ".mod files (%s) found in the installation." % ', '.join(mod_files)
+
+        return fail_msg
+
     def _sanity_check_step_common(self, custom_paths, custom_commands):
         """
         Determine sanity check paths and commands to use.
@@ -3624,6 +3637,14 @@ class EasyBlock(object):
         if linked_shared_lib_fails:
             self.log.warning("Check for required/banned linked shared libraries failed!")
             self.sanity_check_fail_msgs.append(linked_shared_lib_fails)
+
+        if self.toolchain.name in ['GCCcore']:
+            mod_files_found = self.sanity_check_mod_files()
+            if mod_files_found:
+                if build_option('fail_on_mod_files'):
+                    self.sanity_check_fail_msgs.append(mod_files_found)
+                else:
+                    print_warning(mod_files_found)
 
         # cleanup
         if self.fake_mod_data:

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -277,6 +277,7 @@ BUILD_OPTIONS_CMDLINE = {
         'enforce_checksums',
         'experimental',
         'extended_dry_run',
+        'fail_on_mod_files',
         'force',
         'generate_devel_module',
         'group_writable_installdir',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -400,6 +400,7 @@ class EasyBuildOptions(GeneralOption):
                              None, 'store_true', False),
             'extra-modules': ("List of extra modules to load after setting up the build environment",
                               'strlist', 'extend', None),
+            'fail-on-mod-files': ("Fail if .mod files are detected in a GCCcore install", None, 'store_true', False),
             'fetch': ("Allow downloading sources ignoring OS and modules tool dependencies, "
                       "implies --stop=fetch, --ignore-osdeps and ignore modules tool", None, 'store_true', False),
             'filter-deps': ("List of dependencies that you do *not* want to install with EasyBuild, "


### PR DESCRIPTION
fixes #4203

Targeting the `5.0.x` branch so I can use `**` in `glob` and that is not available in Python 2.7.

TODO:
* add a `bypass_mod_files_check` easyconfig parameter (see #4203 for an example of where we'll need this bypass)
* tests