### PR TITLE
Ignore "ambiguous variable name" warning for EasyConfig style check

### DIFF
--- a/easybuild/framework/easyconfig/style.py
+++ b/easybuild/framework/easyconfig/style.py
@@ -137,6 +137,7 @@ def check_easyconfigs_style(easyconfigs, verbose=False):
     # note that W291 has been replaced by our custom W299
     options.ignore = (
         'W291',  # replaced by W299
+        'E741',  # 'l' is considered an ambiguous name, but we use it often for 'lib'
     )
     options.verbose = int(verbose)
 


### PR DESCRIPTION
'l' is considered an ambiguous name, but we use it often for 'lib'

Required for https://github.com/easybuilders/easybuild-easyconfigs/pull/21405