### PR TITLE
Use default value `$XDG_CONFIG_DIRS` from XDG basedir spec: `/etc/xdg` (instead of `/etc`)

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -213,6 +213,12 @@ class EasyBuildOptions(GeneralOption):
 
     DEFAULT_LOGLEVEL = 'INFO'
     DEFAULT_CONFIGFILES = DEFAULT_SYS_CFGFILES[:]
+    if 'XDG_CONFIG_DIRS' not in os.environ:
+        old_etc_location = os.path.join('/etc', 'easybuild.d')
+        if os.path.isdir(old_etc_location) and glob.glob(os.path.join(old_etc_location, '*.cfg')):
+            _log.deprecated(f"Using {old_etc_location} is deprecated. Please use /etc/xdg/easybuild.d "
+                                "instead or add /etc to XDG_CONFIG_DIRS", '6.0')
+
     if os.path.exists(DEFAULT_USER_CFGFILE):
         DEFAULT_CONFIGFILES.append(DEFAULT_USER_CFGFILE)
 

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -123,7 +123,7 @@ except ImportError:
 CONFIG_ENV_VAR_PREFIX = 'EASYBUILD'
 
 XDG_CONFIG_HOME = os.environ.get('XDG_CONFIG_HOME', os.path.join(os.path.expanduser('~'), ".config"))
-XDG_CONFIG_DIRS = os.environ.get('XDG_CONFIG_DIRS', '/etc').split(os.pathsep)
+XDG_CONFIG_DIRS = os.environ.get('XDG_CONFIG_DIRS', '/etc/xdg').split(os.pathsep)
 DEFAULT_SYS_CFGFILES = [f for d in XDG_CONFIG_DIRS for f in sorted(glob.glob(os.path.join(d, 'easybuild.d', '*.cfg')))]
 DEFAULT_USER_CFGFILE = os.path.join(XDG_CONFIG_HOME, 'easybuild', 'config.cfg')
 
@@ -1313,7 +1313,7 @@ class EasyBuildOptions(GeneralOption):
             '',
             "* user-level: %s" % os.path.join('${XDG_CONFIG_HOME:-$HOME/.config}', 'easybuild', 'config.cfg'),
             "  -> %s => %s" % (DEFAULT_USER_CFGFILE, ('not found', 'found')[os.path.exists(DEFAULT_USER_CFGFILE)]),
-            "* system-level: %s" % os.path.join('${XDG_CONFIG_DIRS:-/etc}', 'easybuild.d', '*.cfg'),
+            "* system-level: %s" % os.path.join('${XDG_CONFIG_DIRS:-/etc/xdg}', 'easybuild.d', '*.cfg'),
             "  -> %s => %s" % (system_cfg_glob_paths, ', '.join(DEFAULT_SYS_CFGFILES) or "(no matches)"),
             '',
             "Default list of existing configuration files (%d): %s" % (found_cfgfile_cnt, found_cfgfile_list),

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -216,8 +216,8 @@ class EasyBuildOptions(GeneralOption):
     if 'XDG_CONFIG_DIRS' not in os.environ:
         old_etc_location = os.path.join('/etc', 'easybuild.d')
         if os.path.isdir(old_etc_location) and glob.glob(os.path.join(old_etc_location, '*.cfg')):
-            _log.deprecated(f"Using {old_etc_location} is deprecated. Please use /etc/xdg/easybuild.d "
-                                "instead or add /etc to XDG_CONFIG_DIRS", '6.0')
+            _log.deprecated(f"Using {old_etc_location} is deprecated. Please use "
+                            "/etc/xdg/easybuild.d instead or add /etc to XDG_CONFIG_DIRS", '6.0')
 
     if os.path.exists(DEFAULT_USER_CFGFILE):
         DEFAULT_CONFIGFILES.append(DEFAULT_USER_CFGFILE)

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -3493,7 +3493,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '',
             "* user-level: ${XDG_CONFIG_HOME:-$HOME/.config}/easybuild/config.cfg",
             "  -> %s",
-            "* system-level: ${XDG_CONFIG_DIRS:-/etc}/easybuild.d/*.cfg",
+            "* system-level: ${XDG_CONFIG_DIRS:-/etc/xdg}/easybuild.d/*.cfg",
             "  -> %s/easybuild.d/*.cfg => ",
         ])
 
@@ -3508,12 +3508,12 @@ class CommandLineOptionsTest(EnhancedTestCase):
             homecfgfile_str += " => found"
         else:
             homecfgfile_str += " => not found"
-        expected = expected_tmpl % ('(not set)', '(not set)', homecfgfile_str, '{/etc}')
+        expected = expected_tmpl % ('(not set)', '(not set)', homecfgfile_str, '{/etc/xdg}')
         self.assertIn(expected, logtxt)
 
         # to predict the full output, we need to take control over $HOME and $XDG_CONFIG_DIRS
         os.environ['HOME'] = self.test_prefix
-        xdg_config_dirs = os.path.join(self.test_prefix, 'etc')
+        xdg_config_dirs = os.path.join(self.test_prefix, 'etc', 'xdg')
         os.environ['XDG_CONFIG_DIRS'] = xdg_config_dirs
 
         expected_tmpl += '\n'.join([
@@ -3538,12 +3538,12 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         xdg_config_home = os.path.join(self.test_prefix, 'home')
         os.environ['XDG_CONFIG_HOME'] = xdg_config_home
-        xdg_config_dirs = [os.path.join(self.test_prefix, 'etc'), os.path.join(self.test_prefix, 'moaretc')]
+        xdg_config_dirs = [os.path.join(self.test_prefix, 'etc', 'xdg'), os.path.join(self.test_prefix, 'moaretc')]
         os.environ['XDG_CONFIG_DIRS'] = os.pathsep.join(xdg_config_dirs)
 
         # put various dummy cfgfiles in place
         cfgfiles = [
-            os.path.join(self.test_prefix, 'etc', 'easybuild.d', 'config.cfg'),
+            os.path.join(self.test_prefix, 'etc', 'xdg', 'easybuild.d', 'config.cfg'),
             os.path.join(self.test_prefix, 'moaretc', 'easybuild.d', 'bar.cfg'),
             os.path.join(self.test_prefix, 'moaretc', 'easybuild.d', 'foo.cfg'),
             os.path.join(xdg_config_home, 'easybuild', 'config.cfg'),


### PR DESCRIPTION
The [spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html#variables) mandates `/etc/xdg` instead of `/etc` for the default value of `XDG_CONFIG_DIRS`.

I'm pretty sure this requires documentation changes because this is potentially a breaking change, but I'm not entirely sure where. I hope a project member can point me to where. :no_mouth::sweat_drops:

Fixes https://github.com/easybuilders/easybuild-framework/issues/4581