### PR TITLE
take into account alternate sysroot for `/bin/bash` used by `run_cmd`

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1969,7 +1969,7 @@ def set_tmpdir(tmpdir=None, raise_error=False):
             os.close(fd)
             os.chmod(tmptest_file, 0o700)
             if not run_cmd(tmptest_file, simple=True, log_ok=False, regexp=False, force_in_dry_run=True, trace=False,
-                           stream_output=False, with_hooks=False):
+                           stream_output=False, with_hooks=False, with_sysroot=False):
                 msg = "The temporary directory (%s) does not allow to execute files. " % tempfile.gettempdir()
                 msg += "This can cause problems in the build process, consider using --tmpdir."
                 if raise_error:

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -227,14 +227,17 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
     if cmd_log:
         cmd_log.write("# output for command: %s\n\n" % cmd_msg)
 
+    exec_cmd = "/bin/bash"
+
+    # if EasyBuild is configured to use an alternate sysroot,
+    # we should also run shell commands using the bash shell provided in there,
+    # since /bin/bash may not be compatible with the alternate sysroot
     if with_sysroot:
         sysroot = build_option('sysroot')
         if sysroot:
-            exec_cmd = "%s/bin/bash" % sysroot
-        else:
-            exec_cmd = "/bin/bash"
-    else:
-        exec_cmd = "/bin/bash"
+            sysroot_bin_bash = os.path.join(sysroot, 'bin', 'bash')
+            if os.path.exists(sysroot_bin_bash):
+                exec_cmd = sysroot_bin_bash
 
     if not shell:
         if isinstance(cmd, list):
@@ -244,6 +247,8 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
             cmd = '/usr/bin/env %s' % cmd
         else:
             raise EasyBuildError("Don't know how to prefix with /usr/bin/env for commands of type %s", type(cmd))
+
+    _log.info("Using %s as shell for running cmd: %s", exec_cmd, cmd)
 
     if with_hooks:
         hooks = load_hooks(build_option('hooks'))

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -134,7 +134,7 @@ def get_output_from_process(proc, read_size=None, asynchronous=False):
 @run_cmd_cache
 def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True, log_output=False, path=None,
             force_in_dry_run=False, verbose=True, shell=None, trace=True, stream_output=None, asynchronous=False,
-            with_hooks=True):
+            with_hooks=True, with_sysroot=True):
     """
     Run specified command (in a subshell)
     :param cmd: command to run
@@ -152,6 +152,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
     :param stream_output: enable streaming command output to stdout
     :param asynchronous: run command asynchronously (returns subprocess.Popen instance if set to True)
     :param with_hooks: trigger pre/post run_shell_cmd hooks (if defined)
+    :param with_sysroot: prepend sysroot to exec_cmd (if defined)
     """
     cwd = os.getcwd()
 
@@ -226,11 +227,14 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
     if cmd_log:
         cmd_log.write("# output for command: %s\n\n" % cmd_msg)
 
-    sysroot = build_option('sysroot')
-    if sysroot:
-        exec_cmd = "%s/bin/bash" % sysroot
+    if with_sysroot:
+        sysroot = build_option('sysroot')
+        if sysroot:
+            exec_cmd = "%s/bin/bash" % sysroot
+        else:
+            exec_cmd = "/bin/bash"
     else:
-        exec_cmd = "/bin/bash"
+         exec_cmd = "/bin/bash"
 
     if not shell:
         if isinstance(cmd, list):

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -234,7 +234,7 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
         else:
             exec_cmd = "/bin/bash"
     else:
-         exec_cmd = "/bin/bash"
+        exec_cmd = "/bin/bash"
 
     if not shell:
         if isinstance(cmd, list):

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -226,7 +226,11 @@ def run_cmd(cmd, log_ok=True, log_all=False, simple=False, inp=None, regexp=True
     if cmd_log:
         cmd_log.write("# output for command: %s\n\n" % cmd_msg)
 
-    exec_cmd = "/bin/bash"
+    sysroot = build_option('sysroot')
+    if sysroot:
+        exec_cmd = "%s/bin/bash" % sysroot
+    else:
+        exec_cmd = "/bin/bash"
 
     if not shell:
         if isinstance(cmd, list):


### PR DESCRIPTION
EasyBuild's `run_cmd` runs commands in a subshell. The shell used is defined in the `exec_cmd`. However, in context where the use of a `sysroot` is configured, one would want to use `<sysroot>/bin/bash` instead. This PR implements that change. Note that since `run_cmd` is _also_ called a few times _before_ `set_up_configuration` is called, we need to be able to disable the check for the `build_option('sysroot')` for those instances (similar to how this is already don for `build_option('hooks')`).

Solves [this issue](https://github.com/EESSI/software-layer/pull/585#issuecomment-2313143191).

Edit: hmmm, I made this PR, and then realized, this is probably one of the components that is very different in EB 5.0. And it seems to be indeed... 

Someone with more EB 5.0 knowledge needs to give me a pointer of how to fix this for EB 5.0 :)