### PR TITLE
don't hardcode `/bin/bash` in `eb` script, RPATH wrapper script, and `run_shell_cmd`

### DIFF
--- a/easybuild/scripts/rpath_wrapper_template.sh.in
+++ b/easybuild/scripts/rpath_wrapper_template.sh.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ##
 # Copyright 2016-2023 Ghent University
 #

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -41,6 +41,7 @@ import inspect
 import os
 import re
 import signal
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -276,7 +277,9 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
     # (which could be dash instead of bash, like on Ubuntu, see https://wiki.ubuntu.com/DashAsBinSh)
     # stick to None (default value) when not running command via a shell
     if use_bash:
-        executable, shell = '/bin/bash', True
+        bash = shutil.which('bash')
+        _log.info(f"Path to bash that will be used to run shell commands: {bash}")
+        executable, shell = bash, True
     else:
         executable, shell = None, False
 

--- a/eb
+++ b/eb
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ##
 # Copyright 2009-2023 Ghent University
 #

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2082,7 +2082,7 @@ class EasyBlockTest(EnhancedTestCase):
         eb.silent = True
         error_pattern = r"Sanity check failed: extensions sanity check failed for 1 extensions: toy\n"
         error_pattern += r"failing sanity check for 'toy' extension: "
-        error_pattern += r'command "thisshouldfail" failed; output:\n/bin/bash:.* thisshouldfail: command not found'
+        error_pattern += r'command "thisshouldfail" failed; output:\n.* thisshouldfail: command not found'
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, error_pattern, eb.run_all_steps, True)
 


### PR DESCRIPTION
I was wondering we should provide an EasyBuild configuration option to hard specify the path to `bash` that should be used, rather than relying on `$PATH`, but I currently don't see a real need for that. If a need does arise, it can be implemented in a follow-up PR.

fixes #4320