### PR TITLE
handle post-install patches in `check_checksums_for`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2482,7 +2482,7 @@ class EasyBlock(object):
         checksum_issues = []
 
         sources = ent.get('sources', [])
-        patches = ent.get('patches', [])
+        patches = ent.get('patches', []) + ent.get('postinstallpatches', [])
         checksums = ent.get('checksums', [])
         # Single source should be re-wrapped as a list, and checksums with it
         if isinstance(sources, dict):


### PR DESCRIPTION
Checksums for post-install patches come after the patch checksums, see `fetch_patches`. As those were not included in the check specifying a checksum for those patches leads to errors such as
> found 0 sources + 0 patches vs 1 checksums