### PR TITLE
prepend to `$PYTHONPATH` or `$EBPYTHONPREFIXES` in generated module files by automatically scanning for python site package directories

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1440,8 +1440,9 @@ class EasyBlock(object):
 
         # Add automatic PYTHONPATH or EBPYTHONPREFIXES if they aren't already present and python paths exist
         if not os.path.isfile(os.path.join(self.installdir, 'bin/python')):  # only needed when not a python install
-            python_paths = [path for path in glob.glob('lib/python*/site-packages', root_dir=self.installdir)
-                            if re.match(r'lib/python\d+\.\d+/site-packages', path)]
+            candidate_paths = (os.path.relpath(path, self.installdir)
+                               for path in glob.glob(f'{self.installdir}/lib/python*/site-packages'))
+            python_paths = [path for path in candidate_paths if re.match(r'lib/python\d+\.\d+/site-packages', path)]
 
             runtime_deps = [dep['name'] for dep in self.cfg.dependencies(runtime_only=True)]
             use_ebpythonprefixes = 'Python' in runtime_deps and \

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1441,8 +1441,9 @@ class EasyBlock(object):
         # Add automatic PYTHONPATH or EBPYTHONPREFIXES if they aren't already present
         if 'PYTHONPATH' not in self.module_generator.added_paths_per_key and \
            'EBPYTHONPREFIXES' not in self.module_generator.added_paths_per_key:
-            python_paths = [path for path in glob.glob('lib*/python*/site-packages')
-                            if re.match(r'lib(64)?/python\d+\.\d+/site-packages', path)]
+            python_paths = [path[len(self.installdir)+1:]
+                            for path in glob.glob(f'{self.installdir}/lib*/python*/site-packages')
+                            if re.match(self.installdir + r'/lib(64)?/python\d+\.\d+/site-packages', path)]
             use_ebpythonprefixes = get_software_root('Python') and build_option('prefer_ebpythonprefixes') and \
                 self.cfg['prefer_ebpythonprefixes']
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1440,7 +1440,7 @@ class EasyBlock(object):
 
         # Add automatic PYTHONPATH or EBPYTHONPREFIXES if they aren't already present and python paths exist
         if not os.path.isfile(f'{self.installdir}/bin/python'):  # only needed when not a base python installation
