### PR TITLE
Add new 'authors' to default for JSON software listing

### DIFF
--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -778,7 +778,7 @@ def list_software(output_format=FORMAT_TXT, detailed=False, only_installed=False
         else:
             toolchain = '%s/%s' % (ec['toolchain']['name'], ec['toolchain']['version'])
 
-        keys = ['description', 'homepage', 'version', 'versionsuffix']
+        keys = ['description', 'homepage', 'version', 'versionsuffix', 'authors']
 
         info = {'toolchain': toolchain}
         for key in keys:


### PR DESCRIPTION
The current default and markdown behavior are unaffected by this change.
The JSON listing will however show a list of authors (empty atm for (almost?) all packages).

The format in easybuilds would probably be best close to pyproject.tomls:
```
authors = ["Alexander Puck Neuwirth <alexander@neuwirth-informatik.de>"]
```
I have not found a good place to add a check for the `name <email>` format, if one even wants to enforce it?

This comes in handy for keeping software up to date by comparing with repology once https://github.com/easybuilders/easybuild-docs/pull/233 is merged and repology includes easybuild.