### PR TITLE
Add flushing and possible closing of `stdin` on `run_shell_cmd`

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -414,6 +414,9 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
 
         if stdin:
             proc.stdin.write(stdin)
+            proc.stdin.flush()
+            if not qa_patterns:
+                proc.stdin.close()
 
         exit_code = None
         stdout, stderr = b'', b''

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -1367,6 +1367,25 @@ class RunTest(EnhancedTestCase):
         for line in expected:
             self.assertIn(line, stdout)
 
+    def test_run_shell_cmd_eof_stdin(self):
+        """Test use of run_shell_cmd with streaming output and blocking stdin read."""
+        cmd = 'timeout 1 cat -'
+
+        inp = 'hello\nworld\n'
+        # test with streaming output
+        with self.mocked_stdout_stderr():
+            res = run_shell_cmd(cmd, stream_output=True, stdin=inp, fail_on_error=False)
+
+        self.assertEqual(res.exit_code, 0, "Streaming output: Command timed out")
+        self.assertEqual(res.output, inp)
+
+        # test with non-streaming output (proc.communicate() is used)
+        with self.mocked_stdout_stderr():
+            res = run_shell_cmd(cmd, stdin=inp, fail_on_error=False)
+
+        self.assertEqual(res.exit_code, 0, "Non-streaming output: Command timed out")
+        self.assertEqual(res.output, inp)
+
     def test_run_cmd_async(self):
         """Test asynchronously running of a shell command via run_cmd + complete_cmd."""
 


### PR DESCRIPTION
When using `streaming_output` and writing directly from the STDIN process pipe, commands that attempt to read from STDIN until EOF, or attempt to read a larger size than what is being passed will block.

An example of a bash command that will result in a blocking behavior

```
cat -
```

when executed via

```
cmd = f'cat -'
run_shell_cmd(cmd, stdin='Hello\nWorld\n')
```

Flushing and closing (in case of a non-interactive run) the STDIN as proposed in the changes would allow the example code to run

A test case has been added to catch such behavior