### PR TITLE
Add cuda_cc_space_sep variant that does not have periods

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -191,7 +191,7 @@ jobs:
             # run test suite
             python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
             # try and make sure output of running tests is clean (no printed messages/warnings)
-            IGNORE_PATTERNS="no GitHub token available|skipping SvnRepository test|requires Lmod as modules tool|stty: 'standard input': Inappropriate ioctl for device|CryptographyDeprecationWarning: Python 3.[56]|from cryptography.* import |CryptographyDeprecationWarning: Python 2|Blowfish|GC3Pie not available, skipping test|CryptographyDeprecationWarning: TripleDES has been moved"
+            IGNORE_PATTERNS="no GitHub token available|skipping SvnRepository test|requires Lmod as modules tool|stty: 'standard input': Inappropriate ioctl for device|CryptographyDeprecationWarning: Python 3.[56]|from cryptography.* import |CryptographyDeprecationWarning: Python 2|Blowfish|GC3Pie not available, skipping test|CryptographyDeprecationWarning: TripleDES has been moved|algorithms.TripleDES"
             # '|| true' is needed to avoid that GitHub Actions stops the job on non-zero exit of grep (i.e. when there are no matches)
             PRINTED_MSG=$(egrep -v "${IGNORE_PATTERNS}" test_framework_suite.log | grep '\.\n*[A-Za-z]' || true)
             test "x$PRINTED_MSG" = "x" || (echo "ERROR: Found printed messages in output of test suite" && echo "${PRINTED_MSG}" && exit 1)

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -191,7 +191,7 @@ jobs:
             # run test suite
             python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
             # try and make sure output of running tests is clean (no printed messages/warnings)
-            IGNORE_PATTERNS="no GitHub token available|skipping SvnRepository test|requires Lmod as modules tool|stty: 'standard input': Inappropriate ioctl for device|CryptographyDeprecationWarning: Python 3.[56]|from cryptography.* import |CryptographyDeprecationWarning: Python 2|Blowfish|GC3Pie not available, skipping test"
+            IGNORE_PATTERNS="no GitHub token available|skipping SvnRepository test|requires Lmod as modules tool|stty: 'standard input': Inappropriate ioctl for device|CryptographyDeprecationWarning: Python 3.[56]|from cryptography.* import |CryptographyDeprecationWarning: Python 2|Blowfish|GC3Pie not available, skipping test|CryptographyDeprecationWarning: TripleDES has been moved"
             # '|| true' is needed to avoid that GitHub Actions stops the job on non-zero exit of grep (i.e. when there are no matches)
             PRINTED_MSG=$(egrep -v "${IGNORE_PATTERNS}" test_framework_suite.log | grep '\.\n*[A-Za-z]' || true)
             test "x$PRINTED_MSG" = "x" || (echo "ERROR: Found printed messages in output of test suite" && echo "${PRINTED_MSG}" && exit 1)

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -365,7 +365,7 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
 
     # step 6. CUDA compute capabilities
     #         Use the commandline / easybuild config option if given, else use the value from the EC (as a default)
-    cuda_cc = build_option('cuda_cc') or config.get('cuda_cc')
+    cuda_cc = build_option('cuda_cc') or config.get('cuda_compute_capabilities')
     if cuda_cc:
         template_values['cuda_compute_capabilities'] = ','.join(cuda_cc)
         template_values['cuda_cc_space_sep'] = ' '.join(cuda_cc)

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -97,6 +97,8 @@ TEMPLATE_NAMES_DYNAMIC = [
      "--cuda-compute-capabilities configuration option or via cuda_compute_capabilities easyconfig parameter"),
     ('cuda_cc_cmake', "List of CUDA compute capabilities suitable for use with $CUDAARCHS in CMake 3.18+"),
     ('cuda_cc_space_sep', "Space-separated list of CUDA compute capabilities"),
