### PR TITLE
Enable `module-depends-on` by default

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1209,6 +1209,8 @@ class EasyBlock(object):
         # these should be all the dependencies and we should load them
         recursive_unload = self.cfg['recursive_module_unload']
         depends_on = self.cfg['module_depends_on']
+        if depends_on is not None:
+            print_warning("easyconfig parameter module_depends_on is deprecated.")
         for key in os.environ:
             # legacy support
             if key.startswith(DEVEL_ENV_VAR_NAME_PREFIX):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1210,7 +1210,7 @@ class EasyBlock(object):
         recursive_unload = self.cfg['recursive_module_unload']
         depends_on = self.cfg['module_depends_on']
         if depends_on is not None:
-            print_warning("easyconfig parameter module_depends_on is deprecated.")
+            self.log.deprecated("'module_depends_on' easyconfig parameter should not be used anymore", '6.0')
         for key in os.environ:
             # legacy support
             if key.startswith(DEVEL_ENV_VAR_NAME_PREFIX):
@@ -1338,6 +1338,8 @@ class EasyBlock(object):
         # include load statements for retained dependencies
         recursive_unload = self.cfg['recursive_module_unload']
         depends_on = self.cfg['module_depends_on']
+        if depends_on is not None:
+            self.log.deprecated("'module_depends_on' easyconfig parameter should not be used anymore", '6.0')
         loads = []
         for dep in deps:
             unload_modules = []

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -206,7 +206,7 @@ DEFAULT_CONFIG = {
     'moduleclass': [MODULECLASS_BASE, 'Module class to be used for this software', MODULES],
     'moduleforceunload': [False, 'Force unload of all modules when loading the extension', MODULES],
     'moduleloadnoconflict': [False, "Don't check for conflicts, unload other versions instead ", MODULES],
-    'module_depends_on': [False, 'Use depends_on (Lmod 7.6.1+) for dependencies in generated module '
+    'module_depends_on': [True, 'Use depends_on (Lmod 7.6.1+) for dependencies in generated module '
                           '(implies recursive unloading of modules).', MODULES],
     'recursive_module_unload': [None, "Recursive unload of all dependencies when unloading module "
                                       "(True/False to hard enable/disable; None implies honoring "

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -207,7 +207,7 @@ DEFAULT_CONFIG = {
     'moduleforceunload': [False, 'Force unload of all modules when loading the extension', MODULES],
     'moduleloadnoconflict': [False, "Don't check for conflicts, unload other versions instead ", MODULES],
     'module_depends_on': [None, 'Use depends_on (Lmod 7.6.1+) for dependencies in generated module '
-                          '(implies recursive unloading of modules).', MODULES],
+                          '(implies recursive unloading of modules) [DEPRECATED]', MODULES],
     'recursive_module_unload': [None, "Recursive unload of all dependencies when unloading module "
                                       "(True/False to hard enable/disable; None implies honoring "
                                       "the --recursive-module-unload EasyBuild configuration setting",

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -206,7 +206,7 @@ DEFAULT_CONFIG = {
     'moduleclass': [MODULECLASS_BASE, 'Module class to be used for this software', MODULES],
     'moduleforceunload': [False, 'Force unload of all modules when loading the extension', MODULES],
     'moduleloadnoconflict': [False, "Don't check for conflicts, unload other versions instead ", MODULES],
-    'module_depends_on': [True, 'Use depends_on (Lmod 7.6.1+) for dependencies in generated module '
+    'module_depends_on': [None, 'Use depends_on (Lmod 7.6.1+) for dependencies in generated module '
                           '(implies recursive unloading of modules).', MODULES],
     'recursive_module_unload': [None, "Recursive unload of all dependencies when unloading module "
                                       "(True/False to hard enable/disable; None implies honoring "

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -415,13 +415,13 @@ BUILD_OPTIONS_OTHER = {
         'command_line',
         'external_modules_metadata',
         'extra_ec_paths',
+        'mod_depends_on',  # deprecated
         'robot_path',
         'valid_module_classes',
         'valid_stops',
     ],
     False: [
         'dry_run',
-        'mod_depends_on',
         'recursive_mod_unload',
         'retain_all_deps',
         'silent',

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -894,9 +894,7 @@ class ModuleGeneratorTcl(ModuleGenerator):
             body.extend([self.unload_module(m).strip() for m in unload_modules])
         load_template = self.LOAD_TEMPLATE
         # Lmod 7.6.1+ supports depends-on which does this most nicely:
-        if build_option('mod_depends_on') or depends_on:
-            if not self.modules_tool.supports_depends_on:
-                raise EasyBuildError("depends-on statements in generated module are not supported by modules tool")
+        if (build_option('mod_depends_on') or depends_on) and self.modules_tool.supports_depends_on:
             load_template = self.LOAD_TEMPLATE_DEPENDS_ON
 
         body.append(load_template)
@@ -1320,9 +1318,7 @@ class ModuleGeneratorLua(ModuleGenerator):
 
         load_template = self.LOAD_TEMPLATE
         # Lmod 7.6+ supports depends_on which does this most nicely:
-        if build_option('mod_depends_on') or depends_on:
-            if not self.modules_tool.supports_depends_on:
-                raise EasyBuildError("depends_on statements in generated module are not supported by modules tool")
+        if (build_option('mod_depends_on') or depends_on) and self.modules_tool.supports_depends_on:
             load_template = self.LOAD_TEMPLATE_DEPENDS_ON
 
         body.append(load_template)

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -483,13 +483,13 @@ class ModuleGenerator(object):
         """
         raise NotImplementedError
 
-    def load_module(self, mod_name, recursive_unload=False, depends_on=False, unload_modules=None, multi_dep_mods=None):
+    def load_module(self, mod_name, recursive_unload=False, depends_on=None, unload_modules=None, multi_dep_mods=None):
         """
         Generate load statement for specified module.
 
         :param mod_name: name of module to generate load statement for
         :param recursive_unload: boolean indicating whether the 'load' statement should be reverted on unload
-        :param depends_on: use depends_on statements rather than (guarded) load statements
+        :param depends_on: use depends_on statements rather than (guarded) load statements (deprecated)
         :param unload_modules: name(s) of module to unload first
         :param multi_dep_mods: list of module names in multi_deps context, to use for guarding load statement
         """
@@ -878,14 +878,14 @@ class ModuleGeneratorTcl(ModuleGenerator):
                 cmd = '[if { [info exists %(envvar)s] } { concat $%(envvar)s } else { concat "%(default)s" } ]' % values
         return cmd
 
-    def load_module(self, mod_name, recursive_unload=None, depends_on=False, unload_modules=None, multi_dep_mods=None):
+    def load_module(self, mod_name, recursive_unload=None, depends_on=None, unload_modules=None, multi_dep_mods=None):
         """
         Generate load statement for specified module.
 
         :param mod_name: name of module to generate load statement for
         :param recursive_unload: boolean indicating whether the 'load' statement should be reverted on unload
                                  (if None: enable if recursive_mod_unload build option or depends_on is True)
-        :param depends_on: use depends_on statements rather than (guarded) load statements
+        :param depends_on: use depends_on statements rather than (guarded) load statements (deprecated)
         :param unload_modules: name(s) of module to unload first
         :param multi_dep_mods: list of module names in multi_deps context, to use for guarding load statement
         """
@@ -895,6 +895,8 @@ class ModuleGeneratorTcl(ModuleGenerator):
         load_template = self.LOAD_TEMPLATE
         # Lmod 7.6.1+ supports depends-on which does this most nicely:
         if (build_option('mod_depends_on') and self.modules_tool.supports_depends_on) or depends_on:
+            if depends_on is not None:
+                print_warning('Module generator load_module keyword parameter "depends_on" is deprecated.')
             if not self.modules_tool.supports_depends_on:
                 raise EasyBuildError("depends-on statements in generated module are not supported by modules tool")
             load_template = self.LOAD_TEMPLATE_DEPENDS_ON
@@ -1303,14 +1305,14 @@ class ModuleGeneratorLua(ModuleGenerator):
             cmd = 'os.getenv("%s") or "%s"' % (envvar, default)
         return cmd
 
-    def load_module(self, mod_name, recursive_unload=None, depends_on=False, unload_modules=None, multi_dep_mods=None):
+    def load_module(self, mod_name, recursive_unload=None, depends_on=None, unload_modules=None, multi_dep_mods=None):
         """
         Generate load statement for specified module.
 
         :param mod_name: name of module to generate load statement for
         :param recursive_unload: boolean indicating whether the 'load' statement should be reverted on unload
                                  (if None: enable if recursive_mod_unload build option or depends_on is True)
-        :param depends_on: use depends_on statements rather than (guarded) load statements
+        :param depends_on: use depends_on statements rather than (guarded) load statements (deprecated)
         :param unload_modules: name(s) of module to unload first
         :param multi_dep_mods: list of module names in multi_deps context, to use for guarding load statement
         """
@@ -1321,6 +1323,8 @@ class ModuleGeneratorLua(ModuleGenerator):
         load_template = self.LOAD_TEMPLATE
         # Lmod 7.6+ supports depends_on which does this most nicely:
         if (build_option('mod_depends_on') and self.modules_tool.supports_depends_on) or depends_on:
+            if depends_on is not None:
+                print_warning('Module generator load_module keyword parameter "depends_on" is deprecated.')
             if not self.modules_tool.supports_depends_on:
                 raise EasyBuildError("depends_on statements in generated module are not supported by modules tool")
             load_template = self.LOAD_TEMPLATE_DEPENDS_ON

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -894,7 +894,9 @@ class ModuleGeneratorTcl(ModuleGenerator):
             body.extend([self.unload_module(m).strip() for m in unload_modules])
         load_template = self.LOAD_TEMPLATE
         # Lmod 7.6.1+ supports depends-on which does this most nicely:
-        if (build_option('mod_depends_on') or depends_on) and self.modules_tool.supports_depends_on:
+        if (build_option('mod_depends_on') and self.modules_tool.supports_depends_on) or depends_on:
+            if not self.modules_tool.supports_depends_on:
+                raise EasyBuildError("depends-on statements in generated module are not supported by modules tool")
             load_template = self.LOAD_TEMPLATE_DEPENDS_ON
 
         body.append(load_template)
@@ -1318,7 +1320,9 @@ class ModuleGeneratorLua(ModuleGenerator):
 
         load_template = self.LOAD_TEMPLATE
         # Lmod 7.6+ supports depends_on which does this most nicely:
-        if (build_option('mod_depends_on') or depends_on) and self.modules_tool.supports_depends_on:
+        if (build_option('mod_depends_on') and self.modules_tool.supports_depends_on) or depends_on:
+            if not self.modules_tool.supports_depends_on:
+                raise EasyBuildError("depends_on statements in generated module are not supported by modules tool")
             load_template = self.LOAD_TEMPLATE_DEPENDS_ON
 
         body.append(load_template)

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -489,7 +489,7 @@ class ModuleGenerator(object):
 
         :param mod_name: name of module to generate load statement for
         :param recursive_unload: boolean indicating whether the 'load' statement should be reverted on unload
-        :param depends_on: use depends_on statements rather than (guarded) load statements (deprecated)
+        :param depends_on: use depends_on statements rather than (guarded) load statements (DEPRECATED)
         :param unload_modules: name(s) of module to unload first
         :param multi_dep_mods: list of module names in multi_deps context, to use for guarding load statement
         """
@@ -885,7 +885,7 @@ class ModuleGeneratorTcl(ModuleGenerator):
         :param mod_name: name of module to generate load statement for
         :param recursive_unload: boolean indicating whether the 'load' statement should be reverted on unload
                                  (if None: enable if recursive_mod_unload build option or depends_on is True)
-        :param depends_on: use depends_on statements rather than (guarded) load statements (deprecated)
+        :param depends_on: use depends_on statements rather than (guarded) load statements (DEPRECATED)
         :param unload_modules: name(s) of module to unload first
         :param multi_dep_mods: list of module names in multi_deps context, to use for guarding load statement
         """
@@ -896,7 +896,8 @@ class ModuleGeneratorTcl(ModuleGenerator):
         # Lmod 7.6.1+ supports depends-on which does this most nicely:
         if (build_option('mod_depends_on') and self.modules_tool.supports_depends_on) or depends_on:
             if depends_on is not None:
-                print_warning('Module generator load_module keyword parameter "depends_on" is deprecated.')
+                depr_msg = "'depends_on' argument of module generator method 'load_module' should not be used anymore"
+                self.log.deprecated(depr_msg, '6.0')
             if not self.modules_tool.supports_depends_on:
                 raise EasyBuildError("depends-on statements in generated module are not supported by modules tool")
             load_template = self.LOAD_TEMPLATE_DEPENDS_ON
@@ -1312,7 +1313,7 @@ class ModuleGeneratorLua(ModuleGenerator):
         :param mod_name: name of module to generate load statement for
         :param recursive_unload: boolean indicating whether the 'load' statement should be reverted on unload
                                  (if None: enable if recursive_mod_unload build option or depends_on is True)
-        :param depends_on: use depends_on statements rather than (guarded) load statements (deprecated)
+        :param depends_on: use depends_on statements rather than (guarded) load statements (DEPRECATED)
         :param unload_modules: name(s) of module to unload first
         :param multi_dep_mods: list of module names in multi_deps context, to use for guarding load statement
         """
@@ -1324,7 +1325,8 @@ class ModuleGeneratorLua(ModuleGenerator):
         # Lmod 7.6+ supports depends_on which does this most nicely:
         if (build_option('mod_depends_on') and self.modules_tool.supports_depends_on) or depends_on:
             if depends_on is not None:
-                print_warning('Module generator load_module keyword parameter "depends_on" is deprecated.')
+                depr_msg = "'depends_on' argument of module generator method 'load_module' should not be used anymore"
+                self.log.deprecated(depr_msg, '6.0')
             if not self.modules_tool.supports_depends_on:
                 raise EasyBuildError("depends_on statements in generated module are not supported by modules tool")
             load_template = self.LOAD_TEMPLATE_DEPENDS_ON

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -593,7 +593,7 @@ class EasyBuildOptions(GeneralOption):
                                'strtuple', 'store', DEFAULT_LOGFILE_FORMAT[:], {'metavar': 'DIR,FORMAT'}),
             'module-depends-on': ("Use depends_on (Lmod 7.6.1+) for dependencies in all generated modules "
                                   "(implies recursive unloading of modules).",
-                                  None, 'store_true', False),
+                                  None, 'store_true', True),
             'module-extensions': ("Include 'extensions' statement in generated module file (Lua syntax only)",
                                   None, 'store_true', True),
             'module-naming-scheme': ("Module naming scheme to use", None, 'store', DEFAULT_MNS),

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -749,7 +749,6 @@ class EasyBlockTest(EnhancedTestCase):
             "   ('FFTW', '3.3.7'),",
             "   ('OpenBLAS', '0.2.20', '', ('GCC', '6.4.0-2.28')),",
             ']',
-            'module_depends_on = False',
         ])
         self.writeEC()
         eb = EasyBlock(EasyConfig(self.eb_file))

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -749,6 +749,7 @@ class EasyBlockTest(EnhancedTestCase):
             "   ('FFTW', '3.3.7'),",
             "   ('OpenBLAS', '0.2.20', '', ('GCC', '6.4.0-2.28')),",
             ']',
+            'module_depends_on = False',
         ])
         self.writeEC()
         eb = EasyBlock(EasyConfig(self.eb_file))
@@ -873,10 +874,10 @@ class EasyBlockTest(EnhancedTestCase):
         with self.mocked_stdout_stderr():
             mod_dep_txt = eb.make_module_dep()
         for mod in ['GCC/6.4.0-2.28', 'OpenMPI/2.1.2']:
-            regex = re.compile('load.*%s' % mod)
+            regex = re.compile('(load|depends[-_]on).*%s' % mod)
             self.assertFalse(regex.search(mod_dep_txt), "Pattern '%s' found in: %s" % (regex.pattern, mod_dep_txt))
 
-        regex = re.compile('load.*FFTW/3.3.7')
+        regex = re.compile('(load|depends[-_]on).*FFTW/3.3.7')
         self.assertTrue(regex.search(mod_dep_txt), "Pattern '%s' found in: %s" % (regex.pattern, mod_dep_txt))
 
     def test_make_module_dep_of_dep_hmns(self):
@@ -1361,27 +1362,27 @@ class EasyBlockTest(EnhancedTestCase):
 
         for (name, ver) in [('GCC', '6.4.0-2.28')]:
             if get_module_syntax() == 'Tcl':
-                regex = re.compile(r'^\s*module load %s\s*$' % os.path.join(name, ver), re.M)
+                regex = re.compile(r'^\s*(module load|depends-on) %s\s*$' % os.path.join(name, ver), re.M)
             elif get_module_syntax() == 'Lua':
-                regex = re.compile(r'^\s*load\("%s"\)$' % os.path.join(name, ver), re.M)
+                regex = re.compile(r'^\s*(load|depends_on)\("%s"\)$' % os.path.join(name, ver), re.M)
             else:
                 self.fail("Unknown module syntax: %s" % get_module_syntax())
             self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
 
         for (name, ver) in [('test', '1.2.3')]:
             if get_module_syntax() == 'Tcl':
-                regex = re.compile(r'^\s*module load %s/.%s\s*$' % (name, ver), re.M)
+                regex = re.compile(r'^\s*(module load|depends-on) %s/.%s\s*$' % (name, ver), re.M)
             elif get_module_syntax() == 'Lua':
-                regex = re.compile(r'^\s*load\("%s/.%s"\)$' % (name, ver), re.M)
+                regex = re.compile(r'^\s*(load|depends_on)\("%s/.%s"\)$' % (name, ver), re.M)
             else:
                 self.fail("Unknown module syntax: %s" % get_module_syntax())
             self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
 
         for (name, ver) in [('OpenMPI', '2.1.2-GCC-6.4.0-2.28')]:
             if get_module_syntax() == 'Tcl':
-                regex = re.compile(r'^\s*module load %s/.?%s\s*$' % (name, ver), re.M)
+                regex = re.compile(r'^\s*(module load|depends-on) %s/.?%s\s*$' % (name, ver), re.M)
             elif get_module_syntax() == 'Lua':
-                regex = re.compile(r'^\s*load\("%s/.?%s"\)$' % (name, ver), re.M)
+                regex = re.compile(r'^\s*(load|depends_on)\("%s/.?%s"\)$' % (name, ver), re.M)
             else:
                 self.fail("Unknown module syntax: %s" % get_module_syntax())
             self.assertFalse(regex.search(txt), "Pattern '%s' *not* found in %s" % (regex.pattern, txt))

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -4785,7 +4785,9 @@ class EasyConfigTest(EnhancedTestCase):
         toy_ec = os.path.join(test_ecs_dir, 'f', 'foss', 'foss-2018a.eb')
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         test_ec_txt = read_file(toy_ec)
+
         # this test only makes sense if depends_on is not used
+        self.allow_deprecated_behaviour()
         test_ec_txt += '\nmodule_depends_on = False'
         write_file(test_ec, test_ec_txt)
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -4785,6 +4785,8 @@ class EasyConfigTest(EnhancedTestCase):
         toy_ec = os.path.join(test_ecs_dir, 'f', 'foss', 'foss-2018a.eb')
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         test_ec_txt = read_file(toy_ec)
+        # this test only makes sense if depends_on is not used
+        test_ec_txt += '\nmodule_depends_on = False'
         write_file(test_ec, test_ec_txt)
 
         test_module = os.path.join(self.test_installpath, 'modules', 'all', 'foss', '2018a')
@@ -4827,6 +4829,8 @@ class EasyConfigTest(EnhancedTestCase):
         # recursive_module_unload easyconfig parameter is honored
         test_ec_bis = os.path.join(self.test_prefix, 'test_bis.eb')
         test_ec_bis_txt = read_file(toy_ec) + '\nrecursive_module_unload = True'
+        # this test only makes sense if depends_on is not used
+        test_ec_bis_txt += '\nmodule_depends_on = False'
         write_file(test_ec_bis, test_ec_bis_txt)
 
         ec_bis = EasyConfig(test_ec_bis)
@@ -4871,6 +4875,8 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertTrue(build_option('recursive_mod_unload'))
         test_ec_bis = os.path.join(self.test_prefix, 'test_bis.eb')
         test_ec_bis_txt = read_file(toy_ec) + '\nrecursive_module_unload = False'
+        # this test only makes sense if depends_on is not used
+        test_ec_bis_txt += '\nmodule_depends_on = False'
         write_file(test_ec_bis, test_ec_bis_txt)
         ec_bis = EasyConfig(test_ec_bis)
         self.assertEqual(ec_bis['recursive_module_unload'], False)

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -315,7 +315,8 @@ class ModuleGeneratorTest(EnhancedTestCase):
             else:
                 expected = "depends-on statements in generated module are not supported by modules tool"
                 with self.mocked_stdout_stderr():
-                    self.assertErrorRegex(EasyBuildError, expected, self.modgen.load_module, "mod_name", depends_on=True)
+                    self.assertErrorRegex(EasyBuildError, expected,
+                                          self.modgen.load_module, "mod_name", depends_on=True)
                     init_config(build_options={'mod_depends_on': 'True'})
                     self.assertErrorRegex(EasyBuildError, expected, self.modgen.load_module, "mod_name")
         else:
@@ -362,7 +363,8 @@ class ModuleGeneratorTest(EnhancedTestCase):
             else:
                 expected = "depends_on statements in generated module are not supported by modules tool"
                 with self.mocked_stdout_stderr():
-                    self.assertErrorRegex(EasyBuildError, expected, self.modgen.load_module, "mod_name", depends_on=True)
+                    self.assertErrorRegex(EasyBuildError, expected,
+                                          self.modgen.load_module, "mod_name", depends_on=True)
                     init_config(build_options={'mod_depends_on': 'True'})
                     self.assertErrorRegex(EasyBuildError, expected, self.modgen.load_module, "mod_name")
 

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -317,8 +317,6 @@ class ModuleGeneratorTest(EnhancedTestCase):
                 with self.mocked_stdout_stderr():
                     self.assertErrorRegex(EasyBuildError, expected,
                                           self.modgen.load_module, "mod_name", depends_on=True)
-                    init_config(build_options={'mod_depends_on': 'True'})
-                    self.assertErrorRegex(EasyBuildError, expected, self.modgen.load_module, "mod_name")
         else:
             # default: guarded module load (which implies no recursive unloading)
             expected = '\n'.join([
@@ -365,8 +363,6 @@ class ModuleGeneratorTest(EnhancedTestCase):
                 with self.mocked_stdout_stderr():
                     self.assertErrorRegex(EasyBuildError, expected,
                                           self.modgen.load_module, "mod_name", depends_on=True)
-                    init_config(build_options={'mod_depends_on': 'True'})
-                    self.assertErrorRegex(EasyBuildError, expected, self.modgen.load_module, "mod_name")
 
     def test_load_multi_deps(self):
         """Test generated load statement when multi_deps is involved."""

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -298,20 +298,26 @@ class ModuleGeneratorTest(EnhancedTestCase):
             self.assertEqual(expected, self.modgen.load_module("mod_name"))
 
             # Lmod 7.6+ depends-on
+
+            self.allow_deprecated_behaviour()
+
             if self.modtool.supports_depends_on:
                 expected = '\n'.join([
                     '',
                     "depends-on mod_name",
                     '',
                 ])
-                self.assertEqual(expected, self.modgen.load_module("mod_name", depends_on=True))
+                with self.mocked_stdout_stderr():
+                    txt = self.modgen.load_module("mod_name", depends_on=True)
+                self.assertEqual(expected, txt)
                 init_config(build_options={'mod_depends_on': 'True'})
                 self.assertEqual(expected, self.modgen.load_module("mod_name"))
             else:
                 expected = "depends-on statements in generated module are not supported by modules tool"
-                self.assertErrorRegex(EasyBuildError, expected, self.modgen.load_module, "mod_name", depends_on=True)
-                init_config(build_options={'mod_depends_on': 'True'})
-                self.assertErrorRegex(EasyBuildError, expected, self.modgen.load_module, "mod_name")
+                with self.mocked_stdout_stderr():
+                    self.assertErrorRegex(EasyBuildError, expected, self.modgen.load_module, "mod_name", depends_on=True)
+                    init_config(build_options={'mod_depends_on': 'True'})
+                    self.assertErrorRegex(EasyBuildError, expected, self.modgen.load_module, "mod_name")
         else:
             # default: guarded module load (which implies no recursive unloading)
             expected = '\n'.join([
@@ -338,20 +344,27 @@ class ModuleGeneratorTest(EnhancedTestCase):
             self.assertEqual(expected, self.modgen.load_module("mod_name"))
 
             # Lmod 7.6+ depends_on
+
+            self.allow_deprecated_behaviour()
+
             if self.modtool.supports_depends_on:
                 expected = '\n'.join([
                     '',
                     'depends_on("mod_name")',
                     '',
                 ])
-                self.assertEqual(expected, self.modgen.load_module("mod_name", depends_on=True))
+                with self.mocked_stdout_stderr():
+                    txt = self.modgen.load_module("mod_name", depends_on=True)
+
+                self.assertEqual(expected, txt)
                 init_config(build_options={'mod_depends_on': 'True'})
                 self.assertEqual(expected, self.modgen.load_module("mod_name"))
             else:
                 expected = "depends_on statements in generated module are not supported by modules tool"
-                self.assertErrorRegex(EasyBuildError, expected, self.modgen.load_module, "mod_name", depends_on=True)
-                init_config(build_options={'mod_depends_on': 'True'})
-                self.assertErrorRegex(EasyBuildError, expected, self.modgen.load_module, "mod_name")
+                with self.mocked_stdout_stderr():
+                    self.assertErrorRegex(EasyBuildError, expected, self.modgen.load_module, "mod_name", depends_on=True)
+                    init_config(build_options={'mod_depends_on': 'True'})
+                    self.assertErrorRegex(EasyBuildError, expected, self.modgen.load_module, "mod_name")
 
     def test_load_multi_deps(self):
         """Test generated load statement when multi_deps is involved."""
@@ -390,8 +403,12 @@ class ModuleGeneratorTest(EnhancedTestCase):
         self.assertEqual(expected, res)
 
         if self.modtool.supports_depends_on:
+
+            self.allow_deprecated_behaviour()
+
             # two versions with depends_on
-            res = self.modgen.load_module('Python/3.7.4', multi_dep_mods=multi_dep_mods, depends_on=True)
+            with self.mocked_stdout_stderr():
+                res = self.modgen.load_module('Python/3.7.4', multi_dep_mods=multi_dep_mods, depends_on=True)
 
             if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
                 expected = '\n'.join([
@@ -414,6 +431,8 @@ class ModuleGeneratorTest(EnhancedTestCase):
                     '',
                 ])
             self.assertEqual(expected, res)
+
+            self.disallow_deprecated_behaviour()
 
         # now test with more than two versions...
         multi_dep_mods = ['foo/1.2.3', 'foo/2.3.4', 'foo/3.4.5', 'foo/4.5.6']
@@ -452,8 +471,12 @@ class ModuleGeneratorTest(EnhancedTestCase):
         self.assertEqual(expected, res)
 
         if self.modtool.supports_depends_on:
+
+            self.allow_deprecated_behaviour()
+
             # more than two versions, with depends_on
-            res = self.modgen.load_module('foo/1.2.3', multi_dep_mods=multi_dep_mods, depends_on=True)
+            with self.mocked_stdout_stderr():
+                res = self.modgen.load_module('foo/1.2.3', multi_dep_mods=multi_dep_mods, depends_on=True)
 
             if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
                 expected = '\n'.join([
@@ -478,6 +501,8 @@ class ModuleGeneratorTest(EnhancedTestCase):
                     '',
                 ])
             self.assertEqual(expected, res)
+
+            self.disallow_deprecated_behaviour()
 
         # what if we only list a single version?
         # see https://github.com/easybuilders/easybuild-framework/issues/3080
@@ -505,7 +530,11 @@ class ModuleGeneratorTest(EnhancedTestCase):
         self.assertEqual(expected, res)
 
         if self.modtool.supports_depends_on:
-            res = self.modgen.load_module('one/1.0', multi_dep_mods=['one/1.0'], depends_on=True)
+
+            self.allow_deprecated_behaviour()
+
+            with self.mocked_stdout_stderr():
+                res = self.modgen.load_module('one/1.0', multi_dep_mods=['one/1.0'], depends_on=True)
 
             if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
                 expected = '\ndepends-on one/1.0\n'

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3217,22 +3217,15 @@ class ToyBuildTest(EnhancedTestCase):
                 'end',
             ])
         else:
-            if not self.modtool.supports_safe_auto_load:
-                expected = '\n'.join([
-                    '',
-                    "if { [ module-info mode remove ] || [ is-loaded GCC/7.3.0-2.30 ] } {",
-                    "    depends-on GCC",
-                    '} else {',
-                    "    depends-on GCC/4.6.3",
-                    '}',
-                    '',
-                ])
-            else:
-                expected = '\n'.join([
-                    'if { ![ is-loaded GCC/4.6.3 ] && ![ is-loaded GCC/7.3.0-2.30 ] } {',
-                    '    depends-on GCC/4.6.3',
-                    '}',
-                ])
+            expected = '\n'.join([
+                '',
+                "if { [ module-info mode remove ] || [ is-loaded GCC/7.3.0-2.30 ] } {",
+                "    module load GCC",
+                '} else {',
+                "    module load GCC/4.6.3",
+                '}',
+                '',
+            ])
 
         self.assertIn(expected, toy_mod_txt)
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3219,12 +3219,6 @@ class ToyBuildTest(EnhancedTestCase):
         else:
             if not self.modtool.supports_safe_auto_load:
                 expected = '\n'.join([
-                    'if { ![ is-loaded GCC/4.6.3 ] && ![ is-loaded GCC/7.3.0-2.30 ] } {',
-                    '    depends-on GCC/4.6.3',
-                    '}',
-                ])
-            else:
-                expected = '\n'.join([
                     '',
                     "if { [ module-info mode remove ] || [ is-loaded GCC/7.3.0-2.30 ] } {",
                     "    depends-on GCC",
@@ -3232,6 +3226,12 @@ class ToyBuildTest(EnhancedTestCase):
                     "    depends-on GCC/4.6.3",
                     '}',
                     '',
+                ])
+            else:
+                expected = '\n'.join([
+                    'if { ![ is-loaded GCC/4.6.3 ] && ![ is-loaded GCC/7.3.0-2.30 ] } {',
+                    '    depends-on GCC/4.6.3',
+                    '}',
                 ])
 
         self.assertIn(expected, toy_mod_txt)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -873,9 +873,9 @@ class ToyBuildTest(EnhancedTestCase):
         # check that toolchain load is expanded to loads for toolchain dependencies,
         # except for the ones that extend $MODULEPATH to make the toy module available
         if get_module_syntax() == 'Tcl':
-            load_regex_template = "load %s"
+            load_regex_template = "(load|depends-on) %s"
         elif get_module_syntax() == 'Lua':
-            load_regex_template = r'load\("%s/.*"\)'
+            load_regex_template = r'(load|depends_on)\("%s/.*"\)'
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
 
@@ -1739,8 +1739,10 @@ class ToyBuildTest(EnhancedTestCase):
 
         # make sure load statements for dependencies are included in additional module file generated with --module-only
         modtxt = read_file(toy_mod)
-        self.assertTrue(re.search('load.*intel/2018a', modtxt), "load statement for intel/2018a found in module")
-        self.assertTrue(re.search('load.*GCC/6.4.0-2.28', modtxt), "load statement for GCC/6.4.0-2.28 found in module")
+        self.assertTrue(re.search('(load|depends[-_]on).*intel/2018a', modtxt),
+                        "load statement for intel/2018a found in module")
+        self.assertTrue(re.search('(load|depends[-_]on).*GCC/6.4.0-2.28', modtxt),
+                        "load statement for GCC/6.4.0-2.28 found in module")
 
         os.remove(toy_mod)
 
@@ -1782,7 +1784,8 @@ class ToyBuildTest(EnhancedTestCase):
 
         # make sure load statements for dependencies are included
         modtxt = read_file(toy_core_mod)
-        self.assertTrue(re.search('load.*intel/2018a', modtxt), "load statement for intel/2018a found in module")
+        self.assertTrue(re.search('(load|depends[-_]on).*intel/2018a', modtxt),
+                        "load statement for intel/2018a found in module")
 
         # Test we can create a module even for an installation where we don't have write permissions
         os.remove(toy_core_mod)
@@ -1800,7 +1803,8 @@ class ToyBuildTest(EnhancedTestCase):
 
         # make sure load statements for dependencies are included
         modtxt = read_file(toy_core_mod)
-        self.assertTrue(re.search('load.*intel/2018a', modtxt), "load statement for intel/2018a found in module")
+        self.assertTrue(re.search('(load|depends[-_]on).*intel/2018a', modtxt),
+                        "load statement for intel/2018a found in module")
 
         os.remove(toy_core_mod)
         os.remove(toy_mod)
@@ -1826,7 +1830,8 @@ class ToyBuildTest(EnhancedTestCase):
 
             # make sure load statements for dependencies are included
             modtxt = read_file(toy_mod + '.lua')
-            self.assertTrue(re.search('load.*intel/2018a', modtxt), "load statement for intel/2018a found in module")
+            self.assertTrue(re.search('(load|depends[-_]on).*intel/2018a', modtxt),
+                            "load statement for intel/2018a found in module")
 
     def test_module_only_extensions(self):
         """
@@ -2371,7 +2376,7 @@ class ToyBuildTest(EnhancedTestCase):
 
         mod2_txt = read_file(mod2)
 
-        load1_regex = re.compile('load.*toy/0.0-one', re.M)
+        load1_regex = re.compile('(load|depends[-_]on).*toy/0.0-one', re.M)
         self.assertTrue(load1_regex.search(mod2_txt), "Pattern '%s' found in: %s" % (load1_regex.pattern, mod2_txt))
 
         # Check the contents of the dumped env in the reprod dir to ensure it contains the dependency load
@@ -3176,6 +3181,7 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec_txt += "\nexts_list = [('barbar', '1.2', {'start_dir': 'src'})]"
 
         test_ec_txt += "\nmulti_deps = {'GCC': ['4.6.3', '7.3.0-2.30']}"
+
         write_file(test_ec, test_ec_txt)
 
         test_mod_path = os.path.join(self.test_installpath, 'modules', 'all')
@@ -3204,24 +3210,26 @@ class ToyBuildTest(EnhancedTestCase):
         # check whether (guarded) load statement for first version listed in multi_deps is there
         if get_module_syntax() == 'Lua':
             expected = '\n'.join([
-                'if not ( isloaded("GCC/4.6.3") ) and not ( isloaded("GCC/7.3.0-2.30") ) then',
-                '    load("GCC/4.6.3")',
+                'if mode() == "unload" or isloaded("GCC/7.3.0-2.30") then',
+                '    depends_on("GCC")',
+                'else',
+                '    depends_on("GCC/4.6.3")',
                 'end',
             ])
         else:
             if not self.modtool.supports_safe_auto_load:
                 expected = '\n'.join([
                     'if { ![ is-loaded GCC/4.6.3 ] && ![ is-loaded GCC/7.3.0-2.30 ] } {',
-                    '    module load GCC/4.6.3',
+                    '    depends-on GCC/4.6.3',
                     '}',
                 ])
             else:
                 expected = '\n'.join([
                     '',
                     "if { [ module-info mode remove ] || [ is-loaded GCC/7.3.0-2.30 ] } {",
-                    "    module load GCC",
+                    "    depends-on GCC",
                     '} else {',
-                    "    module load GCC/4.6.3",
+                    "    depends-on GCC/4.6.3",
                     '}',
                     '',
                 ])

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3217,12 +3217,16 @@ class ToyBuildTest(EnhancedTestCase):
                 'end',
             ])
         else:
+            if isinstance(self.modtool, EnvironmentModules):
+                load_stmt = "module load"
+            else:
+                load_stmt = "depends-on"
             expected = '\n'.join([
                 '',
                 "if { [ module-info mode remove ] || [ is-loaded GCC/7.3.0-2.30 ] } {",
-                "    module load GCC",
+                "    %s GCC" % load_stmt,
                 '} else {',
-                "    module load GCC/4.6.3",
+                "    %s GCC/4.6.3" % load_stmt,
                 '}',
                 '',
             ])


### PR DESCRIPTION
I suspect I'll need to look into the tests that probably broke from this change.

I'm a bit unsure what to make of the  cli arguments, given the `store_true` behavior is a bit strange when the default is True. But I do see other flags do this, like `cleanup-tmpdir` so i guess we want to keep this for module-depends-on as well.

fixes #4397 