### PR TITLE
Use "alternative" instead of "alternate"

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -912,10 +912,10 @@ class EasyBlock(object):
                     if PYPI_PKG_URL_PATTERN in fullurl and not is_alt_pypi_url(fullurl):
                         alt_url = derive_alt_pypi_url(fullurl)
                         if alt_url:
-                            _log.debug("Using alternate PyPI URL for %s: %s", fullurl, alt_url)
+                            _log.debug("Using alternative PyPI URL for %s: %s", fullurl, alt_url)
                             fullurl = alt_url
                         else:
-                            _log.debug("Failed to derive alternate PyPI URL for %s, so retaining the original", fullurl)
+                            _log.debug("Failed to derive alternative PyPI URL for %s, so retaining the original", fullurl)
 
                     if self.dry_run:
                         self.dry_run_msg("  * %s will be downloaded to %s", filename, targetpath)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -915,7 +915,8 @@ class EasyBlock(object):
                             _log.debug("Using alternative PyPI URL for %s: %s", fullurl, alt_url)
                             fullurl = alt_url
                         else:
-                            _log.debug("Failed to derive alternative PyPI URL for %s, so retaining the original", fullurl)
+                            _log.debug("Failed to derive alternative PyPI URL for %s, so retaining the original",
+                                       fullurl)
 
                     if self.dry_run:
                         self.dry_run_msg("  * %s will be downloaded to %s", filename, targetpath)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -59,9 +59,9 @@ from easybuild.framework.easyconfig.format.convert import Dependency
 from easybuild.framework.easyconfig.format.format import DEPENDENCY_PARAMETERS
 from easybuild.framework.easyconfig.format.one import EB_FORMAT_EXTENSION, retrieve_blocks_in_spec
 from easybuild.framework.easyconfig.licenses import EASYCONFIG_LICENSES_DICT
-from easybuild.framework.easyconfig.parser import ALTERNATE_PARAMETERS, DEPRECATED_PARAMETERS, REPLACED_PARAMETERS
+from easybuild.framework.easyconfig.parser import ALTERNATIVE_EASYCONFIG_PARAMETERS, DEPRECATED_EASYCONFIG_PARAMETERS, REPLACED_PARAMETERS
 from easybuild.framework.easyconfig.parser import EasyConfigParser, fetch_parameters_from_easyconfig
-from easybuild.framework.easyconfig.templates import ALTERNATE_TEMPLATES, DEPRECATED_TEMPLATES, TEMPLATE_CONSTANTS
+from easybuild.framework.easyconfig.templates import ALTERNATIVE_EASYCONFIG_TEMPLATES, DEPRECATED_EASYCONFIG_TEMPLATES, TEMPLATE_CONSTANTS
 from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_DYNAMIC, template_constant_dict
 from easybuild.tools import LooseVersion
 from easybuild.tools.build_log import EasyBuildError, print_warning, print_msg
@@ -119,11 +119,11 @@ def handle_deprecated_or_replaced_easyconfig_parameters(ec_method):
     def new_ec_method(self, key, *args, **kwargs):
         """Check whether any replace easyconfig parameters are still used"""
         # map deprecated parameters to their replacements, issue deprecation warning(/error)
-        if key in ALTERNATE_PARAMETERS:
-            key = ALTERNATE_PARAMETERS[key]
-        elif key in DEPRECATED_PARAMETERS:
+        if key in ALTERNATIVE_EASYCONFIG_PARAMETERS:
+            key = ALTERNATIVE_EASYCONFIG_PARAMETERS[key]
+        elif key in DEPRECATED_EASYCONFIG_PARAMETERS:
             depr_key = key
-            key, ver = DEPRECATED_PARAMETERS[depr_key]
+            key, ver = DEPRECATED_EASYCONFIG_PARAMETERS[depr_key]
             _log.deprecated("Easyconfig parameter '%s' is deprecated, use '%s' instead" % (depr_key, key), ver)
         elif key in REPLACED_PARAMETERS:
             _log.nosupport("Easyconfig parameter '%s' is replaced by '%s'" % (key, REPLACED_PARAMETERS[key]), '2.0')
