### PR TITLE
Drop support for pep8 package

### DIFF
--- a/easybuild/framework/easyconfig/style.py
+++ b/easybuild/framework/easyconfig/style.py
@@ -31,7 +31,6 @@ Authors:
 * Ward Poelmans (Ghent University)
 """
 import re
-import sys
 from importlib import reload
 
 from easybuild.base import fancylogger
@@ -43,12 +42,7 @@ try:
     import pycodestyle
     from pycodestyle import StyleGuide, register_check, trailing_whitespace
 except ImportError:
-    try:
-        # fallback to importing from 'pep8', which was renamed to pycodestyle in 2016
-        import pep8
-        from pep8 import StyleGuide, register_check, trailing_whitespace
-    except ImportError:
-        pass
+    pass
 
 _log = fancylogger.getLogger('easyconfig.style', fname=False)
 
@@ -106,7 +100,7 @@ def _eb_check_trailing_whitespace(physical_line, lines, line_number, checker_sta
     return result
 
 
-@only_if_module_is_available(('pycodestyle', 'pep8'))
+@only_if_module_is_available('pycodestyle')
 def check_easyconfigs_style(easyconfigs, verbose=False):
     """
     Check the given list of easyconfigs for style
@@ -114,12 +108,7 @@ def check_easyconfigs_style(easyconfigs, verbose=False):
     :param verbose: print our statistics and be verbose about the errors and warning
     :return: the number of warnings and errors
     """
-    # importing autopep8 changes some pep8 functions.
-    # We reload it to be sure to get the real pep8 functions.
-    if 'pycodestyle' in sys.modules:
-        reload(pycodestyle)
-    else:
-        reload(pep8)
+    reload(pycodestyle)
 
     # register the extra checks before using pep8:
     # any function in this module starting with `_eb_check_` will be used.

--- a/easybuild/framework/easyconfig/style.py
+++ b/easybuild/framework/easyconfig/style.py
@@ -126,6 +126,7 @@ def check_easyconfigs_style(easyconfigs, verbose=False):
     # note that W291 has been replaced by our custom W299
     options.ignore = (
         'W291',  # replaced by W299
+        'E741',  # 'l' is considered an ambiguous name, but we use it often for 'lib'
     )
     options.verbose = int(verbose)
 

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -202,7 +202,6 @@ EASYBUILD_OPTIONAL_DEPENDENCIES = {
     'graphviz-python': ('gv', "rendering dependency graph with Graphviz: --dep-graph"),
     'keyring': (None, "storing GitHub token"),
     'pbs-python': ('pbs', "using Torque as --job backend"),
-    'pep8': (None, "fallback for code style checking: --check-style, --check-contrib"),
     'pycodestyle': (None, "code style checking: --check-style, --check-contrib"),
     'pysvn': (None, "using SVN repository as easyconfigs archive"),
     'python-graph-core': ('pygraph.classes.digraph', "creating dependency graph: --dep-graph"),

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -85,11 +85,7 @@ from test.framework.utilities import find_full_path
 try:
     import pycodestyle  # noqa
 except ImportError:
-    try:
-        import pep8  # noqa
-    except ImportError:
-        pass
-
+    pass
 
 EXPECTED_DOTTXT_TOY_DEPS = """digraph graphname {
 toy;
@@ -2660,8 +2656,8 @@ class EasyConfigTest(EnhancedTestCase):
     def test_dump_extra(self):
         """Test EasyConfig's dump() method for files containing extra values"""
 
-        if not ('pycodestyle' in sys.modules or 'pep8' in sys.modules):
-            print("Skipping test_dump_extra (no pycodestyle or pep8 available)")
+        if 'pycodestyle' not in sys.modules:
+            print("Skipping test_dump_extra pycodestyle is not available")
             return
 
         rawtxt = '\n'.join([
@@ -2703,8 +2699,8 @@ class EasyConfigTest(EnhancedTestCase):
     def test_dump_template(self):
         """ Test EasyConfig's dump() method for files containing templates"""
 
-        if not ('pycodestyle' in sys.modules or 'pep8' in sys.modules):
-            print("Skipping test_dump_template (no pycodestyle or pep8 available)")
+        if 'pycodestyle' not in sys.modules:
+            print("Skipping test_dump_template pycodestyle is not available")
             return
 
         rawtxt = '\n'.join([
@@ -2792,8 +2788,8 @@ class EasyConfigTest(EnhancedTestCase):
     def test_dump_comments(self):
         """ Test dump() method for files containing comments """
 
-        if not ('pycodestyle' in sys.modules or 'pep8' in sys.modules):
-            print("Skipping test_dump_comments (no pycodestyle or pep8 available)")
+        if 'pycodestyle' not in sys.modules:
+            print("Skipping test_dump_comments pycodestyle is not available")
             return
 
         rawtxt = '\n'.join([

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -72,10 +72,7 @@ from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, clean
 try:
     import pycodestyle  # noqa
 except ImportError:
-    try:
-        import pep8  # noqa
-    except ImportError:
-        pass
+    pass
 
 
 EXTERNAL_MODULES_METADATA = """[foobar/1.2.3]
@@ -5893,14 +5890,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     def test_check_contrib_style(self):
         """Test style checks performed by --check-contrib + dedicated --check-style option."""
-        try:
-            import pycodestyle  # noqa
-        except ImportError:
-            try:
-                import pep8  # noqa
-            except ImportError:
-                print("Skipping test_check_contrib_style, since pycodestyle or pep8 is not available")
-                return
+        if 'pycodestyle' not in sys.modules:
+            print("Skipping test_check_contrib_style pycodestyle is not available")
+            return
 
         regex = re.compile(r"Running style check on 2 easyconfig\(s\)(.|\n)*>> All style checks PASSed!", re.M)
         args = [
@@ -5953,8 +5945,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
     def test_check_contrib_non_style(self):
         """Test non-style checks performed by --check-contrib."""
 
-        if not ('pycodestyle' in sys.modules or 'pep8' in sys.modules):
-            print("Skipping test_check_contrib_non_style (no pycodestyle or pep8 available)")
+        if 'pycodestyle' not in sys.modules:
+            print("Skipping test_check_contrib_non_style pycodestyle is not available")
             return
 
         args = [

--- a/test/framework/style.py
+++ b/test/framework/style.py
@@ -40,10 +40,7 @@ from easybuild.framework.easyconfig.style import _eb_check_trailing_whitespace, 
 try:
     import pycodestyle  # noqa
 except ImportError:
-    try:
-        import pep8  # noqa
-    except ImportError:
-        pass
+    pass
 
 
 class StyleTest(EnhancedTestCase):
@@ -51,8 +48,8 @@ class StyleTest(EnhancedTestCase):
 
     def test_style_conformance(self):
         """Check the easyconfigs for style"""
-        if not ('pycodestyle' in sys.modules or 'pep8' in sys.modules):
-            print("Skipping style checks (no pycodestyle or pep8 available)")
+        if 'pycodestyle' not in sys.modules:
+            print("Skipping test_style_conformance pycodestyle is not available")
             return
 
         # all available easyconfig files
@@ -66,8 +63,8 @@ class StyleTest(EnhancedTestCase):
 
     def test_check_trailing_whitespace(self):
         """Test for trailing whitespace check."""
-        if not ('pycodestyle' in sys.modules or 'pep8' in sys.modules):
-            print("Skipping trailing whitespace checks (no pycodestyle or pep8 available)")
+        if 'pycodestyle' not in sys.modules:
+            print("Skipping test_check_trailing_whitespace is not available")
             return
 
         lines = [


### PR DESCRIPTION
It is outdated for many years now and has been replaced by pycodestyle. Stop using it.