### PR TITLE
deprecate old checksum options (incl. md5)

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -77,7 +77,7 @@ from easybuild.tools.config import FORCE_DOWNLOAD_ALL, FORCE_DOWNLOAD_PATCHES, F
 from easybuild.tools.config import build_option, build_path, get_log_filename, get_repository, get_repositorypath
 from easybuild.tools.config import install_path, log_path, package_path, source_paths
 from easybuild.tools.environment import restore_env, sanitize_env
-from easybuild.tools.filetools import CHECKSUM_TYPE_MD5, CHECKSUM_TYPE_SHA256
+from easybuild.tools.filetools import CHECKSUM_TYPE_SHA256
 from easybuild.tools.filetools import adjust_permissions, apply_patch, back_up_file, change_dir, check_lock
 from easybuild.tools.filetools import compute_checksum, convert_name, copy_file, create_lock, create_patch_info
 from easybuild.tools.filetools import derive_alt_pypi_url, diff_files, dir_contains_files, download_file
@@ -666,8 +666,7 @@ class EasyBlock(object):
                         src_path = ext_src['src']
                         src_fn = os.path.basename(src_path)
 
-                        # report both MD5 and SHA256 checksums, since both are valid default checksum types
-                        for checksum_type in (CHECKSUM_TYPE_MD5, CHECKSUM_TYPE_SHA256):
+                        for checksum_type in [CHECKSUM_TYPE_SHA256]:
                             src_checksum = compute_checksum(src_path, checksum_type=checksum_type)
                             self.log.info("%s checksum for %s: %s", checksum_type, src_path, src_checksum)
 
@@ -695,9 +694,7 @@ class EasyBlock(object):
                         if verify_checksums:
                             for patch in ext_patches:
                                 patch = patch['path']
-                                # report both MD5 and SHA256 checksums,
-                                # since both are valid default checksum types
-                                for checksum_type in (CHECKSUM_TYPE_MD5, CHECKSUM_TYPE_SHA256):
+                                for checksum_type in [CHECKSUM_TYPE_SHA256]:
                                     checksum = compute_checksum(patch, checksum_type=checksum_type)
                                     self.log.info("%s checksum for %s: %s", checksum_type, patch, checksum)
 
@@ -2410,8 +2407,7 @@ class EasyBlock(object):
         # compute checksums for all source and patch files
         if not (skip_checksums or self.dry_run):
             for fil in self.src + self.patches:
-                # report both MD5 and SHA256 checksums, since both are valid default checksum types
-                for checksum_type in [CHECKSUM_TYPE_MD5, CHECKSUM_TYPE_SHA256]:
+                for checksum_type in [CHECKSUM_TYPE_SHA256]:
                     fil[checksum_type] = compute_checksum(fil['path'], checksum_type=checksum_type)
                     self.log.info("%s checksum for %s: %s", checksum_type, fil['path'], fil[checksum_type])
 

--- a/easybuild/framework/easyconfig/types.py
+++ b/easybuild/framework/easyconfig/types.py
@@ -516,7 +516,7 @@ def to_checksums(checksums):
     for checksum in checksums:
         # each list entry can be:
         # * None (indicates no checksum)
-        # * a string (MD5 or SHA256 checksum)
+        # * a string (SHA256 checksum)
         # * a tuple with 2 elements: checksum type + checksum value
         # * a list of checksums (i.e. multiple checksums for a single file)
         # * a dict (filename to checksum mapping)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1200,7 +1200,7 @@ def compute_checksum(path, checksum_type=DEFAULT_CHECKSUM):
 
     if checksum_type in ['adler32', 'crc32', 'md5', 'sha1', 'size']:
         _log.deprecated("Checksum type %s is deprecated. Use sha256 (default) or sha512 instead" % checksum_type,
-                            '6.0')
+                        '6.0')
 
     try:
         checksum = CHECKSUM_FUNCTIONS[checksum_type](path)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -1192,11 +1192,15 @@ def compute_checksum(path, checksum_type=DEFAULT_CHECKSUM):
     Compute checksum of specified file.
 
     :param path: Path of file to compute checksum for
