### PR TITLE
don't use special flags for `strict`, `precise`, `loose`, `veryloose` toolchain options on RISC-V

### DIFF
--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -84,6 +84,8 @@ class Gcc(Compiler):
     if systemtools.get_cpu_family() == systemtools.RISCV:
         COMPILER_UNIQUE_OPTION_MAP['strict'] = []
         COMPILER_UNIQUE_OPTION_MAP['precise'] = []
+        COMPILER_UNIQUE_OPTION_MAP['loose'] = ['fno-math-errno']
+        COMPILER_UNIQUE_OPTION_MAP['verloose'] = ['fno-math-errno']
 
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {

--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -78,6 +78,13 @@ class Gcc(Compiler):
         COMPILER_UNIQUE_OPTION_MAP['strict'] = no_recip_alternative
         COMPILER_UNIQUE_OPTION_MAP['precise'] = no_recip_alternative
 
+    # gcc on RISC-V does not support -mno-recip, -mieee-fp, -mfno-math-errno...
+    # https://gcc.gnu.org/onlinedocs/gcc/RISC-V-Options.html
+    # there are no good alternatives, so stick to the default flags
+    if systemtools.get_cpu_family() == systemtools.RISCV:
+        COMPILER_UNIQUE_OPTION_MAP['strict'] = []
+        COMPILER_UNIQUE_OPTION_MAP['precise'] = []
+
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {
         (systemtools.AARCH32, systemtools.ARM): 'mcpu=native',  # implies -march=native and -mtune=native


### PR DESCRIPTION
While trying to build GMP (which has `precise: True` in `toolchainopts`), the configure step failed because `-mno-recip` is not supported on RISC-V, similar to Arm (see https://github.com/easybuilders/easybuild-framework/pull/3425).

@julianmorillo checked with a compiler expert, and he recommended to use `-fno-reciprocal-math`. This is a generic flag and used by default, so without a sensible alternative, I've just removed the flags for these toolchain options. It will then basically ignore the `precise: True` and use the default flags.