### PR TITLE
use generic chmod command to reset permissions of reproducible archives

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2680,12 +2680,14 @@ def get_source_tarball_from_git(filename, target_dir, git_config):
         tar_cmd = [
             # print names of all files and folders excluding .git directory
             'find', repo_name, '-name ".git"', '-prune', '-o', '-print0',
-            # reset access and modification timestamps to epoch 0
-            '-exec', 'touch', '--date=@0', '{}', r'\;', '|',
-            # sort file list
+            # reset access and modification timestamps to epoch 0 (equivalent to --mtime in GNU tar)
+            '-exec', 'touch', '--date=@0', '{}', r'\;',
+            # reset file permissions of cloned repo (equivalent to --mode in GNU tar)
+            '-exec', 'chmod', '"go+u,go-w"', '{}', r'\;', '|',
+            # sort file list (equivalent to --sort in GNU tar)
             'LC_ALL=C', 'sort', '--zero-terminated', '|',
             # create tarball in GNU format with ownership and permissions reset
-            'tar', '--create', '--no-recursion', '--owner=0', '--group=0', '--numeric-owner', '--mode="go+u,go-w"',
+            'tar', '--create', '--no-recursion', '--owner=0', '--group=0', '--numeric-owner',
             '--format=gnu', '--null', '--files-from', '-', '|',
             # compress tarball with gzip without original file name and timestamp
             'gzip', '--no-name', '>', archive_path


### PR DESCRIPTION
As discussed, we found out that BSD tar lacks the `--mode` option. So we work around that by manually executing `chmod`.