### PR TITLE
implement support for running interactive commands with `run_shell_cmd`

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -360,7 +360,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
 
         exit_code = None
         stdout, stderr = b'', b''
-        check_interval_secs = 0.001
+        check_interval_secs = 0.1
         time_no_match = 0
 
         # collect output piece-wise, while checking for questions to answer (if qa_patterns is provided)
@@ -431,7 +431,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
                         error_msg += f"giving up after {qa_timeout} seconds!"
                         raise EasyBuildError(error_msg)
                     else:
-                        _log.debug(f"{time_no_match} seconds without match in output of interactive shell command")
+                        _log.debug(f"{time_no_match:0.1f} seconds without match in output of interactive shell command")
 
             time.sleep(check_interval_secs)
 

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -363,11 +363,11 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
             hit = False
             if more_stdout.strip() and qa_patterns:
                 for question, answer in qa_patterns:
-                    question += '[\s\n]*$'
+                    question += r'[\s\n]*$'
                     regex = re.compile(question.encode())
                     if regex.search(stdout):
                         answer += '\n'
-                        x= os.write(proc.stdin.fileno(), answer.encode())
+                        os.write(proc.stdin.fileno(), answer.encode())
                         hit = True
 
             time.sleep(check_interval_secs)

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -385,7 +385,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
                     regex = re.compile(question.encode())
                     res = regex.search(stdout)
                     if res:
-                        _log.debug(f"Found match for question pattern '{question}' at end of: {stdout}")
+                        _log.debug(f"Found match for question pattern '{question}' at end of stdout: {stdout[:1000]}")
                         # if answer is specified as a list, we take the first item as current answer,
                         # and add it to the back of the list (so we cycle through answers)
                         if isinstance(answers, list):
@@ -414,8 +414,8 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
                         pattern += r'[\s\n]*$'
                         regex = re.compile(pattern.encode())
                         if regex.search(stdout):
-                            _log.info(f"Found match for question wait pattern '{pattern}'")
-                            _log.debug(f"Found match for question wait pattern '{pattern}' at end of: {stdout}")
+                            _log.info(f"Found match for wait pattern '{pattern}'")
+                            _log.debug(f"Found match for wait pattern '{pattern}' at end of stdout: {stdout[:1000]}")
                             time_no_match = 0
                             match_found = True
                             break
@@ -423,7 +423,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
                         _log.info("No match found for question wait patterns")
 
                 if not match_found:
-                    _log.debug(f"No match found in question or wait patterns at end of current output: {stdout}")
+                    _log.debug(f"No match found in question/wait patterns at end of stdout: {stdout[:1000]}")
                     # this will only run if the for loop above was *not* stopped by the break statement
                     time_no_match += check_interval_secs
                     if time_no_match > qa_timeout:

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -236,7 +236,6 @@ def _answer_question(stdout, proc, qa_patterns, qa_wait_patterns):
             except OSError as err:
                 raise EasyBuildError("Failed to answer question raised by interactive command: %s", err)
 
-            time_no_match = 0
             match_found = True
             break
     else:
@@ -250,7 +249,6 @@ def _answer_question(stdout, proc, qa_patterns, qa_wait_patterns):
             if regex.search(stdout):
                 _log.info(f"Found match for wait pattern '{pattern}'")
                 _log.debug(f"Found match for wait pattern '{pattern}' at end of stdout: {stdout[:1000]}")
-                time_no_match = 0
                 match_found = True
                 break
         else:
@@ -435,7 +433,9 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
                 stderr += proc.stderr.read1(read_size) or b''
 
             if qa_patterns:
-                if not _answer_question(stdout, proc, qa_patterns, qa_wait_patterns):
+                if _answer_question(stdout, proc, qa_patterns, qa_wait_patterns):
+                    time_no_match = 0
+                else:
                     _log.debug(f"No match found in question/wait patterns at end of stdout: {stdout[:1000]}")
                     # this will only run if the for loop above was *not* stopped by the break statement
                     time_no_match += check_interval_secs

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -382,7 +382,8 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
                     # allow extra whitespace at the end
                     question += r'[\s\n]*$'
                     regex = re.compile(question.encode())
-                    if regex.search(stdout):
+                    res = regex.search(stdout)
+                    if res:
                         # if answer is specified as a list, we take the first item as current answer,
                         # and add it to the back of the list (so we cycle through answers)
                         if isinstance(answers, list):
@@ -393,6 +394,8 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
                         else:
                             raise EasyBuildError(f"Unknown type of answers encountered: {answers}")
 
