### PR TITLE
Resolve internal imkl>=2021 version subdir via "latest" symlink

### DIFF
--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -142,6 +142,7 @@ class IntelMKL(LinAlg):
             self.variables.nappend_el('CFLAGS', 'DMKL_ILP64')
 
         # exact paths/linking statements depend on imkl version
+        root = self.get_software_root(self.BLAS_MODULE_NAME)[0]
         found_version = self.get_software_version(self.BLAS_MODULE_NAME)[0]
         ver = LooseVersion(found_version)
         if ver < LooseVersion('10.3'):
@@ -156,6 +157,8 @@ class IntelMKL(LinAlg):
                                      found_version)
             else:
                 if ver >= LooseVersion('2021'):
+                    if os.path.islink(os.path.join(root, 'mkl', 'latest')):
+                        found_version = os.readlink(os.path.join(root, 'mkl', 'latest'))
                     basedir = os.path.join('mkl', found_version)
                 else:
                     basedir = 'mkl'

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1321,8 +1321,11 @@ class ToolchainTest(EnhancedTestCase):
             ])
             write_file(imkl_fftw_module_path, imkl_fftw_mod_txt)
 
-            subdir = 'mkl/%s/lib/intel64' % imklver
+            # put "latest" symbolic link to short version, used in newer MKL
+            imklshortver = '.'.join(imklver.split('.')[:2])
+            subdir = 'mkl/%s/lib/intel64' % imklshortver
             os.makedirs(os.path.join(imkl_dir, subdir))
+            os.symlink(imklshortver, os.path.join(imkl_dir, 'mkl', 'latest'))
             for fftlib in mkl_libs:
                 write_file(os.path.join(imkl_dir, subdir, 'lib%s.a' % fftlib), 'foo')
             subdir = 'lib'


### PR DESCRIPTION
This is already done in the easyblock, and needed since the "latest" symlink pointed to the full version in versions < 2024 but to a shorter version (e.g. 2024.2) in 2024 versions.