### PR TITLE
resolve symlink when making log dir writable

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4309,7 +4309,9 @@ def build_and_install_one(ecdict, init_env):
         def ensure_writable_log_dir(log_dir):
             """Make sure we can write into the log dir"""
             if build_option('read_only_installdir'):
-                # temporarily re-enable write permissions for copying log/easyconfig to install dir
+                # temporarily re-enable write permissions for copying log/easyconfig to install dir,
+                # ensuring that we resolve symlinks
+                log_dir = os.path.realpath(log_dir, strict=True)
                 if os.path.exists(log_dir):
                     adjust_permissions(log_dir, stat.S_IWUSR, add=True, recursive=True)
                 else:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4311,7 +4311,7 @@ def build_and_install_one(ecdict, init_env):
             if build_option('read_only_installdir'):
                 # temporarily re-enable write permissions for copying log/easyconfig to install dir,
                 # ensuring that we resolve symlinks
-                log_dir = os.path.realpath(log_dir, strict=True)
+                log_dir = os.path.realpath(log_dir)
                 if os.path.exists(log_dir):
                     adjust_permissions(log_dir, stat.S_IWUSR, add=True, recursive=True)
                 else:


### PR DESCRIPTION
When installing EB as a module with EB on Ubuntu 24.04, with read only installdirs, I run into the following crash:

```
ERROR: Traceback (most recent call last):
  File "/usr/lib/python3.12/shutil.py", line 886, in move
    os.rename(src, real_dst)
OSError: [Errno 18] Invalid cross-device link: '/tmp/eb-tjbo67c2/reprod_20240926154625_739643' -> '/opt/york/easybuild/software/EasyBuild/4.9.4/easybuild/reprod'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/userfs/c/csrv944/.local/lib/python3.12/site-packages/easybuild/tools/filetools.py", line 2803, in move_file
    shutil.move(path, target_path)
  File "/usr/lib/python3.12/shutil.py", line 902, in move
    copytree(src, real_dst, copy_function=copy_function,
  File "/usr/lib/python3.12/shutil.py", line 600, in copytree
    return _copytree(entries=entries, src=src, dst=dst, symlinks=symlinks,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/shutil.py", line 498, in _copytree
    os.makedirs(dst, exist_ok=dirs_exist_ok)
  File "<frozen os>", line 225, in makedirs
PermissionError: [Errno 13] Permission denied: '/opt/york/easybuild/software/EasyBuild/4.9.4/easybuild/reprod'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/userfs/c/csrv944/.local/lib/python3.12/site-packages/easybuild/main.py", line 137, in build_and_install_software
    (ec_res['success'], app_log, err) = build_and_install_one(ec, init_env)
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/userfs/c/csrv944/.local/lib/python3.12/site-packages/easybuild/framework/easyblock.py", line 4360, in build_and_install_one
    raise error
  File "/home/userfs/c/csrv944/.local/lib/python3.12/site-packages/easybuild/framework/easyblock.py", line 4354, in build_and_install_one
    move_file(reprod_dir, archive_reprod_dir)
  File "/home/userfs/c/csrv944/.local/lib/python3.12/site-packages/easybuild/tools/filetools.py", line 2806, in move_file
    raise EasyBuildError("Failed to move %s to %s: %s", path, target_path, err)
easybuild.tools.build_log.EasyBuildError: "Failed to move /tmp/eb-tjbo67c2/reprod_20240926154625_739643 to /opt/york/easybuild/software/EasyBuild/4.9.4/easybuild/reprod: [Errno 13] Permission denied: '/opt/york/easybuild/software/EasyBuild/4.9.4/easybuild/reprod'"
```

This is due to `<installdir>/easybuild` actually being a symbolic link to `<installdir>/local/easybuild` thanks to the posix_local debian workaround symlinking (see https://github.com/easybuilders/easybuild-easyblocks/pull/2977). Thus, when the write permissions are changed they end up trying to change the permissions of the symlink itself, not the target of the link. 