### PR TITLE
make `is_rpath_wrapper` faster by only checking file contents if file is not located in subdirectory of RPATH wrapper subdirectory

### DIFF
--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -941,10 +941,11 @@ class Toolchain(object):
         """
         Check whether command at specified location already is an RPATH wrapper script rather than the actual command
         """
-        in_rpath_wrappers_dir = os.path.basename(os.path.dirname(os.path.dirname(path))) == RPATH_WRAPPERS_SUBDIR
+        if os.path.basename(os.path.dirname(os.path.dirname(path))) != RPATH_WRAPPERS_SUBDIR:
+            return False
+        # Check if `rpath_args`` is called in the file
         # need to use binary mode to read the file, since it may be an actual compiler command (which is a binary file)
-        calls_rpath_args = b'rpath_args.py $CMD' in read_file(path, mode='rb')
-        return in_rpath_wrappers_dir and calls_rpath_args
+        return b'rpath_args.py $CMD' in read_file(path, mode='rb')
 
     def prepare_rpath_wrappers(self, rpath_filter_dirs=None, rpath_include_dirs=None):
         """


### PR DESCRIPTION
Avoid uneccessary read of the FULL binary file if it cannot be an RPATH wrapper because it is in the wrong folder.