### PR TITLE
Eliminate `distutils.util.strtobool`.

### DIFF
--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -280,9 +280,9 @@ def to_toolchain_dict(spec):
         # 3-element list
         elif len(spec) == 3:
             hidden = spec[2].strip().lower()
-            if hidden in {'yes', 'true', 't', 'y', '1'}:
+            if hidden in {'yes', 'true', 't', 'y', '1', 'on'}:
                 hidden = True
-            elif hidden in {'no', 'false', 'f', 'n', '0'}:
+            elif hidden in {'no', 'false', 'f', 'n', '0', 'off'}:
                 hidden = False
             else:
                 raise EasyBuildError("Invalid truth value %s", hidden)

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -31,7 +31,6 @@ Authors:
 * Caroline De Brouwer (Ghent University)
 * Kenneth Hoste (Ghent University)
 """
-from distutils.util import strtobool
 
 from easybuild.base import fancylogger
 from easybuild.framework.easyconfig.format.format import DEPENDENCY_PARAMETERS
@@ -280,7 +279,14 @@ def to_toolchain_dict(spec):
             res = {'name': spec[0].strip(), 'version': spec[1].strip()}
         # 3-element list
         elif len(spec) == 3:
-            res = {'name': spec[0].strip(), 'version': spec[1].strip(), 'hidden': strtobool(spec[2].strip())}
+            hidden = spec[2].strip().lower()
+            if hidden in {'yes', 'true', 't', 'y', '1'}:
+                hidden = True
+            elif hidden in {'no', 'false', 'f', 'n', '0'}:
+                hidden = False
+            else:
+                raise EasyBuildError("Invalid truth value %s", hidden)
+            res = {'name': spec[0].strip(), 'version': spec[1].strip(), 'hidden': hidden}
         else:
             raise EasyBuildError("Can not convert list %s to toolchain dict. Expected 2 or 3 elements", spec)
 

--- a/test/framework/type_checking.py
+++ b/test/framework/type_checking.py
@@ -317,9 +317,9 @@ class TypeCheckingTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, errstr, to_toolchain_dict, ['gcc', '4', 'False', '7'])
 
         # invalid truth value
-        errstr = "invalid truth value .*"
-        self.assertErrorRegex(ValueError, errstr, to_toolchain_dict, "intel, 2015, foo")
-        self.assertErrorRegex(ValueError, errstr, to_toolchain_dict, ['gcc', '4', '7'])
+        errstr = "Invalid truth value .*"
+        self.assertErrorRegex(EasyBuildError, errstr, to_toolchain_dict, "intel, 2015, foo")
+        self.assertErrorRegex(EasyBuildError, errstr, to_toolchain_dict, ['gcc', '4', '7'])
 
         # missing keys
         self.assertErrorRegex(EasyBuildError, "Incorrect set of keys", to_toolchain_dict, {'name': 'intel'})


### PR DESCRIPTION
It's only used once so I open-coded it. A stricter but not backwards compatible check would be to only allow 'True' and 'False'.

Addresses part of #3963