### PR TITLE
consider both `easybuild-framework*.tar.gz` and `easybuild_framework*.tar.gz` in CI workflows

### DIFF
--- a/.github/workflows/container_tests.yml
+++ b/.github/workflows/container_tests.yml
@@ -73,7 +73,7 @@ jobs:
           python setup.py sdist
           ls dist
           export PREFIX=/tmp/$USER/$GITHUB_SHA
-          pip install --prefix $PREFIX dist/easybuild-framework*tar.gz
+          pip install --prefix $PREFIX dist/easybuild[-_]framework*tar.gz
           pip install --prefix $PREFIX https://github.com/easybuilders/easybuild-easyblocks/archive/develop.tar.gz
 
     - name: run test

--- a/.github/workflows/container_tests_apptainer.yml
+++ b/.github/workflows/container_tests_apptainer.yml
@@ -73,7 +73,7 @@ jobs:
           python setup.py sdist
           ls dist
           export PREFIX=/tmp/$USER/$GITHUB_SHA
-          pip install --prefix $PREFIX dist/easybuild-framework*tar.gz
+          pip install --prefix $PREFIX dist/easybuild[-_]framework*tar.gz
           pip install --prefix $PREFIX https://github.com/easybuilders/easybuild-easyblocks/archive/develop.tar.gz
 
     - name: run test

--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -68,7 +68,7 @@ jobs:
           python setup.py sdist
           ls dist
           export PREFIX=/tmp/$USER/$GITHUB_SHA
-          pip install --prefix $PREFIX dist/easybuild-framework*tar.gz
+          pip install --prefix $PREFIX dist/easybuild[-_]framework*tar.gz
 
     - name: run tests for 'eb' command
       env:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -140,7 +140,7 @@ jobs:
           python setup.py sdist
           ls dist
           export PREFIX=/tmp/$USER/$GITHUB_SHA
-          pip install --prefix $PREFIX dist/easybuild-framework*tar.gz
+          pip install --prefix $PREFIX dist/easybuild[-_]framework*tar.gz
 
     - name: run test suite
       env:


### PR DESCRIPTION
It seems like a recent change in `setuptools` is causing to generate source tarballs named `easybuild_framework*.tar.gz` rather than `easybuild-framework*.tar.gz` as it (always?) has been, so we need to take this into account.

Fix for failing CI workflows with:

```
ERROR: Invalid requirement: 'dist/easybuild-framework*tar.gz'
Hint: It looks like a path. File 'dist/easybuild-framework*tar.gz' does not exist.
```

edit: probably related: https://github.com/pypa/setuptools/issues/4167