+                        # answer may need to be completed via pattern extracted from question
+                        answer = answer % {k: v.decode() for (k, v) in res.groupdict().items()}
                         answer += '\n'
                         os.write(proc.stdin.fileno(), answer.encode())
                         time_no_match = 0

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -352,8 +352,6 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
             # -1 means reading until EOF
             read_size = 128 if exit_code is None else -1
 
-            exit_code = proc.poll()
-
             more_stdout = proc.stdout.read1(read_size) or b''
             stdout += more_stdout
 
@@ -380,6 +378,12 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
                         raise EasyBuildError(error_msg)
 
             time.sleep(check_interval_secs)
+
+            exit_code = proc.poll()
+
+        stdout += proc.stdout.read()
+        if split_stderr:
+            stderr += proc.stderr.read()
     else:
         (stdout, stderr) = proc.communicate(input=stdin)
 

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -223,7 +223,7 @@ def _answer_question(stdout, proc, qa_patterns, qa_wait_patterns):
             elif isinstance(answers, str):
                 answer = answers
             else:
-                raise EasyBuildError(f"Unknown type of answers encountered: {answers}")
+                raise EasyBuildError(f"Unknown type of answers encountered for question ({question}): {answers}")
 
             # answer may need to be completed via pattern extracted from question
             _log.debug(f"Raw answer for question pattern '{question}': {answer}")
@@ -280,8 +280,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
     :param task_id: task ID for specified shell command (included in return value)
     :param with_hooks: trigger pre/post run_shell_cmd hooks (if defined)
     :param qa_patterns: list of 2-tuples with patterns for questions + corresponding answers
-    :param qa_wait_patterns: list of 2-tuples with patterns for non-questions
-                             and number of iterations to allow these patterns to match with end out command output
+    :param qa_wait_patterns: list of strings with patterns for non-questions
     :param qa_timeout: amount of seconds to wait until more output is produced when there is no matching question
 
     :return: Named tuple with:

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -192,7 +192,7 @@ run_shell_cmd_cache = run_cmd_cache
 def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=None,
                   hidden=False, in_dry_run=False, verbose_dry_run=False, work_dir=None, use_bash=True,
                   output_file=True, stream_output=None, asynchronous=False, task_id=None, with_hooks=True,
-                  qa_patterns=None, qa_wait_patterns=None, qa_timeout=10000):
+                  qa_patterns=None, qa_wait_patterns=None, qa_timeout=100):
     """
     Run specified (interactive) shell command, and capture output + exit code.
 
@@ -213,7 +213,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
     :param qa_patterns: list of 2-tuples with patterns for questions + corresponding answers
     :param qa_wait_patterns: list of 2-tuples with patterns for non-questions
                              and number of iterations to allow these patterns to match with end out command output
-    :param qa_timeout: amount of milliseconds to wait until more output is produced when there is no matching question
+    :param qa_timeout: amount of seconds to wait until more output is produced when there is no matching question
 
     :return: Named tuple with:
     - output: command output, stdout+stderr combined if split_stderr is disabled, only stdout otherwise

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -277,7 +277,8 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
     if not in_dry_run and build_option('extended_dry_run'):
         if not hidden or verbose_dry_run:
             silent = build_option('silent')
-            msg = f"  running shell command \"{cmd_str}\"\n"
+            interactive = 'interactive ' if qa_patterns else ''
+            msg = f"  running {interactive}shell command \"{cmd_str}\"\n"
             msg += f"  (in {work_dir})"
             dry_run_msg(msg, silent=silent)
 
@@ -286,7 +287,8 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
 
     start_time = datetime.now()
     if not hidden:
-        _cmd_trace_msg(cmd_str, start_time, work_dir, stdin, cmd_out_fp, cmd_err_fp, thread_id)
+        _cmd_trace_msg(cmd_str, start_time, work_dir, stdin, cmd_out_fp, cmd_err_fp, thread_id,
+                       interactive=bool(qa_patterns))
 
     if stream_output:
         print_msg(f"(streaming) output for command '{cmd_str}':")
@@ -430,7 +432,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
     return res
 
 
-def _cmd_trace_msg(cmd, start_time, work_dir, stdin, cmd_out_fp, cmd_err_fp, thread_id):
+def _cmd_trace_msg(cmd, start_time, work_dir, stdin, cmd_out_fp, cmd_err_fp, thread_id, interactive=False):
     """
     Helper function to construct and print trace message for command being run
 
