### PR TITLE
improve error messages for empty EasyConfigs

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -455,6 +455,8 @@ class EasyConfig(object):
             self.path = path
             self.rawtxt = read_file(path)
             self.log.debug("Raw contents from supplied easyconfig file %s: %s", path, self.rawtxt)
+            if not self.rawtxt.strip():
+                raise EasyBuildError('Easyconfig file is empty')
         else:
             self.rawtxt = rawtxt
             self.log.debug("Supplied raw easyconfig contents: %s" % self.rawtxt)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1909,7 +1909,9 @@ def get_easyblock_class(easyblock, name=None, error_on_failed_import=True, error
         else:
             # if no easyblock specified, try to find if one exists
             if name is None:
-                name = "UNKNOWN"
+                if error_on_missing_easyblock:
+                    raise EasyBuildError("No easyblock found as neither name nor easyblock were specified")
+                return None
             # The following is a generic way to calculate unique class names for any funny software title
             class_name = encode_class_name(name)
             # modulepath will be the namespace + encoded modulename (from the classname)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1634,6 +1634,10 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertErrorRegex(EasyBuildError, "Failed to import EB_TOY", get_easyblock_class, None, name='TOY')
         self.assertEqual(get_easyblock_class(None, name='TOY', error_on_failed_import=False), None)
 
+        # Test passing neither easyblock nor name
+        self.assertErrorRegex(EasyBuildError, "neither name nor easyblock were specified", get_easyblock_class, None)
+        self.assertEqual(get_easyblock_class(None, error_on_missing_easyblock=False), None)
+
         # also test deprecated default_fallback named argument
         self.assertErrorRegex(EasyBuildError, "DEPRECATED", get_easyblock_class, None, name='gzip',
                               default_fallback=False)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -138,10 +138,13 @@ class EasyConfigTest(EnhancedTestCase):
 
     def test_empty(self):
         """ empty files should not parse! """
+        self.assertErrorRegex(EasyBuildError, "expected a valid path", EasyConfig, "")
         self.contents = "# empty string"
         self.prep()
         self.assertRaises(EasyBuildError, EasyConfig, self.eb_file)
-        self.assertErrorRegex(EasyBuildError, "expected a valid path", EasyConfig, "")
+        self.contents = ""
+        self.prep()
+        self.assertErrorRegex(EasyBuildError, "is empty", EasyConfig, self.eb_file)
 
     def test_mandatory(self):
         """ make sure all checking of mandatory parameters works """


### PR DESCRIPTION
Currently we get:

> ERROR: Failed to process easyconfig foo.eb: No software-specific easyblock 'EB_UNKNOWN' found for UNKNOWN

That isn't exactly clear. So improve in 2 steps:

1. Remove the UNKNOWN constant and just handle in the way we would if the class isn't found: Return `None` or error if `error_on_missing_easyblock` is set
2. Check for a fully empty file and error with a clear message

Possible improvement: Pass `error_on_missing_easyblock` in the EasyConfig constructor and use an empty dict as `extra_options` if no `easyblock_class` was found, i.e. `self.extra_options = easyblock_class.extra_options() if easyblock_class else {}`
This will error later in the parser which doesn't find the required keys like "name".   
Not sure if that error ("missing required keys: name, ...") is cleaner than "No easyblock found as neither name nor easyblock were specified" though.