### PR TITLE
Adapt VERSION_REGEXP for EnvironmentModules

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1326,7 +1326,7 @@ class EnvironmentModules(EnvironmentModulesTcl):
     COMMAND_ENVIRONMENT = 'MODULES_CMD'
     REQ_VERSION = '4.0.0'
     MAX_VERSION = None
-    VERSION_REGEXP = r'^Modules\s+Release\s+(?P<version>\d\S*)\s'
+    VERSION_REGEXP = r'^Modules\s+Release\s+(?P<version>\d[^+\s]*)(\+\S*)?\s'
 
     def __init__(self, *args, **kwargs):
         """Constructor, set Environment Modules-specific class variable values."""

--- a/test/framework/modulestool.py
+++ b/test/framework/modulestool.py
@@ -209,6 +209,21 @@ class ModulesToolTest(EnhancedTestCase):
             mt = EnvironmentModules(testing=True)
             self.assertIsInstance(mt.loaded_modules(), list)  # dummy usage
 
+            # initialize Environment Modules tool with non-official version number
+            # pass (fake) full path to 'modulecmd.tcl' via $MODULES_CMD
+            fake_path = os.path.join(self.test_installpath, 'libexec', 'modulecmd.tcl')
+            fake_modulecmd_txt = '\n'.join([
+                'puts stderr {Modules Release 5.3.1+unload-188-g14b6b59b (2023-10-21)}',
+                "puts {os.environ['FOO'] = 'foo'}",
+            ])
+            write_file(fake_path, fake_modulecmd_txt)
+            os.chmod(fake_path, stat.S_IRUSR | stat.S_IXUSR)
+            os.environ['_module_raw'] = "() {  eval `%s' bash $*`;\n}" % fake_path
+            os.environ['MODULES_CMD'] = fake_path
+            EnvironmentModules.COMMAND = fake_path
+            mt = EnvironmentModules(testing=True)
+            self.assertTrue(os.path.samefile(mt.cmd, fake_path), "%s - %s" % (mt.cmd, fake_path))
+
     def tearDown(self):
         """Testcase cleanup."""
         super(ModulesToolTest, self).tearDown()


### PR DESCRIPTION
When using an Environment Modules version built from git repository, version number contains git branch name, number of commit since last released version and commit hash.

This commit adapts VERSION_REGEXP for EnvironmentModules class to allow using development or locally adapted versions of Environment Modules with EasyBuild.

Fixes #4126