### PR TITLE
Add `--allow-unrecognized-configure-options` option

### DIFF
--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -269,6 +269,7 @@ BUILD_OPTIONS_CMDLINE = {
     False: [
         'add_system_to_minimal_toolchains',
         'allow_modules_tool_mismatch',
+        'allow_unrecognized_configure_options',
         'backup_patched_files',
         'consider_archived_easyconfigs',
         'container_build_image',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -349,6 +349,10 @@ class EasyBuildOptions(GeneralOption):
                                      'strlist', 'store', DEFAULT_ALLOW_LOADED_MODULES),
             'allow-modules-tool-mismatch': ("Allow mismatch of modules tool and definition of 'module' function",
                                             None, 'store_true', False),
+            'allow-unrecognized-configure-options': ("Allow builds with unrecognized arguments passed to ./configure "
+                                                     "(NOT RECOMMENDED! It might hide actual errors e.g. "
+                                                     "misspelling of intended or changed options)",
+                                                     None, 'store_true', False),
             'allow-use-as-root-and-accept-consequences': ("Allow using of EasyBuild as root (NOT RECOMMENDED!)",
                                                           None, 'store_true', False),
             'backup-modules': ("Back up an existing module file, if any. Only works when using --module-only",


### PR DESCRIPTION
Intended to disable the error raised by unknown configure arguments. To be used in the ConfigureMake easyblock and potentially related ones.