### PR TITLE
don't try to determine repo version when file that contains version doesn't exist

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -589,13 +589,19 @@ def fetch_files_from_pr(pr, path=None, github_user=None, github_account=None, gi
             raise EasyBuildError("Couldn't find path to patched file %s", full_path)
 
     if github_repo == GITHUB_EASYCONFIGS_REPO:
-        ver = _get_version_for_repo(os.path.join(final_path, 'setup.py'))
+        ver_file = os.path.join(final_path, 'setup.py')
     elif github_repo == GITHUB_EASYBLOCKS_REPO:
-        ver = _get_version_for_repo(os.path.join(final_path, 'easybuild', 'easyblocks', '__init__.py'))
+        ver_file = os.path.join(final_path, 'easybuild', 'easyblocks', '__init__.py')
+    else:
+        raise EasyBuildError("Don't know how to determine version for repo %s", github_repo)
 
-    if different_major_versions(FRAMEWORK_VERSION, ver):
-        raise EasyBuildError("Framework (%s) is a different major version than used in %s/%s PR #%s (%s)",
-                             FRAMEWORK_VERSION, github_account, github_repo, pr, ver)
+    # take into account that the file we need to determine repo version may not be available,
+    # for example when a closed PR is used (since then we only download files patched by the PR)
+    if os.path.exists(ver_file):
+        ver = _get_version_for_repo(ver_file)
+        if different_major_versions(FRAMEWORK_VERSION, ver):
+            raise EasyBuildError("Framework (%s) is a different major version than used in %s/%s PR #%s (%s)",
+                                 FRAMEWORK_VERSION, github_account, github_repo, pr, ver)
 
     return files
 


### PR DESCRIPTION
fix for a couple of broken GitHub tests in framework test suite, and for using `--from-pr` on a closed PR:
```
$ eb --from-pr 8006 -D
== Temporary log file in case of crash /tmp/eb-64svltcd/easybuild-v6yqv27h.log
WARNING: Using easyconfigs from closed PR #8006

ERROR: Couldn't determine version of PR from /tmp/eb-64svltcd/files_pr8006/setup.py
```