+    ('cuda_cc_space_sep_no_period',
+     "Space-separated list of CUDA compute capabilities, without periods (e.g. '80 90')."),
     ('cuda_cc_semicolon_sep', "Semicolon-separated list of CUDA compute capabilities"),
     ('cuda_sm_comma_sep', "Comma-separated list of sm_* values that correspond with CUDA compute capabilities"),
     ('cuda_sm_space_sep', "Space-separated list of sm_* values that correspond with CUDA compute capabilities"),
@@ -367,6 +369,7 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
     if cuda_compute_capabilities:
         template_values['cuda_compute_capabilities'] = ','.join(cuda_compute_capabilities)
         template_values['cuda_cc_space_sep'] = ' '.join(cuda_compute_capabilities)
+        template_values['cuda_cc_space_sep_no_period'] = ' '.join(cc.replace('.', '') for cc in cuda_compute_capabilities)
         template_values['cuda_cc_semicolon_sep'] = ';'.join(cuda_compute_capabilities)
         template_values['cuda_cc_cmake'] = ';'.join(cc.replace('.', '') for cc in cuda_compute_capabilities)
         sm_values = ['sm_' + cc.replace('.', '') for cc in cuda_compute_capabilities]

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -365,7 +365,7 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
 
     # step 6. CUDA compute capabilities
     #         Use the commandline / easybuild config option if given, else use the value from the EC (as a default)
