### PR TITLE
use `--all` option with EnvironmentModules v4.6+ to get available hidden modules

### DIFF
--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -220,6 +220,7 @@ class ModulesTest(EnhancedTestCase):
             self.assertIn('OpenMPI/.2.1.2-GCC-6.4.0-2.28', ms)
         elif (isinstance(self.modtool, EnvironmentModules)
                 and StrictVersion(self.modtool.version) >= StrictVersion('4.6.0')):
+            # bzip2/.1.0.6 is not there, since that's a module file in Lua syntax
             self.assertEqual(len(ms), TEST_MODULES_COUNT + 2)
             self.assertIn('toy/.0.0-deps', ms)
             self.assertIn('OpenMPI/.2.1.2-GCC-6.4.0-2.28', ms)

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -218,6 +218,11 @@ class ModulesTest(EnhancedTestCase):
             self.assertIn('bzip2/.1.0.6', ms)
             self.assertIn('toy/.0.0-deps', ms)
             self.assertIn('OpenMPI/.2.1.2-GCC-6.4.0-2.28', ms)
+        elif (isinstance(self.modtool, EnvironmentModules)
+                and StrictVersion(self.modtool.version) >= StrictVersion('4.6.0')):
+            self.assertEqual(len(ms), TEST_MODULES_COUNT + 2)
+            self.assertIn('toy/.0.0-deps', ms)
+            self.assertIn('OpenMPI/.2.1.2-GCC-6.4.0-2.28', ms)
         else:
             self.assertEqual(len(ms), TEST_MODULES_COUNT)
 


### PR DESCRIPTION
Environment Modules option "--all" was introduced in version 4.6.0 to obtain hidden modules among "module avail" results.

Update EnvironmentModules class to make use of this option to return hidden modules on "available" function like done on Lmod class.

Update "test_avail" unit test to match new results obtain with Environment Modules 4.6+