### PR TITLE
allow extensions to add text to the module file

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1663,21 +1663,30 @@ class EasyBlock:
         Sets optional variables for extensions.
         """
         # add stuff specific to individual extensions
-        lines = [self.module_extra_extensions]
+        txt = self.module_extra_extensions
+
+        if not self.ext_instances:
+            self.prepare_for_extensions()
+            self.init_ext_instances()
+
+        for ext in self.ext_instances:
+            ext_txt = ext.make_extension_module_extra()
+            if ext_txt:
+                txt += ext_txt
 
         # set environment variable that specifies list of extensions
         # We need only name and version, so don't resolve templates
         exts_list = self.make_extension_string(ext_sep=',', sort=False)
         env_var_name = 'EBEXTSLIST' + convert_name(self.name, upper=True)
-        lines.append(self.module_generator.set_environment(env_var_name, exts_list))
+        txt += self.module_generator.set_environment(env_var_name, exts_list)
 
-        return ''.join(lines)
+        return txt
 
     def make_module_footer(self):
         """
         Insert a footer section in the module file, primarily meant for contextual information
         """
-        footer = [self.module_generator.comment("Built with EasyBuild version %s" % VERBOSE_VERSION).rstrip('\n')]
+        footer = []
 
         # add extra stuff for extensions (if any)
         if self.cfg.get_ref('exts_list'):
@@ -1704,6 +1713,7 @@ class EasyBlock:
                 self.log.warning("Not including footer in Lua syntax in non-Lua module file: %s",
                                  self.cfg['modluafooter'])
 
+        footer.append(self.module_generator.comment("Built with EasyBuild version %s" % VERBOSE_VERSION))
         return '\n'.join(footer)
 
     def make_module_extend_modpath(self):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1677,21 +1677,21 @@ class EasyBlock:
         """
         Insert a footer section in the module file, primarily meant for contextual information
         """
-        footer = [self.module_generator.comment("Built with EasyBuild version %s" % VERBOSE_VERSION)]
+        footer = [self.module_generator.comment("Built with EasyBuild version %s" % VERBOSE_VERSION).rstrip('\n')]
 
         # add extra stuff for extensions (if any)
         if self.cfg.get_ref('exts_list'):
             footer.append(self.make_module_extra_extensions())
 
         # include modules footer if one is specified
-        if self.modules_footer is not None:
+        if self.modules_footer:
             self.log.debug("Including specified footer into module: '%s'" % self.modules_footer)
             footer.append(self.modules_footer)
 
         if self.cfg['modtclfooter']:
             if isinstance(self.module_generator, ModuleGeneratorTcl):
                 self.log.debug("Including Tcl footer in module: %s", self.cfg['modtclfooter'])
-                footer.extend([self.cfg['modtclfooter'], '\n'])
+                footer.append(self.cfg['modtclfooter'])
             else:
                 self.log.warning("Not including footer in Tcl syntax in non-Tcl module file: %s",
                                  self.cfg['modtclfooter'])
@@ -1699,12 +1699,12 @@ class EasyBlock:
         if self.cfg['modluafooter']:
             if isinstance(self.module_generator, ModuleGeneratorLua):
                 self.log.debug("Including Lua footer in module: %s", self.cfg['modluafooter'])
-                footer.extend([self.cfg['modluafooter'], '\n'])
+                footer.append(self.cfg['modluafooter'])
             else:
                 self.log.warning("Not including footer in Lua syntax in non-Lua module file: %s",
                                  self.cfg['modluafooter'])
 
-        return ''.join(footer)
+        return '\n'.join(footer)
 
     def make_module_extend_modpath(self):
         """

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -323,6 +323,10 @@ class Extension:
         """
         return self.master.toolchain
 
+    def make_extension_module_extra(self):
+        """Similar to make_module_extra but only called for extensions"""
+        return ''
+
     def sanity_check_step(self):
         """
         Sanity check to run after installing extension

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -218,6 +218,6 @@ class ExtensionEasyBlock(EasyBlock, Extension):
             self.log.deprecated("Passing the parameter 'extra' to make_module_extra should be "
                                 "replaced by concatenating the result", '6.0')
         txt = super().make_module_extra(*args, **kwargs)
-        if extra is not None:
+        if extra:
             txt += extra
         return txt

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -473,6 +473,7 @@ class EasyConfigTest(EnhancedTestCase):
             homepage = "http://example.com"
             description = "test easyconfig"
             toolchain = SYSTEM
