### PR TITLE
use more recent easyblocks PR in `test_github_merge_pr`

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -4822,7 +4822,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # --merge-pr also works on easyblocks (& framework) PRs
         args = [
             '--merge-pr',
-            '2805',
+            '2995',
             '--pr-target-repo=easybuild-easyblocks',
             '-D',
             '--github-user=%s' % GITHUB_TEST_ACCOUNT,
@@ -4830,12 +4830,12 @@ class CommandLineOptionsTest(EnhancedTestCase):
         stdout, stderr = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False)
         self.assertEqual(stderr.strip(), '')
         expected_stdout = '\n'.join([
-            "Checking eligibility of easybuilders/easybuild-easyblocks PR #2805 for merging...",
+            "Checking eligibility of easybuilders/easybuild-easyblocks PR #2995 for merging...",
             "* targets develop branch: OK",
             "* test suite passes: OK",
             "* no pending change requests: OK",
-            "* approved review: OK (by ocaisa)",
-            "* milestone is set: OK (4.6.2)",
+            "* approved review: OK (by boegel)",
+            "* milestone is set: OK (4.8.1)",
             "* mergeable state is clean: PR is already merged",
             '',
             "Review OK, merging pull request!",


### PR DESCRIPTION
fix for broken test because commit status is no longer available (so `test suite passes` fails with `status: None`):

```
FAIL: test_github_merge_pr (__main__.CommandLineOptionsTest)
Test use of --merge-pr (dry run)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Volumes/work/easybuild-framework/easybuild/base/testing.py", line 97, in assertEqual
    super(TestCase, self).assertEqual(a, b)
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/unittest/case.py", line 831, in assertEqual
    assertion_func(first, second, msg=msg)
AssertionError: '* test suite passes: (status: None) => no[110 chars]way)' != ''
- * test suite passes: (status: None) => not eligible for merging!
-
- WARNING: Review indicates this PR should not be merged (use -f/--force to do so anyway)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Volumes/work/easybuild-framework/test/framework/options.py", line 4831, in test_github_merge_pr
    self.assertEqual(stderr.strip(), '')
  File "/Volumes/work/easybuild-framework/easybuild/base/testing.py", line 119, in assertEqual
    raise AssertionError("%s:\nDIFF%s:\n%s" % (msg, limit, ''.join(diff[:self.ASSERT_MAX_DIFF])))
AssertionError: '* test suite passes: (status: None) => no[110 chars]way)' != ''
- * test suite passes: (status: None) => not eligible for merging!
-
- WARNING: Review indicates this PR should not be merged (use -f/--force to do so anyway):
DIFF:
- * test suite passes: (status: None) => not eligible for merging!
-
```