### PR TITLE
Deprecate use of `parallel` easyconfig parameter and fix updating the template value

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2422,7 +2422,7 @@ class EasyBlock(object):
             else:
                 par = min(int(par), int(cfg_par))
 
-        par = det_parallelism(par, maxpar=self.cfg['maxparallel'])
+        par = det_parallelism(par, maxpar=self.cfg['max_parallel'])
         self.log.info("Setting parallelism: %s" % par)
         self.cfg.parallel = par
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2415,7 +2415,6 @@ class EasyBlock(object):
 
         # Transitional only in case some easyblocks still set/change cfg['parallel']
         # Use _parallelLegacy to avoid deprecation warnings
-        # Remove for EasyBuild 5.1
         cfg_par = self.cfg['_parallelLegacy']
         if cfg_par is not None:
             if par is None:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1890,7 +1890,7 @@ class EasyBlock(object):
         exts_cnt = len(self.ext_instances)
         cmds = [resolve_exts_filter_template(exts_filter, ext) for ext in self.ext_instances]
 
-        with ThreadPoolExecutor(max_workers=self.cfg['parallel']) as thread_pool:
+        with ThreadPoolExecutor(max_workers=self.cfg.parallel) as thread_pool:
 
             # list of command to run asynchronously
             async_cmds = [thread_pool.submit(run_shell_cmd, cmd, stdin=stdin, hidden=True, fail_on_error=False,
@@ -2020,7 +2020,7 @@ class EasyBlock(object):
         """
         self.log.info("Installing extensions in parallel...")
 
-        thread_pool = ThreadPoolExecutor(max_workers=self.cfg['parallel'])
+        thread_pool = ThreadPoolExecutor(max_workers=self.cfg.parallel)
 
         running_exts = []
         installed_ext_names = []
@@ -2082,7 +2082,7 @@ class EasyBlock(object):
 
             for _ in range(max_iter):
 
-                if not (exts_queue and len(running_exts) < self.cfg['parallel']):
+                if not (exts_queue and len(running_exts) < self.cfg.parallel):
                     break
 
                 # check whether extension at top of the queue is ready to install

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2326,7 +2326,7 @@ class EasyBlock(object):
 
         # Transitional only in case some easyblocks still set/change cfg['parallel']
         # Use _parallelLegacy to avoid deprecation warnings
-        # Remove for EasyBuild 5.0
+        # Remove for EasyBuild 5.1
         cfg_par = self.cfg['_parallelLegacy']
         if cfg_par is not None:
             if par is None:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2321,19 +2321,22 @@ class EasyBlock(object):
         """Set 'parallel' easyconfig parameter to determine how many cores can/should be used for parallel builds."""
         # set level of parallelism for build
         par = build_option('parallel')
-        cfg_par = self.cfg['parallel']
-        if cfg_par is None:
+        if par is not None:
             self.log.debug("Desired parallelism specified via 'parallel' build option: %s", par)
-        elif par is None:
-            par = cfg_par
-            self.log.debug("Desired parallelism specified via 'parallel' easyconfig parameter: %s", par)
-        else:
-            par = min(int(par), int(cfg_par))
-            self.log.debug("Desired parallelism: minimum of 'parallel' build option/easyconfig parameter: %s", par)
+
+        # Transitional only in case some easyblocks still set/change cfg['parallel']
+        # Use _parallelLegacy to avoid deprecation warnings
+        # Remove for EasyBuild 5.0
+        cfg_par = self.cfg['_parallelLegacy']
+        if cfg_par is not None:
+            if par is None:
+                par = cfg_par
+            else:
+                par = min(int(par), int(cfg_par))
 
         par = det_parallelism(par, maxpar=self.cfg['maxparallel'])
         self.log.info("Setting parallelism: %s" % par)
-        self.cfg['parallel'] = par
+        self.cfg.parallel = par
 
     def remove_module_file(self):
         """Remove module file (if it exists), and check for ghost installation directory (and deal with it)."""

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -340,6 +340,7 @@ class EasyBlock(object):
             # but needs to be correct if the build is performed in the installation directory
             self.log.info("Changing build dir to %s", self.installdir)
             self.builddir = self.installdir
+        self.set_parallel()
 
     # INIT/CLOSE LOG
     def _init_log(self):
@@ -2470,8 +2471,6 @@ class EasyBlock(object):
         """
         Verify if all is ok to start build.
         """
-        self.set_parallel()
-
         # check whether modules are loaded
         loadedmods = self.modules_tool.loaded_modules()
         if len(loadedmods) > 0:

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -110,8 +110,6 @@ DEFAULT_CONFIG = {
     'installopts': ['', 'Extra options for installation', BUILD],
     'maxparallel': [16, 'Max degree of parallelism', BUILD],
     'module_only': [False, 'Only generate module file', BUILD],
-    'parallel': [None, ('Degree of parallelism for e.g. make (default: based on the number of '
-                        'cores, active cpuset and restrictions in ulimit)'), BUILD],
     'patches': [[], "List of patches to apply", BUILD],
     'prebuildopts': ['', 'Extra options pre-passed to build command.', BUILD],
     'preconfigopts': ['', 'Extra options pre-passed to configure.', BUILD],

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -122,7 +122,7 @@ def handle_deprecated_or_replaced_easyconfig_parameters(ec_method):
         # map deprecated parameters to their replacements, issue deprecation warning(/error)
         if key == 'parallel':
             _log.deprecated("Easyconfig parameter 'parallel' is deprecated, "
-                            "use 'maxparallel' or the parallel property instead.", '5.0')
+                            "use 'maxparallel' or the parallel property instead.", '5.1')
             # Use a "hidden" property for now to match behavior as closely as possible
             key = '_parallelLegacy'
         elif key in ALTERNATIVE_EASYCONFIG_PARAMETERS:
@@ -149,7 +149,7 @@ def is_local_var_name(name):
     """
     res = False
     if name.startswith(LOCAL_VAR_PREFIX) or name.startswith('_'):
-        # Remove with EasyBuild 5.0
+        # Remove with EasyBuild 5.1
         if name != '_parallelLegacy':
             res = True
     # __builtins__ is always defined as a 'local' variables
@@ -508,7 +508,7 @@ class EasyConfig(object):
 
         # Storage for parallel property. Mark as unset initially
         self._parallel = None
-        # Legacy value, remove with EasyBuild 5.0
+        # Legacy value, remove with EasyBuild 5.1
         self._config['_parallelLegacy'] = [None, '', ('', )]
 
         # parse easyconfig file
@@ -713,7 +713,7 @@ class EasyConfig(object):
 
         if 'parallel' in ec_vars:
             # Replace value and issue better warning for EC params (as opposed to warnings meant for easyblocks)
-            self.log.deprecated("Easyconfig parameter 'parallel' is deprecated, use 'maxparallel' instead.", '5.0')
+            self.log.deprecated("Easyconfig parameter 'parallel' is deprecated, use 'maxparallel' instead.", '5.1')
             ec_vars['_parallelLegacy'] = ec_vars.pop('parallel')
 
         # provide suggestions for typos. Local variable names are excluded from this check
@@ -1242,7 +1242,7 @@ class EasyConfig(object):
         # Update backstorage and template value
         self._parallel = value
         self.template_values['parallel'] = value
-        # Backwards compat only. Remove with EasyBuild 5.0
+        # Backwards compat only. Remove with EasyBuild 5.1
         self._config['_parallelLegacy'][0] = value
 
     def dump(self, fp, always_overwrite=True, backup=False, explicit_toolchains=False):

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1259,6 +1259,11 @@ class EasyConfig(object):
         return self._all_dependencies
 
     @property
+    def is_parallel_set(self):
+        """Return if the desired parallelism has been determined yet"""
+        return self._parallel is not None
+
+    @property
     def parallel(self):
         """Number of parallel jobs to be used for building etc."""
         if self._parallel is None:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1261,8 +1261,7 @@ class EasyConfig(object):
     def parallel(self):
         """Number of parallel jobs to be used for building etc."""
         if self._parallel is None:
-            raise EasyBuildError("Parallelism in EasyConfig not set yet. "
-                                 "Need to call the easyblocks set_parallel first.")
+            raise ValueError("Parallelism in EasyConfig not set yet. Need to call the easyblocks set_parallel first.")
         # This gets set when an easyblock changes ec['parallel'].
         # It also gets set/updated in set_parallel to mirror the old behavior during the deprecation phase
         parallelLegacy = self._config['_parallelLegacy'][0]

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1240,10 +1240,10 @@ class EasyConfig(object):
     @parallel.setter
     def parallel(self, value):
         # Update backstorage and template value
-        self._parallel = value
-        self.template_values['parallel'] = value
-        # Backwards compat only. Remove with EasyBuild 5.1
-        self._config['_parallelLegacy'][0] = value
+        self._parallel = max(1, value)  # Also handles False
+        self.template_values['parallel'] = self._parallel
+        # Backwards compat only for easyblocks reading ec['parallel']. Remove with EasyBuild 5.1
+        self._config['_parallelLegacy'][0] = self._parallel
 
     def dump(self, fp, always_overwrite=True, backup=False, explicit_toolchains=False):
         """

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -120,7 +120,12 @@ def handle_deprecated_or_replaced_easyconfig_parameters(ec_method):
     def new_ec_method(self, key, *args, **kwargs):
         """Check whether any replace easyconfig parameters are still used"""
         # map deprecated parameters to their replacements, issue deprecation warning(/error)
-        if key in ALTERNATIVE_EASYCONFIG_PARAMETERS:
+        if key == 'parallel':
+            _log.deprecated("Easyconfig parameter 'parallel' is deprecated, "
+                            "use 'maxparallel' or the parallel property instead.", '5.0')
+            # Use a "hidden" property for now to match behavior as closely as possible
+            key = '_parallelLegacy'
+        elif key in ALTERNATIVE_EASYCONFIG_PARAMETERS:
             key = ALTERNATIVE_EASYCONFIG_PARAMETERS[key]
         elif key in DEPRECATED_EASYCONFIG_PARAMETERS:
             depr_key = key
@@ -144,7 +149,9 @@ def is_local_var_name(name):
     """
     res = False
     if name.startswith(LOCAL_VAR_PREFIX) or name.startswith('_'):
-        res = True
+        # Remove with EasyBuild 5.0
+        if name != '_parallelLegacy':
+            res = True
     # __builtins__ is always defined as a 'local' variables
     # single-letter local variable names are allowed (mainly for use in list comprehensions)
     # in Python 2, variables defined in list comprehensions leak to the outside (no longer the case in Python 3)
@@ -499,6 +506,11 @@ class EasyConfig(object):
         self.iterate_options = []
         self.iterating = False
 
+        # Storage for parallel property. Mark as unset initially
+        self._parallel = None
+        # Legacy value, remove with EasyBuild 5.0
+        self._config['_parallelLegacy'] = [None, '', ('', )]
+
         # parse easyconfig file
         self.build_specs = build_specs
         self.parse()
@@ -698,6 +710,11 @@ class EasyConfig(object):
         missing_mandatory_keys = [key for key in self.mandatory if key not in ec_vars]
         if missing_mandatory_keys:
             raise EasyBuildError("mandatory parameters not provided in %s: %s", self.path, missing_mandatory_keys)
+
+        if 'parallel' in ec_vars:
+            # Replace value and issue better warning for EC params (as opposed to warnings meant for easyblocks)
+            self.log.deprecated("Easyconfig parameter 'parallel' is deprecated, use 'maxparallel' instead.", '5.0')
+            ec_vars['_parallelLegacy'] = ec_vars.pop('parallel')
 
         # provide suggestions for typos. Local variable names are excluded from this check
         possible_typos = [(key, difflib.get_close_matches(key.lower(), self._config.keys(), 1, 0.85))
@@ -1211,6 +1228,22 @@ class EasyConfig(object):
                 self._all_dependencies.append(self.toolchain.as_dict())
 
         return self._all_dependencies
+
+    @property
+    def parallel(self):
+        """Number of parallel jobs to be used for building etc."""
+        if self._parallel is None:
+            raise EasyBuildError("Parallelism in EasyConfig not set yet. "
+                                 "Need to call the easyblocks set_parallel first.")
+        return self._parallel
+
+    @parallel.setter
+    def parallel(self, value):
+        # Update backstorage and template value
+        self._parallel = value
+        self.template_values['parallel'] = value
+        # Backwards compat only. Remove with EasyBuild 5.0
+        self._config['_parallelLegacy'][0] = value
 
     def dump(self, fp, always_overwrite=True, backup=False, explicit_toolchains=False):
         """

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -615,6 +615,7 @@ class EasyConfig(object):
         ec = EasyConfig(self.path, validate=validate, hidden=self.hidden, rawtxt=self.rawtxt)
         # take a copy of the actual config dictionary (which already contains the extra options)
         ec._config = copy.deepcopy(self._config)
+        ec._parallel = self._parallel  # Might be already set, e.g. for extensions
         # since rawtxt is defined, self.path may not get inherited, make sure it does
         if self.path:
             ec.path = self.path
@@ -721,7 +722,7 @@ class EasyConfig(object):
 
         if 'parallel' in ec_vars:
             # Replace value and issue better warning for EC params (as opposed to warnings meant for easyblocks)
-            self.log.deprecated("Easyconfig parameter 'parallel' is deprecated, use 'maxparallel' instead.", '5.1')
+            self.log.deprecated("Easyconfig parameter 'parallel' is deprecated, use 'max_parallel' instead.", '5.1')
             ec_vars['_parallelLegacy'] = ec_vars.pop('parallel')
 
         # provide suggestions for typos. Local variable names are excluded from this check

--- a/easybuild/framework/easyconfig/format/format.py
+++ b/easybuild/framework/easyconfig/format/format.py
@@ -68,7 +68,7 @@ GROUPED_PARAMS = [
     ['preconfigopts', 'configopts'],
     ['prebuildopts', 'buildopts'],
     ['preinstallopts', 'installopts'],
-    ['parallel', 'maxparallel'],
+    ['maxparallel'],
 ]
 LAST_PARAMS = ['exts_default_options', 'exts_list',
                'sanity_check_paths', 'sanity_check_commands',

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -102,12 +102,12 @@ TEMPLATE_NAMES_DYNAMIC = {
     'cuda_sm_comma_sep': 'Comma-separated list of sm_* values that correspond with CUDA compute capabilities',
     'cuda_sm_space_sep': 'Space-separated list of sm_* values that correspond with CUDA compute capabilities',
     'mpi_cmd_prefix': 'Prefix command for running MPI programs (with default number of ranks)',
+    'parallel': "Degree of parallelism for e.g. make",
     # can't be a boolean (True/False), must be a string value since it's a string template
     'rpath_enabled': "String value indicating whether or not RPATH linking is used ('true' or 'false')",
     'software_commit': "Git commit id to use for the software as specified by --software-commit command line option",
     'sysroot': "Location root directory of system, prefix for standard paths like /usr/lib and /usr/include"
                "as specify by the --sysroot configuration option",
-    'parallel': "Degree of parallelism for e.g. make",
 }
 
 # constant templates that can be used in easyconfigs

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -59,7 +59,6 @@ TEMPLATE_NAMES_CONFIG = [
     'bitbucket_account',
     'github_account',
     'name',
-    'parallel',
     'version',
     'versionsuffix',
     'versionprefix',
@@ -108,7 +107,7 @@ TEMPLATE_NAMES_DYNAMIC = {
     'software_commit': "Git commit id to use for the software as specified by --software-commit command line option",
     'sysroot': "Location root directory of system, prefix for standard paths like /usr/lib and /usr/include"
                "as specify by the --sysroot configuration option",
-
+    'parallel': "Degree of parallelism for e.g. make",
 }
 
 # constant templates that can be used in easyconfigs

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -153,10 +153,11 @@ class Extension(object):
                 self.log.debug("Skipping unknown custom easyconfig parameter '%s' for extension %s/%s: %s",
                                key, name, version, value)
 
-        # Take potentially new value into account
-        max_par = self.cfg['max_parallel']
-        if max_par is not None and max_par < self.cfg.parallel:
-            self.cfg.parallel = max_par
+        # If parallelism has been set already take potentially new limitation into account
+        if self.cfg.is_parallel_set:
+            max_par = self.cfg['max_parallel']
+            if max_par is not None and max_par < self.cfg.parallel:
+                self.cfg.parallel = max_par
 
         self.sanity_check_fail_msgs = []
         self.sanity_check_module_loaded = False

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -133,8 +133,9 @@ class Extension(object):
                                         self.cfg.template_values,
                                         expect_resolved=False)
         if 'parallel' in self.options:
-            # Replace value and issue better warning for EC params (as opposed to warnings meant for easyblocks)
-            self.log.deprecated("Easyconfig parameter 'parallel' is deprecated, use 'max_parallel' instead.", '5.1')
+            # Replace value and issue better warning for easyconfig parameters,
+            # as opposed to warnings meant for easyblocks
+            self.log.deprecated("Easyconfig parameter 'parallel' is deprecated, use 'max_parallel' instead.", '6.0')
             self.options['max_parallel'] = self.options.pop('parallel')
 
         if extra_params:

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -132,6 +132,10 @@ class Extension(object):
         self.options = resolve_template(copy.deepcopy(self.ext.get('options', {})),
                                         self.cfg.template_values,
                                         expect_resolved=False)
+        if 'parallel' in self.options:
+            # Replace value and issue better warning for EC params (as opposed to warnings meant for easyblocks)
+            self.log.deprecated("Easyconfig parameter 'parallel' is deprecated, use 'max_parallel' instead.", '5.1')
+            self.options['max_parallel'] = self.options.pop('parallel')
 
         if extra_params:
             self.cfg.extend_params(extra_params, overwrite=False)
@@ -148,6 +152,11 @@ class Extension(object):
             else:
                 self.log.debug("Skipping unknown custom easyconfig parameter '%s' for extension %s/%s: %s",
                                key, name, version, value)
+
+        # Take potentially new value into account
+        max_par = self.cfg['max_parallel']
+        if max_par is not None and max_par < self.cfg.parallel:
+            self.cfg.parallel = max_par
 
         self.sanity_check_fail_msgs = []
         self.sanity_check_module_loaded = False

--- a/easybuild/scripts/mk_tmpl_easyblock_for.py
+++ b/easybuild/scripts/mk_tmpl_easyblock_for.py
@@ -165,7 +165,7 @@ class %(class_name)s(%(parent)s):
         comp_fam = comp_map[self.toolchain.comp_family()]
 
         # enable parallel build
-        par = self.cfg['parallel']
+        par = self.cfg.parallel
         cmd = "build command --parallel %%d --compiler-family %%s" %% (par, comp_fam)
         run_shell_cmd(cmd)
 

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -1214,6 +1214,8 @@ def det_parallelism(par=None, maxpar=None):
             raise EasyBuildError("Specified level of parallelism '%s' is not an integer value: %s", par, err)
 
     if maxpar is not None and maxpar < par:
+        if maxpar is False:
+            maxpar = 1
         _log.info("Limiting parallelism from %s to %s", par, maxpar)
         par = maxpar
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2225,52 +2225,127 @@ class EasyBlockTest(EnhancedTestCase):
 
         handle, toy_ec2 = tempfile.mkstemp(prefix='easyblock_test_file_', suffix='.eb')
         os.close(handle)
-        write_file(toy_ec2, toytxt + "\nparallel = 123\nmaxparallel = 67")
+        write_file(toy_ec2, toytxt + "\nparallel = 12\nmaxparallel = 6")
 
         handle, toy_ec3 = tempfile.mkstemp(prefix='easyblock_test_file_', suffix='.eb')
         os.close(handle)
         write_file(toy_ec3, toytxt + "\nparallel = False")
 
+        handle, toy_ec4 = tempfile.mkstemp(prefix='easyblock_test_file_', suffix='.eb')
+        os.close(handle)
+        write_file(toy_ec4, toytxt + "\nmaxparallel = 6")
+
+        handle, toy_ec5 = tempfile.mkstemp(prefix='easyblock_test_file_', suffix='.eb')
+        os.close(handle)
+        write_file(toy_ec5, toytxt + "\nmaxparallel = False")
+
+        import easybuild.tools.systemtools as st
+        auto_parallel = 15
+        st.det_parallelism._default_parallelism = auto_parallel
+
         # default: parallelism is derived from # available cores + ulimit
+        # Note that maxparallel has a default of 16, so we need a lower auto_paralle value here
         test_eb = EasyBlock(EasyConfig(toy_ec))
         test_eb.check_readiness_step()
-        self.assertTrue(isinstance(test_eb.cfg['parallel'], int) and test_eb.cfg['parallel'] > 0)
+        self.assertEqual(test_eb.cfg.parallel, auto_parallel)
+
+        auto_parallel = 128  # Don't limit by available CPU cores mock
+        st.det_parallelism._default_parallelism = auto_parallel
 
         # only 'parallel' easyconfig parameter specified (no 'parallel' build option)
-        test_eb = EasyBlock(EasyConfig(toy_ec1))
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            test_eb = EasyBlock(EasyConfig(toy_ec1))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], 13)
+        self.assertEqual(test_eb.cfg.parallel, 13)
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            self.assertEqual(test_eb.cfg['parallel'], 13)
 
         # both 'parallel' and 'maxparallel' easyconfig parameters specified (no 'parallel' build option)
-        test_eb = EasyBlock(EasyConfig(toy_ec2))
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            test_eb = EasyBlock(EasyConfig(toy_ec2))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], 67)
+        self.assertEqual(test_eb.cfg.parallel, 6)
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            self.assertEqual(test_eb.cfg['parallel'], 6)
 
         # make sure 'parallel = False' is not overriden (no 'parallel' build option)
-        test_eb = EasyBlock(EasyConfig(toy_ec3))
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            test_eb = EasyBlock(EasyConfig(toy_ec3))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], False)
+        self.assertEqual(test_eb.cfg.parallel, False)
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            self.assertEqual(test_eb.cfg['parallel'], False)
+
+        # only 'maxparallel' easyconfig parameter specified (no 'parallel' build option)
+        test_eb = EasyBlock(EasyConfig(toy_ec4))
+        test_eb.check_readiness_step()
+        self.assertEqual(test_eb.cfg.parallel, 6)
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            self.assertEqual(test_eb.cfg['parallel'], 6)
+
+        # make sure 'maxparallel = False' is treated as 1 (no 'parallel' build option)
+        test_eb = EasyBlock(EasyConfig(toy_ec5))
+        test_eb.check_readiness_step()
+        self.assertEqual(test_eb.cfg.parallel, 1)
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            self.assertEqual(test_eb.cfg['parallel'], 1)
 
         # only 'parallel' build option specified
-        init_config(build_options={'parallel': '9', 'validate': False})
+        init_config(build_options={'parallel': '13', 'validate': False})
         test_eb = EasyBlock(EasyConfig(toy_ec))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], 9)
+        self.assertEqual(test_eb.cfg.parallel, 13)
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            self.assertEqual(test_eb.cfg['parallel'], 13)
 
         # both 'parallel' build option and easyconfig parameter specified (no 'maxparallel')
-        test_eb = EasyBlock(EasyConfig(toy_ec1))
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            test_eb = EasyBlock(EasyConfig(toy_ec1))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], 9)
+        self.assertEqual(test_eb.cfg.parallel, 13)
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            self.assertEqual(test_eb.cfg['parallel'], 13)
 
         # both 'parallel' and 'maxparallel' easyconfig parameters specified + 'parallel' build option
-        test_eb = EasyBlock(EasyConfig(toy_ec2))
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            test_eb = EasyBlock(EasyConfig(toy_ec2))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], 9)
+        self.assertEqual(test_eb.cfg.parallel, 6)
 
         # make sure 'parallel = False' is not overriden (with 'parallel' build option)
-        test_eb = EasyBlock(EasyConfig(toy_ec3))
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            test_eb = EasyBlock(EasyConfig(toy_ec3))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], 0)
+        self.assertEqual(test_eb.cfg.parallel, 0)
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            self.assertEqual(test_eb.cfg['parallel'], 0)
+
+        # only 'maxparallel' easyconfig parameter specified (with 'parallel' build option)
+        test_eb = EasyBlock(EasyConfig(toy_ec4))
+        test_eb.check_readiness_step()
+        self.assertEqual(test_eb.cfg.parallel, 6)
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            self.assertEqual(test_eb.cfg['parallel'], 6)
+
+        # make sure 'maxparallel = False' is treated as 1 (with 'parallel' build option)
+        test_eb = EasyBlock(EasyConfig(toy_ec5))
+        test_eb.check_readiness_step()
+        self.assertEqual(test_eb.cfg.parallel, 1)
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            self.assertEqual(test_eb.cfg['parallel'], 1)
+
+        # Template updated correctly
+        test_eb.cfg['buildopts'] = '-j %(parallel)s'
+        self.assertEqual(test_eb.cfg['buildopts'], '-j 1')
+        # Might be done in an easyblock step
+        test_eb.cfg.parallel = 42
+        self.assertEqual(test_eb.cfg['buildopts'], '-j 42')
+        # Unaffected by build settings
+        test_eb.cfg.parallel = 421337
+        self.assertEqual(test_eb.cfg['buildopts'], '-j 421337')
+
+        # Reset mocked value
+        del st.det_parallelism._default_parallelism
 
     def test_guess_start_dir(self):
         """Test guessing the start dir."""

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2323,6 +2323,22 @@ class EasyBlockTest(EnhancedTestCase):
         test_eb.cfg.parallel = False
         self.assertEqual(test_eb.cfg['buildopts'], '-j 1')
 
+        # Legacy behavior. To be removed after deprecation of the parallel EC parameter
+        self.contents = toytxt + '\nmaxparallel=99'
+        self.writeEC()
+        with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
+            test_eb = EasyBlock(EasyConfig(self.eb_file))
+            parallel = buildopt_parallel - 2
+            test_eb.cfg['parallel'] = parallel  # Old Easyblocks might change that before the ready step
+            test_eb.check_readiness_step()
+            self.assertEqual(test_eb.cfg.parallel, parallel)
+            self.assertEqual(test_eb.cfg['parallel'], parallel)
+            # Afterwards it also gets reflected directly ignoring maxparallel
+            parallel = buildopt_parallel * 3
+            test_eb.cfg['parallel'] = parallel
+            self.assertEqual(test_eb.cfg.parallel, parallel)
+            self.assertEqual(test_eb.cfg['parallel'], parallel)
+
         # Reset mocked value
         del st.det_parallelism._default_parallelism
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2535,7 +2535,7 @@ class EasyBlockTest(EnhancedTestCase):
                 self.writeEC()
                 with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
                     test_eb = EasyBlock(EasyConfig(self.eb_file))
-                test_eb.check_readiness_step()
+                test_eb.post_init()
                 self.assertEqual(test_eb.cfg.parallel, expected)
                 with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
                     self.assertEqual(test_eb.cfg['parallel'], expected)
@@ -2568,7 +2568,7 @@ class EasyBlockTest(EnhancedTestCase):
                 self.writeEC()
                 with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
                     test_eb = EasyBlock(EasyConfig(self.eb_file))
-                test_eb.check_readiness_step()
+                test_eb.post_init()
                 self.assertEqual(test_eb.cfg.parallel, expected)
                 with self.temporarily_allow_deprecated_behaviour(), self.mocked_stdout_stderr():
                     self.assertEqual(test_eb.cfg['parallel'], expected)
@@ -2577,7 +2577,7 @@ class EasyBlockTest(EnhancedTestCase):
         self.contents = toytxt + '\nmaxparallel=2'
         self.writeEC()
         test_eb = EasyBlock(EasyConfig(self.eb_file))
-        test_eb.check_readiness_step()
+        test_eb.post_init()
 
         test_eb.cfg['buildopts'] = '-j %(parallel)s'
         self.assertEqual(test_eb.cfg['buildopts'], '-j 2')
@@ -2598,7 +2598,7 @@ class EasyBlockTest(EnhancedTestCase):
             test_eb = EasyBlock(EasyConfig(self.eb_file))
             parallel = buildopt_parallel - 2
             test_eb.cfg['parallel'] = parallel  # Old Easyblocks might change that before the ready step
-            test_eb.check_readiness_step()
+            test_eb.post_init()
             self.assertEqual(test_eb.cfg.parallel, parallel)
             self.assertEqual(test_eb.cfg['parallel'], parallel)
             # Afterwards it also gets reflected directly ignoring maxparallel

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -671,7 +671,7 @@ class EasyConfigTest(EnhancedTestCase):
             'version = "3.14"',
             'toolchain = {"name": "GCC", "version": "4.6.3"}',
             'patches = %s',
-            'parallel = 1',
+            'maxparallel = 1',
             'keepsymlinks = True',
         ]) % str(patches)
         self.prep()
@@ -694,7 +694,7 @@ class EasyConfigTest(EnhancedTestCase):
             # It should be possible to overwrite values with True/False/None as they often have special meaning
             'runtest': 'False',
             'hidden': 'True',
-            'parallel': 'None',  # Good example: parallel=None means "Auto detect"
+            'maxparallel': 'None',  # Good example: maxparallel=None means "unlimitted"
             # Adding new options (added only by easyblock) should also be possible
             # and in case the string "True/False/None" is really wanted it is possible to quote it first
             'test_none': '"False"',
@@ -711,7 +711,7 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(eb['patches'], new_patches)
         self.assertIs(eb['runtest'], False)
         self.assertIs(eb['hidden'], True)
-        self.assertIsNone(eb['parallel'])
+        self.assertIsNone(eb['maxparallel'])
         self.assertEqual(eb['test_none'], 'False')
         self.assertEqual(eb['test_bool'], 'True')
         self.assertEqual(eb['test_123'], 'None')
@@ -1931,8 +1931,7 @@ class EasyConfigTest(EnhancedTestCase):
 
     def test_deprecated_easyconfig_parameters(self):
         """Test handling of deprecated easyconfig parameters."""
-        os.environ.pop('EASYBUILD_DEPRECATED')
-        easybuild.tools.build_log.CURRENT_VERSION = self.orig_current_version
+        self.allow_deprecated_behaviour()
         init_config()
 
         test_ecs_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'easyconfigs', 'test_ecs')
@@ -3517,7 +3516,6 @@ class EasyConfigTest(EnhancedTestCase):
             'namelower': 'gzip',
             'nameletter': 'g',
             'nameletterlower': 'g',
-            'parallel': None,
             'rpath_enabled': rpath,
             'software_commit': '',
             'sysroot': '',
@@ -3556,7 +3554,6 @@ class EasyConfigTest(EnhancedTestCase):
 
         res = template_constant_dict(ec)
         res.pop('arch')
-        expected['parallel'] = 12
         self.assertEqual(res, expected)
 
         toy_ec = os.path.join(test_ecs_dir, 't', 'toy', 'toy-0.0-deps.eb')
@@ -3598,7 +3595,6 @@ class EasyConfigTest(EnhancedTestCase):
             'toolchain_name': 'system',
             'toolchain_version': 'system',
             'nameletterlower': 't',
-            'parallel': None,
             'pymajver': '3',
             'pyminver': '7',
             'pyshortver': '3.7',
@@ -3634,7 +3630,7 @@ class EasyConfigTest(EnhancedTestCase):
         ec = EasyConfigParser(filename=test_ec).get_config_dict()
 
         expected['module_name'] = None
-        for key in ('bitbucket_account', 'github_account', 'parallel', 'versionprefix'):
+        for key in ('bitbucket_account', 'github_account', 'versionprefix'):
             del expected[key]
 
         dep_names = [x[0] for x in ec['dependencies']]

--- a/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-GCC-6.4.0-2.28.eb
+++ b/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-GCC-6.4.0-2.28.eb
@@ -31,7 +31,7 @@ dependencies = [
     # ('Tcl', '8.6.4'),
 ]
 
-parallel = 1
+maxparallel = 1
 
 sanity_check_paths = {
     'files': ['bin/sqlite3', 'include/sqlite3ext.h', 'include/sqlite3.h', 'lib/libsqlite3.a', 'lib/libsqlite3.so'],

--- a/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-foss-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-foss-2018a.eb
@@ -31,7 +31,7 @@ dependencies = [
     # ('Tcl', '8.6.4'),
 ]
 
-parallel = 1
+maxparallel = 1
 
 sanity_check_paths = {
     'files': ['bin/sqlite3', 'include/sqlite3ext.h', 'include/sqlite3.h', 'lib/libsqlite3.a', 'lib/libsqlite3.so'],

--- a/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-gompi-2018a.eb
+++ b/test/framework/easyconfigs/test_ecs/s/SQLite/SQLite-3.8.10.2-gompi-2018a.eb
@@ -31,7 +31,7 @@ dependencies = [
     # ('Tcl', '8.6.4'),
 ]
 
-parallel = 1
+maxparallel = 1
 
 sanity_check_paths = {
     'files': ['bin/sqlite3', 'include/sqlite3ext.h', 'include/sqlite3.h', 'lib/libsqlite3.a', 'lib/libsqlite3.so'],

--- a/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2018a-OpenBLAS-0.2.20-broken.eb
+++ b/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2018a-OpenBLAS-0.2.20-broken.eb
@@ -23,6 +23,6 @@ builddependencies = [('CMake','2.8.10')]
 dependencies = [(local_blaslib, local_blasver, '')]
 
 # parallel build tends to fail, so disabling it
-parallel = 1
+maxparallel = 1
 
 moduleclass = 'numlib'

--- a/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2018a-OpenBLAS-0.2.20.eb
+++ b/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2018a-OpenBLAS-0.2.20.eb
@@ -22,6 +22,6 @@ versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 dependencies = [(local_blaslib, local_blasver, '')]
 
 # parallel build tends to fail, so disabling it
-parallel = 1
+maxparallel = 1
 
 moduleclass = 'numlib'

--- a/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2018a-OpenBLAS-0.2.20.eb
+++ b/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompic-2018a-OpenBLAS-0.2.20.eb
@@ -22,6 +22,6 @@ versionsuffix = "-%s-%s" % (local_blaslib, local_blasver)
 dependencies = [(local_blaslib, local_blasver)]
 
 # parallel build tends to fail, so disabling it
-parallel = 1
+maxparallel = 1
 
 moduleclass = 'numlib'

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -211,6 +211,14 @@ class EnhancedTestCase(TestCase):
         eb_build_log.CURRENT_VERSION = self.orig_current_version
 
     @contextmanager
+    def temporarily_allow_deprecated_behaviour(self):
+        self.allow_deprecated_behaviour()
+        try:
+            yield
+        finally:
+            self.disallow_deprecated_behaviour()
+
+    @contextmanager
     def log_to_testlogfile(self):
         """Context manager class to capture log output in self.logfile for the scope used. Clears the file first"""
         open(self.logfile, 'w').close()  # Remove all contents


### PR DESCRIPTION
Rebase of #3842 to 5.0x

ec['parallel'] currently doubles as an EC option and as the storage for the calculated parallelism set by the EasyBlock.
This makes it hard to reason about especially as maxparallel has pretty much the same effect. Also changes to ec['parallel'] done by e.g. easyblocks (or the set_parallel method) are not reflected by the template `%(parallel)s`

Solution: Introduce a property which on write updates the template and some magic to mirror the effect of the now deprecated ec['parallel']

Additional change I'd like to do: Treat `parallel = False` (legacy) as `maxparallel =1` so `cfg.parallel` is always a number

See https://github.com/easybuilders/easybuild-framework/pull/3811#issuecomment-911819520 for the motivation

Requires https://github.com/easybuilders/easybuild-easyconfigs/pull/19375 to avoid deprecation warnings

Compared to #3842 I had to move the deprecation to 5.1 as easyblocks need updating but that requires this PR. So either we keep 5.1 as the target or merge this, update the easyblocks, then remove the deprecation (and fail hard) for 5.0

Testing this is possibly by using an EB5 venv and installing this branch with ` pip install --force-reinstall https://github.com/Flamefire/easybuild-framework/archive/deprecate_parallel-5.tar.gz`