### PR TITLE
switch to `run_shell_cmd` where possible in `easybuild.*` modules

### DIFF
--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -42,7 +42,7 @@ from easybuild.framework.easyconfig.easyconfig import resolve_template
 from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_EASYBLOCK_RUN_STEP, template_constant_dict
 from easybuild.tools.build_log import EasyBuildError, raise_nosupport
 from easybuild.tools.filetools import change_dir
-from easybuild.tools.run import check_async_cmd, run_cmd
+from easybuild.tools.run import check_async_cmd, run_cmd, run_shell_cmd
 
 
 def resolve_exts_filter_template(exts_filter, ext):
@@ -274,14 +274,14 @@ class Extension(object):
         elif exts_filter:
             cmd, stdin = resolve_exts_filter_template(exts_filter, self)
             # set log_ok to False so we can catch the error instead of run_cmd
-            (output, ec) = run_cmd(cmd, log_ok=False, simple=False, regexp=False, inp=stdin)
+            cmd_res = run_shell_cmd(cmd, fail_on_error=False, stdin=stdin)
 
-            if ec:
+            if cmd_res.exit_code:
                 if stdin:
                     fail_msg = 'command "%s" (stdin: "%s") failed' % (cmd, stdin)
                 else:
                     fail_msg = 'command "%s" failed' % cmd
-                fail_msg += "; output:\n%s" % output.strip()
+                fail_msg += "; output:\n%s" % cmd_res.output.strip()
                 self.log.warning("Sanity check for '%s' extension failed: %s", self.name, fail_msg)
                 res = (False, fail_msg)
                 # keep track of all reasons of failure

--- a/easybuild/toolchains/linalg/flexiblas.py
+++ b/easybuild/toolchains/linalg/flexiblas.py
@@ -34,7 +34,7 @@ import re
 
 from easybuild.tools.toolchain.linalg import LinAlg
 
-from easybuild.tools.run import run_cmd
+from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.systemtools import get_shared_lib_ext
 
 
@@ -48,11 +48,11 @@ def det_flexiblas_backend_libs():
     # System-wide (config directory):
     #  OPENBLAS
     #    library = libflexiblas_openblas.so
-    out, _ = run_cmd("flexiblas list", simple=False, trace=False)
+    res = run_shell_cmd("flexiblas list", hidden=True)
 
     shlib_ext = get_shared_lib_ext()
     flexiblas_lib_regex = re.compile(r'library = (?P<lib>lib.*\.%s)' % shlib_ext, re.M)
-    flexiblas_libs = flexiblas_lib_regex.findall(out)
+    flexiblas_libs = flexiblas_lib_regex.findall(res.output)
 
     backend_libs = []
     for flexiblas_lib in flexiblas_libs:

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -98,7 +98,7 @@ from easybuild.tools.module_generator import ModuleGeneratorLua, avail_module_ge
 from easybuild.tools.module_naming_scheme.utilities import avail_module_naming_schemes
 from easybuild.tools.modules import Lmod
 from easybuild.tools.robot import det_robot_path
-from easybuild.tools.run import run_cmd
+from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.package.utilities import avail_package_naming_schemes
 from easybuild.tools.toolchain.compiler import DEFAULT_OPT_LEVEL, OPTARCH_MAP_CHAR, OPTARCH_SEP, Compiler
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
@@ -1893,8 +1893,9 @@ def set_tmpdir(tmpdir=None, raise_error=False):
             fd, tmptest_file = tempfile.mkstemp()
             os.close(fd)
             os.chmod(tmptest_file, 0o700)
-            if not run_cmd(tmptest_file, simple=True, log_ok=False, regexp=False, force_in_dry_run=True, trace=False,
-                           stream_output=False, with_hooks=False):
+            res = run_shell_cmd(tmptest_file, fail_on_error=False, in_dry_run=True, hidden=True, stream_output=False,
+                                with_hooks=False)
+            if res.exit_code:
                 msg = "The temporary directory (%s) does not allow to execute files. " % tempfile.gettempdir()
                 msg += "This can cause problems in the build process, consider using --tmpdir."
                 if raise_error:

--- a/easybuild/tools/package/utilities.py
+++ b/easybuild/tools/package/utilities.py
@@ -45,7 +45,7 @@ from easybuild.tools.config import build_option, get_package_naming_scheme, log_
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import change_dir, which
 from easybuild.tools.package.package_naming_scheme.pns import PackageNamingScheme
-from easybuild.tools.run import run_cmd
+from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.utilities import get_subclasses, import_available_modules
 
 
@@ -145,7 +145,7 @@ def package_with_fpm(easyblock):
     ])
     cmd = ' '.join(cmdlist)
     _log.debug("The flattened cmdlist looks like: %s", cmd)
-    run_cmd(cmdlist, log_all=True, simple=True, shell=False)
+    run_shell_cmd(cmdlist, use_bash=False)
 
     _log.info("Created %s package(s) in %s", pkgtype, workdir)
 


### PR DESCRIPTION
Only remaining usage of `run_cmd` in `easybuild.*` are those where `asynchronous=True` is used (which is not supported yet in `run_shell_cmd`)

Changes to `test_index_functions` are necessary because a `run-shell-cmd-output/*/out.txt` file located in `self.test_prefix` was making the test fail (which doesn't make sense)