-            python_paths = [path[len(self.installdir)+1:]
+            python_paths = [os.path.relpath(path, self.installdir)
                             for path in glob.glob(f'{self.installdir}/lib/python*/site-packages')
                             if re.match(self.installdir + r'/lib/python\d+\.\d+/site-packages', path)]
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1439,21 +1439,20 @@ class EasyBlock(object):
             lines.append(self.module_generator.append_paths(key, value, allow_abs=self.cfg['allow_append_abs_path']))
 
         # Add automatic PYTHONPATH or EBPYTHONPREFIXES if they aren't already present
-        if 'PYTHONPATH' not in self.module_generator.added_paths_per_key and \
-           'EBPYTHONPREFIXES' not in self.module_generator.added_paths_per_key:
-            python_paths = [path[len(self.installdir)+1:]
-                            for path in glob.glob(f'{self.installdir}/lib*/python*/site-packages')
-                            if re.match(self.installdir + r'/lib(64)?/python\d+\.\d+/site-packages', path)]
-            use_ebpythonprefixes = get_software_root('Python') and build_option('prefer_ebpythonprefixes') and \
-                self.cfg['prefer_ebpythonprefixes']
+        python_paths = [path[len(self.installdir)+1:]
+                        for path in glob.glob(f'{self.installdir}/lib*/python*/site-packages')
+                        if re.match(self.installdir + r'/lib(64)?/python\d+\.\d+/site-packages', path)]
+        use_ebpythonprefixes = get_software_root('Python') and build_option('prefer_ebpythonprefixes') and \
+            self.cfg['prefer_ebpythonprefixes']
 
-            if len(python_paths) > 1 and not use_ebpythonprefixes:
-                raise EasyBuildError('Multiple python paths requires EBPYTHONPREFIXES: ' + ', '.join(python_paths))
-            elif python_paths:
-                if use_ebpythonprefixes:
-                    lines.append(self.module_generator.prepend_paths('EBPYTHONPREFIXES', ''))
-                else:
-                    lines.append(self.module_generator.prepend_paths('PYTHONPATH', python_paths))
+        if len(python_paths) > 1 and not use_ebpythonprefixes:
+            raise EasyBuildError('Multiple python paths requires EBPYTHONPREFIXES: ' + ', '.join(python_paths))
+        elif python_paths:
+            # Add paths unless they were already added
+            if use_ebpythonprefixes and '' not in self.module_generator.added_paths_per_key['EBPYTHONPREFIXES']:
+                lines.append(self.module_generator.prepend_paths('EBPYTHONPREFIXES', ''))
+            elif python_paths[0] not in self.module_generator.added_paths_per_key['PYTHONPATH']:
+                lines.append(self.module_generator.prepend_paths('PYTHONPATH', python_paths))
 
         modloadmsg = self.cfg['modloadmsg']
         if modloadmsg:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1439,7 +1439,7 @@ class EasyBlock(object):
             lines.append(self.module_generator.append_paths(key, value, allow_abs=self.cfg['allow_append_abs_path']))
 
         # Add automatic PYTHONPATH or EBPYTHONPREFIXES if they aren't already present and python paths exist
-        if self.name not in ['Python', 'Miniconda', 'Anaconda']:  # nothing extra needed for base python installations
+        if not os.path.isfile(f'{self.installdir}/bin/python'):  # only needed when not a base python installation
             # Exclude symlinks lib -> lib64 or vice verse to avoid duplicates
             python_paths = []
             if not os.path.islink(f'{self.installdir}/lib'):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1440,16 +1440,9 @@ class EasyBlock(object):
 
         # Add automatic PYTHONPATH or EBPYTHONPREFIXES if they aren't already present and python paths exist
         if not os.path.isfile(f'{self.installdir}/bin/python'):  # only needed when not a base python installation
-            # Exclude symlinks lib -> lib64 or vice verse to avoid duplicates
-            python_paths = []
-            if not os.path.islink(f'{self.installdir}/lib'):
-                python_paths += [path[len(self.installdir)+1:]
-                                 for path in glob.glob(f'{self.installdir}/lib/python*/site-packages')
-                                 if re.match(self.installdir + r'/lib/python\d+\.\d+/site-packages', path)]
-            if not os.path.islink(f'{self.installdir}/lib64'):
-                python_paths += [path[len(self.installdir)+1:]
-                                 for path in glob.glob(f'{self.installdir}/lib64/python*/site-packages')
-                                 if re.match(self.installdir + r'/lib64/python\d+\.\d+/site-packages', path)]
+            python_paths = [path[len(self.installdir)+1:]
+                            for path in glob.glob(f'{self.installdir}/lib/python*/site-packages')
+                            if re.match(self.installdir + r'/lib/python\d+\.\d+/site-packages', path)]
 
             runtime_deps = [dep['name'] for dep in self.cfg.dependencies(runtime_only=True)]
             use_ebpythonprefixes = 'Python' in runtime_deps and \

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1447,12 +1447,12 @@ class EasyBlock(object):
                 self.cfg['prefer_ebpythonprefixes']
 
             if len(python_paths) > 1 and not use_ebpythonprefixes:
-                raise EasyBuildError('Multiple python paths requires EBPYHONPREFIXES: ' + ', '.join(python_paths))
+                raise EasyBuildError('Multiple python paths requires EBPYTHONPREFIXES: ' + ', '.join(python_paths))
             elif python_paths:
                 if use_ebpythonprefixes:
-                    lines.append(self.module_generator.append_paths('EBPYHONPREFIXES', '.'))
+                    lines.append(self.module_generator.prepend_paths('EBPYTHONPREFIXES', '.'))
                 else:
-                    lines.append(self.module_generator.append_paths('PYTHONPATH', python_paths))
+                    lines.append(self.module_generator.prepend_paths('PYTHONPATH', python_paths))
 
         modloadmsg = self.cfg['modloadmsg']
         if modloadmsg:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -72,7 +72,7 @@ from easybuild.tools import LooseVersion, config
 from easybuild.tools.build_details import get_build_stats
 from easybuild.tools.build_log import EasyBuildError, EasyBuildExit, dry_run_msg, dry_run_warning, dry_run_set_dirs
 from easybuild.tools.build_log import print_error, print_msg, print_warning
-from easybuild.tools.config import CHECKSUM_PRIORITY_JSON, DEFAULT_ENVVAR_USERS_MODULES
+from easybuild.tools.config import CHECKSUM_PRIORITY_JSON, DEFAULT_ENVVAR_USERS_MODULES, PYTHONPATH, EBPYTHONPREFIXES
 from easybuild.tools.config import FORCE_DOWNLOAD_ALL, FORCE_DOWNLOAD_PATCHES, FORCE_DOWNLOAD_SOURCES
 from easybuild.tools.config import EASYBUILD_SOURCES_URL # noqa
 from easybuild.tools.config import build_option, build_path, get_log_filename, get_repository, get_repositorypath
@@ -1446,17 +1446,18 @@ class EasyBlock(object):
 
             runtime_deps = [dep['name'] for dep in self.cfg.dependencies(runtime_only=True)]
             use_ebpythonprefixes = 'Python' in runtime_deps and \
-                build_option('prefer_ebpythonprefixes') and self.cfg['prefer_ebpythonprefixes']
+                build_option('prefer_python_search_path') == EBPYTHONPREFIXES and not self.cfg['force_pythonpath']
 
             if python_paths:
                 # Add paths unless they were already added
                 if use_ebpythonprefixes:
-                    if '' not in self.module_generator.added_paths_per_key['EBPYTHONPREFIXES']:
-                        lines.append(self.module_generator.prepend_paths('EBPYTHONPREFIXES', ''))
+                    path = ''  # EBPYTHONPREFIXES are relative to the install dir
+                    if path not in self.module_generator.added_paths_per_key[EBPYTHONPREFIXES]:
+                        lines.append(self.module_generator.prepend_paths(EBPYTHONPREFIXES, path))
                 else:
                     for python_path in python_paths:
-                        if python_path not in self.module_generator.added_paths_per_key['PYTHONPATH']:
-                            lines.append(self.module_generator.prepend_paths('PYTHONPATH', python_path))
+                        if python_path not in self.module_generator.added_paths_per_key[PYTHONPATH]:
+                            lines.append(self.module_generator.prepend_paths(PYTHONPATH, python_path))
 
         modloadmsg = self.cfg['modloadmsg']
         if modloadmsg:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1454,9 +1454,7 @@ class EasyBlock(object):
             use_ebpythonprefixes = 'Python' in self.cfg.dependencies(runtime_only=True) and \
                 build_option('prefer_ebpythonprefixes') and self.cfg['prefer_ebpythonprefixes']
 
-            if len(python_paths) > 1 and not use_ebpythonprefixes:
-                raise EasyBuildError('Multiple python paths requires EBPYTHONPREFIXES: ' + ', '.join(python_paths))
-            elif python_paths:
+            if python_paths:
                 # Add paths unless they were already added
                 if use_ebpythonprefixes:
                     if '' not in self.module_generator.added_paths_per_key['EBPYTHONPREFIXES']:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1451,7 +1451,8 @@ class EasyBlock(object):
                                  for path in glob.glob(f'{self.installdir}/lib64/python*/site-packages')
                                  if re.match(self.installdir + r'/lib64/python\d+\.\d+/site-packages', path)]
 
