### PR TITLE
use newer version of actions/checkout and actions/setup-python, to avoid relying on deprecated node.js 16

### DIFF
--- a/.github/workflows/container_tests.yml
+++ b/.github/workflows/container_tests.yml
@@ -17,10 +17,10 @@ jobs:
         python: [3.7]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/.github/workflows/container_tests_apptainer.yml
+++ b/.github/workflows/container_tests_apptainer.yml
@@ -18,10 +18,10 @@ jobs:
         apptainer: [1.0.0, 1.1.7]
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -17,10 +17,10 @@ jobs:
         python: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -20,7 +20,7 @@ jobs:
       image: ghcr.io/easybuilders/${{ matrix.container }}-amd64
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: download and unpack easyblocks and easyconfigs repositories
         run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -16,10 +16,10 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9, '3.10', '3.11']
         
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -54,10 +54,10 @@ jobs:
             lc_all: C
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/.github/workflows/unit_tests_python2.yml
+++ b/.github/workflows/unit_tests_python2.yml
@@ -17,7 +17,7 @@ jobs:
       # see https://github.com/easybuilders/easybuild-containers
       image: ghcr.io/easybuilders/centos-7.9-amd64
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: install Python packages
       run: |


### PR DESCRIPTION
fix for warning popping up in GitHub Actions:

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
```