### PR TITLE
fix getting all available output for interactive commands + fix logging end of output when no match was found in `run_shell_cmd`

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -436,7 +436,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
             # note: we assume that there won't be any questions in stderr output
             if split_stderr:
                 more_stderr = True
-                while more_stdout:
+                while more_stderr:
                     more_stderr = proc.stderr.read(read_size) or b''
                     stderr += more_stderr
 

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -433,6 +433,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
             more_stdout = True
             while more_stdout:
                 more_stdout = proc.stdout.read(read_size) or b''
+                _log.debug(f"Obtained more stdout: {more_stdout}")
                 stdout += more_stdout
 
             # note: we assume that there won't be any questions in stderr output

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -425,12 +425,20 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
             # -1 means reading until EOF
             read_size = 128 if exit_code is None else -1
 
-            more_stdout = proc.stdout.read1(read_size) or b''
-            stdout += more_stdout
+            # get output as long as output is available;
+            # note: can't use proc.stdout.read without read_size argument,
+            # since that will always wait until EOF
+            more_stdout = True
+            while more_stdout:
+                more_stdout = proc.stdout.read(read_size) or b''
+                stdout += more_stdout
 
             # note: we assume that there won't be any questions in stderr output
             if split_stderr:
-                stderr += proc.stderr.read1(read_size) or b''
+                more_stderr = True
+                while more_stdout:
+                    more_stderr = proc.stderr.read(read_size) or b''
+                    stderr += more_stderr
 
             if qa_patterns:
                 if _answer_question(stdout, proc, qa_patterns, qa_wait_patterns):

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -907,8 +907,8 @@ class RunTest(EnhancedTestCase):
         """Test whether run_shell_cmd uses unbuffered output when running interactive commands."""
 
         # command that generates a lot of output before waiting for input
-        # note: bug being fixed can be reproduced reliably using 100, but not with too high values like 100000!
-        cmd = 'for x in $(seq 100); do echo "This is a number you can pick: $x"; done; '
+        # note: bug being fixed can be reproduced reliably using 1000, but not with too high values like 100000!
+        cmd = 'for x in $(seq 1000); do echo "This is a number you can pick: $x"; done; '
         cmd += 'echo "Pick a number: "; read number; echo "Picked number: $number"'
         with self.mocked_stdout_stderr():
             res = run_shell_cmd(cmd, qa_patterns=[('Pick a number: ', '42')], qa_timeout=10)


### PR DESCRIPTION
bug fix, required for installing Maple (cfr. https://github.com/easybuilders/easybuild-easyblocks/pull/3286)