-            use_ebpythonprefixes = 'Python' in self.cfg.dependencies(runtime_only=True) and \
+            runtime_deps = [dep['name'] for dep in self.cfg.dependencies(runtime_only=True)]
+            use_ebpythonprefixes = 'Python' in runtime_deps and \
                 build_option('prefer_ebpythonprefixes') and self.cfg['prefer_ebpythonprefixes']
 
             if python_paths:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1451,8 +1451,8 @@ class EasyBlock(object):
                                  for path in glob.glob(f'{self.installdir}/lib64/python*/site-packages')
                                  if re.match(self.installdir + r'/lib64/python\d+\.\d+/site-packages', path)]
 
-            use_ebpythonprefixes = get_software_root('Python') and build_option('prefer_ebpythonprefixes') and \
-                self.cfg['prefer_ebpythonprefixes']
+            use_ebpythonprefixes = 'Python' in self.cfg.dependencies(runtime_only=True) and \
+                build_option('prefer_ebpythonprefixes') and self.cfg['prefer_ebpythonprefixes']
 
             if len(python_paths) > 1 and not use_ebpythonprefixes:
                 raise EasyBuildError('Multiple python paths requires EBPYTHONPREFIXES: ' + ', '.join(python_paths))

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1439,10 +1439,9 @@ class EasyBlock(object):
             lines.append(self.module_generator.append_paths(key, value, allow_abs=self.cfg['allow_append_abs_path']))
 
         # Add automatic PYTHONPATH or EBPYTHONPREFIXES if they aren't already present and python paths exist
