### PR TITLE
fix error reporting when test step fails

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2736,7 +2736,10 @@ class EasyBlock(object):
         try:
             self.test_step()
         except RunShellCmdError as err:
-            self.report_test_failure(err)
+            err.print()
+            ec_path = os.path.basename(self.cfg.path)
+            error_msg = f"shell command '{err.cmd_name} ...' failed in test step for {ec_path}"
+            self.report_test_failure(error_msg)
 
     def stage_install_step(self):
         """

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -4124,6 +4124,22 @@ class ToyBuildTest(EnhancedTestCase):
         regex = re.compile(pattern, re.M)
         self.assertTrue(regex.search(stdout), "Pattern '%s' should be found in: %s" % (regex.pattern, stdout))
 
+    def test_toy_failing_test_step(self):
+        """
+        Test behaviour when test step fails, using toy easyconfig.
+        """
+        test_ecs = os.path.join(os.path.dirname(__file__), 'easyconfigs', 'test_ecs')
+        toy_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
+
+        test_ec_txt = read_file(toy_ec)
+        test_ec_txt += '\nruntest = "false"'
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        write_file(test_ec, test_ec_txt)
+
+        error_pattern = r"shell command 'false \.\.\.' failed in test step"
+        self.assertErrorRegex(EasyBuildError, error_pattern, self.run_test_toy_build_with_output,
+                              ec_file=test_ec, raise_error=True)
+
     def test_eb_crash(self):
         """
         Test behaviour when EasyBuild crashes, for example due to a buggy hook


### PR DESCRIPTION
Without the fix, test fails with:

```
Traceback (most recent call last):
  File "/Volumes/work/easybuild-framework/test/framework/toy_build.py", line 4140, in test_toy_failing_test_step
    self.assertErrorRegex(EasyBuildError, error_pattern, self.run_test_toy_build_with_output,
  File "/Volumes/work/easybuild-framework/easybuild/base/testing.py", line 164, in assertErrorRegex
    call(*args, **kwargs)
  File "/Volumes/work/easybuild-framework/test/framework/toy_build.py", line 239, in run_test_toy_build_with_output
    self._test_toy_build(*args, **kwargs)
  File "/Volumes/work/easybuild-framework/test/framework/toy_build.py", line 195, in _test_toy_build
    raise myerr
  File "/Volumes/work/easybuild-framework/test/framework/toy_build.py", line 190, in _test_toy_build
    outtxt = self.eb_main(args, logfile=self.dummylogfn, do_build=True, verbose=verbose,
  File "/Volumes/work/easybuild-framework/test/framework/utilities.py", line 341, in eb_main
    raise myerr
  File "/Volumes/work/easybuild-framework/test/framework/utilities.py", line 314, in eb_main
    main(args=main_args, logfile=logfile, do_build=do_build, testing=testing, modtool=modtool)
  File "/Volumes/work/easybuild-framework/easybuild/main.py", line 727, in main
    do_cleanup = process_eb_args(orig_paths, eb_go, cfg_settings, modtool, testing, init_session_state,
  File "/Volumes/work/easybuild-framework/easybuild/main.py", line 564, in process_eb_args
    ecs_with_res = build_and_install_software(ordered_ecs, init_session_state,
  File "/Volumes/work/easybuild-framework/easybuild/main.py", line 173, in build_and_install_software
    raise ec_res['err']
  File "/Volumes/work/easybuild-framework/easybuild/main.py", line 134, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyblock.py", line 4428, in build_and_install_one
    succ = "unsuccessfully: " + error_msg
TypeError: can only concatenate str (not "RunShellCmdError") to str
```

Same happens when running an installation that fails in `test` step.

With this fix, the error reporting is as expected:

```
== testing...
  >> running command:
        [started at: 2024-01-19 20:06:22]
        [working dir: /tmp/example/1.2.3/system-system/example-1.2.3]
        [output saved to /tmp/eb-vadju77_/run-shell-cmd-output/command_that_fails-9f3cvv7b/out.txt]
        command_that_fails

ERROR: Shell command failed!
    full command              ->  command_that_fails
    exit code                 ->  2
    working directory         ->  /tmp/example/1.2.3/system-system/example-1.2.3
    output (stdout + stderr)  ->  /tmp/eb-vadju77_/run-shell-cmd-output/command_that_fails-9f3cvv7b/out.txt
    called from               ->  'test_step' function in /Users/kehoste/work/easybuild-easyblocks/easybuild/easyblocks/generic/configuremake.py (line 376)

== ... (took < 1 sec)
== FAILED: Installation ended unsuccessfully: shell command 'command_that_fails ...' failed in test step for example-1.2.3.eb (took 5 secs)
```