### PR TITLE
deprecate `run_cmd` and `run_cmd_qa` & co, move them to `easybuild._deprecated` module

### DIFF
--- a/easybuild/_deprecated.py
+++ b/easybuild/_deprecated.py
@@ -1,0 +1,811 @@
+# #
+# Copyright 2023-2023 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+# #
+"""
+Deprecated functionality, which will be removed with next major EasyBuild version
+
+Authors:
+
+* Kenneth Hoste (Ghent University)
+"""
+import contextlib
+import functools
+import os
+import re
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime
+
+import easybuild.tools.asyncprocess as asyncprocess
+from easybuild.base import fancylogger
+from easybuild.tools.build_log import EasyBuildError, dry_run_msg, print_msg, time_str_since
+from easybuild.tools.config import ERROR, IGNORE, WARN, build_option
+from easybuild.tools.hooks import RUN_SHELL_CMD, load_hooks, run_hook
+from easybuild.tools.utilities import nub, trace_msg
+
+
+_log = fancylogger.getLogger('_deprecated', fname=False)
+
+
+errors_found_in_log = 0
+
+# default strictness level
+strictness = WARN
+
+
+CACHED_COMMANDS = [
+    "sysctl -n hw.cpufrequency_max",  # used in get_cpu_speed (OS X)
+    "sysctl -n hw.memsize",  # used in get_total_memory (OS X)
+    "sysctl -n hw.ncpu",  # used in get_avail_core_count (OS X)
+    "sysctl -n machdep.cpu.brand_string",  # used in get_cpu_model (OS X)
+    "sysctl -n machdep.cpu.vendor",  # used in get_cpu_vendor (OS X)
+    "type module",  # used in ModulesTool.check_module_function
+    "type _module_raw",  # used in EnvironmentModules.check_module_function
+    "ulimit -u",  # used in det_parallelism
+]
+
+
+def run_cmd_cache(func):
+    """Function decorator to cache (and retrieve cached) results of running commands."""
+    cache = {}
+
+    @functools.wraps(func)
+    def cache_aware_func(cmd, *args, **kwargs):
+        """Retrieve cached result of selected commands, or run specified and collect & cache result."""
+
+        # cache key is combination of command and input provided via stdin ('inp' named option)
+        key = (cmd, kwargs.get('inp', None))
+        # fetch from cache if available, cache it if it's not, but only on cmd strings
+        if isinstance(cmd, str) and key in cache:
+            _log.debug("Using cached value for command '%s': %s", cmd, cache[key])
+            return cache[key]
+        else:
+            res = func(cmd, *args, **kwargs)
+            if cmd in CACHED_COMMANDS:
+                cache[key] = res
+            return res
+
+    # expose clear/update methods of cache to wrapped function
+    cache_aware_func.clear_cache = cache.clear
+    cache_aware_func.update_cache = cache.update
+
+    return cache_aware_func
+
+
+def get_output_from_process(proc, read_size=None, asynchronous=False):
+    """
+    Get output from running process (that was opened with subprocess.Popen).
+
+    :param proc: process to get output from
+    :param read_size: number of bytes of output to read (if None: read all output)
+    :param asynchronous: get output asynchronously
+    """
+
+    if asynchronous:
+        # e=False is set to avoid raising an exception when command has completed;
+        # that's needed to ensure we get all output,
+        # see https://github.com/easybuilders/easybuild-framework/issues/3593
+        output = asyncprocess.recv_some(proc, e=False)
+    elif read_size:
+        output = proc.stdout.read(read_size)
+    else:
+        output = proc.stdout.read()
+
+    # need to be careful w.r.t. encoding since we want to obtain a string value,
+    # and the output may include non UTF-8 characters
+    # * in Python 2, .decode() returns a value of type 'unicode',
+    #   but we really want a regular 'str' value (which is also why we use 'ignore' for encoding errors)
+    # * in Python 3, .decode() returns a 'str' value when called on the 'bytes' value obtained from .read()
+    output = str(output.decode('ascii', 'ignore'))
+
+    return output
+
+
+@run_cmd_cache
+def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True, log_output=False, path=None,
+            force_in_dry_run=False, verbose=True, shell=None, trace=True, stream_output=None, asynchronous=False,
+            with_hooks=True):
+    """
+    Run specified command (in a subshell)
+    :param cmd: command to run
+    :param log_ok: only run output/exit code for failing commands (exit code non-zero)
+    :param log_all: always log command output and exit code
+    :param simple: if True, just return True/False to indicate success, else return a tuple: (output, exit_code)
+    :param inp: the input given to the command via stdin
+    :param regexp: regex used to check the output for errors;  if True it will use the default (see parse_log_for_error)
+    :param log_output: indicate whether all output of command should be logged to a separate temporary logfile
+    :param path: path to execute the command in; current working directory is used if unspecified
+    :param force_in_dry_run: force running the command during dry run
+    :param verbose: include message on running the command in dry run output
+    :param shell: allow commands to not run in a shell (especially useful for cmd lists), defaults to True
+    :param trace: print command being executed as part of trace output
+    :param stream_output: enable streaming command output to stdout
+    :param asynchronous: run command asynchronously (returns subprocess.Popen instance if set to True)
+    :param with_hooks: trigger pre/post run_shell_cmd hooks (if defined)
+    """
+
+    _log.deprecated("run_cmd is deprecated, use run_shell_cmd from easybuild.tools.run instead", '6.0')
+
+    cwd = os.getcwd()
+
+    if isinstance(cmd, str):
+        cmd_msg = cmd.strip()
+    elif isinstance(cmd, list):
+        cmd_msg = ' '.join(cmd)
+    else:
+        raise EasyBuildError("Unknown command type ('%s'): %s", type(cmd), cmd)
+
+    if shell is None:
+        shell = True
+        if isinstance(cmd, list):
+            raise EasyBuildError("When passing cmd as a list then `shell` must be set explictely! "
+                                 "Note that all elements of the list but the first are treated as arguments "
+                                 "to the shell and NOT to the command to be executed!")
+
+    if log_output or (trace and build_option('trace')):
+        # collect output of running command in temporary log file, if desired
+        fd, cmd_log_fn = tempfile.mkstemp(suffix='.log', prefix='easybuild-run_cmd-')
+        os.close(fd)
+        try:
+            cmd_log = open(cmd_log_fn, 'w')
+        except IOError as err:
+            raise EasyBuildError("Failed to open temporary log file for output of command: %s", err)
+        _log.debug('run_cmd: Output of "%s" will be logged to %s' % (cmd, cmd_log_fn))
+    else:
+        cmd_log_fn, cmd_log = None, None
+
+    # auto-enable streaming of command output under --logtostdout/-l, unless it was disabled explicitely
+    if stream_output is None and build_option('logtostdout'):
+        _log.info("Auto-enabling streaming output of '%s' command because logging to stdout is enabled", cmd_msg)
+        stream_output = True
+
+    if stream_output:
+        print_msg("(streaming) output for command '%s':" % cmd_msg)
+
+    start_time = datetime.now()
+    if trace:
+        trace_txt = "running command:\n"
+        trace_txt += "\t[started at: %s]\n" % start_time.strftime('%Y-%m-%d %H:%M:%S')
+        trace_txt += "\t[working dir: %s]\n" % (path or os.getcwd())
+        if inp:
+            trace_txt += "\t[input: %s]\n" % inp
+        trace_txt += "\t[output logged in %s]\n" % cmd_log_fn
+        trace_msg(trace_txt + '\t' + cmd_msg)
+
+    # early exit in 'dry run' mode, after printing the command that would be run (unless running the command is forced)
+    if not force_in_dry_run and build_option('extended_dry_run'):
+        if path is None:
+            path = cwd
+        if verbose:
+            dry_run_msg("  running command \"%s\"" % cmd_msg, silent=build_option('silent'))
+            dry_run_msg("  (in %s)" % path, silent=build_option('silent'))
+
+        # make sure we get the type of the return value right
+        if simple:
+            return True
+        else:
+            # output, exit code
+            return ('', 0)
+
+    try:
+        if path:
+            os.chdir(path)
+
+        _log.debug("run_cmd: running cmd %s (in %s)" % (cmd, os.getcwd()))
+    except OSError as err:
+        _log.warning("Failed to change to %s: %s" % (path, err))
+        _log.info("running cmd %s in non-existing directory, might fail!", cmd)
+
+    if cmd_log:
+        cmd_log.write("# output for command: %s\n\n" % cmd_msg)
+
+    exec_cmd = "/bin/bash"
+
+    if not shell:
+        if isinstance(cmd, list):
+            exec_cmd = None
+            cmd.insert(0, '/usr/bin/env')
+        elif isinstance(cmd, str):
+            cmd = '/usr/bin/env %s' % cmd
+        else:
+            raise EasyBuildError("Don't know how to prefix with /usr/bin/env for commands of type %s", type(cmd))
+
+    if with_hooks:
+        hooks = load_hooks(build_option('hooks'))
+        hook_res = run_hook(RUN_SHELL_CMD, hooks, pre_step_hook=True, args=[cmd], kwargs={'work_dir': os.getcwd()})
+        if isinstance(hook_res, str):
+            cmd, old_cmd = hook_res, cmd
+            _log.info("Command to run was changed by pre-%s hook: '%s' (was: '%s')", RUN_SHELL_CMD, cmd, old_cmd)
+
+    _log.info('running cmd: %s ' % cmd)
+    try:
+        proc = subprocess.Popen(cmd, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                stdin=subprocess.PIPE, close_fds=True, executable=exec_cmd)
+    except OSError as err:
+        raise EasyBuildError("run_cmd init cmd %s failed:%s", cmd, err)
+
+    if inp:
+        proc.stdin.write(inp.encode())
+    proc.stdin.close()
+
+    if asynchronous:
+        return (proc, cmd, cwd, start_time, cmd_log)
+    else:
+        return complete_cmd(proc, cmd, cwd, start_time, cmd_log, log_ok=log_ok, log_all=log_all, simple=simple,
+                            regexp=regexp, stream_output=stream_output, trace=trace, with_hook=with_hooks)
+
+
+def check_async_cmd(proc, cmd, owd, start_time, cmd_log, fail_on_error=True, output_read_size=1024, output=''):
+    """
+    Check status of command that was started asynchronously.
+
+    :param proc: subprocess.Popen instance representing asynchronous command
+    :param cmd: command being run
+    :param owd: original working directory
+    :param start_time: start time of command (datetime instance)
+    :param cmd_log: log file to print command output to
+    :param fail_on_error: raise EasyBuildError when command exited with an error
+    :param output_read_size: number of bytes to read from output
+    :param output: already collected output for this command
+
+    :result: dict value with result of the check (boolean 'done', 'exit_code', 'output')
+    """
+
+    # use small read size, to avoid waiting for a long time until sufficient output is produced
+    if output_read_size:
+        if not isinstance(output_read_size, int) or output_read_size < 0:
+            raise EasyBuildError("Number of output bytes to read should be a positive integer value (or zero)")
+        add_out = get_output_from_process(proc, read_size=output_read_size)
+        _log.debug("Additional output from asynchronous command '%s': %s" % (cmd, add_out))
+        output += add_out
+
+    exit_code = proc.poll()
+    if exit_code is None:
+        _log.debug("Asynchronous command '%s' still running..." % cmd)
+        done = False
+    else:
+        _log.debug("Asynchronous command '%s' completed!", cmd)
+        output, _ = complete_cmd(proc, cmd, owd, start_time, cmd_log, output=output,
+                                 simple=False, trace=False, log_ok=fail_on_error)
+        done = True
+
+    res = {
+        'done': done,
+        'exit_code': exit_code,
+        'output': output,
+    }
+    return res
+
+
+def complete_cmd(proc, cmd, owd, start_time, cmd_log, log_ok=True, log_all=False, simple=False,
+                 regexp=True, stream_output=None, trace=True, output='', with_hook=True):
+    """
+    Complete running of command represented by passed subprocess.Popen instance.
+
+    :param proc: subprocess.Popen instance representing running command
+    :param cmd: command being run
+    :param owd: original working directory
+    :param start_time: start time of command (datetime instance)
+    :param cmd_log: log file to print command output to
+    :param log_ok: only run output/exit code for failing commands (exit code non-zero)
+    :param log_all: always log command output and exit code
+    :param simple: if True, just return True/False to indicate success, else return a tuple: (output, exit_code)
+    :param regexp: regex used to check the output for errors;  if True it will use the default (see parse_log_for_error)
+    :param stream_output: enable streaming command output to stdout
+    :param trace: print command being executed as part of trace output
+    :param with_hook: trigger post run_shell_cmd hooks (if defined)
+    """
+    # use small read size when streaming output, to make it stream more fluently
+    # read size should not be too small though, to avoid too much overhead
+    if stream_output:
+        read_size = 128
+    else:
+        read_size = 1024 * 8
+
+    stdouterr = output
+
+    try:
+        ec = proc.poll()
+        while ec is None:
+            # need to read from time to time.
+            # - otherwise the stdout/stderr buffer gets filled and it all stops working
+            output = get_output_from_process(proc, read_size=read_size)
+            if cmd_log:
+                cmd_log.write(output)
+            if stream_output:
+                sys.stdout.write(output)
+            stdouterr += output
+            ec = proc.poll()
+
+        # read remaining data (all of it)
+        output = get_output_from_process(proc)
+    finally:
+        proc.stdout.close()
+
+    if cmd_log:
+        cmd_log.write(output)
+        cmd_log.close()
+    if stream_output:
+        sys.stdout.write(output)
+    stdouterr += output
+
+    if with_hook:
+        hooks = load_hooks(build_option('hooks'))
+        run_hook_kwargs = {
+            'exit_code': ec,
+            'output': stdouterr,
+            'work_dir': os.getcwd(),
+        }
+        run_hook(RUN_SHELL_CMD, hooks, post_step_hook=True, args=[cmd], kwargs=run_hook_kwargs)
+
+    if trace:
+        trace_msg("command completed: exit %s, ran in %s" % (ec, time_str_since(start_time)))
+
+    try:
+        os.chdir(owd)
+    except OSError as err:
+        raise EasyBuildError("Failed to return to %s after executing command: %s", owd, err)
+
+    return parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp)
+
+
+def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, regexp=True, std_qa=None, path=None,
+               maxhits=50, trace=True):
+    """
+    Run specified interactive command (in a subshell)
+    :param cmd: command to run
+    :param qa: dictionary which maps question to answers
+    :param no_qa: list of patters that are not questions
+    :param log_ok: only run output/exit code for failing commands (exit code non-zero)
+    :param log_all: always log command output and exit code
+    :param simple: if True, just return True/False to indicate success, else return a tuple: (output, exit_code)
+    :param regexp: regex used to check the output for errors; if True it will use the default (see parse_log_for_error)
+    :param std_qa: dictionary which maps question regex patterns to answers
+    :param path: path to execute the command is; current working directory is used if unspecified
+    :param maxhits: maximum number of cycles (seconds) without being able to find a known question
+    :param trace: print command being executed as part of trace output
+    """
+    cwd = os.getcwd()
+
+    if not isinstance(cmd, str) and len(cmd) > 1:
+        # We use shell=True and hence we should really pass the command as a string
+        # When using a list then every element past the first is passed to the shell itself, not the command!
+        raise EasyBuildError("The command passed must be a string!")
+
+    if log_all or (trace and build_option('trace')):
+        # collect output of running command in temporary log file, if desired
+        fd, cmd_log_fn = tempfile.mkstemp(suffix='.log', prefix='easybuild-run_cmd_qa-')
+        os.close(fd)
+        try:
+            cmd_log = open(cmd_log_fn, 'w')
+        except IOError as err:
+            raise EasyBuildError("Failed to open temporary log file for output of interactive command: %s", err)
+        _log.debug('run_cmd_qa: Output of "%s" will be logged to %s' % (cmd, cmd_log_fn))
+    else:
+        cmd_log_fn, cmd_log = None, None
+
+    start_time = datetime.now()
+    if trace:
+        trace_txt = "running interactive command:\n"
+        trace_txt += "\t[started at: %s]\n" % start_time.strftime('%Y-%m-%d %H:%M:%S')
+        trace_txt += "\t[working dir: %s]\n" % (path or os.getcwd())
+        trace_txt += "\t[output logged in %s]\n" % cmd_log_fn
+        trace_msg(trace_txt + '\t' + cmd.strip())
+
+    # early exit in 'dry run' mode, after printing the command that would be run
+    if build_option('extended_dry_run'):
+        if path is None:
+            path = cwd
+        dry_run_msg("  running interactive command \"%s\"" % cmd, silent=build_option('silent'))
+        dry_run_msg("  (in %s)" % path, silent=build_option('silent'))
+        if cmd_log:
+            cmd_log.close()
+        if simple:
+            return True
+        else:
+            # output, exit code
+            return ('', 0)
+
+    try:
+        if path:
+            os.chdir(path)
+
+        _log.debug("run_cmd_qa: running cmd %s (in %s)" % (cmd, os.getcwd()))
+    except OSError as err:
+        _log.warning("Failed to change to %s: %s" % (path, err))
+        _log.info("running cmd %s in non-existing directory, might fail!" % cmd)
+
+    # Part 1: process the QandA dictionary
+    # given initial set of Q and A (in dict), return dict of reg. exp. and A
+    #
+    # make regular expression that matches the string with
+    # - replace whitespace
+    # - replace newline
+
+    def escape_special(string):
+        return re.sub(r"([\+\?\(\)\[\]\*\.\\\$])", r"\\\1", string)
+
+    split = r'[\s\n]+'
+    regSplit = re.compile(r"" + split)
+
+    def process_QA(q, a_s):
+        splitq = [escape_special(x) for x in regSplit.split(q)]
+        regQtxt = split.join(splitq) + split.rstrip('+') + "*$"
+        # add optional split at the end
+        for i in [idx for idx, a in enumerate(a_s) if not a.endswith('\n')]:
+            a_s[i] += '\n'
+        regQ = re.compile(r"" + regQtxt)
+        if regQ.search(q):
+            return (a_s, regQ)
+        else:
+            raise EasyBuildError("runqanda: Question %s converted in %s does not match itself", q, regQtxt)
+
+    def check_answers_list(answers):
+        """Make sure we have a list of answers (as strings)."""
+        if isinstance(answers, str):
+            answers = [answers]
+        elif not isinstance(answers, list):
+            if cmd_log:
+                cmd_log.close()
+            raise EasyBuildError("Invalid type for answer on %s, no string or list: %s (%s)",
+                                 question, type(answers), answers)
+        # list is manipulated when answering matching question, so return a copy
+        return answers[:]
+
+    new_qa = {}
+    _log.debug("new_qa: ")
+    for question, answers in qa.items():
+        answers = check_answers_list(answers)
+        (answers, regQ) = process_QA(question, answers)
+        new_qa[regQ] = answers
+        _log.debug("new_qa[%s]: %s" % (regQ.pattern, new_qa[regQ]))
+
+    new_std_qa = {}
+    if std_qa:
+        for question, answers in std_qa.items():
+            regQ = re.compile(r"" + question + r"[\s\n]*$")
+            answers = check_answers_list(answers)
+            for i in [idx for idx, a in enumerate(answers) if not a.endswith('\n')]:
+                answers[i] += '\n'
+            new_std_qa[regQ] = answers
+            _log.debug("new_std_qa[%s]: %s" % (regQ.pattern, new_std_qa[regQ]))
+
+    new_no_qa = []
+    if no_qa:
+        # simple statements, can contain wildcards
+        new_no_qa = [re.compile(r"" + x + r"[\s\n]*$") for x in no_qa]
+
+    _log.debug("New noQandA list is: %s" % [x.pattern for x in new_no_qa])
+
+    # Part 2: Run the command and answer questions
+    # - this needs asynchronous stdout
+
+    hooks = load_hooks(build_option('hooks'))
+    run_hook_kwargs = {
+        'interactive': True,
+        'work_dir': os.getcwd(),
+    }
+    hook_res = run_hook(RUN_SHELL_CMD, hooks, pre_step_hook=True, args=[cmd], kwargs=run_hook_kwargs)
+    if isinstance(hook_res, str):
+        cmd, old_cmd = hook_res, cmd
+        _log.info("Interactive command to run was changed by pre-%s hook: '%s' (was: '%s')",
+                  RUN_SHELL_CMD, cmd, old_cmd)
+
+    # # Log command output
+    if cmd_log:
+        cmd_log.write("# output for interactive command: %s\n\n" % cmd)
+
+    # Make sure we close the proc handles and the cmd_log file
+    @contextlib.contextmanager
+    def get_proc():
+        try:
+            proc = asyncprocess.Popen(cmd, shell=True, stdout=asyncprocess.PIPE, stderr=asyncprocess.STDOUT,
+                                      stdin=asyncprocess.PIPE, close_fds=True, executable='/bin/bash')
+        except OSError as err:
+            if cmd_log:
+                cmd_log.close()
+            raise EasyBuildError("run_cmd_qa init cmd %s failed:%s", cmd, err)
+        try:
+            yield proc
+        finally:
+            if proc.stdout:
+                proc.stdout.close()
+            if proc.stdin:
+                proc.stdin.close()
+            if cmd_log:
+                cmd_log.close()
+
+    with get_proc() as proc:
+        ec = proc.poll()
+        stdout_err = ''
+        old_len_out = -1
+        hit_count = 0
+
+        while ec is None:
+            # need to read from time to time.
+            # - otherwise the stdout/stderr buffer gets filled and it all stops working
+            try:
+                out = get_output_from_process(proc, asynchronous=True)
+
+                if cmd_log:
+                    cmd_log.write(out)
+                stdout_err += out
+            # recv_some used by get_output_from_process for getting asynchronous output may throw exception
+            except (IOError, Exception) as err:
+                _log.debug("run_cmd_qa cmd %s: read failed: %s", cmd, err)
+                out = None
+
+            hit = False
+            for question, answers in new_qa.items():
+                res = question.search(stdout_err)
+                if out and res:
+                    fa = answers[0] % res.groupdict()
+                    # cycle through list of answers
+                    last_answer = answers.pop(0)
+                    answers.append(last_answer)
+                    _log.debug("List of answers for question %s after cycling: %s", question.pattern, answers)
+
+                    _log.debug("run_cmd_qa answer %s question %s out %s", fa, question.pattern, stdout_err[-50:])
+                    asyncprocess.send_all(proc, fa)
+                    hit = True
+                    break
+            if not hit:
+                for question, answers in new_std_qa.items():
+                    res = question.search(stdout_err)
+                    if out and res:
+                        fa = answers[0] % res.groupdict()
+                        # cycle through list of answers
+                        last_answer = answers.pop(0)
+                        answers.append(last_answer)
+                        _log.debug("List of answers for question %s after cycling: %s", question.pattern, answers)
+
+                        _log.debug("run_cmd_qa answer %s std question %s out %s",
+                                   fa, question.pattern, stdout_err[-50:])
+                        asyncprocess.send_all(proc, fa)
+                        hit = True
+                        break
+                if not hit:
+                    if len(stdout_err) > old_len_out:
+                        old_len_out = len(stdout_err)
+                    else:
+                        noqa = False
+                        for r in new_no_qa:
+                            if r.search(stdout_err):
+                                _log.debug("runqanda: noQandA found for out %s", stdout_err[-50:])
+                                noqa = True
+                        if not noqa:
+                            hit_count += 1
+                else:
+                    hit_count = 0
+            else:
+                hit_count = 0
+
+            if hit_count > maxhits:
+                # explicitly kill the child process before exiting
+                try:
+                    os.killpg(proc.pid, signal.SIGKILL)
+                    os.kill(proc.pid, signal.SIGKILL)
+                except OSError as err:
+                    _log.debug("run_cmd_qa exception caught when killing child process: %s", err)
+                _log.debug("run_cmd_qa: full stdouterr: %s", stdout_err)
+                raise EasyBuildError("run_cmd_qa: cmd %s : Max nohits %s reached: end of output %s",
+                                     cmd, maxhits, stdout_err[-500:])
+
+            # the sleep below is required to avoid exiting on unknown 'questions' too early (see above)
+            time.sleep(1)
+            ec = proc.poll()
+
+        # Process stopped. Read all remaining data
+        try:
+            if proc.stdout:
+                out = get_output_from_process(proc)
+                stdout_err += out
+                if cmd_log:
+                    cmd_log.write(out)
+        except IOError as err:
+            _log.debug("runqanda cmd %s: remaining data read failed: %s", cmd, err)
+
+    run_hook_kwargs.update({
+        'interactive': True,
+        'exit_code': ec,
+        'output': stdout_err,
+    })
+    run_hook(RUN_SHELL_CMD, hooks, post_step_hook=True, args=[cmd], kwargs=run_hook_kwargs)
+
+    if trace:
+        trace_msg("interactive command completed: exit %s, ran in %s" % (ec, time_str_since(start_time)))
+
+    try:
+        os.chdir(cwd)
+    except OSError as err:
+        raise EasyBuildError("Failed to return to %s after executing command: %s", cwd, err)
+
+    return parse_cmd_output(cmd, stdout_err, ec, simple, log_all, log_ok, regexp)
+
+
+def parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp):
+    """
+    Parse command output and construct return value.
+    :param cmd: executed command
+    :param stdouterr: combined stdout/stderr of executed command
+    :param ec: exit code of executed command
+    :param simple: if True, just return True/False to indicate success, else return a tuple: (output, exit_code)
+    :param log_all: always log command output and exit code
+    :param log_ok: only run output/exit code for failing commands (exit code non-zero)
+    :param regexp: regex used to check the output for errors; if True it will use the default (see parse_log_for_error)
+    """
+    if strictness == IGNORE:
+        check_ec = False
+        fail_on_error_match = False
+    elif strictness == WARN:
+        check_ec = True
+        fail_on_error_match = False
+    elif strictness == ERROR:
+        check_ec = True
+        fail_on_error_match = True
+    else:
+        raise EasyBuildError("invalid strictness setting: %s", strictness)
+
+    # allow for overriding the regexp setting
+    if not regexp:
+        fail_on_error_match = False
+
+    if ec and (log_all or log_ok):
+        # We don't want to error if the user doesn't care
+        if check_ec:
+            raise EasyBuildError('cmd "%s" exited with exit code %s and output:\n%s', cmd, ec, stdouterr)
+        else:
+            _log.warning('cmd "%s" exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
+    elif not ec:
+        if log_all:
+            _log.info('cmd "%s" exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
+        else:
+            _log.debug('cmd "%s" exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
+
+    # parse the stdout/stderr for errors when strictness dictates this or when regexp is passed in
+    if fail_on_error_match or regexp:
+        res = parse_log_for_error(stdouterr, regexp, stdout=False)
+        if res:
+            errors = "\n\t" + "\n\t".join([r[0] for r in res])
+            error_str = "error" if len(res) == 1 else "errors"
+            if fail_on_error_match:
+                raise EasyBuildError("Found %s %s in output of %s:%s", len(res), error_str, cmd, errors)
+            else:
+                _log.warning("Found %s potential %s (some may be harmless) in output of %s:%s",
+                             len(res), error_str, cmd, errors)
+
+    if simple:
+        if ec:
+            # If the user does not care -> will return true
+            return not check_ec
+        else:
+            return True
+    else:
+        # Because we are not running in simple mode, we return the output and ec to the user
+        return (stdouterr, ec)
+
+
+def parse_log_for_error(txt, regExp=None, stdout=True, msg=None):
+    """
+    txt is multiline string.
+    - in memory
+    regExp is a one-line regular expression
+    - default
+    """
+    global errors_found_in_log
+
+    if regExp and isinstance(regExp, bool):
+        regExp = r"(?<![(,-]|\w)(?:error|segmentation fault|failed)(?![(,-]|\.?\w)"
+        _log.debug('Using default regular expression: %s' % regExp)
+    elif isinstance(regExp, str):
+        pass
+    else:
+        raise EasyBuildError("parse_log_for_error no valid regExp used: %s", regExp)
+
+    reg = re.compile(regExp, re.I)
+
+    res = []
+    for line in txt.split('\n'):
+        r = reg.search(line)
+        if r:
+            res.append([line, r.groups()])
+            errors_found_in_log += 1
+
+    if stdout and res:
+        if msg:
+            _log.info("parse_log_for_error msg: %s" % msg)
+        _log.info("parse_log_for_error (some may be harmless) regExp %s found:\n%s" %
+                  (regExp, '\n'.join([x[0] for x in res])))
+
+    return res
+
+
+def extract_errors_from_log(log_txt, reg_exps):
+    """
+    Check provided string (command output) for messages matching specified regular expressions,
+    and return 2-tuple with list of warnings and errors.
+    :param log_txt: String containing the log, will be split into individual lines
+    :param reg_exps: List of: regular expressions (as strings) to error on,
+                    or tuple of regular expression and action (any of [IGNORE, WARN, ERROR])
+    :return: (warnings, errors) as lists of lines containing a match
+    """
+    actions = (IGNORE, WARN, ERROR)
+
+    # promote single string value to list, since code below expects a list
+    if isinstance(reg_exps, str):
+        reg_exps = [reg_exps]
+
+    re_tuples = []
+    for cur in reg_exps:
+        try:
+            if isinstance(cur, str):
+                # use ERROR as default action if only regexp pattern is specified
+                reg_exp, action = cur, ERROR
+            elif isinstance(cur, tuple) and len(cur) == 2:
+                reg_exp, action = cur
+            else:
+                raise TypeError("Incorrect type of value, expected string or 2-tuple")
+
+            if not isinstance(reg_exp, str):
+                raise TypeError("Regular expressions must be passed as string, got %s" % type(reg_exp))
+            if action not in actions:
+                raise TypeError("action must be one of %s, got %s" % (actions, action))
+
+            re_tuples.append((re.compile(reg_exp), action))
+        except Exception as err:
+            raise EasyBuildError("Invalid input: No regexp or tuple of regexp and action '%s': %s", str(cur), err)
+
+    warnings = []
+    errors = []
+    for line in log_txt.split('\n'):
+        for reg_exp, action in re_tuples:
+            if reg_exp.search(line):
+                if action == ERROR:
+                    errors.append(line)
+                elif action == WARN:
+                    warnings.append(line)
+                break
+    return nub(warnings), nub(errors)
+
+
+def check_log_for_errors(log_txt, reg_exps):
+    """
+    Check log_txt for messages matching regExps in order and do appropriate action
+    :param log_txt: String containing the log, will be split into individual lines
+    :param reg_exps: List of: regular expressions (as strings) to error on,
+                    or tuple of regular expression and action (any of [IGNORE, WARN, ERROR])
+    """
+    global errors_found_in_log
+    warnings, errors = extract_errors_from_log(log_txt, reg_exps)
+
+    errors_found_in_log += len(warnings) + len(errors)
+    if warnings:
+        _log.warning("Found %s potential error(s) in command output:\n\t%s",
+                     len(warnings), "\n\t".join(warnings))
+    if errors:
+        raise EasyBuildError("Found %s error(s) in command output:\n\t%s",
+                             len(errors), "\n\t".join(errors))

--- a/easybuild/base/fancylogger.py
+++ b/easybuild/base/fancylogger.py
@@ -345,7 +345,7 @@ class FancyLogger(logging.getLoggerClass()):
         if loose_cv.version[:depth] >= loose_mv.version[:depth]:
             self.raiseException("DEPRECATED (since v%s) functionality used: %s" % (max_ver, msg), exception=exception)
         else:
-            deprecation_msg = "Deprecated functionality, will no longer work in v%s: %s" % (max_ver, msg)
+            deprecation_msg = "Deprecated functionality, will no longer work in EasyBuild v%s: %s" % (max_ver, msg)
             log_callback(deprecation_msg)
 
     def _handleFunction(self, function, levelno, **kwargs):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4246,7 +4246,6 @@ def build_and_install_one(ecdict, init_env):
 
     # restore original environment, and then sanitize it
     _log.info("Resetting environment")
-    run.errors_found_in_log = 0
     restore_env(init_env)
     sanitize_env()
 
@@ -4448,11 +4447,6 @@ def build_and_install_one(ecdict, init_env):
 
     req_time = time2str(end_timestamp - start_timestamp)
     print_msg("%s: Installation %s %s (took %s)" % (summary, ended, succ, req_time), log=_log, silent=silent)
-
-    # check for errors
-    if run.errors_found_in_log > 0:
-        _log.warning("%d possible error(s) were detected in the "
-                     "build logs, please verify the build.", run.errors_found_in_log)
 
     if app.postmsg:
         print_msg("\nWARNING: %s\n" % app.postmsg, log=_log, silent=silent)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -68,7 +68,7 @@ from easybuild.framework.easyconfig.style import MAX_LINE_LENGTH
 from easybuild.framework.easyconfig.tools import dump_env_easyblock, get_paths_for
 from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_EASYBLOCK_RUN_STEP, template_constant_dict
 from easybuild.framework.extension import Extension, resolve_exts_filter_template
-from easybuild.tools import LooseVersion, config, run
+from easybuild.tools import LooseVersion, config
 from easybuild.tools.build_details import get_build_stats
 from easybuild.tools.build_log import EasyBuildError, dry_run_msg, dry_run_warning, dry_run_set_dirs
 from easybuild.tools.build_log import print_error, print_msg, print_warning

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -55,7 +55,7 @@ CURRENT_VERSION = VERSION
 # allow some experimental experimental code
 EXPERIMENTAL = False
 
-DEPRECATED_DOC_URL = 'http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html'
+DEPRECATED_DOC_URL = 'https://docs.easybuild.io/deprecated-functionality'
 
 DRY_RUN_BUILD_DIR = None
 DRY_RUN_SOFTWARE_INSTALL_DIR = None

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -35,37 +35,31 @@ Authors:
 * Toon Willems (Ghent University)
 * Ward Poelmans (Ghent University)
 """
-import contextlib
 import functools
 import inspect
 import os
-import re
-import signal
 import subprocess
 import sys
 import tempfile
-import time
 from collections import namedtuple
 from datetime import datetime
 
-import easybuild.tools.asyncprocess as asyncprocess
+# import deprecated functions so they can still be imported from easybuild.tools.run for now
+from easybuild._deprecated import check_async_cmd, check_log_for_errors, complete_cmd, extract_errors_from_log  # noqa
+from easybuild._deprecated import get_output_from_process, parse_cmd_output, parse_log_for_error, run_cmd  # noqa
+from easybuild._deprecated import run_cmd_cache, run_cmd_qa  # noqa
+
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError, dry_run_msg, print_msg, time_str_since
-from easybuild.tools.config import ERROR, IGNORE, WARN, build_option
+from easybuild.tools.config import build_option
 from easybuild.tools.hooks import RUN_SHELL_CMD, load_hooks, run_hook
-from easybuild.tools.utilities import nub, trace_msg
+from easybuild.tools.utilities import trace_msg
 
 
 _log = fancylogger.getLogger('run', fname=False)
 
 
-errors_found_in_log = 0
-
-# default strictness level
-strictness = WARN
-
-
-CACHED_COMMANDS = [
+CACHED_COMMANDS = (
     "sysctl -n hw.cpufrequency_max",  # used in get_cpu_speed (OS X)
     "sysctl -n hw.memsize",  # used in get_total_memory (OS X)
     "sysctl -n hw.ncpu",  # used in get_avail_core_count (OS X)
@@ -74,7 +68,7 @@ CACHED_COMMANDS = [
     "type module",  # used in ModulesTool.check_module_function
     "type _module_raw",  # used in EnvironmentModules.check_module_function
     "ulimit -u",  # used in det_parallelism
-]
+)
 
 
 RunShellCmdResult = namedtuple('RunShellCmdResult', ('cmd', 'exit_code', 'output', 'stderr', 'work_dir',
@@ -142,7 +136,7 @@ def raise_run_shell_cmd_error(cmd_res):
     # need to go 3 levels down:
     # 1) this function
     # 2) run_shell_cmd function
-    # 3) run_cmd_cache decorator
+    # 3) run_shell_cmd_cache decorator
     # 4) actual caller site
     frameinfo = inspect.getouterframes(inspect.currentframe())[3]
     caller_info = (frameinfo.filename, frameinfo.lineno, frameinfo.function)
@@ -150,15 +144,15 @@ def raise_run_shell_cmd_error(cmd_res):
     raise RunShellCmdError(cmd_res, caller_info)
 
 
-def run_cmd_cache(func):
+def run_shell_cmd_cache(func):
     """Function decorator to cache (and retrieve cached) results of running commands."""
     cache = {}
 
     @functools.wraps(func)
     def cache_aware_func(cmd, *args, **kwargs):
         """Retrieve cached result of selected commands, or run specified and collect & cache result."""
-        # cache key is combination of command and input provided via stdin ('stdin' for run, 'inp' for run_cmd)
-        key = (cmd, kwargs.get('stdin', None) or kwargs.get('inp', None))
+        # cache key is combination of command and input provided via stdin
+        key = (cmd, kwargs.get('stdin', None))
         # fetch from cache if available, cache it if it's not, but only on cmd strings
         if isinstance(cmd, str) and key in cache:
             _log.debug("Using cached value for command '%s': %s", cmd, cache[key])
@@ -174,9 +168,6 @@ def run_cmd_cache(func):
     cache_aware_func.update_cache = cache.update
 
     return cache_aware_func
-
-
-run_shell_cmd_cache = run_cmd_cache
 
 
 @run_shell_cmd_cache
@@ -245,10 +236,10 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
         os.makedirs(toptmpdir, exist_ok=True)
         tmpdir = tempfile.mkdtemp(dir=toptmpdir, prefix=f'{cmd_name}-')
         cmd_out_fp = os.path.join(tmpdir, 'out.txt')
-        _log.info(f'run_cmd: Output of "{cmd_str}" will be logged to {cmd_out_fp}')
+        _log.info(f'run_shell_cmd: Output of "{cmd_str}" will be logged to {cmd_out_fp}')
         if split_stderr:
             cmd_err_fp = os.path.join(tmpdir, 'err.txt')
-            _log.info(f'run_cmd: Errors and warnings of "{cmd_str}" will be logged to {cmd_err_fp}')
+            _log.info(f'run_shell_cmd: Errors and warnings of "{cmd_str}" will be logged to {cmd_err_fp}')
         else:
             cmd_err_fp = None
     else:
@@ -395,717 +386,6 @@ def cmd_trace_msg(cmd, start_time, work_dir, stdin, cmd_out_fp, cmd_err_fp):
     lines.append('\t' + cmd)
 
     trace_msg('\n'.join(lines))
-
-
-def get_output_from_process(proc, read_size=None, asynchronous=False):
-    """
-    Get output from running process (that was opened with subprocess.Popen).
-
-    :param proc: process to get output from
-    :param read_size: number of bytes of output to read (if None: read all output)
-    :param asynchronous: get output asynchronously
-    """
-
-    if asynchronous:
-        # e=False is set to avoid raising an exception when command has completed;
-        # that's needed to ensure we get all output,
-        # see https://github.com/easybuilders/easybuild-framework/issues/3593
-        output = asyncprocess.recv_some(proc, e=False)
-    elif read_size:
-        output = proc.stdout.read(read_size)
-    else:
-        output = proc.stdout.read()
-
-    # need to be careful w.r.t. encoding since we want to obtain a string value,
-    # and the output may include non UTF-8 characters
-    # * in Python 2, .decode() returns a value of type 'unicode',
-    #   but we really want a regular 'str' value (which is also why we use 'ignore' for encoding errors)
-    # * in Python 3, .decode() returns a 'str' value when called on the 'bytes' value obtained from .read()
-    output = str(output.decode('ascii', 'ignore'))
-
-    return output
-
-
-@run_cmd_cache
-def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True, log_output=False, path=None,
-            force_in_dry_run=False, verbose=True, shell=None, trace=True, stream_output=None, asynchronous=False,
-            with_hooks=True):
-    """
-    Run specified command (in a subshell)
-    :param cmd: command to run
-    :param log_ok: only run output/exit code for failing commands (exit code non-zero)
-    :param log_all: always log command output and exit code
-    :param simple: if True, just return True/False to indicate success, else return a tuple: (output, exit_code)
-    :param inp: the input given to the command via stdin
-    :param regexp: regex used to check the output for errors;  if True it will use the default (see parse_log_for_error)
-    :param log_output: indicate whether all output of command should be logged to a separate temporary logfile
-    :param path: path to execute the command in; current working directory is used if unspecified
-    :param force_in_dry_run: force running the command during dry run
-    :param verbose: include message on running the command in dry run output
-    :param shell: allow commands to not run in a shell (especially useful for cmd lists), defaults to True
-    :param trace: print command being executed as part of trace output
-    :param stream_output: enable streaming command output to stdout
-    :param asynchronous: run command asynchronously (returns subprocess.Popen instance if set to True)
-    :param with_hooks: trigger pre/post run_shell_cmd hooks (if defined)
-    """
-    cwd = os.getcwd()
-
-    if isinstance(cmd, str):
-        cmd_msg = cmd.strip()
-    elif isinstance(cmd, list):
-        cmd_msg = ' '.join(cmd)
-    else:
-        raise EasyBuildError("Unknown command type ('%s'): %s", type(cmd), cmd)
-
-    if shell is None:
-        shell = True
-        if isinstance(cmd, list):
-            raise EasyBuildError("When passing cmd as a list then `shell` must be set explictely! "
-                                 "Note that all elements of the list but the first are treated as arguments "
-                                 "to the shell and NOT to the command to be executed!")
-
-    if log_output or (trace and build_option('trace')):
-        # collect output of running command in temporary log file, if desired
-        fd, cmd_log_fn = tempfile.mkstemp(suffix='.log', prefix='easybuild-run_cmd-')
-        os.close(fd)
-        try:
-            cmd_log = open(cmd_log_fn, 'w')
-        except IOError as err:
-            raise EasyBuildError("Failed to open temporary log file for output of command: %s", err)
-        _log.debug('run_cmd: Output of "%s" will be logged to %s' % (cmd, cmd_log_fn))
-    else:
-        cmd_log_fn, cmd_log = None, None
-
-    # auto-enable streaming of command output under --logtostdout/-l, unless it was disabled explicitely
-    if stream_output is None and build_option('logtostdout'):
-        _log.info("Auto-enabling streaming output of '%s' command because logging to stdout is enabled", cmd_msg)
-        stream_output = True
-
-    if stream_output:
-        print_msg("(streaming) output for command '%s':" % cmd_msg)
-
-    start_time = datetime.now()
-    if trace:
-        trace_txt = "running command:\n"
-        trace_txt += "\t[started at: %s]\n" % start_time.strftime('%Y-%m-%d %H:%M:%S')
-        trace_txt += "\t[working dir: %s]\n" % (path or os.getcwd())
-        if inp:
-            trace_txt += "\t[input: %s]\n" % inp
-        trace_txt += "\t[output logged in %s]\n" % cmd_log_fn
-        trace_msg(trace_txt + '\t' + cmd_msg)
-
-    # early exit in 'dry run' mode, after printing the command that would be run (unless running the command is forced)
-    if not force_in_dry_run and build_option('extended_dry_run'):
-        if path is None:
-            path = cwd
-        if verbose:
-            dry_run_msg("  running command \"%s\"" % cmd_msg, silent=build_option('silent'))
-            dry_run_msg("  (in %s)" % path, silent=build_option('silent'))
-
-        # make sure we get the type of the return value right
-        if simple:
-            return True
-        else:
-            # output, exit code
-            return ('', 0)
-
-    try:
-        if path:
-            os.chdir(path)
-
-        _log.debug("run_cmd: running cmd %s (in %s)" % (cmd, os.getcwd()))
-    except OSError as err:
-        _log.warning("Failed to change to %s: %s" % (path, err))
-        _log.info("running cmd %s in non-existing directory, might fail!", cmd)
-
-    if cmd_log:
-        cmd_log.write("# output for command: %s\n\n" % cmd_msg)
-
-    exec_cmd = "/bin/bash"
-
-    if not shell:
-        if isinstance(cmd, list):
-            exec_cmd = None
-            cmd.insert(0, '/usr/bin/env')
-        elif isinstance(cmd, str):
-            cmd = '/usr/bin/env %s' % cmd
-        else:
-            raise EasyBuildError("Don't know how to prefix with /usr/bin/env for commands of type %s", type(cmd))
-
-    if with_hooks:
-        hooks = load_hooks(build_option('hooks'))
-        hook_res = run_hook(RUN_SHELL_CMD, hooks, pre_step_hook=True, args=[cmd], kwargs={'work_dir': os.getcwd()})
-        if isinstance(hook_res, str):
-            cmd, old_cmd = hook_res, cmd
-            _log.info("Command to run was changed by pre-%s hook: '%s' (was: '%s')", RUN_SHELL_CMD, cmd, old_cmd)
-
-    _log.info('running cmd: %s ' % cmd)
-    try:
-        proc = subprocess.Popen(cmd, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                                stdin=subprocess.PIPE, close_fds=True, executable=exec_cmd)
-    except OSError as err:
-        raise EasyBuildError("run_cmd init cmd %s failed:%s", cmd, err)
-
-    if inp:
-        proc.stdin.write(inp.encode())
-    proc.stdin.close()
-
-    if asynchronous:
-        return (proc, cmd, cwd, start_time, cmd_log)
-    else:
-        return complete_cmd(proc, cmd, cwd, start_time, cmd_log, log_ok=log_ok, log_all=log_all, simple=simple,
-                            regexp=regexp, stream_output=stream_output, trace=trace, with_hook=with_hooks)
-
-
-def check_async_cmd(proc, cmd, owd, start_time, cmd_log, fail_on_error=True, output_read_size=1024, output=''):
-    """
-    Check status of command that was started asynchronously.
-
-    :param proc: subprocess.Popen instance representing asynchronous command
-    :param cmd: command being run
-    :param owd: original working directory
-    :param start_time: start time of command (datetime instance)
-    :param cmd_log: log file to print command output to
-    :param fail_on_error: raise EasyBuildError when command exited with an error
-    :param output_read_size: number of bytes to read from output
-    :param output: already collected output for this command
-
-    :result: dict value with result of the check (boolean 'done', 'exit_code', 'output')
-    """
-    # use small read size, to avoid waiting for a long time until sufficient output is produced
-    if output_read_size:
-        if not isinstance(output_read_size, int) or output_read_size < 0:
-            raise EasyBuildError("Number of output bytes to read should be a positive integer value (or zero)")
-        add_out = get_output_from_process(proc, read_size=output_read_size)
-        _log.debug("Additional output from asynchronous command '%s': %s" % (cmd, add_out))
-        output += add_out
-
-    exit_code = proc.poll()
-    if exit_code is None:
-        _log.debug("Asynchronous command '%s' still running..." % cmd)
-        done = False
-    else:
-        _log.debug("Asynchronous command '%s' completed!", cmd)
-        output, _ = complete_cmd(proc, cmd, owd, start_time, cmd_log, output=output,
-                                 simple=False, trace=False, log_ok=fail_on_error)
-        done = True
-
-    res = {
-        'done': done,
-        'exit_code': exit_code,
-        'output': output,
-    }
-    return res
-
-
-def complete_cmd(proc, cmd, owd, start_time, cmd_log, log_ok=True, log_all=False, simple=False,
-                 regexp=True, stream_output=None, trace=True, output='', with_hook=True):
-    """
-    Complete running of command represented by passed subprocess.Popen instance.
-
-    :param proc: subprocess.Popen instance representing running command
-    :param cmd: command being run
-    :param owd: original working directory
-    :param start_time: start time of command (datetime instance)
-    :param cmd_log: log file to print command output to
-    :param log_ok: only run output/exit code for failing commands (exit code non-zero)
-    :param log_all: always log command output and exit code
-    :param simple: if True, just return True/False to indicate success, else return a tuple: (output, exit_code)
-    :param regexp: regex used to check the output for errors;  if True it will use the default (see parse_log_for_error)
-    :param stream_output: enable streaming command output to stdout
-    :param trace: print command being executed as part of trace output
-    :param with_hook: trigger post run_shell_cmd hooks (if defined)
-    """
-    # use small read size when streaming output, to make it stream more fluently
-    # read size should not be too small though, to avoid too much overhead
-    if stream_output:
-        read_size = 128
-    else:
-        read_size = 1024 * 8
-
-    stdouterr = output
-
-    try:
-        ec = proc.poll()
-        while ec is None:
-            # need to read from time to time.
-            # - otherwise the stdout/stderr buffer gets filled and it all stops working
-            output = get_output_from_process(proc, read_size=read_size)
-            if cmd_log:
-                cmd_log.write(output)
-            if stream_output:
-                sys.stdout.write(output)
-            stdouterr += output
-            ec = proc.poll()
-
-        # read remaining data (all of it)
-        output = get_output_from_process(proc)
-    finally:
-        proc.stdout.close()
-
-    if cmd_log:
-        cmd_log.write(output)
-        cmd_log.close()
-    if stream_output:
-        sys.stdout.write(output)
-    stdouterr += output
-
-    if with_hook:
-        hooks = load_hooks(build_option('hooks'))
-        run_hook_kwargs = {
-            'exit_code': ec,
-            'output': stdouterr,
-            'work_dir': os.getcwd(),
-        }
-        run_hook(RUN_SHELL_CMD, hooks, post_step_hook=True, args=[cmd], kwargs=run_hook_kwargs)
-
-    if trace:
-        trace_msg("command completed: exit %s, ran in %s" % (ec, time_str_since(start_time)))
-
-    try:
-        os.chdir(owd)
-    except OSError as err:
-        raise EasyBuildError("Failed to return to %s after executing command: %s", owd, err)
-
-    return parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp)
-
-
-def run_cmd_qa(cmd, qa, no_qa=None, log_ok=True, log_all=False, simple=False, regexp=True, std_qa=None, path=None,
-               maxhits=50, trace=True):
-    """
-    Run specified interactive command (in a subshell)
-    :param cmd: command to run
-    :param qa: dictionary which maps question to answers
-    :param no_qa: list of patters that are not questions
-    :param log_ok: only run output/exit code for failing commands (exit code non-zero)
-    :param log_all: always log command output and exit code
-    :param simple: if True, just return True/False to indicate success, else return a tuple: (output, exit_code)
-    :param regexp: regex used to check the output for errors; if True it will use the default (see parse_log_for_error)
-    :param std_qa: dictionary which maps question regex patterns to answers
-    :param path: path to execute the command is; current working directory is used if unspecified
-    :param maxhits: maximum number of cycles (seconds) without being able to find a known question
-    :param trace: print command being executed as part of trace output
-    """
-    cwd = os.getcwd()
-
-    if not isinstance(cmd, str) and len(cmd) > 1:
-        # We use shell=True and hence we should really pass the command as a string
-        # When using a list then every element past the first is passed to the shell itself, not the command!
-        raise EasyBuildError("The command passed must be a string!")
-
-    if log_all or (trace and build_option('trace')):
-        # collect output of running command in temporary log file, if desired
-        fd, cmd_log_fn = tempfile.mkstemp(suffix='.log', prefix='easybuild-run_cmd_qa-')
-        os.close(fd)
-        try:
-            cmd_log = open(cmd_log_fn, 'w')
-        except IOError as err:
-            raise EasyBuildError("Failed to open temporary log file for output of interactive command: %s", err)
-        _log.debug('run_cmd_qa: Output of "%s" will be logged to %s' % (cmd, cmd_log_fn))
-    else:
-        cmd_log_fn, cmd_log = None, None
-
-    start_time = datetime.now()
-    if trace:
-        trace_txt = "running interactive command:\n"
-        trace_txt += "\t[started at: %s]\n" % start_time.strftime('%Y-%m-%d %H:%M:%S')
-        trace_txt += "\t[working dir: %s]\n" % (path or os.getcwd())
-        trace_txt += "\t[output logged in %s]\n" % cmd_log_fn
-        trace_msg(trace_txt + '\t' + cmd.strip())
-
-    # early exit in 'dry run' mode, after printing the command that would be run
-    if build_option('extended_dry_run'):
-        if path is None:
-            path = cwd
-        dry_run_msg("  running interactive command \"%s\"" % cmd, silent=build_option('silent'))
-        dry_run_msg("  (in %s)" % path, silent=build_option('silent'))
-        if cmd_log:
-            cmd_log.close()
-        if simple:
-            return True
-        else:
-            # output, exit code
-            return ('', 0)
-
-    try:
-        if path:
-            os.chdir(path)
-
-        _log.debug("run_cmd_qa: running cmd %s (in %s)" % (cmd, os.getcwd()))
-    except OSError as err:
-        _log.warning("Failed to change to %s: %s" % (path, err))
-        _log.info("running cmd %s in non-existing directory, might fail!" % cmd)
-
-    # Part 1: process the QandA dictionary
-    # given initial set of Q and A (in dict), return dict of reg. exp. and A
-    #
-    # make regular expression that matches the string with
-    # - replace whitespace
-    # - replace newline
-
-    def escape_special(string):
-        return re.sub(r"([\+\?\(\)\[\]\*\.\\\$])", r"\\\1", string)
-
-    split = r'[\s\n]+'
-    regSplit = re.compile(r"" + split)
-
-    def process_QA(q, a_s):
-        splitq = [escape_special(x) for x in regSplit.split(q)]
-        regQtxt = split.join(splitq) + split.rstrip('+') + "*$"
-        # add optional split at the end
-        for i in [idx for idx, a in enumerate(a_s) if not a.endswith('\n')]:
-            a_s[i] += '\n'
-        regQ = re.compile(r"" + regQtxt)
-        if regQ.search(q):
-            return (a_s, regQ)
-        else:
-            raise EasyBuildError("runqanda: Question %s converted in %s does not match itself", q, regQtxt)
-
-    def check_answers_list(answers):
-        """Make sure we have a list of answers (as strings)."""
-        if isinstance(answers, str):
-            answers = [answers]
-        elif not isinstance(answers, list):
-            if cmd_log:
-                cmd_log.close()
-            raise EasyBuildError("Invalid type for answer on %s, no string or list: %s (%s)",
-                                 question, type(answers), answers)
-        # list is manipulated when answering matching question, so return a copy
-        return answers[:]
-
-    new_qa = {}
-    _log.debug("new_qa: ")
-    for question, answers in qa.items():
-        answers = check_answers_list(answers)
-        (answers, regQ) = process_QA(question, answers)
-        new_qa[regQ] = answers
-        _log.debug("new_qa[%s]: %s" % (regQ.pattern, new_qa[regQ]))
-
-    new_std_qa = {}
-    if std_qa:
-        for question, answers in std_qa.items():
-            regQ = re.compile(r"" + question + r"[\s\n]*$")
-            answers = check_answers_list(answers)
-            for i in [idx for idx, a in enumerate(answers) if not a.endswith('\n')]:
-                answers[i] += '\n'
-            new_std_qa[regQ] = answers
-            _log.debug("new_std_qa[%s]: %s" % (regQ.pattern, new_std_qa[regQ]))
-
-    new_no_qa = []
-    if no_qa:
-        # simple statements, can contain wildcards
-        new_no_qa = [re.compile(r"" + x + r"[\s\n]*$") for x in no_qa]
-
-    _log.debug("New noQandA list is: %s" % [x.pattern for x in new_no_qa])
-
-    # Part 2: Run the command and answer questions
-    # - this needs asynchronous stdout
-
-    hooks = load_hooks(build_option('hooks'))
-    run_hook_kwargs = {
-        'interactive': True,
-        'work_dir': os.getcwd(),
-    }
-    hook_res = run_hook(RUN_SHELL_CMD, hooks, pre_step_hook=True, args=[cmd], kwargs=run_hook_kwargs)
-    if isinstance(hook_res, str):
-        cmd, old_cmd = hook_res, cmd
-        _log.info("Interactive command to run was changed by pre-%s hook: '%s' (was: '%s')",
-                  RUN_SHELL_CMD, cmd, old_cmd)
-
-    # # Log command output
-    if cmd_log:
-        cmd_log.write("# output for interactive command: %s\n\n" % cmd)
-
-    # Make sure we close the proc handles and the cmd_log file
-    @contextlib.contextmanager
-    def get_proc():
-        try:
-            proc = asyncprocess.Popen(cmd, shell=True, stdout=asyncprocess.PIPE, stderr=asyncprocess.STDOUT,
-                                      stdin=asyncprocess.PIPE, close_fds=True, executable='/bin/bash')
-        except OSError as err:
-            if cmd_log:
-                cmd_log.close()
-            raise EasyBuildError("run_cmd_qa init cmd %s failed:%s", cmd, err)
-        try:
-            yield proc
-        finally:
-            if proc.stdout:
-                proc.stdout.close()
-            if proc.stdin:
-                proc.stdin.close()
-            if cmd_log:
-                cmd_log.close()
-
-    with get_proc() as proc:
-        ec = proc.poll()
-        stdout_err = ''
-        old_len_out = -1
-        hit_count = 0
-
-        while ec is None:
-            # need to read from time to time.
-            # - otherwise the stdout/stderr buffer gets filled and it all stops working
-            try:
-                out = get_output_from_process(proc, asynchronous=True)
-
-                if cmd_log:
-                    cmd_log.write(out)
-                stdout_err += out
-            # recv_some used by get_output_from_process for getting asynchronous output may throw exception
-            except (IOError, Exception) as err:
-                _log.debug("run_cmd_qa cmd %s: read failed: %s", cmd, err)
-                out = None
-
-            hit = False
-            for question, answers in new_qa.items():
-                res = question.search(stdout_err)
-                if out and res:
-                    fa = answers[0] % res.groupdict()
-                    # cycle through list of answers
-                    last_answer = answers.pop(0)
-                    answers.append(last_answer)
-                    _log.debug("List of answers for question %s after cycling: %s", question.pattern, answers)
-
-                    _log.debug("run_cmd_qa answer %s question %s out %s", fa, question.pattern, stdout_err[-50:])
-                    asyncprocess.send_all(proc, fa)
-                    hit = True
-                    break
-            if not hit:
-                for question, answers in new_std_qa.items():
-                    res = question.search(stdout_err)
-                    if out and res:
-                        fa = answers[0] % res.groupdict()
-                        # cycle through list of answers
-                        last_answer = answers.pop(0)
-                        answers.append(last_answer)
-                        _log.debug("List of answers for question %s after cycling: %s", question.pattern, answers)
-
-                        _log.debug("run_cmd_qa answer %s std question %s out %s",
-                                   fa, question.pattern, stdout_err[-50:])
-                        asyncprocess.send_all(proc, fa)
-                        hit = True
-                        break
-                if not hit:
-                    if len(stdout_err) > old_len_out:
-                        old_len_out = len(stdout_err)
-                    else:
-                        noqa = False
-                        for r in new_no_qa:
-                            if r.search(stdout_err):
-                                _log.debug("runqanda: noQandA found for out %s", stdout_err[-50:])
-                                noqa = True
-                        if not noqa:
-                            hit_count += 1
-                else:
-                    hit_count = 0
-            else:
-                hit_count = 0
-
-            if hit_count > maxhits:
-                # explicitly kill the child process before exiting
-                try:
-                    os.killpg(proc.pid, signal.SIGKILL)
-                    os.kill(proc.pid, signal.SIGKILL)
-                except OSError as err:
-                    _log.debug("run_cmd_qa exception caught when killing child process: %s", err)
-                _log.debug("run_cmd_qa: full stdouterr: %s", stdout_err)
-                raise EasyBuildError("run_cmd_qa: cmd %s : Max nohits %s reached: end of output %s",
-                                     cmd, maxhits, stdout_err[-500:])
-
-            # the sleep below is required to avoid exiting on unknown 'questions' too early (see above)
-            time.sleep(1)
-            ec = proc.poll()
-
-        # Process stopped. Read all remaining data
-        try:
-            if proc.stdout:
-                out = get_output_from_process(proc)
-                stdout_err += out
-                if cmd_log:
-                    cmd_log.write(out)
-        except IOError as err:
-            _log.debug("runqanda cmd %s: remaining data read failed: %s", cmd, err)
-
-    run_hook_kwargs.update({
-        'interactive': True,
-        'exit_code': ec,
-        'output': stdout_err,
-    })
-    run_hook(RUN_SHELL_CMD, hooks, post_step_hook=True, args=[cmd], kwargs=run_hook_kwargs)
-
-    if trace:
-        trace_msg("interactive command completed: exit %s, ran in %s" % (ec, time_str_since(start_time)))
-
-    try:
-        os.chdir(cwd)
-    except OSError as err:
-        raise EasyBuildError("Failed to return to %s after executing command: %s", cwd, err)
-
-    return parse_cmd_output(cmd, stdout_err, ec, simple, log_all, log_ok, regexp)
-
-
-def parse_cmd_output(cmd, stdouterr, ec, simple, log_all, log_ok, regexp):
-    """
-    Parse command output and construct return value.
-    :param cmd: executed command
-    :param stdouterr: combined stdout/stderr of executed command
-    :param ec: exit code of executed command
-    :param simple: if True, just return True/False to indicate success, else return a tuple: (output, exit_code)
-    :param log_all: always log command output and exit code
-    :param log_ok: only run output/exit code for failing commands (exit code non-zero)
-    :param regexp: regex used to check the output for errors; if True it will use the default (see parse_log_for_error)
-    """
-    if strictness == IGNORE:
-        check_ec = False
-        fail_on_error_match = False
-    elif strictness == WARN:
-        check_ec = True
-        fail_on_error_match = False
-    elif strictness == ERROR:
-        check_ec = True
-        fail_on_error_match = True
-    else:
-        raise EasyBuildError("invalid strictness setting: %s", strictness)
-
-    # allow for overriding the regexp setting
-    if not regexp:
-        fail_on_error_match = False
-
-    if ec and (log_all or log_ok):
-        # We don't want to error if the user doesn't care
-        if check_ec:
-            raise EasyBuildError('cmd "%s" exited with exit code %s and output:\n%s', cmd, ec, stdouterr)
-        else:
-            _log.warning('cmd "%s" exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
-    elif not ec:
-        if log_all:
-            _log.info('cmd "%s" exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
-        else:
-            _log.debug('cmd "%s" exited with exit code %s and output:\n%s' % (cmd, ec, stdouterr))
-
-    # parse the stdout/stderr for errors when strictness dictates this or when regexp is passed in
-    if fail_on_error_match or regexp:
-        res = parse_log_for_error(stdouterr, regexp, stdout=False)
-        if res:
-            errors = "\n\t" + "\n\t".join([r[0] for r in res])
-            error_str = "error" if len(res) == 1 else "errors"
-            if fail_on_error_match:
-                raise EasyBuildError("Found %s %s in output of %s:%s", len(res), error_str, cmd, errors)
-            else:
-                _log.warning("Found %s potential %s (some may be harmless) in output of %s:%s",
-                             len(res), error_str, cmd, errors)
-
-    if simple:
-        if ec:
-            # If the user does not care -> will return true
-            return not check_ec
-        else:
-            return True
-    else:
-        # Because we are not running in simple mode, we return the output and ec to the user
-        return (stdouterr, ec)
-
-
-def parse_log_for_error(txt, regExp=None, stdout=True, msg=None):
-    """
-    txt is multiline string.
-    - in memory
-    regExp is a one-line regular expression
-    - default
-    """
-    global errors_found_in_log
-
-    if regExp and isinstance(regExp, bool):
-        regExp = r"(?<![(,-]|\w)(?:error|segmentation fault|failed)(?![(,-]|\.?\w)"
-        _log.debug('Using default regular expression: %s' % regExp)
-    elif isinstance(regExp, str):
-        pass
-    else:
-        raise EasyBuildError("parse_log_for_error no valid regExp used: %s", regExp)
-
-    reg = re.compile(regExp, re.I)
-
-    res = []
-    for line in txt.split('\n'):
-        r = reg.search(line)
-        if r:
-            res.append([line, r.groups()])
-            errors_found_in_log += 1
-
-    if stdout and res:
-        if msg:
-            _log.info("parse_log_for_error msg: %s" % msg)
-        _log.info("parse_log_for_error (some may be harmless) regExp %s found:\n%s" %
-                  (regExp, '\n'.join([x[0] for x in res])))
-
-    return res
-
-
-def extract_errors_from_log(log_txt, reg_exps):
-    """
-    Check provided string (command output) for messages matching specified regular expressions,
-    and return 2-tuple with list of warnings and errors.
-    :param log_txt: String containing the log, will be split into individual lines
-    :param reg_exps: List of: regular expressions (as strings) to error on,
-                    or tuple of regular expression and action (any of [IGNORE, WARN, ERROR])
-    :return: (warnings, errors) as lists of lines containing a match
-    """
-    actions = (IGNORE, WARN, ERROR)
-
-    # promote single string value to list, since code below expects a list
-    if isinstance(reg_exps, str):
-        reg_exps = [reg_exps]
-
-    re_tuples = []
-    for cur in reg_exps:
-        try:
-            if isinstance(cur, str):
-                # use ERROR as default action if only regexp pattern is specified
-                reg_exp, action = cur, ERROR
-            elif isinstance(cur, tuple) and len(cur) == 2:
-                reg_exp, action = cur
-            else:
-                raise TypeError("Incorrect type of value, expected string or 2-tuple")
-
-            if not isinstance(reg_exp, str):
-                raise TypeError("Regular expressions must be passed as string, got %s" % type(reg_exp))
-            if action not in actions:
-                raise TypeError("action must be one of %s, got %s" % (actions, action))
-
-            re_tuples.append((re.compile(reg_exp), action))
-        except Exception as err:
-            raise EasyBuildError("Invalid input: No regexp or tuple of regexp and action '%s': %s", str(cur), err)
-
-    warnings = []
-    errors = []
-    for line in log_txt.split('\n'):
-        for reg_exp, action in re_tuples:
-            if reg_exp.search(line):
-                if action == ERROR:
-                    errors.append(line)
-                elif action == WARN:
-                    warnings.append(line)
-                break
-    return nub(warnings), nub(errors)
-
-
-def check_log_for_errors(log_txt, reg_exps):
-    """
-    Check log_txt for messages matching regExps in order and do appropriate action
-    :param log_txt: String containing the log, will be split into individual lines
-    :param reg_exps: List of: regular expressions (as strings) to error on,
-                    or tuple of regular expression and action (any of [IGNORE, WARN, ERROR])
-    """
-    global errors_found_in_log
-    warnings, errors = extract_errors_from_log(log_txt, reg_exps)
-
-    errors_found_in_log += len(warnings) + len(errors)
-    if warnings:
-        _log.warning("Found %s potential error(s) in command output:\n\t%s",
-                     len(warnings), "\n\t".join(warnings))
-    if errors:
-        raise EasyBuildError("Found %s error(s) in command output:\n\t%s",
-                             len(errors), "\n\t".join(errors))
 
 
 def subprocess_popen_text(cmd, **kwargs):

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -46,13 +46,14 @@ import string
 import subprocess
 import sys
 import tempfile
+import time
 from collections import namedtuple
 from datetime import datetime
 
 # import deprecated functions so they can still be imported from easybuild.tools.run, for now
 from easybuild._deprecated import check_async_cmd, check_log_for_errors, complete_cmd, extract_errors_from_log  # noqa
-from easybuild._deprecated import get_output_from_process, parse_cmd_output, parse_log_for_error, run_cmd  # noqa
-from easybuild._deprecated import run_cmd_cache, run_cmd_qa  # noqa
+from easybuild._deprecated import get_output_from_process, parse_cmd_output, parse_log_for_error  # noqa
+from easybuild._deprecated import run_cmd, run_cmd_qa  # noqa
 
 try:
     # get_native_id is only available in Python >= 3.8
@@ -180,9 +181,6 @@ def run_shell_cmd_cache(func):
     cache_aware_func.update_cache = cache.update
 
     return cache_aware_func
-
-
-run_shell_cmd_cache = run_cmd_cache
 
 
 def fileprefix_from_cmd(cmd, allowed_chars=False):

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -118,9 +118,9 @@ class BuildLogTest(EnhancedTestCase):
 
         more_info = "see https://docs.easybuild.io/deprecated-functionality/ for more information"
         expected_stderr = '\n\n'.join([
-            "\nWARNING: Deprecated functionality, will no longer work in v10000001: anotherwarning; " + more_info,
-            "\nWARNING: Deprecated functionality, will no longer work in v2.0: onemorewarning",
-            "\nWARNING: Deprecated functionality, will no longer work in v2.0: lastwarning",
+            "\nWARNING: Deprecated functionality, will no longer work in EasyBuild v10000001: anotherwarning; " + more_info,
+            "\nWARNING: Deprecated functionality, will no longer work in EasyBuild v2.0: onemorewarning",
+            "\nWARNING: Deprecated functionality, will no longer work in EasyBuild v2.0: lastwarning",
         ]) + '\n\n'
         self.assertEqual(stderr, expected_stderr)
 
@@ -183,7 +183,7 @@ class BuildLogTest(EnhancedTestCase):
         self.mock_stderr(False)
         logtxt = read_file(tmplog)
         expected_logtxt = '\n'.join([
-            "[WARNING] :: Deprecated functionality, will no longer work in v10000001: ",
+            "[WARNING] :: Deprecated functionality, will no longer work in EasyBuild v10000001: ",
             "this is just a test",
             "(see URLGOESHERE for more information)",
         ])

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -117,10 +117,11 @@ class BuildLogTest(EnhancedTestCase):
         self.mock_stderr(False)
 
         more_info = "see https://docs.easybuild.io/deprecated-functionality/ for more information"
+        common_warning = "\nWARNING: Deprecated functionality, will no longer work in"
         expected_stderr = '\n\n'.join([
-            "\nWARNING: Deprecated functionality, will no longer work in EasyBuild v10000001: anotherwarning; " + more_info,
-            "\nWARNING: Deprecated functionality, will no longer work in EasyBuild v2.0: onemorewarning",
-            "\nWARNING: Deprecated functionality, will no longer work in EasyBuild v2.0: lastwarning",
+            common_warning + " EasyBuild v10000001: anotherwarning; " + more_info,
+            common_warning + " EasyBuild v2.0: onemorewarning",
+            common_warning + " EasyBuild v2.0: lastwarning",
         ]) + '\n\n'
         self.assertEqual(stderr, expected_stderr)
 

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -38,7 +38,6 @@ from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_
 from unittest import TextTestRunner
 
 import easybuild.tools.options as eboptions
-from easybuild.tools import run
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import ERROR, IGNORE, WARN, BuildOptions, ConfigurationVariables
 from easybuild.tools.config import build_option, build_path, get_build_log_path, get_log_filename, get_repositorypath

--- a/test/framework/config.py
+++ b/test/framework/config.py
@@ -40,10 +40,10 @@ from unittest import TextTestRunner
 import easybuild.tools.options as eboptions
 from easybuild.tools import run
 from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import ERROR, IGNORE, WARN, BuildOptions, ConfigurationVariables
 from easybuild.tools.config import build_option, build_path, get_build_log_path, get_log_filename, get_repositorypath
 from easybuild.tools.config import install_path, log_file_format, log_path, source_paths
 from easybuild.tools.config import update_build_option, update_build_options
-from easybuild.tools.config import BuildOptions, ConfigurationVariables
 from easybuild.tools.config import DEFAULT_PATH_SUBDIRS, init_build_options
 from easybuild.tools.filetools import copy_dir, mkdir, write_file
 from easybuild.tools.options import CONFIG_ENV_VAR_PREFIX
@@ -580,9 +580,9 @@ class EasyBuildConfigTest(EnhancedTestCase):
     def test_strict(self):
         """Test use of --strict."""
         # check default
-        self.assertEqual(build_option('strict'), run.WARN)
+        self.assertEqual(build_option('strict'), WARN)
 
-        for strict_str, strict_val in [('error', run.ERROR), ('ignore', run.IGNORE), ('warn', run.WARN)]:
+        for strict_str, strict_val in [('error', ERROR), ('ignore', IGNORE), ('warn', WARN)]:
             options = init_config(args=['--strict=%s' % strict_str])
             init_config(build_options={'strict': options.strict})
             self.assertEqual(build_option('strict'), strict_val)

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -47,10 +47,9 @@ from test.framework.github import requires_github_access
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
 from urllib import request
-from easybuild.tools import run
 import easybuild.tools.filetools as ft
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import IGNORE, ERROR, build_option, update_build_option
+from easybuild.tools.config import IGNORE, ERROR, WARN, build_option, update_build_option
 from easybuild.tools.multidiff import multidiff
 
 
@@ -1442,7 +1441,7 @@ class FileToolsTest(EnhancedTestCase):
 
         # passing empty list of substitions is a no-op
         ft.write_file(testfile, testtxt)
-        ft.apply_regex_substitutions(testfile, [], on_missing_match=run.IGNORE)
+        ft.apply_regex_substitutions(testfile, [], on_missing_match=IGNORE)
         new_testtxt = ft.read_file(testfile)
         self.assertEqual(new_testtxt, testtxt)
 
@@ -1452,17 +1451,17 @@ class FileToolsTest(EnhancedTestCase):
         error_pat = 'Nothing found to replace in %s' % testfile
         # Error
         self.assertErrorRegex(EasyBuildError, error_pat, ft.apply_regex_substitutions, testfile, regex_subs_no_match,
-                              on_missing_match=run.ERROR)
+                              on_missing_match=ERROR)
 
         # Warn
         with self.log_to_testlogfile():
-            ft.apply_regex_substitutions(testfile, regex_subs_no_match, on_missing_match=run.WARN)
+            ft.apply_regex_substitutions(testfile, regex_subs_no_match, on_missing_match=WARN)
         logtxt = ft.read_file(self.logfile)
         self.assertIn('WARNING ' + error_pat, logtxt)
 
         # Ignore
         with self.log_to_testlogfile():
-            ft.apply_regex_substitutions(testfile, regex_subs_no_match, on_missing_match=run.IGNORE)
+            ft.apply_regex_substitutions(testfile, regex_subs_no_match, on_missing_match=IGNORE)
         logtxt = ft.read_file(self.logfile)
         self.assertIn('INFO ' + error_pat, logtxt)
 

--- a/test/framework/lib.py
+++ b/test/framework/lib.py
@@ -74,14 +74,14 @@ class EasyBuildLibTest(TestCase):
 
         error_pattern = r"Undefined build option: .*"
         error_pattern += r" Make sure you have set up the EasyBuild configuration using set_up_configuration\(\)"
-        self.assertErrorRegex(EasyBuildError, error_pattern, run_cmd, "echo hello")
+        with self.mocked_stdout_stderr():
+            self.assertErrorRegex(EasyBuildError, error_pattern, run_cmd, "echo hello")
 
         self.configure()
 
         # run_cmd works fine if set_up_configuration was called first
-        self.mock_stdout(True)
-        (out, ec) = run_cmd("echo hello")
-        self.mock_stdout(False)
+        with self.mocked_stdout_stderr():
+            (out, ec) = run_cmd("echo hello")
         self.assertEqual(ec, 0)
         self.assertEqual(out, 'hello\n')
 

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -821,7 +821,8 @@ class RunTest(EnhancedTestCase):
 
         # fails because non-question is encountered
         error_pattern = "Max nohits 1 reached: end of output not-a-question-but-a-statement"
-        self.assertErrorRegex(EasyBuildError, error_pattern, run_cmd_qa, cmd, qa, maxhits=1, trace=False)
+        with self.mocked_stdout_stderr():
+            self.assertErrorRegex(EasyBuildError, error_pattern, run_cmd_qa, cmd, qa, maxhits=1, trace=False)
 
         with self.mocked_stdout_stderr():
             (out, ec) = run_cmd_qa(cmd, qa, no_qa=["not-a-question-but-a-statement"], maxhits=1, trace=False)

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -142,6 +142,10 @@ class RunTest(EnhancedTestCase):
 
     def test_run_cmd(self):
         """Basic test for run_cmd function."""
+
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         with self.mocked_stdout_stderr():
             (out, ec) = run_cmd("echo hello")
         self.assertEqual(out, "hello\n")
@@ -217,6 +221,10 @@ class RunTest(EnhancedTestCase):
 
     def test_run_cmd_log(self):
         """Test logging of executed commands."""
+
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         fd, logfile = tempfile.mkstemp(suffix='.log', prefix='eb-test-')
         os.close(fd)
 
@@ -300,6 +308,10 @@ class RunTest(EnhancedTestCase):
 
     def test_run_cmd_negative_exit_code(self):
         """Test run_cmd function with command that has negative exit code."""
+
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         # define signal handler to call in case run_cmd takes too long
         def handler(signum, _):
             raise RuntimeError("Signal handler called with signal %s" % signum)
@@ -433,6 +445,10 @@ class RunTest(EnhancedTestCase):
 
     def test_run_cmd_bis(self):
         """More 'complex' test for run_cmd function."""
+
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         # a more 'complex' command to run, make sure all required output is there
         with self.mocked_stdout_stderr():
             (out, ec) = run_cmd("for j in `seq 1 3`; do for i in `seq 1 100`; do echo hello; done; sleep 1.4; done")
@@ -453,6 +469,10 @@ class RunTest(EnhancedTestCase):
         """
         Test running command in specific directory with run_cmd function.
         """
+
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         orig_wd = os.getcwd()
         self.assertFalse(os.path.samefile(orig_wd, self.test_prefix))
 
@@ -493,6 +513,10 @@ class RunTest(EnhancedTestCase):
 
     def test_run_cmd_log_output(self):
         """Test run_cmd with log_output enabled"""
+
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         with self.mocked_stdout_stderr():
             (out, ec) = run_cmd("seq 1 100", log_output=True)
         self.assertEqual(ec, 0)
@@ -548,6 +572,9 @@ class RunTest(EnhancedTestCase):
     def test_run_cmd_trace(self):
         """Test run_cmd in trace mode, and with tracing disabled."""
 
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         pattern = [
             r"^  >> running command:",
             r"\t\[started at: .*\]",
@@ -567,7 +594,7 @@ class RunTest(EnhancedTestCase):
         self.mock_stderr(False)
         self.assertEqual(out, 'hello\n')
         self.assertEqual(ec, 0)
-        self.assertEqual(stderr, '')
+        self.assertTrue(stderr.strip().startswith("WARNING: Deprecated functionality"))
         regex = re.compile('\n'.join(pattern))
         self.assertTrue(regex.search(stdout), "Pattern '%s' found in: %s" % (regex.pattern, stdout))
 
@@ -582,7 +609,7 @@ class RunTest(EnhancedTestCase):
         self.mock_stderr(False)
         self.assertEqual(out, 'hello\n')
         self.assertEqual(ec, 0)
-        self.assertEqual(stderr, '')
+        self.assertTrue(stderr.strip().startswith("WARNING: Deprecated functionality"))
         self.assertEqual(stdout, '')
 
         init_config(build_options={'trace': True})
@@ -597,7 +624,7 @@ class RunTest(EnhancedTestCase):
         self.mock_stderr(False)
         self.assertEqual(out, 'hello')
         self.assertEqual(ec, 0)
-        self.assertEqual(stderr, '')
+        self.assertTrue(stderr.strip().startswith("WARNING: Deprecated functionality"))
         pattern.insert(3, r"\t\[input: hello\]")
         pattern[-2] = "\tcat"
         regex = re.compile('\n'.join(pattern))
@@ -614,7 +641,7 @@ class RunTest(EnhancedTestCase):
         self.mock_stderr(False)
         self.assertEqual(out, 'hello')
         self.assertEqual(ec, 0)
-        self.assertEqual(stderr, '')
+        self.assertTrue(stderr.strip().startswith("WARNING: Deprecated functionality"))
         self.assertEqual(stdout, '')
 
         # trace output can be disabled on a per-command basis
@@ -631,7 +658,7 @@ class RunTest(EnhancedTestCase):
             self.assertEqual(out, 'hello\n')
             self.assertEqual(ec, 0)
             self.assertEqual(stdout, '')
-            self.assertEqual(stderr, '')
+            self.assertTrue(stderr.strip().startswith("WARNING: Deprecated functionality"))
 
     def test_run_shell_cmd_trace(self):
         """Test run_shell_cmd function in trace mode, and with tracing disabled."""
@@ -963,6 +990,9 @@ class RunTest(EnhancedTestCase):
     def test_run_cmd_qa_trace(self):
         """Test run_cmd under --trace"""
 
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         # --trace is enabled by default
         self.mock_stdout(True)
         self.mock_stderr(True)
@@ -989,7 +1019,7 @@ class RunTest(EnhancedTestCase):
         self.mock_stdout(False)
         self.mock_stderr(False)
         self.assertEqual(stdout, '')
-        self.assertEqual(stderr, '')
+        self.assertTrue(stderr.strip().startswith("WARNING: Deprecated functionality"))
 
     def test_run_shell_cmd_qa_trace(self):
         """Test run_shell_cmd with qa_patterns under --trace"""
@@ -1071,12 +1101,20 @@ class RunTest(EnhancedTestCase):
 
     def test_run_cmd_simple(self):
         """Test return value for run_cmd in 'simple' mode."""
+
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         with self.mocked_stdout_stderr():
             self.assertEqual(True, run_cmd("echo hello", simple=True))
             self.assertEqual(False, run_cmd("exit 1", simple=True, log_all=False, log_ok=False))
 
     def test_run_cmd_cache(self):
         """Test caching for run_cmd"""
+
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         with self.mocked_stdout_stderr():
             (first_out, ec) = run_cmd("ulimit -u")
         self.assertEqual(ec, 0)
@@ -1164,6 +1202,10 @@ class RunTest(EnhancedTestCase):
 
     def test_run_cmd_dry_run(self):
         """Test use of run_cmd function under (extended) dry run."""
+
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         build_options = {
             'extended_dry_run': True,
             'silent': False,
@@ -1172,43 +1214,38 @@ class RunTest(EnhancedTestCase):
 
         cmd = "somecommand foo 123 bar"
 
-        self.mock_stdout(True)
-        run_cmd(cmd)
-        stdout = self.get_stdout()
-        self.mock_stdout(False)
+        with self.mocked_stdout_stderr():
+            run_cmd(cmd)
+            stdout = self.get_stdout()
 
         expected = """  running command "somecommand foo 123 bar"\n"""
         self.assertIn(expected, stdout)
 
         # check disabling 'verbose'
-        self.mock_stdout(True)
-        run_cmd("somecommand foo 123 bar", verbose=False)
-        stdout = self.get_stdout()
-        self.mock_stdout(False)
+        with self.mocked_stdout_stderr():
+            run_cmd("somecommand foo 123 bar", verbose=False)
+            stdout = self.get_stdout()
         self.assertNotIn(expected, stdout)
 
         # check forced run_cmd
         outfile = os.path.join(self.test_prefix, 'cmd.out')
         self.assertNotExists(outfile)
-        self.mock_stdout(True)
-        run_cmd("echo 'This is always echoed' > %s" % outfile, force_in_dry_run=True)
-        self.mock_stdout(False)
+        with self.mocked_stdout_stderr():
+            run_cmd("echo 'This is always echoed' > %s" % outfile, force_in_dry_run=True)
         self.assertExists(outfile)
         self.assertEqual(read_file(outfile), "This is always echoed\n")
 
         # Q&A commands
-        self.mock_stdout(True)
-        run_shell_cmd("some_qa_cmd", qa_patterns=[('question1', 'answer1')])
-        stdout = self.get_stdout()
-        self.mock_stdout(False)
+        with self.mocked_stdout_stderr():
+            run_shell_cmd("some_qa_cmd", qa_patterns=[('question1', 'answer1')])
+            stdout = self.get_stdout()
 
         expected = """  running interactive shell command "some_qa_cmd"\n"""
         self.assertIn(expected, stdout)
 
-        self.mock_stdout(True)
-        run_cmd_qa("some_qa_cmd", {'question1': 'answer1'})
-        stdout = self.get_stdout()
-        self.mock_stdout(False)
+        with self.mocked_stdout_stderr():
+            run_cmd_qa("some_qa_cmd", {'question1': 'answer1'})
+            stdout = self.get_stdout()
 
         expected = """  running interactive command "some_qa_cmd"\n"""
         self.assertIn(expected, stdout)
@@ -1264,6 +1301,10 @@ class RunTest(EnhancedTestCase):
 
     def test_run_cmd_list(self):
         """Test run_cmd with command specified as a list rather than a string"""
+
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         cmd = ['/bin/sh', '-c', "echo hello"]
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, "When passing cmd as a list then `shell` must be set explictely!",
@@ -1275,6 +1316,10 @@ class RunTest(EnhancedTestCase):
 
     def test_run_cmd_script(self):
         """Testing use of run_cmd with shell=False to call external scripts"""
+
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         py_test_script = os.path.join(self.test_prefix, 'test.py')
         write_file(py_test_script, '\n'.join([
             '#!%s' % sys.executable,
@@ -1313,6 +1358,10 @@ class RunTest(EnhancedTestCase):
 
     def test_run_cmd_stream(self):
         """Test use of run_cmd with streaming output."""
+
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         self.mock_stdout(True)
         self.mock_stderr(True)
         (out, ec) = run_cmd("echo hello", stream_output=True)
@@ -1324,7 +1373,7 @@ class RunTest(EnhancedTestCase):
         self.assertEqual(ec, 0)
         self.assertEqual(out, "hello\n")
 
-        self.assertEqual(stderr, '')
+        self.assertTrue(stderr.strip().startswith("WARNING: Deprecated functionality"))
         expected = [
             "== (streaming) output for command 'echo hello':",
             "hello",
@@ -1369,6 +1418,9 @@ class RunTest(EnhancedTestCase):
 
     def test_run_cmd_async(self):
         """Test asynchronously running of a shell command via run_cmd + complete_cmd."""
+
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
 
         os.environ['TEST'] = 'test123'
 
@@ -1604,6 +1656,10 @@ class RunTest(EnhancedTestCase):
         """
         Test running command with run_cmd with pre/post run_shell_cmd hooks in place.
         """
+
+        # use of run_cmd is deprecated, so we need to allow it here
+        self.allow_deprecated_behaviour()
+
         cwd = os.getcwd()
 
         hooks_file = os.path.join(self.test_prefix, 'my_hooks.py')


### PR DESCRIPTION
All code in `easybuild/_deprecated.py` was cut from `easybuild/tools/run.py` without changes, with one small exception: the `run_cmd_cache` decorator was changed to only consider `inp`, not `stdin` (since the latter is specific to `run_shell_cmd`).

WIP because more work is needed here once the implementation of `run_shell_cmd` is complete (incl. support for `asynchronous` and `qa_patterns` + `qa_wait_patterns`):

* [x] also deprecate other functions in `easybuild._deprecated`, like `run_cmd_qa`, etc.;
* [x] use `self.allow_deprecated_behaviour()` in tests where needed, or catch deprecation warning to ignore it;