### PR TITLE
fix definition of gmpflf toolchain

### DIFF
--- a/easybuild/toolchains/gmpflf.py
+++ b/easybuild/toolchains/gmpflf.py
@@ -36,7 +36,6 @@ from easybuild.toolchains.gmpich import Gmpich
 from easybuild.toolchains.gfbf import Gfbf
 from easybuild.toolchains.fft.fftw import Fftw
 from easybuild.toolchains.linalg.flexiblas import FlexiBLAS
-from easybuild.toolchains.linalg.openblas import OpenBLAS
 from easybuild.toolchains.linalg.scalapack import ScaLAPACK
 
 

--- a/easybuild/toolchains/gmpflf.py
+++ b/easybuild/toolchains/gmpflf.py
@@ -45,3 +45,12 @@ class Gmpflf(Gmpich, OpenBLAS, FlexiBLAS,  ScaLAPACK, Fftw):
     """Compiler toolchain with GCC, MPICH, OpenBLAS, ScaLAPACK and FFTW."""
     NAME = 'gmpflf'
     SUBTOOLCHAIN = [Gmpich.NAME, Golf.NAME, Gfbf.NAME]
+
+    def __init__(self, *args, **kwargs):
+        """Toolchain constructor."""
+        super(Gmpflf, self).__init__(*args, **kwargs)
+        constants = ('BLAS_MODULE_NAME', 'BLAS_LIB', 'BLAS_LIB_MT', 'BLAS_FAMILY',
+                     'LAPACK_MODULE_NAME', 'LAPACK_IS_BLAS', 'LAPACK_FAMILY')
+
+        for constant in constants:
+            setattr(self, constant, getattr(FlexiBLAS, constant))

--- a/easybuild/toolchains/gmpflf.py
+++ b/easybuild/toolchains/gmpflf.py
@@ -41,6 +41,6 @@ from easybuild.toolchains.linalg.scalapack import ScaLAPACK
 
 
 class Gmpflf(Gmpich, FlexiBLAS,  ScaLAPACK, Fftw):
-    """Compiler toolchain with GCC, MPICH, OpenBLAS, ScaLAPACK and FFTW."""
+    """Compiler toolchain with GCC, MPICH, FlexiBLAS, ScaLAPACK and FFTW."""
     NAME = 'gmpflf'
     SUBTOOLCHAIN = [Gmpich.NAME, Gfbf.NAME]

--- a/easybuild/toolchains/gmpflf.py
+++ b/easybuild/toolchains/gmpflf.py
@@ -34,23 +34,13 @@ Authors:
 """
 from easybuild.toolchains.gmpich import Gmpich
 from easybuild.toolchains.gfbf import Gfbf
-from easybuild.toolchains.golf import Golf
 from easybuild.toolchains.fft.fftw import Fftw
 from easybuild.toolchains.linalg.flexiblas import FlexiBLAS
 from easybuild.toolchains.linalg.openblas import OpenBLAS
 from easybuild.toolchains.linalg.scalapack import ScaLAPACK
 
 
-class Gmpflf(Gmpich, OpenBLAS, FlexiBLAS,  ScaLAPACK, Fftw):
+class Gmpflf(Gmpich, FlexiBLAS,  ScaLAPACK, Fftw):
     """Compiler toolchain with GCC, MPICH, OpenBLAS, ScaLAPACK and FFTW."""
     NAME = 'gmpflf'
-    SUBTOOLCHAIN = [Gmpich.NAME, Golf.NAME, Gfbf.NAME]
-
-    def __init__(self, *args, **kwargs):
-        """Toolchain constructor."""
-        super(Gmpflf, self).__init__(*args, **kwargs)
-        constants = ('BLAS_MODULE_NAME', 'BLAS_LIB', 'BLAS_LIB_MT', 'BLAS_FAMILY',
-                     'LAPACK_MODULE_NAME', 'LAPACK_IS_BLAS', 'LAPACK_FAMILY')
-
-        for constant in constants:
-            setattr(self, constant, getattr(FlexiBLAS, constant))
+    SUBTOOLCHAIN = [Gmpich.NAME, Gfbf.NAME]


### PR DESCRIPTION
Fixes toolchain dependency error:
```
List of toolchain dependency modules and toolchain definition do not match 
(found 
['GCC/12.3.0', 'MPICH/4.2.1-GCC-12.3.0', 'FlexiBLAS/3.3.1-GCC-12.3.0', 'FFTW/3.3.10-GCC-12.3.0', 'FFTW.MPI/3.3.10-gmpich-2024.06', 'ScaLAPACK/2.2.0-gmpich-2024.06-fb'] 
vs expected 
{'MPICH', 'GCC', 'OpenBLAS', 'ScaLAPACK', 'FFTW'})
```