### PR TITLE
create `env.sh` and `cmd.sh` helper scripts in `run_shell_cmd`

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -214,6 +214,8 @@ def save_cmd(cmd_str, work_dir, env, tmpdir):
         # excludes bash functions (environment variables ending with %)
         fid.write('\n'.join(f'export {key}={shlex.quote(value)}' for key, value in full_env.items()
                             if not key.endswith('%')))
+        fid.write('\n\nPS1="eb-shell> "')
+        fid.write(f'\nhistory -s {shlex.quote(cmd_str)}')
 
     # Make script that sets up bash shell with given environments set.
     cmd_fp = os.path.join(tmpdir, 'cmd.sh')
@@ -225,9 +227,7 @@ def save_cmd(cmd_str, work_dir, env, tmpdir):
             'EB_SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )',
             f'echo Shell for the command: {shlex.quote(cmd_str)}',
             'echo Use command history, exit to stop',
-            'bash --rcfile <(cat $EB_SCRIPT_DIR/env.sh; '
-            'echo \'PS1="eb-shell> "\'; '
-            f'echo history -s {shlex.quote(cmd_str)})',
+            'bash --rcfile $EB_SCRIPT_DIR/env.sh',
             ]))
     os.chmod(cmd_fp, 0o775)
 

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -212,9 +212,9 @@ def save_cmd(cmd_str, work_dir, env, filename):
     with open(filename, 'w') as fid:
         fid.write('\n'.join(f'{key}={shlex.quote(value)}' for key, value in full_env.items()))
         fid.write('\n'.join([
-            f'cd "{work_dir}"',
-            f'history -s "{shlex.quote(cmd_str)}"',
-            f'echo Shell for the command: "{shlex.quote(cmd_str)}"',
+            f'\ncd "{work_dir}"',
+            f'history -s {shlex.quote(cmd_str)}',
+            f'echo Shell for the command: {shlex.quote(cmd_str)}',
             'echo Use command history, exit to stop',
             'export PS1="eb-shell> $PS1"',
             'bash',

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -204,18 +204,18 @@ def fileprefix_from_cmd(cmd, allowed_chars=False):
     return ''.join([c for c in cmd if c in allowed_chars])
 
 
-def save_cmd(cmd, work_dir, env):
-    cmd_name = fileprefix_from_cmd(os.path.basename(to_cmd_str(cmd).split(' ')[0]))
+def save_cmd(cmd_str, work_dir, env):
+    cmd_name = fileprefix_from_cmd(os.path.basename(cmd_str.split(' ')[0]))
     full_env = os.environ.copy()
     full_env.update(env)
 
     with tempfile.NamedTemporaryFile(prefix=f"{cmd_name}-", suffix=".sh", delete=False) as fid:
         fid.write(f'cd "{work_dir}"\n')
-        fid.write(f'history -s "{shlex.quote(cmd)}"\n')
+        fid.write(f'history -s "{shlex.quote(cmd_str)}"\n')
         for key, value in full_env.items():
             fid.write(f'{key}={shlex.quote(value)}\n')
         fid.write(f'export PS1="eb-shell> $PS1"\n')
-        fid.write(f'echo Shell for the command: "{shlex.quote(cmd)}"\n')
+        fid.write(f'echo Shell for the command: "{shlex.quote(cmd_str)}"\n')
         fid.write(f'echo Use command history, exit to stop\n')
         fid.write(f'bash\n')
 
@@ -410,7 +410,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
         log_msg += f" (via thread with ID {thread_id})"
     _log.info(log_msg)
 
-    save_cmd(cmd, work_dir, env)
+    save_cmd(cmd_str, work_dir, env)
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=stderr, stdin=subprocess.PIPE,
                             cwd=work_dir, env=env, shell=shell, executable=executable)
 

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -207,7 +207,8 @@ def fileprefix_from_cmd(cmd, allowed_chars=False):
 def save_cmd(cmd_str, work_dir, env):
     cmd_name = fileprefix_from_cmd(os.path.basename(cmd_str.split(' ')[0]))
     full_env = os.environ.copy()
-    full_env.update(env)
+    if env is not None:
+        full_env.update(env)
 
     with tempfile.NamedTemporaryFile(prefix=f"{cmd_name}-", suffix=".sh", delete=False) as fid:
         fid.write(f'cd "{work_dir}"\n')

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -215,10 +215,10 @@ def save_cmd(cmd_str, work_dir, env):
         fid.write('\n'.join([
             f'cd "{work_dir}"',
             f'history -s "{shlex.quote(cmd_str)}"',
-            f'export PS1="eb-shell> $PS1"',
             f'echo Shell for the command: "{shlex.quote(cmd_str)}"',
-            f'echo Use command history, exit to stop',
-            f'bash',
+            'echo Use command history, exit to stop',
+            'export PS1="eb-shell> $PS1"',
+            'bash',
             ]).encode('utf-8'))
 
 

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -209,7 +209,6 @@ def save_cmd(cmd_str, work_dir, env, filename):
     if env is not None:
         full_env.update(env)
 
-    os.chmod(filename, 0o775)
     with open(filename, 'w') as fid:
         fid.write('#!/usr/bin/env bash')
         # excludes bash functions (environment variables ending with %)
@@ -222,6 +221,7 @@ def save_cmd(cmd_str, work_dir, env, filename):
             'export PS1="eb-shell> $PS1"',
             'bash --norc',
             ]))
