### PR TITLE
add generic GCC and Clang compiler flags for RISC-V

### DIFF
--- a/easybuild/toolchains/compiler/clang.py
+++ b/easybuild/toolchains/compiler/clang.py
@@ -98,6 +98,7 @@ class Clang(Compiler):
     }
     # used with --optarch=GENERIC
     COMPILER_GENERIC_OPTION = {
+        (systemtools.RISCV64, systemtools.RISCV): 'march=rv64gc -mabi=lp64d', # the default for -mabi is system-dependent
         (systemtools.X86_64, systemtools.AMD): 'march=x86-64 -mtune=generic',
         (systemtools.X86_64, systemtools.INTEL): 'march=x86-64 -mtune=generic',
     }

--- a/easybuild/toolchains/compiler/clang.py
+++ b/easybuild/toolchains/compiler/clang.py
@@ -98,7 +98,7 @@ class Clang(Compiler):
     }
     # used with --optarch=GENERIC
     COMPILER_GENERIC_OPTION = {
-        (systemtools.RISCV64, systemtools.RISCV): 'march=rv64gc -mabi=lp64d', # the default for -mabi is system-dependent
+        (systemtools.RISCV64, systemtools.RISCV): 'march=rv64gc -mabi=lp64d',  # default for -mabi is system-dependent
         (systemtools.X86_64, systemtools.AMD): 'march=x86-64 -mtune=generic',
         (systemtools.X86_64, systemtools.INTEL): 'march=x86-64 -mtune=generic',
     }

--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -94,7 +94,7 @@ class Gcc(Compiler):
         (systemtools.AARCH64, systemtools.ARM): 'mcpu=generic',       # implies -march=armv8-a and -mtune=generic
         (systemtools.POWER, systemtools.POWER): 'mcpu=powerpc64',    # no support for -march on POWER
         (systemtools.POWER, systemtools.POWER_LE): 'mcpu=powerpc64le',    # no support for -march on POWER
-        (systemtools.RISCV64, systemtools.RISCV): 'march=rv64gc -mabi=lp64d', # the default for -mabi is system-dependent
+        (systemtools.RISCV64, systemtools.RISCV): 'march=rv64gc -mabi=lp64d',  # default for -mabi is system-dependent
         (systemtools.X86_64, systemtools.AMD): 'march=x86-64 -mtune=generic',
         (systemtools.X86_64, systemtools.INTEL): 'march=x86-64 -mtune=generic',
     }

--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -94,6 +94,7 @@ class Gcc(Compiler):
         (systemtools.AARCH64, systemtools.ARM): 'mcpu=generic',       # implies -march=armv8-a and -mtune=generic
         (systemtools.POWER, systemtools.POWER): 'mcpu=powerpc64',    # no support for -march on POWER
         (systemtools.POWER, systemtools.POWER_LE): 'mcpu=powerpc64le',    # no support for -march on POWER
+        (systemtools.RISCV64, systemtools.RISCV): 'march=rv64gc -mabi=lp64d', # the default for -mabi is system-dependent
         (systemtools.X86_64, systemtools.AMD): 'march=x86-64 -mtune=generic',
         (systemtools.X86_64, systemtools.INTEL): 'march=x86-64 -mtune=generic',
     }


### PR DESCRIPTION
This adds compiler flags (GCC and Clang) for generic builds on RISC-V. It's a bit more involved than on for instance x86_64, because of all the different extensions and ABIs, see:
https://gcc.gnu.org/onlinedocs/gcc/RISC-V-Options.html#index-march-14
https://five-embeddev.com/toolchain/2019/06/26/gcc-targets/

I've picked a sensible default, which also is in line with what Gentoo uses:
https://wiki.gentoo.org/wiki/RISC-V_Multilib

The optimal flags are a bit more complex, since there is no such things as `-march=native` for RISC-V. I'll try to take a stab at in a follow-up PR.