@@ -182,7 +182,7 @@ def triage_easyconfig_params(variables, ec):
 
     for key in variables:
         # validations are skipped, just set in the config
-        if any(key in d for d in (ec, DEPRECATED_PARAMETERS.keys(), ALTERNATE_PARAMETERS.keys())):
+        if any(key in d for d in (ec, DEPRECATED_EASYCONFIG_PARAMETERS.keys(), ALTERNATIVE_EASYCONFIG_PARAMETERS.keys())):
             ec_params[key] = variables[key]
             _log.debug("setting config option %s: value %s (type: %s)", key, ec_params[key], type(ec_params[key]))
         elif key in REPLACED_PARAMETERS:
@@ -661,7 +661,7 @@ class EasyConfig(object):
         with self.disable_templating():
             for key in sorted(params.keys()):
                 # validations are skipped, just set in the config
-                if any(key in x.keys() for x in (self._config, ALTERNATE_PARAMETERS, DEPRECATED_PARAMETERS)):
+                if any(key in x.keys() for x in (self._config, ALTERNATIVE_EASYCONFIG_PARAMETERS, DEPRECATED_EASYCONFIG_PARAMETERS)):
                     self[key] = params[key]
                     self.log.info("setting easyconfig parameter %s: value %s (type: %s)",
                                   key, self[key], type(self[key]))
@@ -1998,24 +1998,24 @@ def resolve_template(value, tmpl_dict):
             try:
                 value = value % tmpl_dict
             except KeyError:
-                # check if any alternate and/or deprecated templates resolve
+                # check if any alternative and/or deprecated templates resolve
                 try:
                     orig_value = value
-                    # map old templates to new values for alternate and deprecated templates
+                    # map old templates to new values for alternative and deprecated templates
                     alt_map = {old_tmpl: tmpl_dict[new_tmpl] for (old_tmpl, new_tmpl) in
-                               ALTERNATE_TEMPLATES.items() if new_tmpl in tmpl_dict.keys()}
+                               ALTERNATIVE_EASYCONFIG_TEMPLATES.items() if new_tmpl in tmpl_dict.keys()}
                     alt_map2 = {new_tmpl: tmpl_dict[old_tmpl] for (old_tmpl, new_tmpl) in
-                                ALTERNATE_TEMPLATES.items() if old_tmpl in tmpl_dict.keys()}
+                                ALTERNATIVE_EASYCONFIG_TEMPLATES.items() if old_tmpl in tmpl_dict.keys()}
                     depr_map = {old_tmpl: tmpl_dict[new_tmpl] for (old_tmpl, (new_tmpl, ver)) in
-                                DEPRECATED_TEMPLATES.items() if new_tmpl in tmpl_dict.keys()}
+                                DEPRECATED_EASYCONFIG_TEMPLATES.items() if new_tmpl in tmpl_dict.keys()}
 
-                    # try templating with alternate and deprecated templates included
+                    # try templating with alternative and deprecated templates included
                     value = value % {**tmpl_dict, **alt_map, **alt_map2, **depr_map}
 
                     for old_tmpl, val in depr_map.items():
                         # check which deprecated templates were replaced, and issue deprecation warnings
                         if old_tmpl in orig_value and val in value:
-                            new_tmpl, ver = DEPRECATED_TEMPLATES[old_tmpl]
+                            new_tmpl, ver = DEPRECATED_EASYCONFIG_TEMPLATES[old_tmpl]
                             _log.deprecated(f"Easyconfig template '{old_tmpl}' is deprecated, use '{new_tmpl}' instead",
                                             ver)
                 except KeyError:
@@ -2023,8 +2023,8 @@ def resolve_template(value, tmpl_dict):
                     value = raw_value  # Undo "%"-escaping
 
                 for key in tmpl_dict:
