### PR TITLE
also run test_cases_step with --sanity-check-only

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3860,6 +3860,10 @@ class EasyBlock(object):
         """
         Run provided test cases.
         """
+        # ensure parallel is set in case check_readiness_step is skipped (e.g. with --sanity-check-only)
+        if not self.cfg['parallel']:
+            self.set_parallel()
+
         for test in self.cfg['tests']:
             change_dir(self.orig_workdir)
             if os.path.isabs(test):
@@ -3915,7 +3919,7 @@ class EasyBlock(object):
             self.log.info("Skipping %s step because of forced module-only mode", step)
             skip = True
 
-        elif sanity_check_only and step != SANITYCHECK_STEP:
+        elif sanity_check_only and step not in [SANITYCHECK_STEP, TESTCASES_STEP]:
             self.log.info("Skipping %s step because of sanity-check-only mode", step)
             skip = True
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3860,10 +3860,6 @@ class EasyBlock(object):
         """
         Run provided test cases.
         """
-        # ensure parallel is set in case check_readiness_step is skipped (e.g. with --sanity-check-only)
-        if not self.cfg['parallel']:
-            self.set_parallel()
-
         for test in self.cfg['tests']:
             change_dir(self.orig_workdir)
             if os.path.isabs(test):


### PR DESCRIPTION
the goal is to be able to run the `test_cases_step` without rebuilding/reinstalling.
it seems logical to also run it with `--sanity-check-only`?

the alternative would be to implement a `--test-cases-only` option, maybe the test cases are too big for a sanity check?

in any case, we will need to run `self.set_parallel()` before the `test_cases_step` to make sure the test cases are run with the correct number of cores. i'm not sure where would be the best place. maybe we should also run the `check_readiness_step`?