### PR TITLE
add `check_group` support for module files in Tcl syntax

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -1186,21 +1186,12 @@ class ModuleGeneratorLua(ModuleGenerator):
         :param group: string with the group name
         :param error_msg: error message to print for users outside that group
         """
-        lmod_version = self.modules_tool.version
-        min_lmod_version = '6.0.8'
+        if error_msg is None:
+            error_msg = "You are not part of '%s' group of users that have access to this software; " % group
+            error_msg += "Please consult with user support how to become a member of this group"
 
-        if LooseVersion(lmod_version) >= LooseVersion(min_lmod_version):
-            if error_msg is None:
-                error_msg = "You are not part of '%s' group of users that have access to this software; " % group
-                error_msg += "Please consult with user support how to become a member of this group"
-
-            error_msg = 'LmodError("' + error_msg + '")'
-            res = self.conditional_statement('userInGroup("%s")' % group, error_msg, negative=True)
-        else:
-            warn_msg = "Can't generate robust check in Lua modules for users belonging to group %s. "
-            warn_msg += "Lmod version not recent enough (%s), should be >= %s"
-            self.log.warning(warn_msg, group, lmod_version, min_lmod_version)
-            res = ''
+        error_msg = 'LmodError("' + error_msg + '")'
+        res = self.conditional_statement('userInGroup("%s")' % group, error_msg, negative=True)
 
         return res
 

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -757,8 +757,18 @@ class ModuleGeneratorTcl(ModuleGenerator):
         :param group: string with the group name
         :param error_msg: error message to print for users outside that group
         """
-        self.log.warning("Can't generate robust check in TCL modules for users belonging to group %s.", group)
-        return ''
+        if self.modules_tool.supports_tcl_check_group:
+            if error_msg is None:
+                error_msg = "You are not part of '%s' group of users that have access to this software; " % group
+                error_msg += "Please consult with user support how to become a member of this group"
+
+            error_msg = 'error "%s"' % error_msg
+            res = self.conditional_statement('module-info usergroups %s' % group, error_msg, negative=True)
+        else:
+            self.log.warning("Can't generate robust check in Tcl modules for users belonging to group %s.", group)
+            res = ''
+
+        return res
 
     def comment(self, msg):
         """Return string containing given message as a comment."""

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -150,6 +150,8 @@ class ModulesTool(object):
     REQ_VERSION = None
     # minimal required version to use getenv Tcl modulefile command
     REQ_VERSION_TCL_GETENV = None
+    # minimal required version to check user's group in modulefile
+    REQ_VERSION_TCL_CHECK_GROUP = None
     # deprecated version limit (support for versions below this version is deprecated)
     DEPR_VERSION = None
     # maximum version allowed (cannot include -beta or rc)
@@ -212,6 +214,7 @@ class ModulesTool(object):
         self.set_and_check_version()
         self.supports_depends_on = False
         self.supports_tcl_getenv = False
+        self.supports_tcl_check_group = False
 
     def __str__(self):
         """String representation of this ModulesTool instance."""
@@ -1321,6 +1324,7 @@ class EnvironmentModules(EnvironmentModulesTcl):
     REQ_VERSION_TCL_GETENV = '4.2.0'
     DEPR_VERSION = '4.0.0'  # needs to be set as EnvironmentModules inherits from EnvironmentModulesTcl
     MAX_VERSION = None
+    REQ_VERSION_TCL_CHECK_GROUP = '4.6.0'
     VERSION_REGEXP = r'^Modules\s+Release\s+(?P<version>\d[^+\s]*)(\+\S*)?\s'
 
     SHOW_HIDDEN_OPTION = '--all'
@@ -1349,6 +1353,7 @@ class EnvironmentModules(EnvironmentModulesTcl):
         super(EnvironmentModules, self).__init__(*args, **kwargs)
         version = LooseVersion(self.version)
         self.supports_tcl_getenv = version >= LooseVersion(self.REQ_VERSION_TCL_GETENV)
+        self.supports_tcl_check_group = version >= LooseVersion(self.REQ_VERSION_TCL_CHECK_GROUP)
 
     def check_module_function(self, allow_mismatch=False, regex=None):
         """Check whether selected module tool matches 'module' function definition."""

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -1608,6 +1608,28 @@ class ModuleGeneratorTest(EnhancedTestCase):
         # one/1.0 module was swapped for one/1.1
         self.assertEqual(loaded_mods[-2]['mod_name'], 'one/1.1')
 
+    def test_check_group(self):
+        """Test check_group method."""
+        if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
+            if self.modtool.supports_tcl_check_group:
+                expected = '\n'.join([
+                    "if { ![ module-info usergroups group_name ] } {",
+                    "    error \"mesg\"",
+                    "}",
+                    '',
+                ])
+                self.assertEqual(expected, self.modgen.check_group("group_name", error_msg="mesg"))
+            else:
+                self.assertEqual('', self.modgen.check_group("group_name", error_msg="mesg"))
+        else:
+            expected = '\n'.join([
+                'if not ( userInGroup("group_name") ) then',
+                '    LmodError("mesg")',
+                'end',
+                '',
+            ])
+            self.assertEqual(expected, self.modgen.check_group("group_name", error_msg="mesg"))
+
 
 class TclModuleGeneratorTest(ModuleGeneratorTest):
     """Test for module_generator module for Tcl syntax."""

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -57,7 +57,7 @@ from easybuild.tools.environment import modify_env
 from easybuild.tools.filetools import adjust_permissions, change_dir, copy_file, mkdir, move_file
 from easybuild.tools.filetools import read_file, remove_dir, remove_file, which, write_file
 from easybuild.tools.module_generator import ModuleGeneratorTcl
