### PR TITLE
fix `--inject-checksums` when extension specifies patch file in tuple format

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4656,8 +4656,14 @@ def inject_checksums(ecs, checksum_type):
     """
     def make_list_lines(values, indent_level):
         """Make lines for list of values."""
+        def to_str(s):
+            if isinstance(s, string_type):
+                return "'%s'" % s
+            else:
+                return str(s)
+
         line_indent = INDENT_4SPACES * indent_level
-        return [line_indent + "'%s'," % x for x in values]
+        return [line_indent + to_str(x) + ',' for x in values]
 
     def make_checksum_lines(checksums, indent_level):
         """Make lines for list of checksums."""


### PR DESCRIPTION
`make_list_lines` had a `"'%s'" % x` part where `x` is the patch entry.

However that could be a tuple (or even dict) to designate extra options such as the subdir or level where the patch should be applied. This then failed with "TypeError: not all arguments converted during string formatting"

Fix by checking the type first and add a test for this case.