+            exts_defaultclass = "DummyExtension"
             exts_default_options = {
                 "source_tmpl": "gzip-1.4.eb", # dummy source template to avoid download fail
                 "source_urls": ["http://example.com/%(name)s/%(version)s"]

--- a/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
@@ -105,6 +105,15 @@ class Toy_Extension(ExtensionEasyBlock):
 
         EB_toy.install_step(self.master, name=self.name)
 
+    def make_extension_module_extra(self):
+        """Extra stuff for toy extensions"""
+        txt = super(Toy_Extension, self).make_extension_module_extra()
+        value = self.name
+        if self.version:
+            value += '-' + self.version
+        txt += self.module_generator.set_environment('TOY_EXT_VAR', value)
+        return txt
+
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for toy extensions."""
         self.log.info("Loaded modules: %s", self.modules_tool.list())

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1202,6 +1202,8 @@ class ToyBuildTest(EnhancedTestCase):
             # set by ToyExtension easyblock used to install extensions
             '^setenv.*TOY_EXT_BAR.*bar',
             '^setenv.*TOY_EXT_BARBAR.*barbar',
+            '^setenv.*TOY_EXT_VAR.*bar',
+            '^setenv.*TOY_EXT_VAR.*barbar',
         ]
         for pattern in patterns:
             self.assertTrue(re.search(pattern, toy_mod_txt, re.M), "Pattern '%s' found in: %s" % (pattern, toy_mod_txt))
@@ -1650,8 +1652,8 @@ class ToyBuildTest(EnhancedTestCase):
             ] + modloadmsg_lua + [
                 r'end',
                 r'setenv\("TOY", "toy-0.0"\)',
-                r'-- Built with EasyBuild version .*',
                 r'io.stderr:write\("oh hai\!"\)',
+                r'-- Built with EasyBuild version .*',
             ])
         elif get_module_syntax() == 'Tcl':
             mod_txt_regex_pattern = '\n'.join([
@@ -1691,8 +1693,8 @@ class ToyBuildTest(EnhancedTestCase):
             ] + modloadmsg_tcl + [
                 r'}',
                 r'setenv	TOY		"toy-0.0"',
-                r'# Built with EasyBuild version .*',
                 r'puts stderr "oh hai\!"',
+                r'# Built with EasyBuild version .*',
             ])
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
@@ -1929,6 +1931,8 @@ class ToyBuildTest(EnhancedTestCase):
         with self.mocked_stdout_stderr():
             self.eb_main([test_ec, '--module-only'], do_build=True, raise_error=True)
         self.assertExists(toy_mod)
+        # Extra stuff from extension(s) is included
+        self.assertRegex(read_file(toy_mod), 'TOY_EXT_VAR.*barbar-0.0')
         remove_file(toy_mod)
 
         # rename file required for barbar extension, so we can check whether sanity check catches it
@@ -1959,10 +1963,6 @@ class ToyBuildTest(EnhancedTestCase):
         """
         Common code for test_toy_exts_sequential and test_toy_exts_parallel tests
         """
-        toy_mod = os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0')
-        if get_module_syntax() == 'Lua':
-            toy_mod += '.lua'
-
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         test_ec_txt = TOY_EC_TXT
         test_ec_txt += '\n' + '\n'.join([
@@ -1995,6 +1995,18 @@ class ToyBuildTest(EnhancedTestCase):
         stdout, stderr = self.run_test_toy_build_with_output(ec_file=test_ec, versionsuffix='-GCC-12.3.0',
                                                              extra_args=extra_args, raise_error=True)
         self.assertEqual(stderr, '')
+
+        toy_mod = os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0-GCC-12.3.0')
+        if get_module_syntax() == 'Lua':
+            toy_mod += '.lua'
+        module_contents = read_file(toy_mod)
+        # Extra stuff from extension(s) should be included
+        ext_var_patterns = [
+            'TOY_EXT_VAR.*ls',
+            'TOY_EXT_VAR.*bar-0.0',
+            'TOY_EXT_VAR.*barbar-0.0',
+        ]
+        self.assert_multi_regex(ext_var_patterns, module_contents)
 
         logtxt = read_file(self.logfile)
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1651,7 +1651,7 @@ class ToyBuildTest(EnhancedTestCase):
                 r'end',
                 r'setenv\("TOY", "toy-0.0"\)',
                 r'-- Built with EasyBuild version .*',
-                r'io.stderr:write\("oh hai\!"\)$',
+                r'io.stderr:write\("oh hai\!"\)',
             ])
         elif get_module_syntax() == 'Tcl':
             mod_txt_regex_pattern = '\n'.join([
@@ -1692,14 +1692,12 @@ class ToyBuildTest(EnhancedTestCase):
                 r'}',
                 r'setenv	TOY		"toy-0.0"',
                 r'# Built with EasyBuild version .*',
-                r'puts stderr "oh hai\!"$',
+                r'puts stderr "oh hai\!"',
             ])
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
 
-        mod_txt_regex = re.compile(mod_txt_regex_pattern)
-        msg = "Pattern '%s' matches with: %s" % (mod_txt_regex.pattern, toy_mod_txt)
-        self.assertTrue(mod_txt_regex.match(toy_mod_txt), msg)
+        self.assertRegex(toy_mod_txt, mod_txt_regex_pattern)
 
     def test_external_dependencies(self):
         """Test specifying external (build) dependencies."""


### PR DESCRIPTION
Introduce `make_extension_module_extra` which gets called during module
file creation for every extension similar to `make_module_extra`.
This ensures it will also be called for parallel extension or --module-only builds.

Fixes https://github.com/easybuilders/easybuild-framework/issues/4647

I'm open for a better name but `make_module_extra_extensions` already exists so `make_module_extra_extension` might be confusing.

Currently the (now deprecated) feature is only used by the numpy easyblock to add the numpy includes to `$CPATH`. So that easyblock needs to be updated. I'd argue that we shouldn't add the numpy includes as a regular `pip install numpy` doesn't do that either. So if a user updates the numpy in a virtualenv using our current approach might end up using headers from one numpy and libs/python files from another.

However I'm not sure if (and why) other software we have already relies on that. One which did will be fixed by https://github.com/easybuilders/easybuild-easyconfigs/pull/21467