### PR TITLE
restore `%(software_commit)s` in `TEMPLATE_NAMES_DYNAMIC`

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -89,9 +89,6 @@ TEMPLATE_SOFTWARE_VERSIONS = {
 # template values which are only generated dynamically
 TEMPLATE_NAMES_DYNAMIC = {
     'arch': 'System architecture (e.g. x86_64, aarch64, ppc64le, ...)',
-    'sysroot': "Location root directory of system, prefix for standard paths like /usr/lib and /usr/include"
-               "as specify by the --sysroot configuration option",
-    'mpi_cmd_prefix': 'Prefix command for running MPI programs (with default number of ranks)',
     'cuda_compute_capabilities': "Comma-separated list of CUDA compute capabilities, as specified via "
                                  "--cuda-compute-capabilities configuration option or "
                                  "via cuda_compute_capabilities easyconfig parameter",
@@ -105,6 +102,11 @@ TEMPLATE_NAMES_DYNAMIC = {
     'cuda_int_semicolon_sep': 'Semicolon-separated list of integer CUDA compute capabilities',
     'cuda_sm_comma_sep': 'Comma-separated list of sm_* values that correspond with CUDA compute capabilities',
     'cuda_sm_space_sep': 'Space-separated list of sm_* values that correspond with CUDA compute capabilities',
+    'mpi_cmd_prefix': 'Prefix command for running MPI programs (with default number of ranks)',
+    'software_commit': "Git commit id to use for the software as specified by --software-commit command line option",
+    'sysroot': "Location root directory of system, prefix for standard paths like /usr/lib and /usr/include"
+               "as specify by the --sysroot configuration option",
+
 }
 
 # constant templates that can be used in easyconfigs

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -604,6 +604,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
                     r'^``%\(arch\)s``\s+System architecture \(e.g. x86_64, aarch64, ppc64le, ...\)\s*$',
                     r'^``%\(cuda_cc_space_sep\)s``\s+Space-separated list of CUDA compute capabilities\s*$',
                     r'^``SOURCE_TAR_GZ``\s+Source \.tar\.gz bundle\s+``%\(name\)s-%\(version\)s.tar.gz``\s*$',
+                    r'^``%\(software_commit\)s``\s+Git commit id to use for the software as specified '
+                    'by --software-commit command line option',
                 ]
             else:
                 pattern_lines = [
@@ -616,6 +618,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
                     r'^\s+%\(arch\)s: System architecture \(e.g. x86_64, aarch64, ppc64le, ...\)$',
                     r'^\s+%\(cuda_cc_space_sep\)s: Space-separated list of CUDA compute capabilities$',
                     r'^\s+SOURCE_TAR_GZ: Source \.tar\.gz bundle \(%\(name\)s-%\(version\)s.tar.gz\)$',
+                    r'^\s+%\(software_commit\)s: Git commit id to use for the software as specified '
+                    'by --software-commit command line option',
                 ]
 
             for pattern_line in pattern_lines:


### PR DESCRIPTION
Only impact of this is that `%(software_commit)s` is not included in output of "`eb --avail-easyconfig-templates`", using the template itself actually still works as verified by `test_software_commit_template` (becuase the corresponding values is set in `template_constant_dict` regardless of whether or not it's listed in `TEMPLATE_NAMES_DYNAMIC`)