### PR TITLE
clean up uses of `getattr` and `hasattr`

### DIFF
--- a/easybuild/base/fancylogger.py
+++ b/easybuild/base/fancylogger.py
@@ -286,7 +286,7 @@ class FancyLogger(logging.getLoggerClass()):
         overwrite make record to use a fancy record (with more options)
         """
         logrecordcls = logging.LogRecord
-        if hasattr(self, 'fancyrecord') and self.fancyrecord:
+        if getattr(self, 'fancyrecord', None):
             logrecordcls = FancyLogRecord
         try:
             new_msg = str(msg)

--- a/easybuild/base/generaloption.py
+++ b/easybuild/base/generaloption.py
@@ -1031,7 +1031,7 @@ class GeneralOption(object):
         # make_init is deprecated
         if hasattr(self, 'make_init'):
             self.log.debug('main_options: make_init is deprecated. Rename function to main_options.')
-            getattr(self, 'make_init')()
+            self.make_init()
         else:
             # function names which end with _options and do not start with main or _
             reg_main_options = re.compile("^(?!_|main).*_options$")

--- a/easybuild/base/optcomplete.py
+++ b/easybuild/base/optcomplete.py
@@ -513,14 +513,15 @@ def autocomplete(parser, arg_completer=None, opt_completer=None, subcmd_complete
             if option:
                 if option.nargs > 0:
                     optarg = True
-                    if hasattr(option, 'completer'):
+                    try:
                         completer = option.completer
-                    elif option.choices:
-                        completer = ListCompleter(option.choices)
-                    elif option.type in ('string',):
-                        completer = opt_completer
-                    else:
-                        completer = NoneCompleter()
+                    except AttributeError:
+                        if option.choices:
+                            completer = ListCompleter(option.choices)
+                        elif option.type in ('string',):
+                            completer = opt_completer
+                        else:
+                            completer = NoneCompleter()
                 # Warn user at least, it could help him figure out the problem.
                 elif hasattr(option, 'completer'):
                     msg = "Error: optparse option with a completer does not take arguments: %s" % (option)
@@ -616,11 +617,9 @@ class CmdComplete(object):
     def autocomplete(self, completer=None):
         parser = OPTIONPARSER_CLASS(self.__doc__.strip())
         if hasattr(self, 'addopts'):
-            fnc = getattr(self, 'addopts')
-            fnc(parser)
+            self.addopts(parser)
 
-        if hasattr(self, 'completer'):
-            completer = getattr(self, 'completer')
+        completer = getattr(self, 'completer', completer)
 
         return autocomplete(parser, completer)
 

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -233,12 +233,13 @@ class EasyConfigFormatConfigObj(EasyConfigFormat):
             current_builtins = globals()['__builtins__']
             builtins = {}
             for name in self.PYHEADER_ALLOWED_BUILTINS:
-                if hasattr(current_builtins, name):
+                try:
                     builtins[name] = getattr(current_builtins, name)
-                elif isinstance(current_builtins, dict) and name in current_builtins:
-                    builtins[name] = current_builtins[name]
-                else:
-                    self.log.warning('No builtin %s found.' % name)
+                except AttributeError:
+                    if isinstance(current_builtins, dict) and name in current_builtins:
+                        builtins[name] = current_builtins[name]
+                    else:
+                        self.log.warning('No builtin %s found.' % name)
             global_vars['__builtins__'] = builtins
             self.log.debug("Available builtins: %s" % global_vars['__builtins__'])
 

--- a/easybuild/tools/configobj.py
+++ b/easybuild/tools/configobj.py
@@ -1254,7 +1254,7 @@ class ConfigObj(Section):
                 self.configspec = None
             return
 
-        elif getattr(infile, 'read', MISSING) is not MISSING:
+        elif hasattr(infile, 'read'):
             # This supports file like objects
             infile = infile.read() or []
             # needs splitting into lines - but needs doing *after* decoding

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -1182,10 +1182,9 @@ def avail_toolchain_opts(name, output_format=FORMAT_TXT):
 
     tc_dict = {}
     for cst in ['COMPILER_SHARED_OPTS', 'COMPILER_UNIQUE_OPTS', 'MPI_SHARED_OPTS', 'MPI_UNIQUE_OPTS']:
-        if hasattr(tc, cst):
-            opts = getattr(tc, cst)
-            if opts is not None:
-                tc_dict.update(opts)
+        opts = getattr(tc, cst, None)
+        if opts is not None:
+            tc_dict.update(opts)
 
     return generate_doc('avail_toolchain_opts_%s' % output_format, [name, tc_dict])
 

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -719,9 +719,9 @@ def setup_repo_from(git_repo, github_url, target_account, branch_name, silent=Fa
         raise EasyBuildError("Fetching branch '%s' from remote %s failed: empty result", branch_name, origin)
 
     # git checkout -b <branch>; git pull
-    if hasattr(origin.refs, branch_name):
+    try:
         origin_branch = getattr(origin.refs, branch_name)
-    else:
+    except AttributeError:
         raise EasyBuildError("Branch '%s' not found at %s", branch_name, github_url)
 
     _log.debug("Checking out branch '%s' from remote %s", branch_name, github_url)

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -1340,8 +1340,8 @@ def det_pypkg_version(pkg_name, imported_pkg, import_name=None):
             except pkg_resources.DistributionNotFound as err:
                 _log.debug("%s Python package not found: %s", pkg_name, err)
 
-    if version is None and hasattr(imported_pkg, '__version__'):
-        version = imported_pkg.__version__
+    if version is None:
+        version = getattr(imported_pkg, '__version__', None)
 
     return version
 

--- a/easybuild/tools/toolchain/linalg.py
+++ b/easybuild/tools/toolchain/linalg.py
@@ -212,9 +212,9 @@ class LinAlg(Toolchain):
         """Set BLACS related variables"""
 
         lib_map = {}
-        if hasattr(self, 'BLAS_LIB_MAP') and self.BLAS_LIB_MAP is not None:
+        if getattr(self, 'BLAS_LIB_MAP', None) is not None:
             lib_map.update(self.BLAS_LIB_MAP)
-        if hasattr(self, 'BLACS_LIB_MAP') and self.BLACS_LIB_MAP is not None:
+        if getattr(self, 'BLACS_LIB_MAP', None) is not None:
             lib_map.update(self.BLACS_LIB_MAP)
 
         # BLACS
@@ -254,11 +254,11 @@ class LinAlg(Toolchain):
             raise EasyBuildError("_set_blas_variables: SCALAPACK_LIB not set")
 
         lib_map = {}
-        if hasattr(self, 'BLAS_LIB_MAP') and self.BLAS_LIB_MAP is not None:
+        if getattr(self, 'BLAS_LIB_MAP', None) is not None:
             lib_map.update(self.BLAS_LIB_MAP)
-        if hasattr(self, 'BLACS_LIB_MAP') and self.BLACS_LIB_MAP is not None:
+        if getattr(self, 'BLACS_LIB_MAP', None) is not None:
             lib_map.update(self.BLACS_LIB_MAP)
-        if hasattr(self, 'SCALAPACK_LIB_MAP') and self.SCALAPACK_LIB_MAP is not None:
+        if getattr(self, 'SCALAPACK_LIB_MAP', None) is not None:
             lib_map.update(self.SCALAPACK_LIB_MAP)
 
         self.SCALAPACK_LIB = self.variables.nappend('LIBSCALAPACK_ONLY', [x % lib_map for x in self.SCALAPACK_LIB])

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -366,17 +366,14 @@ class SystemToolsTest(EnhancedTestCase):
         self.orig_is_readable = st.is_readable
         self.orig_read_file = st.read_file
         self.orig_run_cmd = st.run_cmd
-        self.orig_platform_dist = st.platform.dist if hasattr(st.platform, 'dist') else None
+        self.orig_platform_dist = getattr(st.platform, 'dist', None)
         self.orig_platform_uname = st.platform.uname
         self.orig_get_tool_version = st.get_tool_version
         self.orig_sys_version_info = st.sys.version_info
         self.orig_HAVE_ARCHSPEC = st.HAVE_ARCHSPEC
         self.orig_HAVE_DISTRO = st.HAVE_DISTRO
         self.orig_ETC_OS_RELEASE = st.ETC_OS_RELEASE
-        if hasattr(st, 'archspec_cpu_host'):
-            self.orig_archspec_cpu_host = st.archspec_cpu_host
-        else:
-            self.orig_archspec_cpu_host = None
+        self.orig_archspec_cpu_host = getattr(st, 'archspec_cpu_host', None)
 
     def tearDown(self):
         """Cleanup after systemtools test."""


### PR DESCRIPTION
`hasattr` is basically calling `getattr` and checking for `AttributeError`.
It also supports a default value in case the attribute is not found. Make use of that default value and catch the exception directly instead of checking `hasattr` where that makes sense.