-                    if key in DEPRECATED_TEMPLATES:
-                        new_key, ver = DEPRECATED_TEMPLATES[key]
+                    if key in DEPRECATED_EASYCONFIG_TEMPLATES:
+                        new_key, ver = DEPRECATED_EASYCONFIG_TEMPLATES[key]
                         _log.deprecated(f"Easyconfig template '{key}' is deprecated, use '{new_key}' instead", ver)
 
     else:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -59,10 +59,11 @@ from easybuild.framework.easyconfig.format.convert import Dependency
 from easybuild.framework.easyconfig.format.format import DEPENDENCY_PARAMETERS
 from easybuild.framework.easyconfig.format.one import EB_FORMAT_EXTENSION, retrieve_blocks_in_spec
 from easybuild.framework.easyconfig.licenses import EASYCONFIG_LICENSES_DICT
-from easybuild.framework.easyconfig.parser import ALTERNATIVE_EASYCONFIG_PARAMETERS, DEPRECATED_EASYCONFIG_PARAMETERS, REPLACED_PARAMETERS
-from easybuild.framework.easyconfig.parser import EasyConfigParser, fetch_parameters_from_easyconfig
-from easybuild.framework.easyconfig.templates import ALTERNATIVE_EASYCONFIG_TEMPLATES, DEPRECATED_EASYCONFIG_TEMPLATES, TEMPLATE_CONSTANTS
-from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_DYNAMIC, template_constant_dict
+from easybuild.framework.easyconfig.parser import ALTERNATIVE_EASYCONFIG_PARAMETERS, DEPRECATED_EASYCONFIG_PARAMETERS
+from easybuild.framework.easyconfig.parser import REPLACED_PARAMETERS, EasyConfigParser
+from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconfig
+from easybuild.framework.easyconfig.templates import ALTERNATIVE_EASYCONFIG_TEMPLATES, DEPRECATED_EASYCONFIG_TEMPLATES
+from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS, TEMPLATE_NAMES_DYNAMIC, template_constant_dict
 from easybuild.tools import LooseVersion
 from easybuild.tools.build_log import EasyBuildError, print_warning, print_msg
 from easybuild.tools.config import GENERIC_EASYBLOCK_PKG, LOCAL_VAR_NAMING_CHECK_ERROR, LOCAL_VAR_NAMING_CHECK_LOG
@@ -182,7 +183,8 @@ def triage_easyconfig_params(variables, ec):
 
     for key in variables:
         # validations are skipped, just set in the config
-        if any(key in d for d in (ec, DEPRECATED_EASYCONFIG_PARAMETERS.keys(), ALTERNATIVE_EASYCONFIG_PARAMETERS.keys())):
+        if any(key in d for d in (ec, DEPRECATED_EASYCONFIG_PARAMETERS.keys(),
+                                  ALTERNATIVE_EASYCONFIG_PARAMETERS.keys())):
             ec_params[key] = variables[key]
             _log.debug("setting config option %s: value %s (type: %s)", key, ec_params[key], type(ec_params[key]))
         elif key in REPLACED_PARAMETERS:
@@ -661,7 +663,8 @@ class EasyConfig(object):
         with self.disable_templating():
             for key in sorted(params.keys()):
                 # validations are skipped, just set in the config
-                if any(key in x.keys() for x in (self._config, ALTERNATIVE_EASYCONFIG_PARAMETERS, DEPRECATED_EASYCONFIG_PARAMETERS)):
+                if any(key in x.keys() for x in (self._config, ALTERNATIVE_EASYCONFIG_PARAMETERS,
+                                                 DEPRECATED_EASYCONFIG_PARAMETERS)):
                     self[key] = params[key]
                     self.log.info("setting easyconfig parameter %s: value %s (type: %s)",
                                   key, self[key], type(self[key]))

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -39,7 +39,7 @@ from easybuild.base import fancylogger
 from easybuild.framework.easyconfig.constants import EASYCONFIG_CONSTANTS
 from easybuild.framework.easyconfig.format.format import get_format_version, EasyConfigFormat
 from easybuild.framework.easyconfig.licenses import EASYCONFIG_LICENSES_DICT
-from easybuild.framework.easyconfig.templates import ALTERNATE_TEMPLATE_CONSTANTS, DEPRECATED_TEMPLATE_CONSTANTS
+from easybuild.framework.easyconfig.templates import ALTERNATIVE_EASYCONFIG_TEMPLATE_CONSTANTS, DEPRECATED_EASYCONFIG_TEMPLATE_CONSTANTS
 from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.configobj import ConfigObj