-        if not os.path.isfile(f'{self.installdir}/bin/python'):  # only needed when not a base python installation
-            python_paths = [os.path.relpath(path, self.installdir)
-                            for path in glob.glob(f'{self.installdir}/lib/python*/site-packages')
-                            if re.match(self.installdir + r'/lib/python\d+\.\d+/site-packages', path)]
+        if not os.path.isfile(os.path.join(self.installdir, 'bin/python')):  # only needed when not a python install
+            python_paths = [path for path in glob.glob('lib/python*/site-packages', root_dir=self.installdir)
+                            if re.match(r'lib/python\d+\.\d+/site-packages', path)]
 
             runtime_deps = [dep['name'] for dep in self.cfg.dependencies(runtime_only=True)]
             use_ebpythonprefixes = 'Python' in runtime_deps and \

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1458,8 +1458,9 @@ class EasyBlock(object):
                 raise EasyBuildError('Multiple python paths requires EBPYTHONPREFIXES: ' + ', '.join(python_paths))
             elif python_paths:
                 # Add paths unless they were already added
-                if use_ebpythonprefixes and '' not in self.module_generator.added_paths_per_key['EBPYTHONPREFIXES']:
-                    lines.append(self.module_generator.prepend_paths('EBPYTHONPREFIXES', ''))
+                if use_ebpythonprefixes:
+                    if '' not in self.module_generator.added_paths_per_key['EBPYTHONPREFIXES']:
+                        lines.append(self.module_generator.prepend_paths('EBPYTHONPREFIXES', ''))
                 elif python_paths[0] not in self.module_generator.added_paths_per_key['PYTHONPATH']:
                     lines.append(self.module_generator.prepend_paths('PYTHONPATH', python_paths))
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1451,7 +1451,7 @@ class EasyBlock(object):
                 raise EasyBuildError('Multiple python paths requires EBPYTHONPREFIXES: ' + ', '.join(python_paths))
             elif python_paths:
                 if use_ebpythonprefixes:
-                    lines.append(self.module_generator.prepend_paths('EBPYTHONPREFIXES', '.'))
+                    lines.append(self.module_generator.prepend_paths('EBPYTHONPREFIXES', ''))
                 else:
                     lines.append(self.module_generator.prepend_paths('PYTHONPATH', python_paths))
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1460,8 +1460,10 @@ class EasyBlock(object):
                 if use_ebpythonprefixes:
                     if '' not in self.module_generator.added_paths_per_key['EBPYTHONPREFIXES']:
                         lines.append(self.module_generator.prepend_paths('EBPYTHONPREFIXES', ''))