@@ -441,13 +443,15 @@ def _cmd_trace_msg(cmd, start_time, work_dir, stdin, cmd_out_fp, cmd_err_fp, thr
     :param cmd_out_fp: path to output file for command
     :param cmd_err_fp: path to errors/warnings output file for command
     :param thread_id: thread ID (None when not running shell command asynchronously)
+    :param interactive: boolean indicating whether it is an interactive command, or not
     """
     start_time = start_time.strftime('%Y-%m-%d %H:%M:%S')
 
+    interactive = 'interactive ' if interactive else ''
     if thread_id:
-        run_cmd_msg = f"running shell command (asynchronously, thread ID: {thread_id}):"
+        run_cmd_msg = f"running {interactive}shell command (asynchronously, thread ID: {thread_id}):"
     else:
-        run_cmd_msg = "running shell command:"
+        run_cmd_msg = f"running {interactive}shell command:"
 
     lines = [
         run_cmd_msg,

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -779,7 +779,7 @@ class RunTest(EnhancedTestCase):
         cmd += "; cat %s" % test_file
 
         with self.mocked_stdout_stderr():
-             res = run_shell_cmd(cmd, qa_patterns=qa)
+            res = run_shell_cmd(cmd, qa_patterns=qa)
         self.assertEqual(res.exit_code, 0)
         self.assertTrue(res.output.startswith("question1\nanswer1\nquestion2\nanswer2\nfoo "))
         self.assertTrue(res.output.endswith('bar'))

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -907,8 +907,8 @@ class RunTest(EnhancedTestCase):
         """Test whether run_shell_cmd uses unbuffered output when running interactive commands."""
 
         # command that generates a lot of output before waiting for input
-        # note: bug being fixed can be reproduced reliably using 1000, but not with too high values like 100000!
-        cmd = 'for x in $(seq 1000); do echo "This is a number you can pick: $x"; done; '
+        # note: bug being fixed can be reproduced reliably using 100, but not with too high values like 100000!
+        cmd = 'for x in $(seq 100); do echo "This is a number you can pick: $x"; done; '
         cmd += 'echo "Pick a number: "; read number; echo "Picked number: $number"'
         with self.mocked_stdout_stderr():
             res = run_shell_cmd(cmd, qa_patterns=[('Pick a number: ', '42')], qa_timeout=10)

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -1047,7 +1047,8 @@ class RunTest(EnhancedTestCase):
         self.assertEqual(res.exit_code, 0)
 
         with self.mocked_stdout_stderr():
-            self.assertErrorRegex(EasyBuildError, "Unknown type of answers encountered", run_shell_cmd, cmd, qa_patterns=[('question', 1)])
+            self.assertErrorRegex(EasyBuildError, "Unknown type of answers encountered", run_shell_cmd, cmd,
+                                  qa_patterns=[('question', 1)])
 
         # test cycling of answers
         cmd = cmd * 2

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -838,6 +838,18 @@ class RunTest(EnhancedTestCase):
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, error_pattern, run_shell_cmd, cmd, qa_patterns=qa, qa_timeout=1)
 
+        # check using answer that is completed via pattern extracted from question
+        cmd = ';'.join([
+            "echo 'and the magic number is: 42'",
+            "read magic_number",
+            "echo $magic_number",
+        ])
+        qa = [("and the magic number is: (?P<nr>[0-9]+)", "%(nr)s")]
+        with self.mocked_stdout_stderr():
+            res = run_shell_cmd(cmd, qa_patterns=qa)
+        self.assertEqual(res.exit_code, 0)
+        self.assertEqual(res.output, "and the magic number is: 42\n42\n")
+
         # test handling of output that is not actually a question
         cmd = ';'.join([
             "echo not-a-question-but-a-statement",


### PR DESCRIPTION
Currently sits on top of #4444, which should definitely get merged first - I'll sync with PR with `5.0.x` branch once that's done.

~WIP because:~ (ready for review)
* [x] ~more tests for `run_cmd_qa` should also be implemented for `run_shell_cmd` using `qa_patterns`~ (done)
* [x] ~use of `qa_wait_patterns` not supported yet;~ (now implemented)
* [x] ~probably need to add a `qa_timeout` option (equivalent to `maxhits` in `run_cmd_qa`);~ (implemented)
* [x] ~maybe some refactoring should be done, like moving code to actually answer questions to a dedicated (private) `_handle_cmd_qa` function, to avoid making `run_shell_cmd` even bigger than it already is~ (done, see `_answer_question` helper function);
* [x] ~testing with actual easyblocks not done yet~ (see https://github.com/easybuilders/easybuild-easyblocks/pull/3270)