### PR TITLE
earlier return to original directory after executing a command

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -354,6 +354,11 @@ def complete_cmd(proc, cmd, owd, start_time, cmd_log, log_ok=True, log_all=False
         sys.stdout.write(output)
     stdouterr += output
 
+    try:
+        os.chdir(owd)
+    except OSError as err:
+        raise EasyBuildError("Failed to return to %s after executing command: %s", owd, err)
+
     if with_hook:
         hooks = load_hooks(build_option('hooks'))
         run_hook_kwargs = {
@@ -365,11 +370,6 @@ def complete_cmd(proc, cmd, owd, start_time, cmd_log, log_ok=True, log_all=False
 
     if trace:
         trace_msg("command completed: exit %s, ran in %s" % (ec, time_str_since(start_time)))
-
-    try:
-        os.chdir(owd)
-    except OSError as err:
-        raise EasyBuildError("Failed to return to %s after executing command: %s", owd, err)
 
     return parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp)
 


### PR DESCRIPTION
OpenFOAM installation fails after a successful build because the hooks after the run command fail to determine the working directory. The reason is that the last working directory during the build gets deleted just before that step.

```
[...]
OMPI_CXX="g++" mpicxx -Dlinux64 -DWM_ARCH_OPTION=64 -DWM_DP -DWM_LABEL_SIZE=32 -Wall -Wextra -Wold-style-cast -Wnon-virtual-dtor -Wno-unused-parameter -Wno-invalid-offsetof -Wno-attributes -O2 -ftree-vectorize -march=native -fno-math-errno -fuse-ld=bfd
  -DNoRepository -ftemplate-depth-100 -I/vscmnt/brussel_pixiu_apps/_apps_brussel/RL8/broadwell/software/OpenFOAM/10-foss-2022a-20230119/OpenFOAM-10/src/finiteVolume/lnInclude -I/vscmnt/brussel_pixiu_apps/_apps_brussel/RL8/broadwell/software/OpenFOAM/10
-foss-2022a-20230119/OpenFOAM-10/src/dynamicMesh/lnInclude -I/vscmnt/brussel_pixiu_apps/_apps_brussel/RL8/broadwell/software/OpenFOAM/10-foss-2022a-20230119/OpenFOAM-10/src/meshTools/lnInclude -IlnInclude -I. -I/vscmnt/brussel_pixiu_apps/_apps_brussel/
RL8/broadwell/software/OpenFOAM/10-foss-2022a-20230119/OpenFOAM-10/src/OpenFOAM/lnInclude -I/vscmnt/brussel_pixiu_apps/_apps_brussel/RL8/broadwell/software/OpenFOAM/10-foss-2022a-20230119/OpenFOAM-10/src/OSspecific/POSIX/lnInclude   -fPIC -fuse-ld=bfd
-Xlinker --add-needed -Xlinker --no-as-needed /vscmnt/brussel_pixiu_apps/_apps_brussel/RL8/broadwell/software/OpenFOAM/10-foss-2022a-20230119/OpenFOAM-10/platforms/linux64GccDPInt32Opt/applications/utilities/mesh/manipulation/subsetMesh/subsetMesh.o -L
/vscmnt/brussel_pixiu_apps/_apps_brussel/RL8/broadwell/software/OpenFOAM/10-foss-2022a-20230119/OpenFOAM-10/platforms/linux64GccDPInt32Opt/lib \
    -ldynamicMesh -lgenericPatchFields -lOpenFOAM -ldl  \
     -lm -o /vscmnt/brussel_pixiu_apps/_apps_brussel/RL8/broadwell/software/OpenFOAM/10-foss-2022a-20230119/OpenFOAM-10/platforms/linux64GccDPInt32Opt/bin/subsetMesh
== 2023-11-26 03:00:19,509 build_log.py:267 INFO ... (took 54 mins 11 secs)
== ... (took 54 mins 11 secs)
== 2023-11-26 03:00:19,510 config.py:695 DEBUG software install path as specified by 'installpath' and 'subdir_software': /apps/brussel/RL8/broadwell/software
== 2023-11-26 03:00:19,510 filetools.py:2012 INFO Removing lock /apps/brussel/RL8/broadwell/software/.locks/_apps_brussel_RL8_broadwell_software_OpenFOAM_10-foss-2022a-20230119.lock...
== 2023-11-26 03:00:19,516 filetools.py:383 INFO Path /apps/brussel/RL8/broadwell/software/.locks/_apps_brussel_RL8_broadwell_software_OpenFOAM_10-foss-2022a-20230119.lock successfully removed.
== 2023-11-26 03:00:19,516 filetools.py:2016 INFO Lock removed: /apps/brussel/RL8/broadwell/software/.locks/_apps_brussel_RL8_broadwell_software_OpenFOAM_10-foss-2022a-20230119.lock
== 2023-11-26 03:00:19,587 build_log.py:171 ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:126 in __init__): Traceback (most recent call last):
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/main.py", line 135, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/framework/easyblock.py", line 4256, in build_and_install_one
    result = app.run_all_steps(run_test_cases=run_test_cases)
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/framework/easyblock.py", line 4135, in run_all_steps
    self.run_step(step_name, step_methods)
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/framework/easyblock.py", line 3970, in run_step
    step_method(self)()
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-easyblocks/easybuild/easyblocks/o/openfoam.py", line 341, in build_step
    run_cmd(cmd_tmpl % cmd, log_all=True, simple=True, log_output=True)
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/tools/run.py", line 92, in cache_aware_func
    res = func(cmd, *args, **kwargs)
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/tools/run.py", line 261, in run_cmd
    regexp=regexp, stream_output=stream_output, trace=trace, with_hook=with_hooks)
  File "/scratch/brussel/vo/000/bvo00005/vsc10001/easybuild-framework/easybuild/tools/run.py", line 362, in complete_cmd
    'work_dir': os.getcwd(),
FileNotFoundError: [Errno 2] No such file or directory
 (at easybuild/main.py:174 in build_and_install_software)
```

I suggest to change a bit the order of execution here, to make sure that we sit in an existing working directory before we call the hooks.