### PR TITLE
implement workaround for permission error when copying read-only files that have extended attributes set and using Python 3.6

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2444,6 +2444,7 @@ def copy_file(path, target_path, force_in_dry_run=False):
                         # double-check whether the copy actually succeeded
                         if not os.path.exists(target_path):
                             raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
+                        _log.info("%s copied to %s ignoring permissions error: %s", path, target_path, err)
                 elif os.path.islink(path):
                     if os.path.isdir(target_path):
                         target_path = os.path.join(target_path, os.path.basename(path))

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2443,11 +2443,11 @@ def copy_file(path, target_path, force_in_dry_run=False):
                         # see https://bugs.python.org/issue24538
                         shutil.copy2(path, target_path)
                         _log.info("%s copied to %s", path, target_path)
+                    # catch the more general OSError instead of PermissionError,
+                    # since Python 2.7 doesn't support PermissionError
                     except OSError as err:
-                        # catch the more general OSError instead of PermissionError, since python2 doesn't support
-                        # PermissionError
-                        if not os.stat(path).st_mode & stat.S_IWUSR:
-                            # failure not due to read-only file
+                        # if file is writable (not read-only), then we give up since it's not a simple permission error
+                        if os.path.exists(target_path) and os.stat(target_path).st_mode & stat.S_IWUSR:
                             raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
 
                         pyver = LooseVersion(platform.python_version())

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2463,9 +2463,9 @@ def copy_file(path, target_path, force_in_dry_run=False):
 
                         try:
                             # re-enable user write permissions in target, copy xattrs, then remove write perms again
-                            adjust_permissions(target_path, stat.I_IWUSR)
+                            adjust_permissions(target_path, stat.S_IWUSR)
                             shutil._copyxattr(path, target_path)
-                            adjust_permissions(target_path, stat.I_IWUSR, add=False)
+                            adjust_permissions(target_path, stat.S_IWUSR, add=False)
                         except OSError as err:
                             raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2455,7 +2455,8 @@ def copy_file(path, target_path, force_in_dry_run=False):
                         # double-check whether the copy actually succeeded
                         if not os.path.exists(target_path) or not filecmp.cmp(path, target_path, shallow=False):
                             raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
-                        msg = "%s copied to %s, ignoring permissions error (likely due to https://bugs.python.org/issue24538): %s"
+                        msg = ("%s copied to %s, ignoring permissions error (likely due to "
+                               "https://bugs.python.org/issue24538): %s")
                         _log.info(msg, path, target_path, err)
                 elif os.path.islink(path):
                     if os.path.isdir(target_path):

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -42,6 +42,7 @@ Authors:
 """
 import datetime
 import difflib
+import filecmp
 import glob
 import hashlib
 import inspect
@@ -2448,7 +2449,7 @@ def copy_file(path, target_path, force_in_dry_run=False):
                             if not isinstance(err, PermissionError):
                                 raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
                         # double-check whether the copy actually succeeded
-                        if not os.path.exists(target_path) or not os.path.samefile(path, target_path):
+                        if not os.path.exists(target_path) or not filecmp.cmp(path, target_path, shallow=False):
                             raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
                         _log.info("%s copied to %s, ignoring permissions error: %s", path, target_path, err)
                 elif os.path.islink(path):

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -47,6 +47,7 @@ import hashlib
 import inspect
 import itertools
 import os
+import platform
 import re
 import shutil
 import signal


### PR DESCRIPTION
Ran into this issue like this, when configuring EasyBuild with read-only-installdir:
```
== 2024-09-16 13:26:56,117 build_log.py:171 ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:126 in __init__): Failed to copy file /mnt/scratch/users/jfg508/eb/software/EasyBuild/4.9.2/lib/python3.6/site-packages/easybuild/easyblocks/e/easybuildmeta.py to /tmp/eb-l7y97vxy/reprod_20240916132656_823857/easyblocks/easybuildmeta.py: [Errno 13] Permission denied: '/tmp/eb-l7y97vxy/reprod_20240916132656_823857/easyblocks/easybuildmeta.py' (at easybuild/tools/filetools.py:2437 in copy_file)
```

Having taken a closer look, it seems that on our system `shutil.copy2()` spits out a `PermissionError` when the file to be copied is read-only. However, the copy still succeeds (and has the correct contents). 