### PR TITLE
limit `maxparallel` to 16 by default

### DIFF
--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -108,7 +108,7 @@ DEFAULT_CONFIG = {
                        BUILD],
     'hidden': [False, "Install module file as 'hidden' by prefixing its version with '.'", BUILD],
     'installopts': ['', 'Extra options for installation', BUILD],
-    'maxparallel': [None, 'Max degree of parallelism', BUILD],
+    'maxparallel': [16, 'Max degree of parallelism', BUILD],
     'module_only': [False, 'Only generate module file', BUILD],
     'parallel': [None, ('Degree of parallelism for e.g. make (default: based on the number of '
                         'cores, active cpuset and restrictions in ulimit)'), BUILD],

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2188,7 +2188,7 @@ class EasyBlockTest(EnhancedTestCase):
 
         handle, toy_ec2 = tempfile.mkstemp(prefix='easyblock_test_file_', suffix='.eb')
         os.close(handle)
-        write_file(toy_ec2, toytxt + "\nparallel = 14\nmaxparallel = 7")
+        write_file(toy_ec2, toytxt + "\nparallel = 123\nmaxparallel = 67")
 
         handle, toy_ec3 = tempfile.mkstemp(prefix='easyblock_test_file_', suffix='.eb')
         os.close(handle)
@@ -2207,7 +2207,7 @@ class EasyBlockTest(EnhancedTestCase):
         # both 'parallel' and 'maxparallel' easyconfig parameters specified (no 'parallel' build option)
         test_eb = EasyBlock(EasyConfig(toy_ec2))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], 7)
+        self.assertEqual(test_eb.cfg['parallel'], 67)
 
         # make sure 'parallel = False' is not overriden (no 'parallel' build option)
         test_eb = EasyBlock(EasyConfig(toy_ec3))
@@ -2228,7 +2228,7 @@ class EasyBlockTest(EnhancedTestCase):
         # both 'parallel' and 'maxparallel' easyconfig parameters specified + 'parallel' build option
         test_eb = EasyBlock(EasyConfig(toy_ec2))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], 7)
+        self.assertEqual(test_eb.cfg['parallel'], 9)
 
         # make sure 'parallel = False' is not overriden (with 'parallel' build option)
         test_eb = EasyBlock(EasyConfig(toy_ec3))

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2184,7 +2184,7 @@ class EasyBlockTest(EnhancedTestCase):
 
         handle, toy_ec1 = tempfile.mkstemp(prefix='easyblock_test_file_', suffix='.eb')
         os.close(handle)
-        write_file(toy_ec1, toytxt + "\nparallel = 123")
+        write_file(toy_ec1, toytxt + "\nparallel = 13")
 
         handle, toy_ec2 = tempfile.mkstemp(prefix='easyblock_test_file_', suffix='.eb')
         os.close(handle)
@@ -2202,7 +2202,7 @@ class EasyBlockTest(EnhancedTestCase):
         # only 'parallel' easyconfig parameter specified (no 'parallel' build option)
         test_eb = EasyBlock(EasyConfig(toy_ec1))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], 123)
+        self.assertEqual(test_eb.cfg['parallel'], 13)
 
         # both 'parallel' and 'maxparallel' easyconfig parameters specified (no 'parallel' build option)
         test_eb = EasyBlock(EasyConfig(toy_ec2))

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2188,7 +2188,7 @@ class EasyBlockTest(EnhancedTestCase):
 
         handle, toy_ec2 = tempfile.mkstemp(prefix='easyblock_test_file_', suffix='.eb')
         os.close(handle)
-        write_file(toy_ec2, toytxt + "\nparallel = 123\nmaxparallel = 67")
+        write_file(toy_ec2, toytxt + "\nparallel = 14\nmaxparallel = 7")
 
         handle, toy_ec3 = tempfile.mkstemp(prefix='easyblock_test_file_', suffix='.eb')
         os.close(handle)
@@ -2207,7 +2207,7 @@ class EasyBlockTest(EnhancedTestCase):
         # both 'parallel' and 'maxparallel' easyconfig parameters specified (no 'parallel' build option)
         test_eb = EasyBlock(EasyConfig(toy_ec2))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], 67)
+        self.assertEqual(test_eb.cfg['parallel'], 7)
 
         # make sure 'parallel = False' is not overriden (no 'parallel' build option)
         test_eb = EasyBlock(EasyConfig(toy_ec3))
@@ -2215,20 +2215,20 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(test_eb.cfg['parallel'], False)
 
         # only 'parallel' build option specified
-        init_config(build_options={'parallel': '97', 'validate': False})
+        init_config(build_options={'parallel': '9', 'validate': False})
         test_eb = EasyBlock(EasyConfig(toy_ec))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], 97)
+        self.assertEqual(test_eb.cfg['parallel'], 9)
 
         # both 'parallel' build option and easyconfig parameter specified (no 'maxparallel')
         test_eb = EasyBlock(EasyConfig(toy_ec1))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], 97)
+        self.assertEqual(test_eb.cfg['parallel'], 9)
 
         # both 'parallel' and 'maxparallel' easyconfig parameters specified + 'parallel' build option
         test_eb = EasyBlock(EasyConfig(toy_ec2))
         test_eb.check_readiness_step()
-        self.assertEqual(test_eb.cfg['parallel'], 67)
+        self.assertEqual(test_eb.cfg['parallel'], 7)
 
         # make sure 'parallel = False' is not overriden (with 'parallel' build option)
         test_eb = EasyBlock(EasyConfig(toy_ec3))

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3476,7 +3476,7 @@ class EasyConfigTest(EnhancedTestCase):
         except AttributeError:
             pass  # Ignore if not present
         orig_get_avail_core_count = st.get_avail_core_count
-        st.get_avail_core_count = lambda: 42
+        st.get_avail_core_count = lambda: 12
 
         # also check template values after running check_readiness_step (which runs set_parallel)
         eb = EasyBlock(ec)
@@ -3487,7 +3487,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         res = template_constant_dict(ec)
         res.pop('arch')
-        expected['parallel'] = 42
+        expected['parallel'] = 12
         self.assertEqual(res, expected)
 
         toy_ec = os.path.join(test_ecs_dir, 't', 'toy', 'toy-0.0-deps.eb')


### PR DESCRIPTION
We often see it where the large numbers of cores available on modern systems causes either the build to progress slowly or to fail. I propose we add this default to `maxparallel` to counter that.