@@ -91,10 +91,10 @@ def handle_deprecated_constants(method):
     """Decorator to handle deprecated easyconfig template constants"""
     def wrapper(self, key, *args, **kwargs):
         """Check whether any deprecated constants are used"""
-        alternate = ALTERNATE_TEMPLATE_CONSTANTS
-        deprecated = DEPRECATED_TEMPLATE_CONSTANTS
-        if key in alternate:
-            key = alternate[key]
+        alternative = ALTERNATIVE_EASYCONFIG_TEMPLATE_CONSTANTS
+        deprecated = DEPRECATED_EASYCONFIG_TEMPLATE_CONSTANTS
+        if key in alternative:
+            key = alternative[key]
         elif key in deprecated:
             depr_key = key
             key, ver = deprecated[depr_key]

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -39,8 +39,8 @@ from easybuild.base import fancylogger
 from easybuild.framework.easyconfig.constants import EASYCONFIG_CONSTANTS
 from easybuild.framework.easyconfig.format.format import get_format_version, EasyConfigFormat
 from easybuild.framework.easyconfig.licenses import EASYCONFIG_LICENSES_DICT
-from easybuild.framework.easyconfig.templates import ALTERNATIVE_EASYCONFIG_TEMPLATE_CONSTANTS, DEPRECATED_EASYCONFIG_TEMPLATE_CONSTANTS
-from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS
+from easybuild.framework.easyconfig.templates import ALTERNATIVE_EASYCONFIG_TEMPLATE_CONSTANTS
+from easybuild.framework.easyconfig.templates import DEPRECATED_EASYCONFIG_TEMPLATE_CONSTANTS, TEMPLATE_CONSTANTS
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.configobj import ConfigObj
 from easybuild.tools.systemtools import get_shared_lib_ext