-    cuda_cc = build_option('cuda_cc') or config.get('cuda_compute_capabilities')
+    cuda_cc = build_option('cuda_compute_capabilities') or config.get('cuda_compute_capabilities')
     if cuda_cc:
         template_values['cuda_compute_capabilities'] = ','.join(cuda_cc)
         template_values['cuda_cc_space_sep'] = ' '.join(cuda_cc)

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -93,8 +93,8 @@ TEMPLATE_NAMES_DYNAMIC = [
     ('sysroot', "Location root directory of system, prefix for standard paths like /usr/lib and /usr/include"
      "as specify by the --sysroot configuration option"),
     ('mpi_cmd_prefix', "Prefix command for running MPI programs (with default number of ranks)"),
-    ('cuda_compute_capabilities', "Comma-separated list of CUDA compute capabilities, as specified via "
-     "--cuda-compute-capabilities configuration option or via cuda_compute_capabilities easyconfig parameter"),
+    ('cuda_cc', "Comma-separated list of CUDA compute capabilities, as specified via "
+     "--cuda-compute-capabilities configuration option or via cuda_cc easyconfig parameter"),
     ('cuda_cc_cmake', "List of CUDA compute capabilities suitable for use with $CUDAARCHS in CMake 3.18+"),
     ('cuda_cc_space_sep', "Space-separated list of CUDA compute capabilities"),
     ('cuda_cc_space_sep_no_period',
@@ -365,14 +365,14 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
 
     # step 6. CUDA compute capabilities
     #         Use the commandline / easybuild config option if given, else use the value from the EC (as a default)
-    cuda_compute_capabilities = build_option('cuda_compute_capabilities') or config.get('cuda_compute_capabilities')
-    if cuda_compute_capabilities:
-        template_values['cuda_compute_capabilities'] = ','.join(cuda_compute_capabilities)
-        template_values['cuda_cc_space_sep'] = ' '.join(cuda_compute_capabilities)
-        template_values['cuda_cc_space_sep_no_period'] = ' '.join(cc.replace('.', '') for cc in cuda_compute_capabilities)
-        template_values['cuda_cc_semicolon_sep'] = ';'.join(cuda_compute_capabilities)
-        template_values['cuda_cc_cmake'] = ';'.join(cc.replace('.', '') for cc in cuda_compute_capabilities)
-        sm_values = ['sm_' + cc.replace('.', '') for cc in cuda_compute_capabilities]
+    cuda_cc = build_option('cuda_cc') or config.get('cuda_cc')
+    if cuda_cc:
+        template_values['cuda_compute_capabilities'] = ','.join(cuda_cc)
+        template_values['cuda_cc_space_sep'] = ' '.join(cuda_cc)
+        template_values['cuda_cc_space_sep_no_period'] = ' '.join(cc.replace('.', '') for cc in cuda_cc)
+        template_values['cuda_cc_semicolon_sep'] = ';'.join(cuda_cc)
+        template_values['cuda_cc_cmake'] = ';'.join(cc.replace('.', '') for cc in cuda_cc)
+        sm_values = ['sm_' + cc.replace('.', '') for cc in cuda_cc]
         template_values['cuda_sm_comma_sep'] = ','.join(sm_values)
         template_values['cuda_sm_space_sep'] = ' '.join(sm_values)
 

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -93,7 +93,7 @@ TEMPLATE_NAMES_DYNAMIC = [
     ('sysroot', "Location root directory of system, prefix for standard paths like /usr/lib and /usr/include"
      "as specify by the --sysroot configuration option"),
     ('mpi_cmd_prefix', "Prefix command for running MPI programs (with default number of ranks)"),
-    ('cuda_cc', "Comma-separated list of CUDA compute capabilities, as specified via "
+    ('cuda_compute_capabilities', "Comma-separated list of CUDA compute capabilities, as specified via "
      "--cuda-compute-capabilities configuration option or via cuda_cc easyconfig parameter"),
     ('cuda_cc_cmake', "List of CUDA compute capabilities suitable for use with $CUDAARCHS in CMake 3.18+"),
     ('cuda_cc_space_sep', "Space-separated list of CUDA compute capabilities"),

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -4625,7 +4625,7 @@ class EasyConfigTest(EnhancedTestCase):
         init_config(build_options={'cuda_compute_capabilities': ['4.2', '6.3']})
         ec = EasyConfig(self.eb_file)
         self.assertEqual(ec['installopts'], '4.2,6.3')
-        self.assertEqual(ec['preinstallopts'], '4.2 6.3')
+        self.assertEqual(ec['preinstallopts'], 'period="4.2 6.3" noperiod="42 63"')
         self.assertEqual(ec['prebuildopts'], '4.2;6.3')
         self.assertEqual(ec['configopts'], 'comma="sm_42,sm_63" '
                                            'space="sm_42 sm_63"')

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -4606,7 +4606,7 @@ class EasyConfigTest(EnhancedTestCase):
             toolchain = SYSTEM
             cuda_compute_capabilities = ['5.1', '7.0', '7.1']
             installopts = '%(cuda_compute_capabilities)s'
-            preinstallopts = '%(cuda_cc_space_sep)s'
+            preinstallopts = 'period="%(cuda_cc_space_sep)s" noperiod="%(cuda_cc_space_sep_no_period)s"'
             prebuildopts = '%(cuda_cc_semicolon_sep)s'
             configopts = 'comma="%(cuda_sm_comma_sep)s" space="%(cuda_sm_space_sep)s"'
             preconfigopts = 'CUDAARCHS="%(cuda_cc_cmake)s"'
@@ -4615,7 +4615,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         ec = EasyConfig(self.eb_file)
         self.assertEqual(ec['installopts'], '5.1,7.0,7.1')
-        self.assertEqual(ec['preinstallopts'], '5.1 7.0 7.1')
+        self.assertEqual(ec['preinstallopts'], 'period="5.1 7.0 7.1" noperiod="51 70 71"')
         self.assertEqual(ec['prebuildopts'], '5.1;7.0;7.1')
         self.assertEqual(ec['configopts'], 'comma="sm_51,sm_70,sm_71" '
                                            'space="sm_51 sm_70 sm_71"')


### PR DESCRIPTION
E.g. '80 90' if cuda compute capabilities is '8.0,9.0'

Can be used in e.g. Cuda-Samples as value to `SMS` argument, see the readme at https://github.com/NVIDIA/cuda-samples