-from easybuild.tools.modules import Lmod
+from easybuild.tools.modules import EnvironmentModules, Lmod
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.utilities import nub
 from easybuild.tools.systemtools import get_shared_lib_ext
@@ -774,9 +774,29 @@ class ToyBuildTest(EnhancedTestCase):
             self.mock_stdout(False)
 
             if get_module_syntax() == 'Tcl':
-                pattern = "Can't generate robust check in TCL modules for users belonging to group %s." % group_name
-                regex = re.compile(pattern, re.M)
-                self.assertTrue(regex.search(outtxt), "Pattern '%s' found in: %s" % (regex.pattern, outtxt))
+                module_version = LooseVersion(self.modtool.version)
+                if isinstance(self.modtool, EnvironmentModules) and module_version >= LooseVersion('4.6.0'):
+                    toy_mod = os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0')
+                    toy_mod_txt = read_file(toy_mod)
+
+                    if isinstance(group, tuple):
+                        group_name = group[0]
+                        error_msg_pattern = "Hey, you're not in the '%s' group!" % group_name
+                    else:
+                        group_name = group
+                        error_msg_pattern = "You are not part of '%s' group of users" % group_name
+
+                    pattern = '\n'.join([
+                        r'^if \{ \!\[ module-info usergroups %s \] \} \{' % group_name,
+                        r'    error "%s[^"]*"' % error_msg_pattern,
+                        r'\}$',
+                    ])
+                    regex = re.compile(pattern, re.M)
+                    self.assertTrue(regex.search(outtxt), "Pattern '%s' found in: %s" % (regex.pattern, toy_mod_txt))
+                else:
+                    pattern = "Can't generate robust check in Tcl modules for users belonging to group %s." % group_name
+                    regex = re.compile(pattern, re.M)
+                    self.assertTrue(regex.search(outtxt), "Pattern '%s' found in: %s" % (regex.pattern, outtxt))
 
             elif get_module_syntax() == 'Lua':
                 toy_mod = os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0.lua')

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -779,30 +779,23 @@ class ToyBuildTest(EnhancedTestCase):
                 self.assertTrue(regex.search(outtxt), "Pattern '%s' found in: %s" % (regex.pattern, outtxt))
 
             elif get_module_syntax() == 'Lua':
-                lmod_version = os.getenv('LMOD_VERSION', 'NOT_FOUND')
-                if LooseVersion(lmod_version) >= LooseVersion('6.0.8'):
-                    toy_mod = os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0.lua')
-                    toy_mod_txt = read_file(toy_mod)
+                toy_mod = os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0.lua')
+                toy_mod_txt = read_file(toy_mod)
 
-                    if isinstance(group, tuple):
-                        group_name = group[0]
-                        error_msg_pattern = "Hey, you're not in the '%s' group!" % group_name
-                    else:
-                        group_name = group
-                        error_msg_pattern = "You are not part of '%s' group of users" % group_name
-
-                    pattern = '\n'.join([
-                        r'^if not \( userInGroup\("%s"\) \) then' % group_name,
-                        r'    LmodError\("%s[^"]*"\)' % error_msg_pattern,
-                        r'end$',
-                    ])
-                    regex = re.compile(pattern, re.M)
-                    self.assertTrue(regex.search(outtxt), "Pattern '%s' found in: %s" % (regex.pattern, toy_mod_txt))
+                if isinstance(group, tuple):
+                    group_name = group[0]
+                    error_msg_pattern = "Hey, you're not in the '%s' group!" % group_name
                 else:
-                    pattern = r"Can't generate robust check in Lua modules for users belonging to group %s. "
-                    pattern += r"Lmod version not recent enough \(%s\), should be >= 6.0.8" % lmod_version
-                    regex = re.compile(pattern % group_name, re.M)
-                    self.assertTrue(regex.search(outtxt), "Pattern '%s' found in: %s" % (regex.pattern, outtxt))
+                    group_name = group
+                    error_msg_pattern = "You are not part of '%s' group of users" % group_name
+
+                pattern = '\n'.join([
+                    r'^if not \( userInGroup\("%s"\) \) then' % group_name,
+                    r'    LmodError\("%s[^"]*"\)' % error_msg_pattern,
+                    r'end$',
+                ])
+                regex = re.compile(pattern, re.M)
+                self.assertTrue(regex.search(outtxt), "Pattern '%s' found in: %s" % (regex.pattern, toy_mod_txt))
             else:
                 self.fail("Unknown module syntax: %s" % get_module_syntax())
 


### PR DESCRIPTION
"module-info usergroups" modulefile command has been introduced on Environment Modules version 4.6.0. This commit adds support for check_group in Tcl modulefile when required module tool and version is used.