+    os.chmod(filename, 0o775)
 
 
 def _answer_question(stdout, proc, qa_patterns, qa_wait_patterns):

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -210,7 +210,7 @@ def save_cmd(cmd_str, work_dir, env, filename):
         full_env.update(env)
 
     with open(filename, 'w') as fid:
-        fid.write('#!/usr/bin/env bash')
+        fid.write('#!/usr/bin/env bash\n')
         # excludes bash functions (environment variables ending with %)
         fid.write('\n'.join(f'{key}={shlex.quote(value)}' for key, value in full_env.items() if not key.endswith('%')))
         fid.write('\n'.join([

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -211,14 +211,15 @@ def save_cmd(cmd_str, work_dir, env):
         full_env.update(env)
 
     with tempfile.NamedTemporaryFile(prefix=f"{cmd_name}-", suffix=".sh", delete=False) as fid:
-        fid.write(f'cd "{work_dir}"\n')
-        fid.write(f'history -s "{shlex.quote(cmd_str)}"\n')
-        for key, value in full_env.items():
-            fid.write(f'{key}={shlex.quote(value)}\n')
-        fid.write(f'export PS1="eb-shell> $PS1"\n')
-        fid.write(f'echo Shell for the command: "{shlex.quote(cmd_str)}"\n')
-        fid.write(f'echo Use command history, exit to stop\n')
-        fid.write(f'bash\n')
+        fid.write('\n'.join(f'{key}={shlex.quote(value)}' for key, value in full_env.items()).encode('utf-8'))
+        fid.write('\n'.join([
+            f'cd "{work_dir}"',
+            f'history -s "{shlex.quote(cmd_str)}"',
+            f'export PS1="eb-shell> $PS1"',
+            f'echo Shell for the command: "{shlex.quote(cmd_str)}"',
+            f'echo Use command history, exit to stop',
+            f'bash',
+            ]).encode('utf-8'))
 
 
 def _answer_question(stdout, proc, qa_patterns, qa_wait_patterns):

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -209,15 +209,18 @@ def save_cmd(cmd_str, work_dir, env, filename):
     if env is not None:
         full_env.update(env)
 
+    os.chmod(filename, 0o775)
     with open(filename, 'w') as fid:
-        fid.write('\n'.join(f'{key}={shlex.quote(value)}' for key, value in full_env.items()))
+        fid.write('#!/usr/bin/env bash')
+        # excludes bash functions (environment variables ending with %)
+        fid.write('\n'.join(f'{key}={shlex.quote(value)}' for key, value in full_env.items() if not key.endswith('%'))
         fid.write('\n'.join([
             f'\ncd "{work_dir}"',
             f'history -s {shlex.quote(cmd_str)}',
             f'echo Shell for the command: {shlex.quote(cmd_str)}',
             'echo Use command history, exit to stop',
             'export PS1="eb-shell> $PS1"',
-            'bash',
+            'bash --norc',
             ]))
 
 

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -372,7 +372,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
         else:
             cmd_err_fp = None
     else:
-        cmd_out_fp, cmd_err_fp = None, None
+        tmpdir, cmd_out_fp, cmd_err_fp = None, None, None
 
     interactive = bool(qa_patterns)
     interactive_msg = 'interactive ' if interactive else ''
@@ -390,7 +390,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
 
     start_time = datetime.now()
     if not hidden:
-        _cmd_trace_msg(cmd_str, start_time, work_dir, stdin, cmd_out_fp, cmd_err_fp, thread_id, interactive=interactive)
+        _cmd_trace_msg(cmd_str, start_time, work_dir, stdin, tmpdir, thread_id, interactive=interactive)
 
     if stream_output:
         print_msg(f"(streaming) output for command '{cmd_str}':")
@@ -551,7 +551,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
     return res
 
 
-def _cmd_trace_msg(cmd, start_time, work_dir, stdin, cmd_out_fp, cmd_err_fp, thread_id, interactive=False):
+def _cmd_trace_msg(cmd, start_time, work_dir, stdin, tmpdir, thread_id, interactive=False):
     """
     Helper function to construct and print trace message for command being run
 
@@ -559,8 +559,7 @@ def _cmd_trace_msg(cmd, start_time, work_dir, stdin, cmd_out_fp, cmd_err_fp, thr
     :param start_time: datetime object indicating when command was started
     :param work_dir: path of working directory in which command is run
     :param stdin: stdin input value for command
-    :param cmd_out_fp: path to output file for command
-    :param cmd_err_fp: path to errors/warnings output file for command
+    :param tmpdir: path to temporary output directory for command
     :param thread_id: thread ID (None when not running shell command asynchronously)
     :param interactive: boolean indicating whether it is an interactive command, or not
     """
@@ -580,10 +579,8 @@ def _cmd_trace_msg(cmd, start_time, work_dir, stdin, cmd_out_fp, cmd_err_fp, thr
     ]
     if stdin:
         lines.append(f"\t[input: {stdin}]")
-    if cmd_out_fp:
-        lines.append(f"\t[output saved to {cmd_out_fp}]")
-    if cmd_err_fp:
-        lines.append(f"\t[errors/warnings saved to {cmd_err_fp}]")
+    if tmpdir:
+        lines.append(f"\t[output and state saved to {tmpdir}]")
 
     trace_msg('\n'.join(lines))
 

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -213,7 +213,7 @@ def save_cmd(cmd_str, work_dir, env, filename):
     with open(filename, 'w') as fid:
         fid.write('#!/usr/bin/env bash')
         # excludes bash functions (environment variables ending with %)
-        fid.write('\n'.join(f'{key}={shlex.quote(value)}' for key, value in full_env.items() if not key.endswith('%'))
+        fid.write('\n'.join(f'{key}={shlex.quote(value)}' for key, value in full_env.items() if not key.endswith('%')))
         fid.write('\n'.join([
             f'\ncd "{work_dir}"',
             f'history -s {shlex.quote(cmd_str)}',

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -219,6 +219,7 @@ def save_cmd(cmd_str, work_dir, env, tmpdir):
     cmd_fp = os.path.join(tmpdir, 'cmd.sh')
     with open(cmd_fp, 'w') as fid:
         fid.write('#!/usr/bin/env bash\n')
+        fid.write('# Run this script to replicate the environment that EB used to run the shell command\n')
         fid.write('\n'.join([
             f'\ncd "{work_dir}"',
             'EB_SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )',

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -226,7 +226,7 @@ def save_cmd(cmd_str, work_dir, env, tmpdir):
             'echo Use command history, exit to stop',
             'bash --rcfile <(cat $EB_SCRIPT_DIR/env.sh; '
             'echo \'PS1="eb-shell> "\'; '
-            'echo history -s {shlex.quote(cmd_str)})',
+            f'echo history -s {shlex.quote(cmd_str)})',
             ]))
     os.chmod(cmd_fp, 0o775)
 

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -676,7 +676,7 @@ class RunTest(EnhancedTestCase):
             r"\techo hello",
             r"\t\[started at: .*\]",
             r"\t\[working dir: .*\]",
-            r"\t\[output saved to .*\]",
+            r"\t\[output and state saved to .*\]",
             r"  >> command completed: exit 0, ran in .*",
         ]
 
@@ -736,7 +736,7 @@ class RunTest(EnhancedTestCase):
             r"\techo hello",
             r"\t\[started at: [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9]\]",
             r"\t\[working dir: .*\]",
-            r"\t\[output saved to .*\]",
+            r"\t\[output and state saved to .*\]",
             r"  >> command completed: exit 0, ran in .*",
         ]
 
@@ -1092,7 +1092,7 @@ class RunTest(EnhancedTestCase):
         pattern += r"\techo \'n: \'; read n; seq 1 \$n\n"
         pattern += r"\t\[started at: .*\]\n"
         pattern += r"\t\[working dir: .*\]\n"
-        pattern += r"\t\[output saved to .*\]\n"
+        pattern += r"\t\[output and state saved to .*\]\n"
         pattern += r'  >> command completed: exit 0, ran in .*'
         self.assertTrue(re.search(pattern, stdout), "Pattern '%s' found in: %s" % (pattern, stdout))
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2985,7 +2985,7 @@ class ToyBuildTest(EnhancedTestCase):
                 r"\tgcc toy.c -o toy\n"
                 r"\t\[started at: .*\]",
                 r"\t\[working dir: .*\]",
-                r"\t\[output saved to .*\]",
+                r"\t\[output and state saved to .*\]",
                 r'',
             ]),
             r"  >> command completed: exit 0, ran in .*",


### PR DESCRIPTION
fixes #970

As discussed, I think this would be a greatly useful feature for anyone struggling to 


Rather than directly dropping users into the shell when things fail, just writing these temp files allow some advantages, primarily:
1. No need to break the flow in EB, so no need to limit this to tty sessions only or introducing any options, we can just always do this since it's cheap.
2. Allows users to revisit any of the commands (want to experiment with the configure step before going back to attempt another "make -j"? trivial with this approach)

Maybe we want to be able to limit when we generate this? Maybe, we do run a lot of shell cmds so i guess many of these are not worth ever really revisiting.


This is completely untested yet, just my somewhat formed ideas. 


