### PR TITLE
fix easyconfig parameter deprecation

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -179,7 +179,7 @@ def triage_easyconfig_params(variables, ec):
 
     for key in variables:
         # validations are skipped, just set in the config
-        if key in ec:
+        if key in ec or key in DEPRECATED_PARAMETERS.keys():
             ec_params[key] = variables[key]
             _log.debug("setting config option %s: value %s (type: %s)", key, ec_params[key], type(ec_params[key]))
         elif key in REPLACED_PARAMETERS:
@@ -658,7 +658,7 @@ class EasyConfig(object):
         with self.disable_templating():
             for key in sorted(params.keys()):
                 # validations are skipped, just set in the config
-                if key in self._config.keys():
+                if key in self._config.keys() or key in DEPRECATED_PARAMETERS.keys():
                     self[key] = params[key]
                     self.log.info("setting easyconfig parameter %s: value %s (type: %s)",
                                   key, self[key], type(self[key]))


### PR DESCRIPTION
We currently have support for deprecating easyconfig parameters by adding them to the `DEPRECATED_PARAMETERS` dict in `easybuild/framework/easyconfigs/parser.py`. 
However, there is currently a bug -- both `triage_easyconfig_params()` and `set_keys()` in `easybuild/framework/easyconfig/easyconfig.py` end up ignoring deprecated parameters, should they appear in an easyconfig. Instead, they're treated as a local variables/unkown easyconfig parameter.

this isn't actually specific to easybuild 5 (exists in 4.x at least, maybe older versions too), but since it hasn't come up before I've just targetted 5.0.x