### PR TITLE
don't allow using `--pr-commit-msg` when only adding new files with `--new-pr` (unless `--force` is used)

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -1129,7 +1129,7 @@ def _easyconfigs_pr_common(paths, ecs, start_branch=None, pr_branch=None, start_
             msg += "the PR title will be automatically generated."
             if build_option('force'):
                 print_msg(msg)
-                print_msg("Using the specified --pr-commit-msg As the force build option was specified.")
+                print_msg("Using the specified --pr-commit-msg as the force build option was specified.")
             else:
                 raise EasyBuildError(msg)
         cnt = len(file_info['paths_in_repo'])


### PR DESCRIPTION
We should force the generated message in these cases.

An alternative to raising an error (as implemented here) would be to generate the default PR title and replace the `commit_msg` in these cases while printing a warning.