### PR TITLE
replace `'` with `"` for `printf` to have bash replace a variable

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -178,7 +178,7 @@ jobs:
               echo "Not testing with '${module_syntax}' as module syntax with '${EASYBUILD_MODULES_TOOL}' as modules tool"
               continue
             fi
-            printf '\n\n=====================> Using $module_syntax module syntax <=====================\n\n'
+            printf "\n\n=====================> Using $module_syntax module syntax <=====================\n\n"
             export EASYBUILD_MODULE_SYNTAX="${module_syntax}"
             export TEST_EASYBUILD_MODULE_SYNTAX="${EASYBUILD_MODULE_SYNTAX}"
 


### PR DESCRIPTION
```bash
$ printf '$USER\n'
$USER
$ printf "$USER\n"
branfosj
```

See https://github.com/easybuilders/easybuild-framework/actions/runs/7928571371/job/21647078762#step:9:127 vs https://github.com/easybuilders/easybuild-framework/actions/runs/8007069992/job/21870694989?pr=4461#step:9:101