### PR TITLE
add support for alternate easyconfig parameters/templates/constants

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -661,7 +661,7 @@ class EasyConfig(object):
         with self.disable_templating():
             for key in sorted(params.keys()):
                 # validations are skipped, just set in the config
-                if any(key in x.keys() for x in (self._config,ALTERNATE_PARAMTERS, DEPRECATED_PARAMETERS)):
+                if any(key in x.keys() for x in (self._config,ALTERNATE_PARAMETERS, DEPRECATED_PARAMETERS)):
                     self[key] = params[key]
                     self.log.info("setting easyconfig parameter %s: value %s (type: %s)",
                                   key, self[key], type(self[key]))

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -59,7 +59,7 @@ from easybuild.framework.easyconfig.format.convert import Dependency
 from easybuild.framework.easyconfig.format.format import DEPENDENCY_PARAMETERS
 from easybuild.framework.easyconfig.format.one import EB_FORMAT_EXTENSION, retrieve_blocks_in_spec
 from easybuild.framework.easyconfig.licenses import EASYCONFIG_LICENSES_DICT
-from easybuild.framework.easyconfig.parser import DEPRECATED_PARAMETERS, REPLACED_PARAMETERS
+from easybuild.framework.easyconfig.parser import ALTERNATE_PARAMETERS, DEPRECATED_PARAMETERS, REPLACED_PARAMETERS
 from easybuild.framework.easyconfig.parser import EasyConfigParser, fetch_parameters_from_easyconfig
 from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS, TEMPLATE_NAMES_DYNAMIC, template_constant_dict
 from easybuild.tools import LooseVersion
@@ -118,6 +118,8 @@ def handle_deprecated_or_replaced_easyconfig_parameters(ec_method):
     def new_ec_method(self, key, *args, **kwargs):
         """Check whether any replace easyconfig parameters are still used"""
         # map deprecated parameters to their replacements, issue deprecation warning(/error)
+        if key in ALTERNATE_PARAMETERS:
+            key = ALTERNATE_PARAMETERS[key]
         if key in DEPRECATED_PARAMETERS:
             depr_key = key
             key, ver = DEPRECATED_PARAMETERS[depr_key]
@@ -179,7 +181,7 @@ def triage_easyconfig_params(variables, ec):
 
     for key in variables:
         # validations are skipped, just set in the config
