### PR TITLE
Clean up parameter deprecation warnings, and update easybuild doc urls

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -121,7 +121,7 @@ def handle_deprecated_or_replaced_easyconfig_parameters(ec_method):
         if key in DEPRECATED_PARAMETERS:
             depr_key = key
             key, ver = DEPRECATED_PARAMETERS[depr_key]
-            _log.deprecated("Easyconfig parameter '%s' is deprecated, use '%s' instead." % (depr_key, key), ver)
+            _log.deprecated("Easyconfig parameter '%s' is deprecated, use '%s' instead" % (depr_key, key), ver)
         if key in REPLACED_PARAMETERS:
             _log.nosupport("Easyconfig parameter '%s' is replaced by '%s'" % (key, REPLACED_PARAMETERS[key]), '2.0')
         return ec_method(self, key, *args, **kwargs)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -792,7 +792,7 @@ class EasyConfig(object):
             msg = "Use of %d unknown easyconfig parameters detected %s: %s\n" % (cnt, in_fn, unknown_keys_msg)
             msg += "If these are just local variables please rename them to start with '%s', " % LOCAL_VAR_PREFIX
             msg += "or try using --fix-deprecated-easyconfigs to do this automatically.\nFor more information, see "
-            msg += "https://easybuild.readthedocs.io/en/latest/Easyconfig-files-local-variables.html ."
+            msg += "https://docs.easybuild.io/easyconfig-files-local-variables/ ."
 
             # always log a warning if local variable that don't follow recommended naming scheme are found
             self.log.warning(msg)
@@ -830,7 +830,7 @@ class EasyConfig(object):
             depr_maj_ver = int(str(VERSION).split('.')[0]) + 1
             depr_ver = '%s.0' % depr_maj_ver
 
-            more_info_depr_ec = " (see also http://easybuild.readthedocs.org/en/latest/Deprecated-easyconfigs.html)"
+            more_info_depr_ec = " (https://docs.easybuild.io/deprecated-easyconfigs)"
 
             self.log.deprecated(depr_msg, depr_ver, more_info=more_info_depr_ec, silent=build_option('silent'))
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -830,7 +830,7 @@ class EasyConfig(object):
             depr_maj_ver = int(str(VERSION).split('.')[0]) + 1
             depr_ver = '%s.0' % depr_maj_ver
 
-            more_info_depr_ec = " (https://docs.easybuild.io/deprecated-easyconfigs)"
+            more_info_depr_ec = " (see also https://docs.easybuild.io/deprecated-easyconfigs)"
 
             self.log.deprecated(depr_msg, depr_ver, more_info=more_info_depr_ec, silent=build_option('silent'))
 

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -55,7 +55,7 @@ CURRENT_VERSION = VERSION
 # allow some experimental experimental code
 EXPERIMENTAL = False
 
-DEPRECATED_DOC_URL = 'http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html'
+DEPRECATED_DOC_URL = 'https://docs.easybuild.io/deprecated-functionality/'
 
 DRY_RUN_BUILD_DIR = None
 DRY_RUN_SOFTWARE_INSTALL_DIR = None

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -2178,7 +2178,7 @@ def check_github():
         msg = '\n'.join([
             '',
             "One or more checks FAILed, GitHub configuration not fully complete!",
-            "See http://easybuild.readthedocs.org/en/latest/Integration_with_GitHub.html#configuration for help.",
+            "See https://docs.easybuild.io/integration-with-github/#github_configuration for help.",
             '',
         ])
     print_msg(msg, log=_log, prefix=False)

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -945,7 +945,7 @@ class ModulesTool(object):
                     "use the --allow-loaded-modules configuration option.",
                     "To specify action to take when loaded modules are detected, use %s." % opt,
                     '',
-                    "See http://easybuild.readthedocs.io/en/latest/Detecting_loaded_modules.html for more information.",
+                    "See https://docs.easybuild.io/detecting-loaded-modules/ for more information.",
                 ])
 
                 action = build_option('detect_loaded_modules')

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -358,9 +358,9 @@ class Compiler(Toolchain):
             optarch_flags_str = "%soptarch flags" % ('', 'generic ')[use_generic]
             error_msg = "Don't know how to set %s for %s/%s! " % (optarch_flags_str, self.arch, self.cpu_family)
             error_msg += "Use --optarch='<flags>' to override (see "
-            error_msg += "http://easybuild.readthedocs.io/en/latest/Controlling_compiler_optimization_flags.html "
+            error_msg += "https://docs.easybuild.io/controlling-compiler-optimization-flags/ "
             error_msg += "for details) and consider contributing your settings back (see "
-            error_msg += "http://easybuild.readthedocs.io/en/latest/Contributing.html)."
+            error_msg += "https://docs.easybuild.io/contributing/)."
             raise EasyBuildError(error_msg)
 
     def comp_family(self, prefix=None):

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -116,7 +116,7 @@ class BuildLogTest(EnhancedTestCase):
         stderr = self.get_stderr()
         self.mock_stderr(False)
 
-        more_info = "see http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html for more information"
+        more_info = "see https://docs.easybuild.io/deprecated-functionality/ for more information"
         expected_stderr = '\n\n'.join([
             "\nWARNING: Deprecated functionality, will no longer work in v10000001: anotherwarning; " + more_info,
             "\nWARNING: Deprecated functionality, will no longer work in v2.0: onemorewarning",


### PR DESCRIPTION
* updates any instances of easybuild.readthedocs.io to point to the corresponding docs.easybuild.io page
* fixes getting `.;` in deprecation warnings for easyconfig parameters, which are currently of the form:
```
WARNING: Deprecated functionality, will no longer work in v6.0: Easyconfig parameter 'configopts' is deprecated, use 'configure_opts' instead.; see http://easybuild.readthedocs.org/en/latest/Deprecated-functionality.html for more information
```