### PR TITLE
Fix stability of reproducible tarballs from git repos

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2680,8 +2680,8 @@ def get_source_tarball_from_git(filename, target_dir, git_config):
         tar_cmd = [
             # print names of all files and folders excluding .git directory
             'find', repo_name, '-name ".git"', '-prune', '-o', '-print0',
-            # reset access and modification timestamps
-            '-exec', 'touch', '-t 197001010100', '{}', r'\;', '|',
+            # reset access and modification timestamps to epoch 0
+            '-exec', 'touch', '--date=@0', '{}', r'\;', '|',
             # sort file list
             'LC_ALL=C', 'sort', '--zero-terminated', '|',
             # create tarball in GNU format with ownership reset

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2684,9 +2684,9 @@ def get_source_tarball_from_git(filename, target_dir, git_config):
             '-exec', 'touch', '--date=@0', '{}', r'\;', '|',
             # sort file list
             'LC_ALL=C', 'sort', '--zero-terminated', '|',
-            # create tarball in GNU format with ownership reset
-            'tar', '--create', '--no-recursion', '--owner=0', '--group=0', '--numeric-owner', '--format=gnu',
-            '--null', '--files-from', '-', '|',
+            # create tarball in GNU format with ownership and permissions reset
+            'tar', '--create', '--no-recursion', '--owner=0', '--group=0', '--numeric-owner', '--mode="go+u,go-w"',
+            '--format=gnu', '--null', '--files-from', '-', '|',
             # compress tarball with gzip without original file name and timestamp
             'gzip', '--no-name', '>', archive_path
         ]


### PR DESCRIPTION
Following some test failures with our build bots (see https://github.com/easybuilders/easybuild-easyconfigs/pull/19770), I found out that the tarballs of git repos are not fully reproducible as they dependent on some local settings of the host system:
1. resetting file modification times with `touch -t` depends on the local timezone
2. some file permissions of the cloned repository depend on default directory permissions

This PR fixes both issues:
1. reset file modification times with  `touch --date` and using unix epoch zero
2. always remove write permissions from group and others (follows recommendation in https://www.gnu.org/software/tar/manual/html_node/Reproducibility.html)