### PR TITLE
update easyblocks for toy extensions to make sure that asynchronous installation command is run in correct working directory

### DIFF
--- a/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
@@ -93,7 +93,7 @@ class Toy_Extension(ExtensionEasyBlock):
             cmd = f"echo 'no sources for {self.name}'"
 
         return thread_pool.submit(run_shell_cmd, cmd, asynchronous=True, env=os.environ.copy(),
-                                  fail_on_error=False, task_id=task_id)
+                                  fail_on_error=False, task_id=task_id, work_dir=os.getcwd())
 
     def postrun(self):
         """

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -170,7 +170,7 @@ class EB_toy(ExtensionEasyBlock):
         cmd = compose_toy_build_cmd(self.cfg, self.name, self.cfg['prebuildopts'], self.cfg['buildopts'])
         task_id = f'ext_{self.name}_{self.version}'
         return thread_pool.submit(run_shell_cmd, cmd, asynchronous=True, env=os.environ.copy(),
-                                  fail_on_error=False, task_id=task_id)
+                                  fail_on_error=False, task_id=task_id, work_dir=os.getcwd())
 
     def postrun(self):
         """


### PR DESCRIPTION
Fixes flaky test failures in `test_toy_exts_parallel`, which are blocking #4469 (and also #4453), because the installation command for the extension is being run from the wrong working directory.

Apparently all threads are affected by an `os.chdir` call, which is global state for the whole process, so we can't rely on it.
It seems like for newer Python versions this is less of a problem, I've only seen failing tests with Python 3.6-3.8.

<details>

```
======================================================================
ERROR: test_toy_exts_parallel (test.framework.toy_build.ToyBuildTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/runner/cf2839720f6465e4fb88190e2f581e088d205f7d/lib/python3.6/site-packages/test/framework/toy_build.py", line 1920, in test_toy_exts_parallel
    stdout, stderr = self.run_test_toy_build_with_output(ec_file=test_ec, extra_args=args, raise_error=True)
  File "/tmp/runner/cf2839720f6465e4fb88190e2f581e088d205f7d/lib/python3.6/site-packages/test/framework/toy_build.py", line 239, in run_test_toy_build_with_output
    self._test_toy_build(*args, **kwargs)
  File "/tmp/runner/cf2839720f6465e4fb88190e2f581e088d205f7d/lib/python3.6/site-packages/test/framework/toy_build.py", line 195, in _test_toy_build
    raise myerr
  File "/tmp/runner/cf2839720f6465e4fb88190e2f581e088d205f7d/lib/python3.6/site-packages/test/framework/toy_build.py", line 191, in _test_toy_build
    raise_error=raise_error, testing=testing, raise_systemexit=raise_systemexit)
  File "/tmp/runner/cf2839720f6465e4fb88190e2f581e088d205f7d/lib/python3.6/site-packages/test/framework/utilities.py", line 341, in eb_main
    raise myerr
  File "/tmp/runner/cf2839720f6465e4fb88190e2f581e088d205f7d/lib/python3.6/site-packages/test/framework/utilities.py", line 314, in eb_main
    main(args=main_args, logfile=logfile, do_build=do_build, testing=testing, modtool=modtool)
  File "/tmp/runner/cf2839720f6465e4fb88190e2f581e088d205f7d/lib/python3.6/site-packages/easybuild/main.py", line 728, in main
    hooks, do_build)
  File "/tmp/runner/cf2839720f6465e4fb88190e2f581e088d205f7d/lib/python3.6/site-packages/easybuild/main.py", line 565, in process_eb_args
    exit_on_failure=exit_on_failure)
  File "/tmp/runner/cf2839720f6465e4fb88190e2f581e088d205f7d/lib/python3.6/site-packages/easybuild/main.py", line 175, in build_and_install_software
    raise EasyBuildError(test_msg)
easybuild.tools.build_log.EasyBuildError: 'Installation of test.eb failed: "shell command \'gcc ...\' failed in extensions step for test.eb"'
```

</details>