### PR TITLE
add `--module-cache-suffix` configuration setting to allow multiple (Lmod) caches

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -239,6 +239,7 @@ BUILD_OPTIONS_CMDLINE = {
         'job_polling_interval',
         'job_target_resource',
         'locks_dir',
+        'module_cache_suffix',
         'modules_footer',
         'modules_header',
         'mpi_cmd_template',

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1436,7 +1436,8 @@ class Lmod(ModulesTool):
                 # don't actually update local cache when testing, just return the cache contents
                 return stdout
             else:
-                cache_fp = os.path.join(self.USER_CACHE_DIR, 'moduleT.lua')
+                suffix = build_option('module_cache_suffix') or ''
+                cache_fp = os.path.join(self.USER_CACHE_DIR, 'moduleT%s.lua' % suffix)
                 self.log.debug("Updating Lmod spider cache %s with output from '%s'" % (cache_fp, ' '.join(cmd)))
                 cache_dir = os.path.dirname(cache_fp)
                 if not os.path.exists(cache_dir):

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -461,6 +461,9 @@ class EasyBuildOptions(GeneralOption):
                                   "environment variable and its value separated by a colon (':')",
                                   None, 'store', DEFAULT_MINIMAL_BUILD_ENV),
             'minimal-toolchains': ("Use minimal toolchain when resolving dependencies", None, 'store_true', False),
+            'module-cache-suffix': ("Suffix to add to the cache file name (before the extension) "
+                                    "when updating the modules tool cache",
+                                    None, 'store', None),
             'module-only': ("Only generate module file(s); skip all steps except for %s" % ', '.join(MODULE_ONLY_STEPS),
                             None, 'store_true', False),
             'modules-tool-version-check': ("Check version of modules tool being used", None, 'store_true', True),


### PR DESCRIPTION
This is useful when having multiple module trees (i.e. different `--installprefix`) to not overwrite the cache file of one with the other when using `--update-modules-tool-cache`. Inspired by how LMod itself creates the cache, e.g. `~/.cache/lmod/spiderT.rapids_x86_64_Linux.lua`

Actually the name is created by the default ["groupName" hook ](https://lmod.readthedocs.io/en/latest/170_hooks.html)

The logic is actually: `spiderT.${LMOD_SYSTEM_NAME}_.$(uname -m)_$(uname -s).lua`, see https://github.com/TACC/Lmod/blob/55d353b3a3a4649cbaaef18b2f00cdc017d7cc92/src/StandardPackage.lua#L88