-    :param checksum_type: type(s) of checksum ('adler32', 'crc32', 'md5' (default), 'sha1', 'sha256', 'sha512', 'size')
+    :param checksum_type: type(s) of checksum ('adler32', 'crc32', 'md5', 'sha1', 'sha256', 'sha512', 'size')
     """
     if checksum_type not in CHECKSUM_FUNCTIONS:
         raise EasyBuildError("Unknown checksum type (%s), supported types are: %s",
                              checksum_type, CHECKSUM_FUNCTIONS.keys())
+
+    if checksum_type in ['adler32', 'crc32', 'md5', 'sha1', 'size']:
+        _log.deprecated("Checksum type %s is deprecated. Use sha256 (default) or sha512 instead" % checksum_type,
+                            '6.0')
 
     try:
         checksum = CHECKSUM_FUNCTIONS[checksum_type](path)
@@ -1235,7 +1239,7 @@ def verify_checksum(path, checksums):
     Verify checksum of specified file.
 
     :param path: path of file to verify checksum of
-    :param checksums: checksum values (and type, optionally, default is MD5), e.g., 'af314', ('sha', '5ec1b')
+    :param checksums: checksum values (and type, optionally, default is sha256), e.g., 'af314', ('sha', '5ec1b')
     """
 
     filename = os.path.basename(path)
@@ -1287,7 +1291,7 @@ def verify_checksum(path, checksums):
                 # no matching checksums
                 return False
         else:
-            raise EasyBuildError("Invalid checksum spec '%s': should be a string (MD5 or SHA256), "
+            raise EasyBuildError("Invalid checksum spec '%s': should be a string (SHA256), "
                                  "2-tuple (type, value), or tuple of alternative checksum specs.",
                                  checksum)
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2565,6 +2565,8 @@ class EasyBlockTest(EnhancedTestCase):
         copy_file(toy_ec, self.test_prefix)
         toy_ec = os.path.join(self.test_prefix, os.path.basename(toy_ec))
         ectxt = read_file(toy_ec)
+        # replace SHA256 checksum for toy-0.0.tar.gz
+        ectxt = ectxt.replace('44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc', '76543210' * 8)
         # replace SHA256 checksums for source of bar extension
         ectxt = ectxt.replace('f3676716b610545a4e8035087f5be0a0248adee0abb3930d3edb76d498ae91e7', '01234567' * 8)
         write_file(toy_ec, ectxt)
@@ -2654,7 +2656,9 @@ class EasyBlockTest(EnhancedTestCase):
         self.mock_stderr(False)
         self.mock_stdout(False)
         self.assertEqual(stdout, '')
-        self.assertEqual(stderr.strip(), "WARNING: Ignoring failing checksum verification for bar-0.0.tar.gz")
+        print(stderr.strip())
+        self.assertEqual(stderr.strip(), "WARNING: Ignoring failing checksum verification for bar-0.0.tar.gz\n\n\n"
+                                         "WARNING: Ignoring failing checksum verification for toy-0.0.tar.gz")
 
     def test_check_checksums(self):
         """Test for check_checksums_for and check_checksums methods."""

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1536,9 +1536,8 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertTrue(os.path.samefile(eb.src[0]['path'], toy_source))
         self.assertEqual(eb.src[0]['name'], 'toy-0.0.tar.gz')
         self.assertEqual(eb.src[0]['cmd'], None)
-        self.assertEqual(len(eb.src[0]['checksum']), 7)
-        self.assertEqual(eb.src[0]['checksum'][0], 'be662daa971a640e40be5c804d9d7d10')
-        self.assertEqual(eb.src[0]['checksum'][1], '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc')
+        self.assertEqual(len(eb.src[0]['checksum']), 2)
+        self.assertEqual(eb.src[0]['checksum'][0], '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc')
 
         # reconfigure EasyBuild so we can check 'downloaded' sources
         os.environ['EASYBUILD_SOURCEPATH'] = self.test_prefix
@@ -2566,8 +2565,6 @@ class EasyBlockTest(EnhancedTestCase):
         copy_file(toy_ec, self.test_prefix)
         toy_ec = os.path.join(self.test_prefix, os.path.basename(toy_ec))
         ectxt = read_file(toy_ec)
-        # replace MD5 checksum for toy-0.0.tar.gz
-        ectxt = ectxt.replace('be662daa971a640e40be5c804d9d7d10', '00112233445566778899aabbccddeeff')
         # replace SHA256 checksums for source of bar extension
         ectxt = ectxt.replace('f3676716b610545a4e8035087f5be0a0248adee0abb3930d3edb76d498ae91e7', '01234567' * 8)
         write_file(toy_ec, ectxt)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2656,7 +2656,6 @@ class EasyBlockTest(EnhancedTestCase):
         self.mock_stderr(False)
         self.mock_stdout(False)
         self.assertEqual(stdout, '')
-        print(stderr.strip())
         self.assertEqual(stderr.strip(), "WARNING: Ignoring failing checksum verification for bar-0.0.tar.gz\n\n\n"
                                          "WARNING: Ignoring failing checksum verification for toy-0.0.tar.gz")
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -485,7 +485,7 @@ class EasyConfigTest(EnhancedTestCase):
                        # SHA256 checksum for source (gzip-1.4.eb)
                        "6a5abcab719cefa95dca4af0db0d2a9d205d68f775a33b452ec0f2b75b6a3a45",
                        # SHA256 checksum for 'patch' (toy-0.0.eb)
-                       "2d964e0e8f05a7cce0dd83a3e68c9737da14b87b61b8b8b0291d58d4c8d1031c",
+                       "177b34bcdfa1abde96f30354848a01894ebc9c24913bc5145306cd30f78fc8ad",
                    ],
                }),
                # Can use templates in name and version