-        if key in ec or key in DEPRECATED_PARAMETERS.keys():
+        if any(key in d for d in (ec, DEPRECATED_PARAMETERS.keys(), ALTERNATE_PARAMETERS.keys()):
             ec_params[key] = variables[key]
             _log.debug("setting config option %s: value %s (type: %s)", key, ec_params[key], type(ec_params[key]))
         elif key in REPLACED_PARAMETERS:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -61,8 +61,8 @@ from easybuild.framework.easyconfig.format.one import EB_FORMAT_EXTENSION, retri
 from easybuild.framework.easyconfig.licenses import EASYCONFIG_LICENSES_DICT
 from easybuild.framework.easyconfig.parser import ALTERNATE_PARAMETERS, DEPRECATED_PARAMETERS, REPLACED_PARAMETERS
 from easybuild.framework.easyconfig.parser import EasyConfigParser, fetch_parameters_from_easyconfig
-from easybuild.framework.easyconfig.templates import DEPRECATED_TEMPLATES, TEMPLATE_CONSTANTS, TEMPLATE_NAMES_DYNAMIC
-from easybuild.framework.easyconfig.templates import template_constant_dict
+from easybuild.framework.easyconfig.templates import ALTERNATE_TEMPLATES, DEPRECATED_TEMPLATES, TEMPLATE_CONSTANTS,
+from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_DYNAMIC, template_constant_dict
 from easybuild.tools import LooseVersion
 from easybuild.tools.build_log import EasyBuildError, print_warning, print_msg
 from easybuild.tools.config import GENERIC_EASYBLOCK_PKG, LOCAL_VAR_NAMING_CHECK_ERROR, LOCAL_VAR_NAMING_CHECK_LOG
@@ -1997,13 +1997,16 @@ def resolve_template(value, tmpl_dict):
             try:
                 value = value % tmpl_dict
             except KeyError:
-                # check if any deprecated templates resolve
+                # check if any alternate or deprecated templates resolve
                 try:
                     orig_value = value
-                    # map old templates to new values
+                    # map old templates to new values for alternate and deprecated templates
+                    alt_map = {old_tmpl: tmpl_dict[new_tmpl] for (old_tmpl, new_tmpl) in
+                               ALTERNATE_TEMPLATES.items() if new_tmpl in tmpl_dict.keys()}
                     depr_map = {old_tmpl: tmpl_dict[new_tmpl] for (old_tmpl, (new_tmpl, ver)) in
                                 DEPRECATED_TEMPLATES.items() if new_tmpl in tmpl_dict.keys()}
-                    value = value % depr_map
+                    # try templating with tmpl_dict, alt_map and depr_map
+                    value = value % {**tmpl_dict, **alt_map, **depr_map}
 
                     for old_tmpl, val in depr_map.items():
                         # check which deprecated templates were replaced, and issue deprecation warnings

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -661,7 +661,7 @@ class EasyConfig(object):
         with self.disable_templating():
             for key in sorted(params.keys()):
                 # validations are skipped, just set in the config
-                if any(key in x.keys() for x in (self._config,ALTERNATE_PARAMETERS, DEPRECATED_PARAMETERS)):
+                if any(key in x.keys() for x in (self._config, ALTERNATE_PARAMETERS, DEPRECATED_PARAMETERS)):
                     self[key] = params[key]
                     self.log.info("setting easyconfig parameter %s: value %s (type: %s)",
                                   key, self[key], type(self[key]))

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -182,7 +182,7 @@ def triage_easyconfig_params(variables, ec):
 
     for key in variables:
         # validations are skipped, just set in the config
-        if any(key in d for d in (ec, DEPRECATED_PARAMETERS.keys(), ALTERNATE_PARAMETERS.keys()):
+        if any(key in d for d in (ec, DEPRECATED_PARAMETERS.keys(), ALTERNATE_PARAMETERS.keys())):
             ec_params[key] = variables[key]
             _log.debug("setting config option %s: value %s (type: %s)", key, ec_params[key], type(ec_params[key]))
         elif key in REPLACED_PARAMETERS:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -661,7 +661,7 @@ class EasyConfig(object):
         with self.disable_templating():
             for key in sorted(params.keys()):
                 # validations are skipped, just set in the config
-                if key in self._config.keys() or key in DEPRECATED_PARAMETERS.keys():
+                if any(key in x.keys() for x in (self._config,ALTERNATE_PARAMTERS, DEPRECATED_PARAMETERS)):
                     self[key] = params[key]
                     self.log.info("setting easyconfig parameter %s: value %s (type: %s)",
                                   key, self[key], type(self[key]))

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -121,11 +121,11 @@ def handle_deprecated_or_replaced_easyconfig_parameters(ec_method):
         # map deprecated parameters to their replacements, issue deprecation warning(/error)
         if key in ALTERNATE_PARAMETERS:
             key = ALTERNATE_PARAMETERS[key]
-        if key in DEPRECATED_PARAMETERS:
+        elif key in DEPRECATED_PARAMETERS:
             depr_key = key
             key, ver = DEPRECATED_PARAMETERS[depr_key]
             _log.deprecated("Easyconfig parameter '%s' is deprecated, use '%s' instead" % (depr_key, key), ver)
-        if key in REPLACED_PARAMETERS:
+        elif key in REPLACED_PARAMETERS:
             _log.nosupport("Easyconfig parameter '%s' is replaced by '%s'" % (key, REPLACED_PARAMETERS[key]), '2.0')
         return ec_method(self, key, *args, **kwargs)
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -61,7 +61,7 @@ from easybuild.framework.easyconfig.format.one import EB_FORMAT_EXTENSION, retri
 from easybuild.framework.easyconfig.licenses import EASYCONFIG_LICENSES_DICT
 from easybuild.framework.easyconfig.parser import ALTERNATE_PARAMETERS, DEPRECATED_PARAMETERS, REPLACED_PARAMETERS
 from easybuild.framework.easyconfig.parser import EasyConfigParser, fetch_parameters_from_easyconfig
-from easybuild.framework.easyconfig.templates import ALTERNATE_TEMPLATES, DEPRECATED_TEMPLATES, TEMPLATE_CONSTANTS,
+from easybuild.framework.easyconfig.templates import ALTERNATE_TEMPLATES, DEPRECATED_TEMPLATES, TEMPLATE_CONSTANTS
 from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_DYNAMIC, template_constant_dict
 from easybuild.tools import LooseVersion
 from easybuild.tools.build_log import EasyBuildError, print_warning, print_msg

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -39,7 +39,8 @@ from easybuild.base import fancylogger
 from easybuild.framework.easyconfig.constants import EASYCONFIG_CONSTANTS
 from easybuild.framework.easyconfig.format.format import get_format_version, EasyConfigFormat
 from easybuild.framework.easyconfig.licenses import EASYCONFIG_LICENSES_DICT
-from easybuild.framework.easyconfig.templates import DEPRECATED_TEMPLATE_CONSTANTS, TEMPLATE_CONSTANTS
+from easybuild.framework.easyconfig.templates import ALTERNATE_TEMPLATE_CONSTANTS, DEPRECATED_TEMPLATE_CONSTANTS
+from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.configobj import ConfigObj
 from easybuild.tools.systemtools import get_shared_lib_ext
@@ -90,8 +91,11 @@ def handle_deprecated_constants(method):
     """Decorator to handle deprecated easyconfig template constants"""
     def wrapper(self, key, *args, **kwargs):
         """Check whether any deprecated constants are used"""
+        alternate = ALTERNATE_TEMPLATE_CONSTANTS
         deprecated = DEPRECATED_TEMPLATE_CONSTANTS
-        if key in deprecated:
+        if key in alternate:
+            key = alternate[key]
+        elif key in deprecated:
             depr_key = key
             key, ver = deprecated[depr_key]
             _log.deprecated(f"Easyconfig template constant '{depr_key}' is deprecated, use '{key}' instead", ver)

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -39,7 +39,7 @@ from easybuild.base import fancylogger
 from easybuild.framework.easyconfig.constants import EASYCONFIG_CONSTANTS
 from easybuild.framework.easyconfig.format.format import get_format_version, EasyConfigFormat
 from easybuild.framework.easyconfig.licenses import EASYCONFIG_LICENSES_DICT
-from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS
+from easybuild.framework.easyconfig.templates import DEPRECATED_TEMPLATE_CONSTANTS, TEMPLATE_CONSTANTS
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.configobj import ConfigObj
 from easybuild.tools.systemtools import get_shared_lib_ext
@@ -84,6 +84,55 @@ def build_easyconfig_variables_dict():
     }
 
     return vars_dict
+
+
+def handle_deprecated_constants(method):
+    """Decorator to handle deprecated easyconfig template constants"""
+    def wrapper(self, key, *args, **kwargs):
+        """Check whether any deprecated constants are used"""
+        deprecated = DEPRECATED_TEMPLATE_CONSTANTS
+        if key in deprecated:
+            depr_key = key
+            key, ver = deprecated[depr_key]
+            _log.deprecated(f"Easyconfig template constant '{depr_key}' is deprecated, use '{key}' instead", ver)
+        return method(self, key, *args, **kwargs)
+    return wrapper
+
+
+class DeprecatedDict(dict):
+    """Custom dictionary that handles deprecated easyconfig template constants gracefully"""
+
+    def __init__(self, *args, **kwargs):
+        self.clear()
+        self.update(*args, **kwargs)
+
+    @handle_deprecated_constants
+    def __contains__(self, key):
+        return super().__contains__(key)
+
+    @handle_deprecated_constants
+    def __delitem__(self, key):
+        return super().__delitem__(key)
+
+    @handle_deprecated_constants
+    def __getitem__(self, key):
+        return super().__getitem__(key)
+
+    @handle_deprecated_constants
+    def __setitem__(self, key, value):
+        return super().__setitem__(key, value)
+
+    def update(self, *args, **kwargs):
+        if args:
+            if isinstance(args[0], dict):
+                for key, value in args[0].items():
+                    self.__setitem__(key, value)
+            else:
+                for key, value in args[0]:
+                    self.__setitem__(key, value)
+
+        for key, value in kwargs.items():
+            self.__setitem__(key, value)
 
 
 class EasyConfigFormatConfigObj(EasyConfigFormat):
@@ -176,7 +225,7 @@ class EasyConfigFormatConfigObj(EasyConfigFormat):
 
     def parse_pyheader(self, pyheader):
         """Parse the python header, assign to docstring and cfg"""
-        global_vars = self.pyheader_env()
+        global_vars = DeprecatedDict(self.pyheader_env())
         self.log.debug("pyheader initial global_vars %s", global_vars)
         self.log.debug("pyheader text being exec'ed: %s", pyheader)
 

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -44,7 +44,7 @@ from easybuild.tools.filetools import read_file, write_file
 
 # alternate easyconfig parameters, and their non-deprecated equivalents
 ALTERNATE_PARAMETERS = {
-    # <equivalent_param>: <new_param>,
+    # <new_param>: <equivalent_param>,
 }
 
 # deprecated easyconfig parameters, and their replacements

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -43,7 +43,7 @@ from easybuild.tools.filetools import read_file, write_file
 
 
 # alternate easyconfig parameters, and their non-deprecated equivalents
-ALTNERATE_PARAMETERS = {
+ALTERNATE_PARAMETERS = {
     # <equivalent_param>: <new_param>,
 }
 

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -42,6 +42,11 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import read_file, write_file
 
 
+# alternate easyconfig parameters, and their non-deprecated equivalents
+ALTNERATE_PARAMETERS = {
+    # <equivalent_param>: <new_param>,
+}
+
 # deprecated easyconfig parameters, and their replacements
 DEPRECATED_PARAMETERS = {
     # <old_param>: (<new_param>, <deprecation_version>),

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -161,6 +161,16 @@ TEMPLATE_CONSTANTS = [
     ('SHLIB_EXT', get_shared_lib_ext(), 'extension for shared libraries'),
 ]
 
+# deprecated templates, and their replacements
+DEPRECATED_TEMPLATES = {
+    # <old_template>: (<new_template>, <deprecation_version>),
+}
+
+# deprecated template constants, and their replacements
+DEPRECATED_TEMPLATE_CONSTANTS = {
+    # <old_template_constant>: (<new_template_constant>, <deprecation_version>),
+}
+
 extensions = ['tar.gz', 'tar.xz', 'tar.bz2', 'tgz', 'txz', 'tbz2', 'tb2', 'gtgz', 'zip', 'tar', 'xz', 'tar.Z']
 for ext in extensions:
     suffix = ext.replace('.', '_').upper()

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -161,9 +161,19 @@ TEMPLATE_CONSTANTS = [
     ('SHLIB_EXT', get_shared_lib_ext(), 'extension for shared libraries'),
 ]
 
+# alternate templates, and their equivalents
+ALTERNATE_TEMPLATES = {
+    # <equivalent_template>: <new_template>,
+}
+
 # deprecated templates, and their replacements
 DEPRECATED_TEMPLATES = {
     # <old_template>: (<new_template>, <deprecation_version>),
+}
+
+# alternate template constants, and their equivalents
+ALTERNATE_TEMPLATE_CONSTANTS = {
+    # <equivalent_template_constant>: <new_template_constant>,
 }
 
 # deprecated template constants, and their replacements

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -163,7 +163,7 @@ TEMPLATE_CONSTANTS = [
 
 # alternate templates, and their equivalents
 ALTERNATE_TEMPLATES = {
-    # <equivalent_template>: <new_template>,
+    # <new>: <equivalent_template>,
 }
 
 # deprecated templates, and their replacements
@@ -173,7 +173,7 @@ DEPRECATED_TEMPLATES = {
 
 # alternate template constants, and their equivalents
 ALTERNATE_TEMPLATE_CONSTANTS = {
-    # <equivalent_template_constant>: <new_template_constant>,
+    # <new_template_constant>: <equivalent_template_constant>,
 }
 
 # deprecated template constants, and their replacements

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -120,11 +120,6 @@ class EasyConfigTest(EnhancedTestCase):
         github_token = gh.fetch_github_token(GITHUB_TEST_ACCOUNT)
         self.skip_github_tests = github_token is None and os.getenv('FORCE_EB_GITHUB_TESTS') is None
 
-        self.orig_alternate_constants = copy.deepcopy(easyconfig.templates.ALTERNATE_TEMPLATE_CONSTANTS)
-        self.orig_alternate_templates = copy.deepcopy(easyconfig.templates.ALTERNATE_TEMPLATES)
-        self.orig_deprecated_constants = copy.deepcopy(easyconfig.templates.DEPRECATED_TEMPLATE_CONSTANTS)
-        self.orig_deprecated_templates = copy.deepcopy(easyconfig.templates.DEPRECATED_TEMPLATES)
-
     def prep(self):
         """Prepare for test."""
         # (re)cleanup last test file
@@ -139,11 +134,10 @@ class EasyConfigTest(EnhancedTestCase):
         """ make sure to remove the temporary file """
         st.get_cpu_architecture = self.orig_get_cpu_architecture
 
-        easyconfig.templates.ALTERNATE_TEMPLATE_CONSTANTS = self.orig_alternate_constants
-        easyconfig.templates.ALTERNATE_TEMPLATES = self.orig_alternate_templates
-        easyconfig.templates.DEPRECATED_TEMPLATE_CONSTANTS = self.orig_deprecated_constants
-        easyconfig.templates.DEPRECATED_TEMPLATES = self.orig_deprecated_templates
+        # reload easyconfig.template module to restore orignal values of DEPRECATED_TEMPLATES & co
         reload(easyconfig.templates)
+        # also reload easyconfig.easyconfig module, which imports from easyconfig.templates
+        reload(easyconfig.easyconfig)
 
         super(EasyConfigTest, self).tearDown()
         if os.path.exists(self.eb_file):

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1825,7 +1825,9 @@ class EasyConfigTest(EnhancedTestCase):
         test_ecs_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'easyconfigs', 'test_ecs')
         toy_ec = os.path.join(test_ecs_dir, 't', 'toy', 'toy-0.0.eb')
 
-        test_ec_txt = read_file(toy_ec).replace('postinstallcmds', 'post_install_cmds').replace('moduleclass', 'env_mod_class')
+        test_ec_txt = read_file(toy_ec)
+        test_ec_txt = test_ec_txt.replace('postinstallcmds', 'post_install_cmds')
+        test_ec_txt = test_ec_txt.replace('moduleclass', 'env_mod_class')
 
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         write_file(test_ec, test_ec_txt)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1475,18 +1475,19 @@ class EasyConfigTest(EnhancedTestCase):
 
         template_test_alternates = {
             'installdir': 'alt_install_dir',
-            'version_maj_min': 'alt_ver_maj_min',
+            'version_major_minor': 'alt_ver_maj_min',
         }
         easyconfig.templates.ALTERNATE_TEMPLATES.update(template_test_alternates)
 
-        tmpl_str = ("cd %(start_dir)s && make PREFIX=%(installdir)s -Dbuild=%(builddir)s --with-cuda='%(cudaver)s'"
-                    " && echo %(installdir)s %(version_maj_min)s")
+        tmpl_str = ("cd %(start_dir)s && make %(namelower)s -Dbuild=%(builddir)s --with-cuda='%(cudaver)s'"
+                    " && echo %(alt_install_dir)s %(version_major_minor)s")
         tmpl_dict = {
             'depr_build_dir': '/example/build_dir',
             'depr_cuda_ver': '12.1.1',
             'installdir': '/example/installdir',
-            'startdir': '/example/build_dir/start_dir',
-            'alt_version_maj_min': '1.2',
+            'start_dir': '/example/build_dir/start_dir',
+            'alt_ver_maj_min': '1.2',
+            'namelower': 'foo',
         }
 
         with self.mocked_stdout_stderr() as (_, stderr):
@@ -1497,8 +1498,8 @@ class EasyConfigTest(EnhancedTestCase):
             self.assertNotIn("%(" + tmpl + ")s", res)
 
         for old, (new, ver) in template_test_deprecations.items():
-            depr_str = (f"WARNING: Deprecated functionality, will no longer work in v{ver}: Easyconfig template '{old}'"
-                        f" is deprecated, use '{new}' instead")
+            depr_str = (f"WARNING: Deprecated functionality, will no longer work in EasyBuild v{ver}: "
+                        f"Easyconfig template '{old}' is deprecated, use '{new}' instead")
             self.assertIn(depr_str, stderr)
 
     def test_constant_doc(self):

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1480,7 +1480,7 @@ class EasyConfigTest(EnhancedTestCase):
         easyconfig.templates.ALTERNATE_TEMPLATES.update(template_test_deprecations)
 
         tmpl_str = ("cd %(start_dir)s && make PREFIX=%(installdir)s -Dbuild=%(builddir)s --with-cuda='%(cudaver)s'"
-                    " && echo %(installdir)s %(version_maj_min)s"
+                    " && echo %(installdir)s %(version_maj_min)s")
         tmpl_dict = {
             'depr_build_dir': '/example/build_dir',
             'depr_cuda_ver': '12.1.1',

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1466,6 +1466,8 @@ class EasyConfigTest(EnhancedTestCase):
     def test_template_deprecation_and_alternate(self):
         """Test deprecation of (and alternate) templates"""
 
+        self.prep()
+
         template_test_deprecations = {
             'builddir': ('depr_build_dir', '1000000000'),
             'cudaver': ('depr_cuda_ver', '1000000000'),

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -139,7 +139,7 @@ class EasyConfigTest(EnhancedTestCase):
         """ make sure to remove the temporary file """
         st.get_cpu_architecture = self.orig_get_cpu_architecture
 
-        easyconfig.templates.ALTERNATE_TEMPLATE_CONSTANTS = self.orig_alternate_template_constants
+        easyconfig.templates.ALTERNATE_TEMPLATE_CONSTANTS = self.orig_alternate_constants
         easyconfig.templates.ALTERNATE_TEMPLATES = self.orig_alternate_templates
         easyconfig.templates.DEPRECATED_TEMPLATE_CONSTANTS = self.orig_deprecated_constants
         easyconfig.templates.DEPRECATED_TEMPLATES = self.orig_deprecated_templates
@@ -1477,7 +1477,7 @@ class EasyConfigTest(EnhancedTestCase):
             'installdir': 'alt_install_dir',
             'version_maj_min': 'alt_ver_maj_min',
         }
-        easyconfig.templates.ALTERNATE_TEMPLATES.update(template_test_deprecations)
+        easyconfig.templates.ALTERNATE_TEMPLATES.update(template_test_alternates)
 
         tmpl_str = ("cd %(start_dir)s && make PREFIX=%(installdir)s -Dbuild=%(builddir)s --with-cuda='%(cudaver)s'"
                     " && echo %(installdir)s %(version_maj_min)s")

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -40,7 +40,6 @@ import tempfile
 import textwrap
 from collections import OrderedDict
 from easybuild.tools import LooseVersion
-from importlib import reload
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 from unittest import TextTestRunner
 
@@ -1849,6 +1848,21 @@ class EasyConfigTest(EnhancedTestCase):
         expected = ['echo TOY > %(installdir)s/README']
         self.assertEqual(ec['postinstallcmds'], expected)
         self.assertEqual(ec['post_install_cmds'], expected)
+
+        # test setting of easyconfig parameter with original & alternate name
+        ec['moduleclass'] = 'test1'
+        self.assertEqual(ec['moduleclass'], 'test1')
+        self.assertEqual(ec['env_mod_class'], 'test1')
+        ec.update('moduleclass', 'test2')
+        self.assertEqual(ec['moduleclass'], 'test1 test2 ')
+        self.assertEqual(ec['env_mod_class'], 'test1 test2 ')
+
+        ec['env_mod_class'] = 'test3'
+        self.assertEqual(ec['moduleclass'], 'test3')
+        self.assertEqual(ec['env_mod_class'], 'test3')
+        ec.update('env_mod_class', 'test4')
+        self.assertEqual(ec['moduleclass'], 'test3 test4 ')
+        self.assertEqual(ec['env_mod_class'], 'test3 test4 ')
 
     def test_deprecated_easyconfig_parameters(self):
         """Test handling of deprecated easyconfig parameters."""


### PR DESCRIPTION
As discussed in slack, this is an alternative approach to introducing new parameters and deprecating old ones in one go. Instead, it's a multi-stage process:
1. Introduce new names, as alternatives
2. Do the renaming
3. Deprecate
This would allow is to do it iteratively across the different parameters / etc. over a series of EB 5.x releases.

https://github.com/easybuilders/easybuild-framework/issues/4464


To play around with this, check out the branch and modify:
* `easybuild/framework/easyconfig/parser.py`:
```
 45 # alternate easyconfig parameters, and their non-deprecated equivalents                                                 
 46 ALTERNATE_PARAMETERS = {                                                                                                
 47     # <new_param>: <equivalent_param>,                                                                                  
 48 } 
 ```
 
* `easybuild/framework/easyconfig/templates.py`:
```
164 # alternate templates, and their equivalents                                                                            
165 ALTERNATE_TEMPLATES = {                                                                                                 
166     # <new>: <equivalent_template>,                                                                                     
167 }
```
```
174 # alternate template constants, and their equivalents                                                                   
175 ALTERNATE_TEMPLATE_CONSTANTS = {                                                                                        
176     # <new_template_constant>: <equivalent_template_constant>,                                                          
177 }
```