### PR TITLE
create `lib` -> `lib64` symlink (or vice versa) *before* running `postinstallcmds`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3019,12 +3019,6 @@ class EasyBlock(object):
         - run post install commands if any were specified
         """
 
-        self.run_post_install_commands()
-        self.apply_post_install_patches()
-        self.print_post_install_messages()
-
-        self.fix_shebang()
-
         lib_dir = os.path.join(self.installdir, 'lib')
         lib64_dir = os.path.join(self.installdir, 'lib64')
 
@@ -3044,6 +3038,12 @@ class EasyBlock(object):
             if os.path.exists(lib64_dir) and not os.path.exists(lib_dir):
                 # create *relative* 'lib' symlink to 'lib64';
                 symlink('lib64', lib_dir, use_abspath_source=False)
+
+        self.run_post_install_commands()
+        self.apply_post_install_patches()
+        self.print_post_install_messages()
+
+        self.fix_shebang()
 
     def sanity_check_step(self, *args, **kwargs):
         """


### PR DESCRIPTION
Not having the symlinks in place means that `postinstallcmds` that rely on using/modifying something in the library directory have to use tricks to figure out the correct location.