### PR TITLE
allow for case where `homepage = None` when generating the docs

### DIFF
--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -789,7 +789,7 @@ def list_software(output_format=FORMAT_TXT, detailed=False, only_installed=False
         if isinstance(ec, dict):
             template_values = template_constant_dict(ec)
             for key in keys:
-                if '%(' in info[key]:
+                if info[key] and '%(' in info[key]:
                     try:
                         info[key] = info[key] % template_values
                     except (KeyError, TypeError, ValueError) as err:


### PR DESCRIPTION
If [an easyconfig has](https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/s/Single-cell-python-bundle/Single-cell-python-bundle-2024.02-foss-2023a.eb) `homepage = (None)` then we fail with

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/simon/work/easybuild-framework/easybuild/main.py", line 799, in <module>
    main_with_hooks()
  File "/home/simon/work/easybuild-framework/easybuild/main.py", line 785, in main_with_hooks
    main(args=args, prepared_cfg_data=(init_session_state, eb_go, cfg_settings))
  File "/home/simon/work/easybuild-framework/easybuild/main.py", line 686, in main
    print(list_software(output_format=options.output_format, detailed=options.list_software == 'detailed'))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/simon/work/easybuild-framework/easybuild/tools/docs.py", line 809, in list_software
    if '%(' in info[key]:
       ^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```