### PR TITLE
fix `test_compiler_cache`

### DIFF
--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -2237,7 +2237,8 @@ class ToolchainTest(EnhancedTestCase):
                 "#!/bin/bash",
                 "echo 'This is a %s wrapper'" % cache_tool,
                 "NAME=${0##*/}",
-                "comm=$(which -a $NAME | sed 1d)",
+                "comms=($(which -a $NAME))",
+                "comm=${comms[1]}",  # First entry is this wrapper, take 2nd
                 "$comm $@",
                 "exit 0"
             ]


### PR DESCRIPTION
The test searches for the real command, e.g. `gcc`, deletes the first one found and uses the rest.
However there could be multiple ones: /usr/bin/gcc /bin/gcc In this case the second would be wrongly used as the input. Fix by converting the output of `which` into an array and using the 2nd entry.