### PR TITLE
tweak `setup.py` to fall back to importing `setup` from `setuptools` if `distutils` is not available

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -123,7 +123,7 @@ jobs:
       run: |
           # make sure there are no (top-level) "import setuptools" or "import pkg_resources" statements,
           # since EasyBuild should not have a runtime requirement on setuptools
-          SETUPTOOLS_IMPORTS=$(egrep -RI '^(from|import)[ ]*pkg_resources|^(from|import)[ ]*setuptools' * || true)
+          SETUPTOOLS_IMPORTS=$(egrep --exclude setup.py -RI '^(from|import)[ ]*pkg_resources|^(from|import)[ ]*setuptools' * || true)
           test "x$SETUPTOOLS_IMPORTS" = "x" || (echo "Found setuptools and/or pkg_resources imports in easybuild/:\n${SETUPTOOLS_IMPORTS}" && exit 1)
 
     - name: install sources

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ API_VERSION = str(VERSION).split('.')[0]
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+
 log = logging.getLogger("EasyBuild")
 
 # log levels: NOTSET (default), DEBUG, INFO, WARNING, ERROR, CRITICAL

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,10 @@ This script can be used to install easybuild-framework, e.g. using:
 import glob
 import os
 import logging
-from setuptools import setup
+try:
+    from distutils.core import setup
+except ImportError:
+    from setuptools import setup
 
 from easybuild.tools.version import VERSION
 

--- a/setup.py
+++ b/setup.py
@@ -24,16 +24,14 @@
 ##
 """
 This script can be used to install easybuild-framework, e.g. using:
-  easy_install --user .
-or
-  python setup.py --prefix=$HOME/easybuild
+  python setup.py install --prefix=$HOME/easybuild
 
 @author: Kenneth Hoste (Ghent University)
 """
 import glob
 import os
-from distutils import log
-from distutils.core import setup
+import logging
+from setuptools import setup
 
 from easybuild.tools.version import VERSION
 
@@ -44,9 +42,10 @@ API_VERSION = str(VERSION).split('.')[0]
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+log = logging.getLogger("EasyBuild")
 
-# log levels: 0 = WARN (default), 1 = INFO, 2 = DEBUG
-log.set_verbosity(1)
+# log levels: NOTSET (default), DEBUG, INFO, WARNING, ERROR, CRITICAL
+log.setLevel(logging.INFO)
 
 log.info("Installing version %s (API version %s)" % (VERSION, API_VERSION))
 


### PR DESCRIPTION
Use logging and setuptools instead.