### PR TITLE
Add custom delimiter support for update_paths, hack in special case for TCLLIBPATH

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -1147,6 +1147,7 @@ class ModuleGeneratorLua(ModuleGenerator):
 
     PATH_JOIN_TEMPLATE = 'pathJoin(root, "%s")'
     UPDATE_PATH_TEMPLATE = '%s_path("%s", %s)'
+    UPDATE_PATH_TEMPLATE_DELIM = '%s_path {"%s", %s, delim="%s"}'
 
     START_STR = '[==['
     END_STR = ']==]'
@@ -1468,7 +1469,10 @@ class ModuleGeneratorLua(ModuleGenerator):
                 else:
                     abspaths.append('root')
 
-        statements = [self.UPDATE_PATH_TEMPLATE % (update_type, key, p) for p in abspaths]
+        if key == 'TCLLIBPATH':  # special case: requires spaces and not : as the delimiter
+            statements = [self.UPDATE_PATH_TEMPLATE_DELIM % (update_type, key, p, ' ') for p in abspaths]
+        else:
+            statements = [self.UPDATE_PATH_TEMPLATE % (update_type, key, p) for p in abspaths]
         statements.append('')
         return '\n'.join(statements)
 


### PR DESCRIPTION
TCLLIBPATH (and nothing else as far as I know) requires spaces instead of : as the path delimiter.

I opted to just hack in the special case for TCLLIBPATH, but i suppose it could be brought up even further, somehow making this an option for the easyconfigs? I don't really see how one would do this though, where we would add such a field?

```python
modextrapaths_spaces = {
    'TCLLIBPATH': 'lib/tcl8.6',
}
```

meh...