### PR TITLE
CI: Allow using Node 16 actions

### DIFF
--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
     container:
       image: ghcr.io/easybuilders/${{ matrix.container }}-amd64
+    env: {ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true} # Allow using Node16 actions
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/unit_tests_python2.yml
+++ b/.github/workflows/unit_tests_python2.yml
@@ -16,6 +16,7 @@ jobs:
       # CentOS 7.9 container that already includes Lmod & co,
       # see https://github.com/easybuilders/easybuild-containers
       image: ghcr.io/easybuilders/centos-7.9-amd64
+    env: {ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true} # Allow using Node16 actions
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
Required after https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default

edit (by @boegel): see also https://github.com/actions/checkout/issues/1809