### PR TITLE
replace spaces/line breaks in question/wait patterns with regex pattern that matches one or more spaces/line breaks in `run_shell_cmd`

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -214,6 +214,8 @@ def _answer_question(stdout, proc, qa_patterns, qa_wait_patterns):
 
     stdout_end = stdout.decode(errors='ignore')[-1000:]
     for question, answers in qa_patterns:
+        # first replace hard spaces by regular spaces, since they would mess up the join/split below
+        question = question.replace(r'\ ', ' ')
         # replace spaces/line breaks with regex pattern that matches one or more spaces/line breaks,
         # and allow extra whitespace at the end
         question = space_line_break_pattern.join(space_line_break_regex.split(question)) + r'[\s\n]*$'
@@ -249,6 +251,8 @@ def _answer_question(stdout, proc, qa_patterns, qa_wait_patterns):
         # if no match was found among question patterns,
         # take into account patterns for non-questions (qa_wait_patterns)
         for pattern in qa_wait_patterns:
+            # first replace hard spaces by regular spaces, since they would mess up the join/split below
+            pattern = pattern.replace(r'\ ', ' ')
             # replace spaces/line breaks with regex pattern that matches one or more spaces/line breaks,
             # and allow extra whitespace at the end
             pattern = space_line_break_pattern.join(space_line_break_regex.split(pattern)) + r'[\s\n]*$'

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -209,10 +209,14 @@ def _answer_question(stdout, proc, qa_patterns, qa_wait_patterns):
     """
     match_found = False
 
+    space_line_break_pattern = r'[\s\n]+'
+    space_line_break_regex = re.compile(space_line_break_pattern)
+
     stdout_end = stdout.decode(errors='ignore')[-1000:]
     for question, answers in qa_patterns:
-        # allow extra whitespace at the end
-        question += r'[\s\n]*$'
+        # replace spaces/line breaks with regex pattern that matches one or more spaces/line breaks,
+        # and allow extra whitespace at the end
+        question = space_line_break_pattern.join(space_line_break_regex.split(question)) + r'[\s\n]*$'
         regex = re.compile(question.encode())
         res = regex.search(stdout)
         if res:
@@ -245,8 +249,9 @@ def _answer_question(stdout, proc, qa_patterns, qa_wait_patterns):
         # if no match was found among question patterns,
         # take into account patterns for non-questions (qa_wait_patterns)
         for pattern in qa_wait_patterns:
-            # allow extra whitespace at the end
-            pattern += r'[\s\n]*$'
+            # replace spaces/line breaks with regex pattern that matches one or more spaces/line breaks,
+            # and allow extra whitespace at the end
+            pattern = space_line_break_pattern.join(space_line_break_regex.split(pattern)) + r'[\s\n]*$'
             regex = re.compile(pattern.encode())
             if regex.search(stdout):
                 _log.info(f"Found match for wait pattern '{pattern}'")

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -892,6 +892,20 @@ class RunTest(EnhancedTestCase):
         self.assertEqual(res.exit_code, 0)
         self.assertEqual(res.output, "just\nwait\nplease\nanswer\n42\n")
 
+        # test multi-line question pattern with hard space
+        cmd = ';'.join([
+            "echo please",
+            "echo answer",
+            "read x",
+            "echo $x",
+        ])
+        # question pattern uses hard space, should get replaced internally by more liberal whitespace regex pattern
+        qa = [(r"please\ answer", "42")]
+        with self.mocked_stdout_stderr():
+            res = run_shell_cmd(cmd, qa_patterns=qa, qa_timeout=3)
+        self.assertEqual(res.exit_code, 0)
+        self.assertEqual(res.output, "please\nanswer\n42\n")
+
     def test_run_cmd_qa_buffering(self):
         """Test whether run_cmd_qa uses unbuffered output."""
 

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -871,6 +871,27 @@ class RunTest(EnhancedTestCase):
         self.assertEqual(res.exit_code, 0)
         self.assertEqual(res.output, "not-a-question-but-a-statement\nquestion\nanswer\n")
 
+        # test multi-line question
+        cmd = ';'.join([
+            "echo please",
+            "echo answer",
+            "read x",
+            "echo $x",
+        ])
+        qa = [("please answer", "42")]
+        with self.mocked_stdout_stderr():
+            res = run_shell_cmd(cmd, qa_patterns=qa)
+        self.assertEqual(res.exit_code, 0)
+        self.assertEqual(res.output, "please\nanswer\n42\n")
+
+        # also test multi-line wait pattern
+        cmd = "echo just; echo wait; sleep 3; " + cmd
+        qa_wait_patterns = ["just wait"]
+        with self.mocked_stdout_stderr():
+            res = run_shell_cmd(cmd, qa_patterns=qa, qa_wait_patterns=qa_wait_patterns, qa_timeout=1)
+        self.assertEqual(res.exit_code, 0)
+        self.assertEqual(res.output, "just\nwait\nplease\nanswer\n42\n")
+
     def test_run_cmd_qa_buffering(self):
         """Test whether run_cmd_qa uses unbuffered output."""
 


### PR DESCRIPTION
This makes question/wait patterns a bit more forgiving w.r.t. having line breaks rather than spaces in particular questions, which may be the case when running in a narrow terminal for example.