-                elif python_paths[0] not in self.module_generator.added_paths_per_key['PYTHONPATH']:
-                    lines.append(self.module_generator.prepend_paths('PYTHONPATH', python_paths))
+                else:
+                    for python_path in python_paths:
+                        if python_path not in self.module_generator.added_paths_per_key['PYTHONPATH']:
+                            lines.append(self.module_generator.prepend_paths('PYTHONPATH', python_path))
 
         modloadmsg = self.cfg['modloadmsg']
         if modloadmsg:

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -115,7 +115,7 @@ DEFAULT_CONFIG = {
     'patches': [[], "List of patches to apply", BUILD],
     'prebuildopts': ['', 'Extra options pre-passed to build command.', BUILD],
     'preconfigopts': ['', 'Extra options pre-passed to configure.', BUILD],
-    'prefer_ebpythonprefixes': [True, "Prefer EBPYTHONPREFIXES over PYTHONPATH when possible.", BUILD],
+    'force_pythonpath': [False, "Force use of PYTHONPATH for python seearch path when possible.", BUILD],
     'preinstallopts': ['', 'Extra prefix options for installation.', BUILD],
     'pretestopts': ['', 'Extra prefix options for test.', BUILD],
     'postinstallcmds': [[], 'Commands to run after the install step.', BUILD],

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -115,6 +115,7 @@ DEFAULT_CONFIG = {
     'patches': [[], "List of patches to apply", BUILD],
     'prebuildopts': ['', 'Extra options pre-passed to build command.', BUILD],
     'preconfigopts': ['', 'Extra options pre-passed to configure.', BUILD],
+    'prefer_ebpythonprefixes': [True, "Prefer EBPYTHONPREFIXES over PYTHONPATH when possible.", BUILD],
     'preinstallopts': ['', 'Extra prefix options for installation.', BUILD],
     'pretestopts': ['', 'Extra prefix options for test.', BUILD],
     'postinstallcmds': [[], 'Commands to run after the install step.', BUILD],

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1105,15 +1105,19 @@ class EasyConfig(object):
 
         return retained_deps
 
-    def dependencies(self, build_only=False):
+    def dependencies(self, build_only=False, runtime_only=False):
         """
         Returns an array of parsed dependencies (after filtering, if requested)
         dependency = {'name': '', 'version': '', 'system': (False|True), 'versionsuffix': '', 'toolchain': ''}
         Iterable builddependencies are flattened when not iterating.
 
         :param build_only: only return build dependencies, discard others
+        :param runtime_only: only return runtime dependencies, discard others
         """
-        deps = self.builddependencies()
+        if runtime_only:
+            deps = []
+        else:
+            deps = self.builddependencies()
 
         if not build_only:
             # use += rather than .extend to get a new list rather than updating list of build deps in place...

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -336,6 +336,7 @@ BUILD_OPTIONS_CMDLINE = {
         'modules_tool_version_check',
         'mpi_tests',
         'pre_create_installdir',
+        'prefer_ebpythonprefixes',
         'show_progress_bar',
         'trace',
     ],

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -175,6 +175,10 @@ OUTPUT_STYLE_NO_COLOR = 'no_color'
 OUTPUT_STYLE_RICH = 'rich'
 OUTPUT_STYLES = (OUTPUT_STYLE_AUTO, OUTPUT_STYLE_BASIC, OUTPUT_STYLE_NO_COLOR, OUTPUT_STYLE_RICH)
 
+PYTHONPATH = 'PYTHONPATH'
+EBPYTHONPREFIXES = 'EBPYTHONPREFIXES'
+PYTHON_SEARCH_PATH_TYPES = [PYTHONPATH, EBPYTHONPREFIXES]
+
 
 class Singleton(ABCMeta):
     """Serves as metaclass for classes that should implement the Singleton pattern.
@@ -336,7 +340,6 @@ BUILD_OPTIONS_CMDLINE = {
         'modules_tool_version_check',
         'mpi_tests',
         'pre_create_installdir',
-        'prefer_ebpythonprefixes',
         'show_progress_bar',
         'trace',
     ],
@@ -408,6 +411,9 @@ BUILD_OPTIONS_CMDLINE = {
     OUTPUT_STYLE_AUTO: [
         'output_style',
     ],
+    PYTHONPATH: [
+        'prefer_python_search_path',
+    ]
 }
 # build option that do not have a perfectly matching command line option
 BUILD_OPTIONS_OTHER = {

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -39,6 +39,7 @@ import copy
 import os
 import re
 import tempfile
+from collections import defaultdict
 from contextlib import contextmanager
 from easybuild.tools import LooseVersion
 from textwrap import wrap
@@ -153,7 +154,7 @@ class ModuleGenerator(object):
             raise EasyBuildError('Module creation already in process. '
                                  'You cannot create multiple modules at the same time!')
         # Mapping of keys/env vars to paths already added
-        self.added_paths_per_key = dict()
+        self.added_paths_per_key = defaultdict(set)
         txt = self.MODULE_SHEBANG
         if txt:
             txt += '\n'
@@ -212,7 +213,7 @@ class ModuleGenerator(object):
             print_warning('Module creation has not been started. Call start_module_creation first!')
             return paths
 
-        added_paths = self.added_paths_per_key.setdefault(key, set())
+        added_paths = self.added_paths_per_key[key]
         # paths can be a string
         if isinstance(paths, str):
             if paths in added_paths:

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -490,6 +490,8 @@ class EasyBuildOptions(GeneralOption):
                                             None, 'store_true', False),
             'pre-create-installdir': ("Create installation directory before submitting build jobs",
                                       None, 'store_true', True),
+            'prefer-ebpythonprefixes': (("Prefer EBPYTHONPREFIXES over PYTHONPATH when possible"),
+                                        None, 'store_true', True),
             'pretend': (("Does the build/installation in a test directory located in $HOME/easybuildinstall"),
                         None, 'store_true', False, 'p'),
             'read-only-installdir': ("Set read-only permissions on installation directory after installation",

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -491,7 +491,7 @@ class EasyBuildOptions(GeneralOption):
             'pre-create-installdir': ("Create installation directory before submitting build jobs",
                                       None, 'store_true', True),
             'prefer-ebpythonprefixes': (("Prefer EBPYTHONPREFIXES over PYTHONPATH when possible"),
-                                        None, 'store_true', True),
+                                        None, 'store_true', False),
             'pretend': (("Does the build/installation in a test directory located in $HOME/easybuildinstall"),
                         None, 'store_true', False, 'p'),
             'read-only-installdir': ("Set read-only permissions on installation directory after installation",

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -78,6 +78,7 @@ from easybuild.tools.config import LOCAL_VAR_NAMING_CHECK_WARN, LOCAL_VAR_NAMING
 from easybuild.tools.config import OUTPUT_STYLE_AUTO, OUTPUT_STYLES, WARN
 from easybuild.tools.config import get_pretend_installpath, init, init_build_options, mk_full_default_path
 from easybuild.tools.config import BuildOptions, ConfigurationVariables
+from easybuild.tools.config import PYTHON_SEARCH_PATH_TYPES, PYTHONPATH
 from easybuild.tools.configobj import ConfigObj, ConfigObjError
 from easybuild.tools.docs import FORMAT_JSON, FORMAT_MD, FORMAT_RST, FORMAT_TXT
 from easybuild.tools.docs import avail_cfgfile_constants, avail_easyconfig_constants, avail_easyconfig_licenses
@@ -490,8 +491,10 @@ class EasyBuildOptions(GeneralOption):
                                             None, 'store_true', False),
             'pre-create-installdir': ("Create installation directory before submitting build jobs",
                                       None, 'store_true', True),
-            'prefer-ebpythonprefixes': (("Prefer EBPYTHONPREFIXES over PYTHONPATH when possible"),
-                                        None, 'store_true', False),
+            'prefer-python-search-path': (("Prefer using specified environment variable when possible to specify where"
+                                           " Python packages were installed; see also "
+                                           "https://docs.easybuild.io/python-search-path"),
+                                          'choice', 'store_or_None', PYTHONPATH, PYTHON_SEARCH_PATH_TYPES),
             'pretend': (("Does the build/installation in a test directory located in $HOME/easybuildinstall"),
                         None, 'store_true', False, 'p'),
             'read-only-installdir': ("Set read-only permissions on installation directory after installation",


### PR DESCRIPTION
Alternative approach, don't attempt to rewrite paths, instead generate them directly. 

Will of course require some easyblocks (primarily pythonpackage and pythonbundle) to adapt by using these new options, though they should be trivial.

Note: very much a draft right now. Completely untested and probably forgot something important.

easyblock PR: https://github.com/easybuilders/easybuild-easyblocks/pull/3343
easyconfig PR: https://github.com/easybuilders/easybuild-easyconfigs/pull/20960