@@ -509,7 +509,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(exts_sources[1]['version'], '2.0')
         self.assertEqual(exts_sources[1]['options'], {
             'checksums': ['6a5abcab719cefa95dca4af0db0d2a9d205d68f775a33b452ec0f2b75b6a3a45',
-                          '2d964e0e8f05a7cce0dd83a3e68c9737da14b87b61b8b8b0291d58d4c8d1031c'],
+                          '177b34bcdfa1abde96f30354848a01894ebc9c24913bc5145306cd30f78fc8ad'],
             'patches': [('toy-0.0.eb', '.')],
             'source_tmpl': 'gzip-1.4.eb',
             'source_urls': [('http://example.com', 'suffix')],

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-deps.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-deps.eb
@@ -9,13 +9,10 @@ toolchain = SYSTEM
 
 sources = [SOURCE_TAR_GZ]
 checksums = [[
-    'be662daa971a640e40be5c804d9d7d10',  # default (MD5)
     '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # default (SHA256)
-    ('adler32', '0x998410035'),
-    ('crc32', '0x1553842328'),
-    ('md5', 'be662daa971a640e40be5c804d9d7d10'),
-    ('sha1', 'f618096c52244539d0e89867405f573fdb0b55b0'),
-    ('size', 273),
+    ('sha512',
+     '3c9dc629e1f2fd01a15c68f9f2a328b5da045c2ec1a189dc72d7195642f32e0'
+     'ff59275aba5fa2a78e84417c7645d0ca5d06aff39e688a8936061ed5c4c600708'),
 ]]
 patches = ['toy-0.0_fix-silly-typo-in-printf-statement.patch']
 

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-2018a-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-2018a-test.eb
@@ -10,13 +10,10 @@ toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
 
 sources = [SOURCE_TAR_GZ]
 checksums = [[
-    'be662daa971a640e40be5c804d9d7d10',  # default (MD5)
     '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # default (SHA256)
-    ('adler32', '0x998410035'),
-    ('crc32', '0x1553842328'),
-    ('md5', 'be662daa971a640e40be5c804d9d7d10'),
-    ('sha1', 'f618096c52244539d0e89867405f573fdb0b55b0'),
-    ('size', 273),
+    ('sha512',
+     '3c9dc629e1f2fd01a15c68f9f2a328b5da045c2ec1a189dc72d7195642f32e0'
+     'ff59275aba5fa2a78e84417c7645d0ca5d06aff39e688a8936061ed5c4c600708'),
     {SOURCE_TAR_GZ: '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',
      'bar.tgz': '33ac60685a3e29538db5094259ea85c15906cbd0f74368733f4111eab6187c8f'},
 ]]

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-2018a.eb
@@ -9,13 +9,10 @@ toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
 
 sources = [SOURCE_TAR_GZ]
 checksums = [[
-    'be662daa971a640e40be5c804d9d7d10',  # default (MD5)
     '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # default (SHA256)
-    ('adler32', '0x998410035'),
-    ('crc32', '0x1553842328'),
-    ('md5', 'be662daa971a640e40be5c804d9d7d10'),
-    ('sha1', 'f618096c52244539d0e89867405f573fdb0b55b0'),
-    ('size', 273),
+    ('sha512',
+     '3c9dc629e1f2fd01a15c68f9f2a328b5da045c2ec1a189dc72d7195642f32e0'
+     'ff59275aba5fa2a78e84417c7645d0ca5d06aff39e688a8936061ed5c4c600708'),
 ]]
 patches = [
     'toy-0.0_fix-silly-typo-in-printf-statement.patch',

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-multiple.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-multiple.eb
@@ -11,8 +11,8 @@ toolchain = SYSTEM
 sources = [SOURCE_TAR_GZ]
 patches = ['toy-0.0_fix-silly-typo-in-printf-statement.patch']
 checksums = [
-    ('adler32', '0x998410035'),
-    'a99f2a72cee1689a2f7e3ace0356efb1',
+    '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',
+    '81a3accc894592152f81814fbf133d39afad52885ab52c25018722c7bda92487',
 ]
 
 moduleclass = 'tools'

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-test.eb
@@ -9,13 +9,10 @@ toolchain = SYSTEM
 
 sources = [SOURCE_TAR_GZ]
 checksums = [[
-    'be662daa971a640e40be5c804d9d7d10',  # default (MD5)
     '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # default (SHA256)
-    ('adler32', '0x998410035'),
-    ('crc32', '0x1553842328'),
-    ('md5', 'be662daa971a640e40be5c804d9d7d10'),
-    ('sha1', 'f618096c52244539d0e89867405f573fdb0b55b0'),
-    ('size', 273),
+    ('sha512',
+     '3c9dc629e1f2fd01a15c68f9f2a328b5da045c2ec1a189dc72d7195642f32e0'
+     'ff59275aba5fa2a78e84417c7645d0ca5d06aff39e688a8936061ed5c4c600708'),
 ]]
 patches = [
     'toy-0.0_fix-silly-typo-in-printf-statement.patch',

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0.eb
@@ -8,13 +8,10 @@ toolchain = SYSTEM
 
 sources = [SOURCE_TAR_GZ]
 checksums = [[
-    'be662daa971a640e40be5c804d9d7d10',  # default (MD5)
     '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # default (SHA256)
-    ('adler32', '0x998410035'),
-    ('crc32', '0x1553842328'),
-    ('md5', 'be662daa971a640e40be5c804d9d7d10'),
-    ('sha1', 'f618096c52244539d0e89867405f573fdb0b55b0'),
-    ('size', 273),
+    ('sha512',
+     '3c9dc629e1f2fd01a15c68f9f2a328b5da045c2ec1a189dc72d7195642f32e0'
+     'ff59275aba5fa2a78e84417c7645d0ca5d06aff39e688a8936061ed5c4c600708'),
 ]]
 patches = [
     'toy-0.0_fix-silly-typo-in-printf-statement.patch',

--- a/test/framework/easyconfigs/v2.0/toy-with-sections.eb
+++ b/test/framework/easyconfigs/v2.0/toy-with-sections.eb
@@ -16,7 +16,6 @@ software_license_urls = ['https://github.com/easybuilders/easybuild/wiki/License
 
 sources = ['%(name)s-0.0.tar.gz']  # purposely fixed to 0.0
 checksums = [
-    'be662daa971a640e40be5c804d9d7d10',  # MD5
     '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # SHA256
 ]
 

--- a/test/framework/easyconfigs/v2.0/toy.eb
+++ b/test/framework/easyconfigs/v2.0/toy.eb
@@ -16,7 +16,6 @@ software_license_urls = ['https://github.com/easybuilders/easybuild/wiki/License
 
 sources = ['%(name)s-0.0.tar.gz']  # purposely fixed to 0.0
 checksums = [
-    'be662daa971a640e40be5c804d9d7d10',  # MD5
     '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',  # SHA256
 ]
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -289,10 +289,6 @@ class FileToolsTest(EnhancedTestCase):
         ft.write_file(fp, "easybuild\n")
 
         known_checksums = {
-            'adler32': '0x379257805',
-            'crc32': '0x1457143216',
-            'md5': '7167b64b1ca062b9674ffef46f9325db',
-            'sha1': 'db05b79e09a4cc67e9dd30b313b5488813db3190',
             'sha256': '1c49562c4b404f3120a3fa0926c8d09c99ef80e470f7de03ffdfa14047960ea5',
             'sha512': '7610f6ce5e91e56e350d25c917490e4815f7986469fafa41056698aec256733e'
                       'b7297da8b547d5e74b851d7c4e475900cec4744df0f887ae5c05bf1757c224b4',
@@ -306,12 +302,10 @@ class FileToolsTest(EnhancedTestCase):
         # default checksum type is SHA256
         self.assertEqual(ft.compute_checksum(fp), known_checksums['sha256'])
 
-        # both MD5 and SHA256 checksums can be verified without specifying type
-        self.assertTrue(ft.verify_checksum(fp, known_checksums['md5']))
+        # SHA256 checksums can be verified without specifying type
         self.assertTrue(ft.verify_checksum(fp, known_checksums['sha256']))
 
-        # providing non-matching MD5 and SHA256 checksums results in failed verification
-        self.assertFalse(ft.verify_checksum(fp, '1c49562c4b404f3120a3fa0926c8d09c'))
+        # providing non-matching SHA256 checksums results in failed verification
         self.assertFalse(ft.verify_checksum(fp, '7167b64b1ca062b9674ffef46f9325db7167b64b1ca062b9674ffef46f9325db'))
 
         # checksum of length 32 is assumed to be MD5, length 64 to be SHA256, other lengths not allowed
@@ -325,23 +319,12 @@ class FileToolsTest(EnhancedTestCase):
         for checksum_type, checksum in broken_checksums.items():
             self.assertFalse(ft.compute_checksum(fp, checksum_type=checksum_type) == checksum)
             self.assertFalse(ft.verify_checksum(fp, (checksum_type, checksum)))
-        # md5 is default
-        self.assertFalse(ft.compute_checksum(fp) == broken_checksums['md5'])
-        self.assertFalse(ft.verify_checksum(fp, broken_checksums['md5']))
+        # sha256 is default
+        self.assertFalse(ft.compute_checksum(fp) == broken_checksums['sha256'])
         self.assertFalse(ft.verify_checksum(fp, broken_checksums['sha256']))
 
         # test specify alternative checksums
         alt_checksums = ('7167b64b1ca062b9674ffef46f9325db7167b64b1ca062b9674ffef46f9325db', known_checksums['sha256'])
-        self.assertTrue(ft.verify_checksum(fp, alt_checksums))
-
-        alt_checksums = ('fecf50db81148786647312bbd3b5c740', '2c829facaba19c0fcd81f9ce96bef712',
-                         '840078aeb4b5d69506e7c8edae1e1b89', known_checksums['md5'])
-        self.assertTrue(ft.verify_checksum(fp, alt_checksums))
-
-        alt_checksums = ('840078aeb4b5d69506e7c8edae1e1b89', known_checksums['md5'], '2c829facaba19c0fcd81f9ce96bef712')
-        self.assertTrue(ft.verify_checksum(fp, alt_checksums))
-
-        alt_checksums = (known_checksums['md5'], '840078aeb4b5d69506e7c8edae1e1b89', '2c829facaba19c0fcd81f9ce96bef712')
         self.assertTrue(ft.verify_checksum(fp, alt_checksums))
 
         alt_checksums = (known_checksums['sha256'],)
@@ -365,15 +348,83 @@ class FileToolsTest(EnhancedTestCase):
         init_config(build_options=build_options)
 
         self.assertErrorRegex(EasyBuildError, "Missing checksum for", ft.verify_checksum, fp, None)
-        self.assertTrue(ft.verify_checksum(fp, known_checksums['md5']))
         self.assertTrue(ft.verify_checksum(fp, known_checksums['sha256']))
 
         # Test dictionary-type checksums
-        for checksum in [known_checksums[x] for x in ('md5', 'sha256')]:
+        for checksum in [known_checksums[x] for x in ['sha256']]:
             dict_checksum = {os.path.basename(fp): checksum, 'foo': 'baa'}
             self.assertTrue(ft.verify_checksum(fp, dict_checksum))
             del dict_checksum[os.path.basename(fp)]
             self.assertErrorRegex(EasyBuildError, "Missing checksum for", ft.verify_checksum, fp, dict_checksum)
+
+    def test_deprecated_checksums(self):
+        """Test checksum functionality."""
+
+        fp = os.path.join(self.test_prefix, 'test.txt')
+        ft.write_file(fp, "easybuild\n")
+
+        known_checksums = {
+            'adler32': '0x379257805',
+            'crc32': '0x1457143216',
+            'md5': '7167b64b1ca062b9674ffef46f9325db',
+            'sha1': 'db05b79e09a4cc67e9dd30b313b5488813db3190',
+        }
+
+        self.allow_deprecated_behaviour()
+        self.mock_stderr(True)  # just to capture deprecation warning
+
+        # make sure checksums computation/verification is correct
+        for checksum_type, checksum in known_checksums.items():
+            self.assertEqual(ft.compute_checksum(fp, checksum_type=checksum_type), checksum)
+            self.assertTrue(ft.verify_checksum(fp, (checksum_type, checksum)))
+
+        # MD5 checksums can be verified without specifying type
+        self.assertTrue(ft.verify_checksum(fp, known_checksums['md5']))
+
+        # providing non-matching MD5 checksums results in failed verification
+        self.assertFalse(ft.verify_checksum(fp, '1c49562c4b404f3120a3fa0926c8d09c'))
+
+        # checksum of length 32 is assumed to be MD5, length 64 to be SHA256, other lengths not allowed
+        # checksum of length other than 32/64 yields an error
+        error_pattern = r"Length of checksum '.*' \(\d+\) does not match with either MD5 \(32\) or SHA256 \(64\)"
+        for checksum in ['tooshort', 'inbetween32and64charactersisnotgoodeither', known_checksums['md5'] + 'foo']:
+            self.assertErrorRegex(EasyBuildError, error_pattern, ft.verify_checksum, fp, checksum)
+
+        # make sure faulty checksums are reported
+        broken_checksums = {typ: (val[:-3] + 'foo') for typ, val in known_checksums.items()}
+        for checksum_type, checksum in broken_checksums.items():
+            self.assertFalse(ft.compute_checksum(fp, checksum_type=checksum_type) == checksum)
+            self.assertFalse(ft.verify_checksum(fp, (checksum_type, checksum)))
+        self.assertFalse(ft.verify_checksum(fp, broken_checksums['md5']))
+
+        # test specify alternative checksums
+        alt_checksums = ('fecf50db81148786647312bbd3b5c740', '2c829facaba19c0fcd81f9ce96bef712',
+                         '840078aeb4b5d69506e7c8edae1e1b89', known_checksums['md5'])
+        self.assertTrue(ft.verify_checksum(fp, alt_checksums))
+
+        alt_checksums = ('840078aeb4b5d69506e7c8edae1e1b89', known_checksums['md5'], '2c829facaba19c0fcd81f9ce96bef712')
+        self.assertTrue(ft.verify_checksum(fp, alt_checksums))
+
+        alt_checksums = (known_checksums['md5'], '840078aeb4b5d69506e7c8edae1e1b89', '2c829facaba19c0fcd81f9ce96bef712')
+        self.assertTrue(ft.verify_checksum(fp, alt_checksums))
+
+        # check whether missing checksums are enforced
+        build_options = {
+            'enforce_checksums': True,
+        }
+        init_config(build_options=build_options)
+
+        self.assertErrorRegex(EasyBuildError, "Missing checksum for", ft.verify_checksum, fp, None)
+        self.assertTrue(ft.verify_checksum(fp, known_checksums['md5']))
+
+        # Test dictionary-type checksums
+        for checksum in [known_checksums[x] for x in ['md5']]:
+            dict_checksum = {os.path.basename(fp): checksum, 'foo': 'baa'}
+            self.assertTrue(ft.verify_checksum(fp, dict_checksum))
+            del dict_checksum[os.path.basename(fp)]
+            self.assertErrorRegex(EasyBuildError, "Missing checksum for", ft.verify_checksum, fp, dict_checksum)
+
+        self.mock_stderr(False)
 
     def test_common_path_prefix(self):
         """Test get common path prefix for a list of paths."""

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1213,9 +1213,9 @@ class FileToolsTest(EnhancedTestCase):
         self.assertTrue(lines[8].startswith(expected))
 
         # no postinstallcmds in toy-0.0-deps.eb
-        expected = "29 %s+ postinstallcmds = " % green
+        expected = "26 %s+ postinstallcmds = " % green
         self.assertTrue(any(line.startswith(expected) for line in lines))
-        expected = "30 %s+%s (1/2) toy-0.0" % (green, endcol)
+        expected = "27 %s+%s (1/2) toy-0.0" % (green, endcol)
         self.assertTrue(any(line.startswith(expected) for line in lines), "Found '%s' in: %s" % (expected, lines))
         self.assertEqual(lines[-1], "=====")
 
@@ -1234,9 +1234,9 @@ class FileToolsTest(EnhancedTestCase):
         self.assertTrue(lines[8].startswith(expected))
 
         # no postinstallcmds in toy-0.0-deps.eb
-        expected = "29 + postinstallcmds = "
+        expected = "26 + postinstallcmds = "
         self.assertTrue(any(line.startswith(expected) for line in lines), "Found '%s' in: %s" % (expected, lines))
-        expected = "30 + (1/2) toy-0.0-"
+        expected = "27 + (1/2) toy-0.0-"
         self.assertTrue(any(line.startswith(expected) for line in lines), "Found '%s' in: %s" % (expected, lines))
 
         self.assertEqual(lines[-1], "=====")

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -6481,8 +6481,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--debug',
             '--tmp-logdir=%s' % tmp_logdir,
         ]
-        # with self.mocked_stdout_stderr():
-        self.eb_main(args, do_build=True, raise_error=True)
+        with self.mocked_stdout_stderr():
+            self.eb_main(args, do_build=True, raise_error=True)
 
         tmp_logs = os.listdir(tmp_logdir)
         self.assertEqual(len(tmp_logs), 1)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -6187,18 +6187,19 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertNotIn('checksums = ', toy_ec_txt)
 
         write_file(test_ec, toy_ec_txt)
-        args = [test_ec, '--inject-checksums=md5']
+        args = [test_ec, '--inject-checksums=sha256']
 
         stdout, stderr = self._run_mock_eb(args, raise_error=True, strip=True)
 
         patterns = [
-            r"^== injecting md5 checksums in .*/test\.eb$",
+            r"^== injecting sha256 checksums in .*/test\.eb$",
             r"^== fetching sources & patches for test\.eb\.\.\.$",
             r"^== backup of easyconfig file saved to .*/test\.eb\.bak_[0-9]+_[0-9]+\.\.\.$",
-            r"^== injecting md5 checksums for sources & patches in test\.eb\.\.\.$",
-            r"^== \* toy-0.0\.tar\.gz: be662daa971a640e40be5c804d9d7d10$",
-            r"^== \* toy-0\.0_fix-silly-typo-in-printf-statement\.patch: a99f2a72cee1689a2f7e3ace0356efb1$",
-            r"^== \* toy-extra\.txt: 3b0787b3bf36603ae1398c4a49097893$",
+            r"^== injecting sha256 checksums for sources & patches in test\.eb\.\.\.$",
+            r"^== \* toy-0.0\.tar\.gz: 44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc$",
+            r"^== \* toy-0\.0_fix-silly-typo-in-printf-statement\.patch: "  # no comma, continues on next line
+            r"81a3accc894592152f81814fbf133d39afad52885ab52c25018722c7bda92487$",
+            r"^== \* toy-extra\.txt: 4196b56771140d8e2468fb77f0240bc48ddbf5dabafe0713d612df7fafb1e458$",
         ]
         for pattern in patterns:
             regex = re.compile(pattern, re.M)
@@ -6214,9 +6215,10 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # no parse errors for updated easyconfig file...
         ec = EasyConfigParser(test_ec).get_config_dict()
         checksums = [
-            {'toy-0.0.tar.gz': 'be662daa971a640e40be5c804d9d7d10'},
-            {'toy-0.0_fix-silly-typo-in-printf-statement.patch': 'a99f2a72cee1689a2f7e3ace0356efb1'},
-            {'toy-extra.txt': '3b0787b3bf36603ae1398c4a49097893'},
+            {'toy-0.0.tar.gz': '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc'},
+            {'toy-0.0_fix-silly-typo-in-printf-statement.patch':
+             '81a3accc894592152f81814fbf133d39afad52885ab52c25018722c7bda92487'},
+            {'toy-extra.txt': '4196b56771140d8e2468fb77f0240bc48ddbf5dabafe0713d612df7fafb1e458'},
         ]
         self.assertEqual(ec['checksums'], checksums)
 
@@ -6479,8 +6481,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--debug',
             '--tmp-logdir=%s' % tmp_logdir,
         ]
-        with self.mocked_stdout_stderr():
-            self.eb_main(args, do_build=True, raise_error=True)
+        # with self.mocked_stdout_stderr():
+        self.eb_main(args, do_build=True, raise_error=True)
 
         tmp_logs = os.listdir(tmp_logdir)
         self.assertEqual(len(tmp_logs), 1)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -262,7 +262,7 @@ class ToyBuildTest(EnhancedTestCase):
         broken_toy_ec = os.path.join(tmpdir, "toy-broken.eb")
         toy_ec_file = os.path.join(os.path.dirname(__file__), 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
         broken_toy_ec_txt = read_file(toy_ec_file)
-        broken_toy_ec_txt += "checksums = ['clearywrongMD5checksumoflength32']"
+        broken_toy_ec_txt += "checksums = ['clearywrongSHA256checksumoflength64-0123456789012345678901234567']"
         write_file(broken_toy_ec, broken_toy_ec_txt)
         error_regex = "Checksum verification .* failed"
         self.assertErrorRegex(EasyBuildError, error_regex, self.run_test_toy_build_with_output, ec_file=broken_toy_ec,


### PR DESCRIPTION
follow on to #4523 - deprecate the old checksum options (including MD5)