### PR TITLE
fix fetch progress bar showing to many files

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -754,7 +754,9 @@ class EasyBlock(object):
         """
         srcpaths = source_paths()
 
-        update_progress_bar(PROGRESS_BAR_DOWNLOAD_ALL, label=filename)
+        # We don't account for the checksums file in the progress bar
+        if filename != 'checksum.json':
+            update_progress_bar(PROGRESS_BAR_DOWNLOAD_ALL, label=filename)
 
         if alt_location is None:
             location = self.name


### PR DESCRIPTION
As we also call `obtain_file` for `checksum.json` the progress bar will show one file to many. E.g.

> Fetching files: 100% (4/3)

Ignore that file for updating the progressbar