### PR TITLE
clean up log file of EasyBlock instance in `check_sha256_checksums`

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -701,7 +701,9 @@ def check_sha256_checksums(ecs, whitelist=None):
             continue
 
         eb_class = get_easyblock_class(ec['easyblock'], name=ec['name'])
-        checksum_issues.extend(eb_class(ec).check_checksums())
+        eb = eb_class(ec)
+        checksum_issues.extend(eb.check_checksums())
+        eb.close_log()
 
     return checksum_issues
 


### PR DESCRIPTION
Not calling `close_log` results in keeping an open log file for every `EasyBlock` instance that gets created, which may cause errors like "`Too many open files`" when a lot of `EasyBlock` instances are being created.