### PR TITLE
switch from `ls` to `bash` in tests that are expecting this to be a binary

### DIFF
--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -924,7 +924,7 @@ class FileToolsTest(EnhancedTestCase):
 
         self.assertTrue(ft.is_binary(b'\00'))
         self.assertTrue(ft.is_binary(b"File is binary when it includes \00 somewhere"))
-        self.assertTrue(ft.is_binary(ft.read_file('/bin/ls', mode='rb')))
+        self.assertTrue(ft.is_binary(ft.read_file('/bin/bash', mode='rb')))
 
     def test_det_patched_files(self):
         """Test det_patched_files function."""

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -1033,15 +1033,15 @@ class SystemToolsTest(EnhancedTestCase):
         self.assertEqual(check_linked_shared_libs(txt_path), None)
         self.assertEqual(check_linked_shared_libs(broken_symlink_path), None)
 
-        bin_ls_path = which('ls')
+        bin_bash_path = which('bash')
 
         os_type = get_os_type()
         if os_type == LINUX:
             with self.mocked_stdout_stderr():
-                res = run_shell_cmd("ldd %s" % bin_ls_path)
+                res = run_shell_cmd("ldd %s" % bin_bash_path)
         elif os_type == DARWIN:
             with self.mocked_stdout_stderr():
-                res = run_shell_cmd("otool -L %s" % bin_ls_path)
+                res = run_shell_cmd("otool -L %s" % bin_bash_path)
         else:
             raise EasyBuildError("Unknown OS type: %s" % os_type)
 
@@ -1061,7 +1061,7 @@ class SystemToolsTest(EnhancedTestCase):
             self.assertEqual(check_linked_shared_libs(self.test_prefix, **pattern_named_args), None)
             self.assertEqual(check_linked_shared_libs(txt_path, **pattern_named_args), None)
             self.assertEqual(check_linked_shared_libs(broken_symlink_path, **pattern_named_args), None)
-            for path in (bin_ls_path, lib_path):
+            for path in (bin_bash_path, lib_path):
                 # path may not exist, especially for library paths obtained via 'otool -L' on macOS
                 if os.path.exists(path):
                     error_msg = "Check on linked libs should pass for %s with %s" % (path, pattern_named_args)
@@ -1078,7 +1078,7 @@ class SystemToolsTest(EnhancedTestCase):
             self.assertEqual(check_linked_shared_libs(self.test_prefix, **pattern_named_args), None)
             self.assertEqual(check_linked_shared_libs(txt_path, **pattern_named_args), None)
             self.assertEqual(check_linked_shared_libs(broken_symlink_path, **pattern_named_args), None)
-            for path in (bin_ls_path, lib_path):
+            for path in (bin_bash_path, lib_path):
                 error_msg = "Check on linked libs should fail for %s with %s" % (path, pattern_named_args)
                 self.assertFalse(check_linked_shared_libs(path, **pattern_named_args), error_msg)
 


### PR DESCRIPTION
I'm running in a Rocky 8.9 container (that is based off the one from https://github.com/easybuilders/easybuild-containers) and I hit two test failures that are caused by `ls` not being as expected, which causes the two tests I am changing to fail.

In the container where I see the failure:
```
$ file /bin/ls
/bin/ls: a /usr/bin/coreutils --coreutils-prog-shebang=ls script, ASCII text executable

$ file /bin/bash
/bin/bash: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, for GNU/Linux 3.2.0, BuildID[sha1]=e4abb3b0b8951a4f746530ae2e9b85559d5fb98f, stripped
```

On Ubuntu:
```
$ file /bin/ls
/bin/ls: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=9a7a491cbe4f1b92cb270406d6642d545b7d1259, for GNU/Linux 3.2.0, stripped

$ file /bin/bash
/bin/bash: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=070009c7b6202e25d64caf24bb49c6cede3a794c, for GNU/Linux 3.2.0, stripped
```