--- a/easybuild/framework/easyconfig/parser.py
+++ b/easybuild/framework/easyconfig/parser.py
@@ -42,8 +42,8 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import read_file, write_file
 
 
-# alternate easyconfig parameters, and their non-deprecated equivalents
-ALTERNATE_PARAMETERS = {
+# alternative easyconfig parameters, and their non-deprecated equivalents
+ALTERNATIVE_EASYCONFIG_PARAMETERS = {
     # <new_param>: <equivalent_param>,
     'build_deps': 'builddependencies',
     'build_in_install_dir': 'buildininstalldir',
@@ -101,7 +101,7 @@ ALTERNATE_PARAMETERS = {
 }
 
 # deprecated easyconfig parameters, and their replacements
-DEPRECATED_PARAMETERS = {
+DEPRECATED_EASYCONFIG_PARAMETERS = {
     # <old_param>: (<new_param>, <deprecation_version>),
 }
 

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -161,8 +161,8 @@ TEMPLATE_CONSTANTS = [
     ('SHLIB_EXT', get_shared_lib_ext(), 'extension for shared libraries'),
 ]
 
-# alternate templates, and their equivalents
-ALTERNATE_TEMPLATES = {
+# alternative templates, and their equivalents
+ALTERNATIVE_EASYCONFIG_TEMPLATES = {
     # <new>: <equivalent_template>,
     'build_dir': 'builddir',
     'cuda_cc_comma_sep': 'cuda_compute_capabilities',
@@ -197,12 +197,12 @@ ALTERNATE_TEMPLATES = {
 }
 
 # deprecated templates, and their replacements
-DEPRECATED_TEMPLATES = {
+DEPRECATED_EASYCONFIG_TEMPLATES = {
     # <old_template>: (<new_template>, <deprecation_version>),
 }
 
-# alternate template constants, and their equivalents
-ALTERNATE_TEMPLATE_CONSTANTS = {
+# alternative template constants, and their equivalents
+ALTERNATIVE_EASYCONFIG_TEMPLATE_CONSTANTS = {
     # <new_template_constant>: <equivalent_template_constant>,
     'APACHE_URL': 'APACHE_SOURCE',
     'BITBUCKET_GET_URL': 'BITBUCKET_SOURCE',
@@ -244,7 +244,7 @@ ALTERNATE_TEMPLATE_CONSTANTS = {
 }
 
 # deprecated template constants, and their replacements
-DEPRECATED_TEMPLATE_CONSTANTS = {
+DEPRECATED_EASYCONFIG_TEMPLATE_CONSTANTS = {
     # <old_template_constant>: (<new_template_constant>, <deprecation_version>),
 }
 

--- a/easybuild/framework/easyconfig/tweak.py
+++ b/easybuild/framework/easyconfig/tweak.py
@@ -1236,7 +1236,7 @@ def find_potential_version_mappings(dep, toolchain_mapping, versionsuffix_mappin
         (highest_version_ignoring_versionsuffix is not None and highest_version is not None and
          LooseVersion(highest_version_ignoring_versionsuffix) > LooseVersion(highest_version))
 
-    exclude_alternate_versionsuffixes = False
+    exclude_alternative_versionsuffixes = False
     if ignored_versionsuffix_greater:
         if ignore_versionsuffixes:
             highest_version = highest_version_ignoring_versionsuffix
@@ -1247,11 +1247,11 @@ def find_potential_version_mappings(dep, toolchain_mapping, versionsuffix_mappin
                     dep['name'], versionsuffix, [d['path'] for d in potential_version_mappings if
                                                  d['version'] == highest_version_ignoring_versionsuffix])
             # exclude candidates with a different versionsuffix
-            exclude_alternate_versionsuffixes = True
+            exclude_alternative_versionsuffixes = True
     else:
         # If the other version suffixes are not greater, then just ignore them
-        exclude_alternate_versionsuffixes = True
-    if exclude_alternate_versionsuffixes:
+        exclude_alternative_versionsuffixes = True
+    if exclude_alternative_versionsuffixes:
         potential_version_mappings = [d for d in potential_version_mappings if d['versionsuffix'] == versionsuffix]
 
     if highest_versions_only and highest_version is not None:

--- a/easybuild/toolchains/compiler/craype.py
+++ b/easybuild/toolchains/compiler/craype.py
@@ -65,7 +65,7 @@ class CrayPECompiler(Compiler):
 
     COMPILER_UNIQUE_OPTS = {
         'dynamic': (True, "Generate dynamically linked executable"),
-        'mpich-mt': (False, "Directs the driver to link in an alternate version of the Cray-MPICH library which \
+        'mpich-mt': (False, "Directs the driver to link in an alternative version of the Cray-MPICH library which \
                              provides fine-grained multi-threading support to applications that perform \
                              MPI operations within threaded regions."),
         'optarch': (False, "Enable architecture optimizations"),

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -586,11 +586,11 @@ def normalize_path(path):
 
 
 def is_alt_pypi_url(url):
-    """Determine whether specified URL is already an alternate PyPI URL, i.e. whether it contains a hash."""
+    """Determine whether specified URL is already an alternative PyPI URL, i.e. whether it contains a hash."""
     # example: .../packages/5b/03/e135b19fadeb9b1ccb45eac9f60ca2dc3afe72d099f6bd84e03cb131f9bf/easybuild-2.7.0.tar.gz
     alt_url_regex = re.compile('/packages/[a-f0-9]{2}/[a-f0-9]{2}/[a-f0-9]{60}/[^/]+$')
     res = bool(alt_url_regex.search(url))
-    _log.debug("Checking whether '%s' is an alternate PyPI URL using pattern '%s'...: %s",
+    _log.debug("Checking whether '%s' is an alternative PyPI URL using pattern '%s'...: %s",
                url, alt_url_regex.pattern, res)
     return res
 
@@ -638,7 +638,7 @@ def pypi_source_urls(pkg_name):
 
 
 def derive_alt_pypi_url(url):
-    """Derive alternate PyPI URL for given URL."""
+    """Derive alternative PyPI URL for given URL."""
     alt_pypi_url = None
 
     # example input URL: https://pypi.python.org/packages/source/e/easybuild/easybuild-2.7.0.tar.gz

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -1028,7 +1028,7 @@ class Toolchain(object):
 
     def handle_sysroot(self):
         """
-        Extra stuff to be done when alternate system root is specified via --sysroot EasyBuild configuration option.
+        Extra stuff to be done when alternative system root is specified via --sysroot EasyBuild configuration option.
 
         * Update $PKG_CONFIG_PATH to include sysroot location to pkg-config files (*.pc).
         """

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -310,7 +310,7 @@ class EasyBlockTest(EnhancedTestCase):
             regex = re.compile(regex, re.M)
             self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
 
-        # Repeat this but using an alternate envvars (instead of $HOME)
+        # Repeat this but using an alternative envvars (instead of $HOME)
         list_of_envvars = ['SITE_INSTALLS', 'USER_INSTALLS']
 
         build_options = {
@@ -1813,7 +1813,7 @@ class EasyBlockTest(EnhancedTestCase):
             res = eb.obtain_file(toy_tarball)
         self.assertEqual(res, toy_tarball_path)
 
-        # finding a file in the alternate location works
+        # finding a file in the alternative location works
         with self.mocked_stdout_stderr():
             res = eb.obtain_file(toy_tarball, alt_location='alt_toy')
         self.assertEqual(res, alt_toy_tarball_path)
@@ -2720,10 +2720,10 @@ class EasyBlockTest(EnhancedTestCase):
         # no checksum issues
         self.assertEqual(eb.check_checksums(), [])
 
-        # tuple of two alternate SHA256 checksums: OK
+        # tuple of two alternative SHA256 checksums: OK
         eb.cfg['checksums'] = [
             (
-                # two alternate checksums for toy-0.0.tar.gz
+                # two alternative checksums for toy-0.0.tar.gz
                 'a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd',
                 '44332000aa33b99ad1e00cbd1a7da769220d74647060a10e807b916d73ea27bc',
             ),

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -119,10 +119,10 @@ class EasyConfigTest(EnhancedTestCase):
         github_token = gh.fetch_github_token(GITHUB_TEST_ACCOUNT)
         self.skip_github_tests = github_token is None and os.getenv('FORCE_EB_GITHUB_TESTS') is None
 
-        self.orig_easyconfig_DEPRECATED_PARAMETERS = easyconfig.easyconfig.DEPRECATED_PARAMETERS
-        self.orig_easyconfig_DEPRECATED_TEMPLATES = easyconfig.easyconfig.DEPRECATED_TEMPLATES
-        self.orig_easyconfig_ALTERNATE_PARAMETERS = easyconfig.easyconfig.ALTERNATE_PARAMETERS
-        self.orig_easyconfig_ALTERNATE_TEMPLATES = easyconfig.easyconfig.ALTERNATE_TEMPLATES
+        self.orig_easyconfig_DEPRECATED_EASYCONFIG_PARAMETERS = easyconfig.easyconfig.DEPRECATED_EASYCONFIG_PARAMETERS
+        self.orig_easyconfig_DEPRECATED_EASYCONFIG_TEMPLATES = easyconfig.easyconfig.DEPRECATED_EASYCONFIG_TEMPLATES
+        self.orig_easyconfig_ALTERNATIVE_EASYCONFIG_PARAMETERS = easyconfig.easyconfig.ALTERNATIVE_EASYCONFIG_PARAMETERS
+        self.orig_easyconfig_ALTERNATIVE_EASYCONFIG_TEMPLATES = easyconfig.easyconfig.ALTERNATIVE_EASYCONFIG_TEMPLATES
 
     def prep(self):
         """Prepare for test."""
@@ -142,11 +142,11 @@ class EasyConfigTest(EnhancedTestCase):
         if os.path.exists(self.eb_file):
             os.remove(self.eb_file)
 
-        # restore orignal values of DEPRECATED_TEMPLATES & co in easyconfig.templates
-        easyconfig.easyconfig.DEPRECATED_PARAMETERS = self.orig_easyconfig_DEPRECATED_PARAMETERS
-        easyconfig.easyconfig.DEPRECATED_TEMPLATES = self.orig_easyconfig_DEPRECATED_TEMPLATES
-        easyconfig.easyconfig.ALTERNATE_PARAMETERS = self.orig_easyconfig_ALTERNATE_PARAMETERS
-        easyconfig.easyconfig.ALTERNATE_TEMPLATES = self.orig_easyconfig_ALTERNATE_TEMPLATES
+        # restore orignal values of DEPRECATED_EASYCONFIG_TEMPLATES & co in easyconfig.templates
+        easyconfig.easyconfig.DEPRECATED_EASYCONFIG_PARAMETERS = self.orig_easyconfig_DEPRECATED_EASYCONFIG_PARAMETERS
+        easyconfig.easyconfig.DEPRECATED_EASYCONFIG_TEMPLATES = self.orig_easyconfig_DEPRECATED_EASYCONFIG_TEMPLATES
+        easyconfig.easyconfig.ALTERNATIVE_EASYCONFIG_PARAMETERS = self.orig_easyconfig_ALTERNATIVE_EASYCONFIG_PARAMETERS
+        easyconfig.easyconfig.ALTERNATIVE_EASYCONFIG_TEMPLATES = self.orig_easyconfig_ALTERNATIVE_EASYCONFIG_TEMPLATES
 
     def test_empty(self):
         """ empty files should not parse! """
@@ -1462,8 +1462,8 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(ec['buildopts'], "--some-opt=%s/" % self.test_prefix)
         self.assertEqual(ec['installopts'], "--some-opt=%s/" % self.test_prefix)
 
-    def test_template_deprecation_and_alternate(self):
-        """Test deprecation of (and alternate) templates"""
+    def test_template_deprecation_and_alternative(self):
+        """Test deprecation of (and alternative) templates"""
 
         self.prep()
 
@@ -1472,13 +1472,13 @@ class EasyConfigTest(EnhancedTestCase):
             'cudaver': ('depr_cuda_ver', '1000000000'),
             'start_dir': ('depr_start_dir', '1000000000'),
         }
-        easyconfig.easyconfig.DEPRECATED_TEMPLATES = template_test_deprecations
+        easyconfig.easyconfig.DEPRECATED_EASYCONFIG_TEMPLATES = template_test_deprecations
 
-        template_test_alternates = {
+        template_test_alternatives = {
             'installdir': 'alt_install_dir',
             'version_major_minor': 'alt_ver_maj_min',
         }
-        easyconfig.easyconfig.ALTERNATE_TEMPLATES = template_test_alternates
+        easyconfig.easyconfig.ALTERNATIVE_EASYCONFIG_TEMPLATES = template_test_alternatives
 
         tmpl_str = ("cd %(start_dir)s && make %(namelower)s -Dbuild=%(builddir)s --with-cuda='%(cudaver)s'"
                     " && echo %(alt_install_dir)s %(version_major_minor)s")
@@ -1495,7 +1495,7 @@ class EasyConfigTest(EnhancedTestCase):
             res = resolve_template(tmpl_str, tmpl_dict)
         stderr = stderr.getvalue()
 
-        for tmpl in [*template_test_deprecations.keys(), *template_test_alternates.keys()]:
+        for tmpl in [*template_test_deprecations.keys(), *template_test_alternatives.keys()]:
             self.assertNotIn("%(" + tmpl + ")s", res)
 
         for old, (new, ver) in template_test_deprecations.items():
@@ -1818,8 +1818,8 @@ class EasyConfigTest(EnhancedTestCase):
 
             self.assertErrorRegex(EasyBuildError, error_regex, foo, key)
 
-    def test_alternate_easyconfig_parameters(self):
-        """Test handling of alternate easyconfig parameters."""
+    def test_alternative_easyconfig_parameters(self):
+        """Test handling of alternative easyconfig parameters."""
 
         test_ecs_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'easyconfigs', 'test_ecs')
         toy_ec = os.path.join(test_ecs_dir, 't', 'toy', 'toy-0.0.eb')
@@ -1832,10 +1832,10 @@ class EasyConfigTest(EnhancedTestCase):
         write_file(test_ec, test_ec_txt)
 
         # post_install_cmds is not accepted unless it's registered as an alternative easyconfig parameter
-        easyconfig.easyconfig.ALTERNATE_PARAMETERS = {}
+        easyconfig.easyconfig.ALTERNATIVE_EASYCONFIG_PARAMETERS = {}
         self.assertErrorRegex(EasyBuildError, "post_install_cmds -> postinstallcmds", EasyConfig, test_ec)
 
-        easyconfig.easyconfig.ALTERNATE_PARAMETERS = {
+        easyconfig.easyconfig.ALTERNATIVE_EASYCONFIG_PARAMETERS = {
             'env_mod_class': 'moduleclass',
             'post_install_cmds': 'postinstallcmds',
         }
@@ -1849,7 +1849,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(ec['postinstallcmds'], expected)
         self.assertEqual(ec['post_install_cmds'], expected)
 
-        # test setting of easyconfig parameter with original & alternate name
+        # test setting of easyconfig parameter with original & alternative name
         ec['moduleclass'] = 'test1'
         self.assertEqual(ec['moduleclass'], 'test1')
         self.assertEqual(ec['env_mod_class'], 'test1')
@@ -1873,7 +1873,7 @@ class EasyConfigTest(EnhancedTestCase):
         test_ecs_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'easyconfigs', 'test_ecs')
         ec = EasyConfig(os.path.join(test_ecs_dir, 't', 'toy', 'toy-0.0.eb'))
 
-        easyconfig.easyconfig.DEPRECATED_PARAMETERS = {
+        easyconfig.easyconfig.DEPRECATED_EASYCONFIG_PARAMETERS = {
             'foobar': ('barfoo', '0.0'),  # deprecated since forever
             # won't be actually deprecated for a while;
             # note that we should map foobarbarfoo to a valid easyconfig parameter here,
@@ -1881,7 +1881,7 @@ class EasyConfigTest(EnhancedTestCase):
             'foobarbarfoo': ('required_linked_shared_libs', '1000000000'),
         }
 
-        for key, (newkey, depr_ver) in easyconfig.easyconfig.DEPRECATED_PARAMETERS.items():
+        for key, (newkey, depr_ver) in easyconfig.easyconfig.DEPRECATED_EASYCONFIG_PARAMETERS.items():
             if LooseVersion(depr_ver) <= easybuild.tools.build_log.CURRENT_VERSION:
                 # deprecation error
                 error_regex = "DEPRECATED.*since v%s.*'%s' is deprecated.*use '%s' instead" % (depr_ver, key, newkey)

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -144,7 +144,7 @@ class ToolchainTest(EnhancedTestCase):
     def test_toolchain_prepare_sysroot(self):
         """Test build environment setup done by Toolchain.prepare in case --sysroot is specified."""
 
-        sysroot = os.path.join(self.test_prefix, 'test', 'alternate', 'sysroot')
+        sysroot = os.path.join(self.test_prefix, 'test', 'alternative', 'sysroot')
         sysroot_pkgconfig = os.path.join(sysroot, 'usr', 'lib', 'pkgconfig')
         mkdir(sysroot_pkgconfig, parents=True)
         init_config(build_options={'sysroot': sysroot})

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3954,7 +3954,7 @@ class ToyBuildTest(EnhancedTestCase):
             self.assertErrorRegex(EasyBuildError, error_msg, self._test_toy_build, force=False,
                                   ec_file=test_ec, extra_args=['--module-only'], raise_error=True, verbose=False)
 
-        # check behaviour when alternate subdirectories are specified
+        # check behaviour when alternative subdirectories are specified
         test_ec_txt = read_file(libtoy_ec)
         test_ec_txt += "\nbin_lib_subdirs = ['', 'lib', 'lib64']"
         write_file(test_ec, test_ec_txt)


### PR DESCRIPTION
* none of the uses of "alternate" in framework refer to "every other" (alternating), they all use the meaning equivalent to "alternative"
* for clarity, this renames all to "alternative" instead
* also clarifies that e.g. `ALTERNATE_PARAMETERS` pertains to easyconfigs --> `ALTERNATIVE_EASYCONFIG_PARAMETERS`