### PR TITLE
replace `log.warn` with `log.warning`

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2240,7 +2240,7 @@ def det_size(path):
                 if os.path.exists(fullpath):
                     installsize += os.path.getsize(fullpath)
     except OSError as err:
-        _log.warn("Could not determine install size: %s" % err)
+        _log.warning("Could not determine install size: %s" % err)
 
     return installsize
 

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -208,7 +208,7 @@ class BuildLogTest(EnhancedTestCase):
             log.error('kaput')
             log.deprecated('almost kaput', '10000000000000')
             log.raiseError = True
-            log.warn('this is a warning')
+            log.warning('this is a warning')
             log.info('fyi')
             log.debug('gdb')
             log.devel('tmi')


### PR DESCRIPTION
`log.warn` has been deprecated since Python 3.3 and will be removed in Python 3.13.