### PR TITLE
add workaround for 404 error when installing packages in CI workflow for testing Apptainer integration

### DIFF
--- a/.github/workflows/container_tests_apptainer.yml
+++ b/.github/workflows/container_tests_apptainer.yml
@@ -31,7 +31,7 @@ jobs:
         # for building CentOS 7 container images
         APT_PKGS="rpm dnf"
         # for modules tool
-        APT_PKGS="lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev"
+        APT_PKGS+="lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev"
 
         # Avoid apt-get update, as we don't really need it,
         # and it does more harm than good (it's fairly expensive, and it results in flaky test runs)

--- a/.github/workflows/container_tests_apptainer.yml
+++ b/.github/workflows/container_tests_apptainer.yml
@@ -29,10 +29,18 @@ jobs:
     - name: install OS & Python packages
       run: |
         # for building CentOS 7 container images
-        sudo apt-get install rpm
-        sudo apt-get install dnf
+        APT_PKGS="rpm dnf"
         # for modules tool
-        sudo apt-get install lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev
+        APT_PKGS="lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev"
+
+        # Avoid apt-get update, as we don't really need it,
+        # and it does more harm than good (it's fairly expensive, and it results in flaky test runs)
+        if ! sudo apt-get install $APT_PKGS; then
+          # Try to update cache, then try again to resolve 404s of old packages
+          sudo apt-get update -yqq || true
+          sudo apt-get install $APT_PKGS
+        fi
+
         # fix for lua-posix packaging issue, see https://bugs.launchpad.net/ubuntu/+source/lua-posix/+bug/1752082
         # needed for Ubuntu 18.04, but not for Ubuntu 20.04, so skipping symlinking if posix.so already exists
         if [ ! -e /usr/lib/x86_64-linux-gnu/lua/5.2/posix.so ] ; then

--- a/.github/workflows/container_tests_apptainer.yml
+++ b/.github/workflows/container_tests_apptainer.yml
@@ -31,7 +31,7 @@ jobs:
         # for building CentOS 7 container images
         APT_PKGS="rpm dnf"
         # for modules tool
-        APT_PKGS+="lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev"
+        APT_PKGS+=" lua5.2 liblua5.2-dev lua-filesystem lua-posix tcl tcl-dev"
 
         # Avoid apt-get update, as we don't really need it,
         # and it does more harm than good (it's fairly expensive, and it results in flaky test runs)


### PR DESCRIPTION
Fix for failing CI when trying to install `dnf` package:

```
Err:19 mirror+file:/etc/apt/apt-mirrors.txt jammy-updates/main amd64 libunbound8 amd64 1.13.1-1ubuntu5.3
  404  Not Found [IP: 52.252.75.106 80]
Ign:20 http://security.ubuntu.com/ubuntu jammy-updates/universe amd64 python3-unbound amd64 1.13.1-1ubuntu5.3
Err:20 mirror+file:/etc/apt/apt-mirrors.txt jammy-updates/universe amd64 python3-unbound amd64 1.13.1-1ubuntu5.3
  404  Not Found [IP: 52.252.75.106 80]
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/main/u/unbound/libunbound8_1.13.1-1ubuntu5.3_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
Fetched 3190 kB in 1s (3669 kB/s)
E: Failed to fetch mirror+file:/etc/apt/apt-mirrors.txt/pool/universe/u/unbound/python3-unbound_1.13.1-1ubuntu5.3_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
Error: Process completed with exit code 100.
```

We're already using this same workaround in the workflow for testing Singularity integration (see also #4176)