### PR TITLE
Add module cache build support on EnvironmentModules

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1419,6 +1419,16 @@ class EnvironmentModules(EnvironmentModulesTcl):
 
         return value
 
+    def update(self):
+        """Update after new modules were added."""
+
+        version = LooseVersion(self.version)
+        if build_option('update_modules_tool_cache') and version >= LooseVersion('5.3.0'):
+            out = self.run_module('cachebuild', return_stderr=True, check_output=False)
+
+            if self.testing:
+                return out
+
 
 class Lmod(ModulesTool):
     """Interface to Lmod."""

--- a/test/framework/modulestool.py
+++ b/test/framework/modulestool.py
@@ -209,6 +209,29 @@ class ModulesToolTest(EnhancedTestCase):
             mt = EnvironmentModules(testing=True)
             self.assertIsInstance(mt.loaded_modules(), list)  # dummy usage
 
+            # test updating module cache
+            test_modulepath = os.path.join(self.test_installpath, 'modules', 'all')
+            os.environ['MODULEPATH'] = test_modulepath
+            test_module_dir = os.path.join(test_modulepath, 'test')
+            test_module_file = os.path.join(test_module_dir, '1.2.3')
+            write_file(test_module_file, '#%Module')
+            build_options = {
+                'update_modules_tool_cache': True,
+            }
+            init_config(build_options=build_options)
+            mt = EnvironmentModules(testing=True)
+            out = mt.update()
+            os.remove(test_module_file)
+            os.rmdir(test_module_dir)
+
+            # test cache file has been created if module tool supports it
+            if LooseVersion(mt.version) >= LooseVersion('5.3.0'):
+                cache_fp = os.path.join(test_modulepath, '.modulecache')
+                expected = "Creating %s\n" % cache_fp
+                self.assertEqual(expected, out, "Module cache created")
+                self.assertTrue(os.path.exists(cache_fp))
+                os.remove(cache_fp)
+
             # initialize Environment Modules tool with non-official version number
             # pass (fake) full path to 'modulecmd.tcl' via $MODULES_CMD
             fake_path = os.path.join(self.test_installpath, 'libexec', 'modulecmd.tcl')


### PR DESCRIPTION
Environment Modules 5.3.0 introduced module cache mechanism. A cache file is generated with cachebuild command and stored under modulepath directory in a .modulecache file.

Add cache build support in "update" function of EnvironmentModules class.