### PR TITLE
Eliminate use of `distutils.version.StrictVersion`

### DIFF
--- a/easybuild/tools/__init__.py
+++ b/easybuild/tools/__init__.py
@@ -37,14 +37,5 @@ Authors:
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
 
-import distutils.version
 import warnings
 from easybuild.tools.loose_version import LooseVersion  # noqa(F401)
-
-
-class StrictVersion(distutils.version.StrictVersion):
-    """Temporary wrapper over distuitls StrictVersion that silences the deprecation warning"""
-    def __init__(self, *args, **kwargs):
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=DeprecationWarning)
-            distutils.version.StrictVersion.__init__(self, *args, **kwargs)

--- a/easybuild/tools/__init__.py
+++ b/easybuild/tools/__init__.py
@@ -37,5 +37,4 @@ Authors:
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
 
-import warnings
 from easybuild.tools.loose_version import LooseVersion  # noqa(F401)

--- a/easybuild/tools/loose_version.py
+++ b/easybuild/tools/loose_version.py
@@ -53,8 +53,8 @@ class LooseVersion(object):
         """Readonly access to the parsed version (list or None)"""
         return self._version
 
-    def is_earlier_or_prerelease(self, other, markers):
-        """Check if this is an earlier version or prerelease of other
+    def is_prerelease(self, other, markers):
+        """Check if this is a prerelease of other
 
         Markers is a list of strings that denote a prerelease
         """
@@ -67,7 +67,7 @@ class LooseVersion(object):
             for marker in markers:
                 if prerelease.startswith(marker):
                     return True
-        return self < other
+        return False
 
     def __str__(self):
         return self._vstring

--- a/easybuild/tools/loose_version.py
+++ b/easybuild/tools/loose_version.py
@@ -53,6 +53,22 @@ class LooseVersion(object):
         """Readonly access to the parsed version (list or None)"""
         return self._version
 
+    def is_earlier_or_prerelease(self, other, markers):
+        """Check if this is an earlier version or prerelease of other
+
+        Markers is a list of strings that denote a prerelease
+        """
+        if isinstance(other, str):
+            vstring = other
+        else:
+            vstring = other._vstring
+        if self._vstring.startswith(vstring):
+            prerelease = self._vstring[len(vstring):]
+            for marker in markers:
+                if prerelease.startswith(marker):
+                    return True
+        return self < other
+
     def __str__(self):
         return self._vstring
 

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -254,7 +254,7 @@ class ModulesTool(object):
             version = LooseVersion(self.version)
             if self.REQ_VERSION is not None:
                 self.log.debug("Required minimum %s version defined: %s", self.NAME, self.REQ_VERSION)
-                if version.is_prerelease(self.REQ_VERSION, ['rc', '-beta']) or version < self.REQ_VERSION:
+                if version < self.REQ_VERSION or version.is_prerelease(self.REQ_VERSION, ['rc', '-beta']):
                     raise EasyBuildError("EasyBuild requires %s >= v%s, found v%s",
                                          self.NAME, self.REQ_VERSION, self.version)
                 else:
@@ -262,14 +262,14 @@ class ModulesTool(object):
 
             if self.DEPR_VERSION is not None:
                 self.log.debug("Deprecated %s version limit defined: %s", self.NAME, self.DEPR_VERSION)
-                if version.is_prerelease(self.DEPR_VERSION, ['rc', '-beta']) or version < self.DEPR_VERSION:
+                if version < self.DEPR_VERSION or version.is_prerelease(self.DEPR_VERSION, ['rc', '-beta']):
                     depr_msg = "Support for %s version < %s is deprecated, " % (self.NAME, self.DEPR_VERSION)
                     depr_msg += "found version %s" % self.version
                     self.log.deprecated(depr_msg, '6.0')
 
             if self.MAX_VERSION is not None:
                 self.log.debug("Maximum allowed %s version defined: %s", self.NAME, self.MAX_VERSION)
-                if not version.is_prerelease(self.MAX_VERSION, ['rc', '-beta']) and self.version > self.MAX_VERSION:
+                if self.version > self.MAX_VERSION and not version.is_prerelease(self.MAX_VERSION, ['rc', '-beta']):
                     raise EasyBuildError("EasyBuild requires %s <= v%s, found v%s",
                                          self.NAME, self.MAX_VERSION, self.version)
                 else:

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -254,7 +254,7 @@ class ModulesTool(object):
             version = LooseVersion(self.version)
             if self.REQ_VERSION is not None:
                 self.log.debug("Required minimum %s version defined: %s", self.NAME, self.REQ_VERSION)
-                if version.is_earlier_or_prerelease(self.REQ_VERSION, ['rc', '-beta']):
+                if version.is_prerelease(self.REQ_VERSION, ['rc', '-beta']) or version < self.REQ_VERSION:
                     raise EasyBuildError("EasyBuild requires %s >= v%s, found v%s",
                                          self.NAME, self.REQ_VERSION, self.version)
                 else:
@@ -262,14 +262,14 @@ class ModulesTool(object):
 
             if self.DEPR_VERSION is not None:
                 self.log.debug("Deprecated %s version limit defined: %s", self.NAME, self.DEPR_VERSION)
-                if version.is_earlier_or_prerelease(self.DEPR_VERSION, ['rc', '-beta']):
+                if version.is_prerelease(self.DEPR_VERSION, ['rc', '-beta']) or version < self.DEPR_VERSION:
                     depr_msg = "Support for %s version < %s is deprecated, " % (self.NAME, self.DEPR_VERSION)
                     depr_msg += "found version %s" % self.version
                     self.log.deprecated(depr_msg, '6.0')
 
             if self.MAX_VERSION is not None:
                 self.log.debug("Maximum allowed %s version defined: %s", self.NAME, self.MAX_VERSION)
-                if version.is_earlier_or_prerelease(self.MAX_VERSION, ['rc', '-beta']):
+                if not version.is_prerelease(self.MAX_VERSION, ['rc', '-beta']) and self.version > self.MAX_VERSION:
                     raise EasyBuildError("EasyBuild requires %s <= v%s, found v%s",
                                          self.NAME, self.MAX_VERSION, self.version)
                 else:

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -42,7 +42,7 @@ from unittest import TextTestRunner
 import easybuild.tools.modules as mod
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig.easyconfig import EasyConfig
-from easybuild.tools import StrictVersion
+from easybuild.tools import LooseVersion
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.environment import modify_env
 from easybuild.tools.filetools import adjust_permissions, copy_file, copy_dir, mkdir
@@ -226,15 +226,16 @@ class ModulesTest(EnhancedTestCase):
 
         # all test modules are accounted for
         ms = self.modtool.available()
+        version = LooseVersion(self.modtool.version)
 
-        if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('5.7.5'):
+        if isinstance(self.modtool, Lmod) and not version.is_prerelease_or_earlier('5.7.5', ['rc']):
             # with recent versions of Lmod, also the hidden modules are included in the output of 'avail'
             self.assertEqual(len(ms), TEST_MODULES_COUNT + 3)
             self.assertIn('bzip2/.1.0.6', ms)
             self.assertIn('toy/.0.0-deps', ms)
             self.assertIn('OpenMPI/.2.1.2-GCC-6.4.0-2.28', ms)
         elif (isinstance(self.modtool, EnvironmentModules)
-                and StrictVersion(self.modtool.version) >= StrictVersion('4.6.0')):
+                and not version.is_prerelease_or_earlier('4.6.0', ['-beta'])):
             # bzip2/.1.0.6 is not there, since that's a module file in Lua syntax
             self.assertEqual(len(ms), TEST_MODULES_COUNT + 2)
             self.assertIn('toy/.0.0-deps', ms)
@@ -314,7 +315,8 @@ class ModulesTest(EnhancedTestCase):
 
         avail_mods = self.modtool.available()
         self.assertIn('Java/1.8.0_181', avail_mods)
-        if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.0'):
+        version = LooseVersion(self.modtool.version)
+        if isinstance(self.modtool, Lmod) and not version.is_earlier_or_prerelease('7.0', ['rc']):
             self.assertIn('Java/1.8', avail_mods)
             self.assertIn('Java/site_default', avail_mods)
             self.assertIn('JavaAlias', avail_mods)
@@ -374,7 +376,7 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(self.modtool.exist(['Core/Java/1.8', 'Core/Java/site_default']), [True, True])
 
         # also check with .modulerc.lua for Lmod 7.8 or newer
-        if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.8'):
+        if isinstance(self.modtool, Lmod) and not version.is_earlier_or_prerelease('7.8', ['rc']):
             shutil.move(os.path.join(self.test_prefix, 'Core', 'Java'), java_mod_dir)
             reset_module_caches()
 
@@ -406,7 +408,7 @@ class ModulesTest(EnhancedTestCase):
             self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
 
         # Test alias in home directory .modulerc
-        if isinstance(self.modtool, Lmod) and StrictVersion(self.modtool.version) >= StrictVersion('7.0'):
+        if isinstance(self.modtool, Lmod) and not version.is_earlier_or_prerelease('7.0', ['rc']):
             # Required or temporary HOME would be in MODULEPATH already
             self.init_testmods()
             # Sanity check: Module aliases don't exist yet

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -228,14 +228,14 @@ class ModulesTest(EnhancedTestCase):
         ms = self.modtool.available()
         version = LooseVersion(self.modtool.version)
 
-        if isinstance(self.modtool, Lmod) and not version.is_prerelease('5.7.5', ['rc']) and version >= '5.7.5':
+        if isinstance(self.modtool, Lmod) and version >= '5.7.5' and not version.is_prerelease('5.7.5', ['rc']):
             # with recent versions of Lmod, also the hidden modules are included in the output of 'avail'
             self.assertEqual(len(ms), TEST_MODULES_COUNT + 3)
             self.assertIn('bzip2/.1.0.6', ms)
             self.assertIn('toy/.0.0-deps', ms)
             self.assertIn('OpenMPI/.2.1.2-GCC-6.4.0-2.28', ms)
         elif (isinstance(self.modtool, EnvironmentModules)
-                and not version.is_prerelease('4.6.0', ['-beta'])) and version >= '4.6.0':
+                and version >= '4.6.0' and not version.is_prerelease('4.6.0', ['-beta'])):
             # bzip2/.1.0.6 is not there, since that's a module file in Lua syntax
             self.assertEqual(len(ms), TEST_MODULES_COUNT + 2)
             self.assertIn('toy/.0.0-deps', ms)
@@ -316,7 +316,7 @@ class ModulesTest(EnhancedTestCase):
         avail_mods = self.modtool.available()
         self.assertIn('Java/1.8.0_181', avail_mods)
         version = LooseVersion(self.modtool.version)
-        if isinstance(self.modtool, Lmod) and not version.is_prerelease('7.0', ['rc']) and version >= '7.0':
+        if isinstance(self.modtool, Lmod) and version >= '7.0' and not version.is_prerelease('7.0', ['rc']):
             self.assertIn('Java/1.8', avail_mods)
             self.assertIn('Java/site_default', avail_mods)
             self.assertIn('JavaAlias', avail_mods)
@@ -376,7 +376,7 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(self.modtool.exist(['Core/Java/1.8', 'Core/Java/site_default']), [True, True])
 
         # also check with .modulerc.lua for Lmod 7.8 or newer
-        if isinstance(self.modtool, Lmod) and not version.is_prerelease('7.8', ['rc']) and version >= '7.8':
+        if isinstance(self.modtool, Lmod) and version >= '7.8' and not version.is_prerelease('7.8', ['rc']):
             shutil.move(os.path.join(self.test_prefix, 'Core', 'Java'), java_mod_dir)
             reset_module_caches()
 
@@ -408,7 +408,7 @@ class ModulesTest(EnhancedTestCase):
             self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
 
         # Test alias in home directory .modulerc
-        if isinstance(self.modtool, Lmod) and not version.is_prerelease('7.0', ['rc']) or version >= '7.0':
+        if isinstance(self.modtool, Lmod) and version >= '7.0' and not version.is_prerelease('7.0', ['rc']):
             # Required or temporary HOME would be in MODULEPATH already
             self.init_testmods()
             # Sanity check: Module aliases don't exist yet

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -228,14 +228,14 @@ class ModulesTest(EnhancedTestCase):
         ms = self.modtool.available()
         version = LooseVersion(self.modtool.version)
 
-        if isinstance(self.modtool, Lmod) and not version.is_prerelease_or_earlier('5.7.5', ['rc']):
+        if isinstance(self.modtool, Lmod) and not version.is_earlier_or_prerelease('5.7.5', ['rc']):
             # with recent versions of Lmod, also the hidden modules are included in the output of 'avail'
             self.assertEqual(len(ms), TEST_MODULES_COUNT + 3)
             self.assertIn('bzip2/.1.0.6', ms)
             self.assertIn('toy/.0.0-deps', ms)
             self.assertIn('OpenMPI/.2.1.2-GCC-6.4.0-2.28', ms)
         elif (isinstance(self.modtool, EnvironmentModules)
-                and not version.is_prerelease_or_earlier('4.6.0', ['-beta'])):
+                and not version.is_earlier_or_prerelease('4.6.0', ['-beta'])):
             # bzip2/.1.0.6 is not there, since that's a module file in Lua syntax
             self.assertEqual(len(ms), TEST_MODULES_COUNT + 2)
             self.assertIn('toy/.0.0-deps', ms)

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -228,14 +228,14 @@ class ModulesTest(EnhancedTestCase):
         ms = self.modtool.available()
         version = LooseVersion(self.modtool.version)
 
-        if isinstance(self.modtool, Lmod) and not version.is_earlier_or_prerelease('5.7.5', ['rc']):
+        if isinstance(self.modtool, Lmod) and not version.is_prerelease('5.7.5', ['rc']) and version >= '5.7.5':
             # with recent versions of Lmod, also the hidden modules are included in the output of 'avail'
             self.assertEqual(len(ms), TEST_MODULES_COUNT + 3)
             self.assertIn('bzip2/.1.0.6', ms)
             self.assertIn('toy/.0.0-deps', ms)
             self.assertIn('OpenMPI/.2.1.2-GCC-6.4.0-2.28', ms)
         elif (isinstance(self.modtool, EnvironmentModules)
-                and not version.is_earlier_or_prerelease('4.6.0', ['-beta'])):
+                and not version.is_prerelease('4.6.0', ['-beta'])) and version >= '4.6.0':
             # bzip2/.1.0.6 is not there, since that's a module file in Lua syntax
             self.assertEqual(len(ms), TEST_MODULES_COUNT + 2)
             self.assertIn('toy/.0.0-deps', ms)
@@ -316,7 +316,7 @@ class ModulesTest(EnhancedTestCase):
         avail_mods = self.modtool.available()
         self.assertIn('Java/1.8.0_181', avail_mods)
         version = LooseVersion(self.modtool.version)
-        if isinstance(self.modtool, Lmod) and not version.is_earlier_or_prerelease('7.0', ['rc']):
+        if isinstance(self.modtool, Lmod) and not version.is_prerelease('7.0', ['rc']) and version >= '7.0':
             self.assertIn('Java/1.8', avail_mods)
             self.assertIn('Java/site_default', avail_mods)
             self.assertIn('JavaAlias', avail_mods)
@@ -376,7 +376,7 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(self.modtool.exist(['Core/Java/1.8', 'Core/Java/site_default']), [True, True])
 
         # also check with .modulerc.lua for Lmod 7.8 or newer
-        if isinstance(self.modtool, Lmod) and not version.is_earlier_or_prerelease('7.8', ['rc']):
+        if isinstance(self.modtool, Lmod) and not version.is_prerelease('7.8', ['rc']) and version >= '7.8':
             shutil.move(os.path.join(self.test_prefix, 'Core', 'Java'), java_mod_dir)
             reset_module_caches()
 
@@ -408,7 +408,7 @@ class ModulesTest(EnhancedTestCase):
             self.assertEqual(self.modtool.exist(['Core/Java/site_default']), [True])
 
         # Test alias in home directory .modulerc
-        if isinstance(self.modtool, Lmod) and not version.is_earlier_or_prerelease('7.0', ['rc']):
+        if isinstance(self.modtool, Lmod) and not version.is_prerelease('7.0', ['rc']) or version >= '7.0':
             # Required or temporary HOME would be in MODULEPATH already
             self.init_testmods()
             # Sanity check: Module aliases don't exist yet

--- a/test/framework/modulestool.py
+++ b/test/framework/modulestool.py
@@ -36,7 +36,7 @@ from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
 
 from easybuild.base import fancylogger
-from easybuild.tools import modules, StrictVersion
+from easybuild.tools import modules, LooseVersion
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import read_file, which, write_file
 from easybuild.tools.modules import EnvironmentModules, Lmod
@@ -76,7 +76,7 @@ class ModulesToolTest(EnhancedTestCase):
         mmt = MockModulesTool(mod_paths=[], testing=True)
 
         # the version of the MMT is the commandline option
-        self.assertEqual(mmt.version, StrictVersion(MockModulesTool.VERSION_OPTION))
+        self.assertEqual(mmt.version, LooseVersion(MockModulesTool.VERSION_OPTION))
 
         cmd_abspath = which(MockModulesTool.COMMAND)
 
@@ -100,7 +100,7 @@ class ModulesToolTest(EnhancedTestCase):
         bmmt = BrokenMockModulesTool(mod_paths=[], testing=True)
         cmd_abspath = which(MockModulesTool.COMMAND)
 
-        self.assertEqual(bmmt.version, StrictVersion(MockModulesTool.VERSION_OPTION))
+        self.assertEqual(bmmt.version, LooseVersion(MockModulesTool.VERSION_OPTION))
         self.assertEqual(bmmt.cmd, cmd_abspath)
 
         # clean it up

--- a/test/framework/utilities_test.py
+++ b/test/framework/utilities_test.py
@@ -145,8 +145,8 @@ class UtilitiesTest(EnhancedTestCase):
         self.assertLess(LooseVersion('1'), LooseVersion('1.0'))
         # checking prereleases
         self.assertGreater(LooseVersion('4.0.0-beta'), LooseVersion('4.0.0'))
-        self.assertEqual(LooseVersion('4.0.0-beta').is_earlier_or_prerelease('4.0.0'), ['-beta'], True)
-        self.assertEqual(LooseVersion('4.0.0-beta').is_earlier_or_prerelease('4.0.0'), ['rc'], False)
+        self.assertEqual(LooseVersion('4.0.0-beta').is_earlier_or_prerelease('4.0.0', ['-beta']), True)
+        self.assertEqual(LooseVersion('4.0.0-beta').is_earlier_or_prerelease('4.0.0', ['rc']), False)
 
         # The following test is taken from Python distutils tests
         # licensed under the Python Software Foundation License Version 2

--- a/test/framework/utilities_test.py
+++ b/test/framework/utilities_test.py
@@ -145,8 +145,8 @@ class UtilitiesTest(EnhancedTestCase):
         self.assertLess(LooseVersion('1'), LooseVersion('1.0'))
         # checking prereleases
         self.assertGreater(LooseVersion('4.0.0-beta'), LooseVersion('4.0.0'))
-        self.assertEqual(LooseVersion('4.0.0-beta').is_earlier_or_prerelease('4.0.0', ['-beta']), True)
-        self.assertEqual(LooseVersion('4.0.0-beta').is_earlier_or_prerelease('4.0.0', ['rc']), False)
+        self.assertEqual(LooseVersion('4.0.0-beta').is_prerelease('4.0.0', ['-beta']), True)
+        self.assertEqual(LooseVersion('4.0.0-beta').is_prerelease('4.0.0', ['rc']), False)
 
         # The following test is taken from Python distutils tests
         # licensed under the Python Software Foundation License Version 2

--- a/test/framework/utilities_test.py
+++ b/test/framework/utilities_test.py
@@ -143,6 +143,10 @@ class UtilitiesTest(EnhancedTestCase):
         # Careful here: 1.0 > 1 !!!
         self.assertGreater(LooseVersion('1.0'), LooseVersion('1'))
         self.assertLess(LooseVersion('1'), LooseVersion('1.0'))
+        # checking prereleases
+        self.assertGreater(LooseVersion('4.0.0-beta'), LooseVersion('4.0.0'))
+        self.assertEqual(LooseVersion('4.0.0-beta').is_earlier_or_prerelease('4.0.0'), ['-beta'], True)
+        self.assertEqual(LooseVersion('4.0.0-beta').is_earlier_or_prerelease('4.0.0'), ['rc'], False)
 
         # The following test is taken from Python distutils tests
         # licensed under the Python Software Foundation License Version 2


### PR DESCRIPTION
distutils was removed in Python 3.12. The only reason EasyBuild uses StrictVersion is that it orders beta/rc versions before the released version, unlike LooseVersion. E.g. 5.0.0-beta < 5.0.0 (but > for LooseVersion).

So a new method
`is_prerelease(self, other, markers)`
was added to LooseVersion to handle that particular case.

Addresses part of #3963