### PR TITLE
fix test_toy_lock_cleanup_signals

### DIFF
--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3753,7 +3753,9 @@ class ToyBuildTest(EnhancedTestCase):
         toy_ec_txt = read_file(os.path.join(test_ecs_dir, 't', 'toy', 'toy-0.0.eb'))
 
         test_ec = os.path.join(self.test_prefix, 'test.eb')
-        write_file(test_ec, toy_ec_txt + '\npostinstallcmds = ["sleep 5"]')
+        write_file(test_ec, toy_ec_txt + '\npostinstallcmds = ["sleep 10"]')
+
+        extra_args = ['--locks-dir=%s' % locks_dir, '--wait-on-lock-limit=3', '--wait-on-lock-interval=3']
 
         signums = [
             (signal.SIGABRT, SystemExit),
@@ -3766,7 +3768,7 @@ class ToyBuildTest(EnhancedTestCase):
             # avoid recycling stderr of previous test
             stderr = ''
 
-            with WaitAndSignal(1, signum):
+            with WaitAndSignal(3, signum):
 
                 # change back to original working directory before each test
                 change_dir(orig_wd)
@@ -3774,7 +3776,7 @@ class ToyBuildTest(EnhancedTestCase):
                 self.mock_stderr(True)
                 self.mock_stdout(True)
                 self.assertErrorRegex(exc, '.*', self._test_toy_build, ec_file=test_ec, verify=False,
-                                      raise_error=True, testing=False, raise_systemexit=True)
+                                      extra_args=extra_args, raise_error=True, testing=False, raise_systemexit=True)
 
                 stderr = self.get_stderr().strip()
                 self.mock_stderr(False)


### PR DESCRIPTION
The 1s timeout might not be enough for the build to create the log (e.g. when ran in a debugger)
Increase the timeout and also pass required arguments to actually create the lock.