### PR TITLE
allow using`amend/try-amend` multiple times in an easystack file entry

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -2018,16 +2018,13 @@ def opts_dict_to_eb_opts(args_dict):
                 value = [value]
             for v in value:
                 args.append(option + '=' + str(v))
-            continue
-
-        if isinstance(value, (list, tuple)):
-            value = ','.join(str(x) for x in value)
-
-        if value in [True, None]:
+        elif value in [True, None]:
             args.append(option)
         elif value is False:
             args.append('--disable-' + option[2:])
         elif value is not None:
+            if isinstance(value, (list, tuple)):
+                value = ','.join(str(x) for x in value)
             args.append(option + '=' + str(value))
 
     _log.debug("Converted dictionary %s to argument list %s" % (args_dict, args))

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -2016,8 +2016,7 @@ def opts_dict_to_eb_opts(args_dict):
         if str(arg) in allow_multiple_calls:
             if not isinstance(value, (list, tuple)):
                 value = [value]
-            for v in value:
-                args.append(option + '=' + str(v))
+            args.extend(option + '=' + str(x) for x in value)
         elif value in [True, None]:
             args.append(option)
         elif value is False:

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -2002,6 +2002,7 @@ def opts_dict_to_eb_opts(args_dict):
     :return: a list of strings representing command-line options for the 'eb' command
     """
 
+    allow_multiple_calls = ['amend', 'try-amend']
     _log.debug("Converting dictionary %s to argument list" % args_dict)
     args = []
     for arg in sorted(args_dict):
@@ -2011,6 +2012,14 @@ def opts_dict_to_eb_opts(args_dict):
             prefix = '--'
         option = prefix + str(arg)
         value = args_dict[arg]
+
+        if str(arg) in allow_multiple_calls:
+            if not isinstance(value, (list, tuple)):
+                value = [value]
+            for v in value:
+                args.append(option + '=' + str(v))
+            continue
+
         if isinstance(value, (list, tuple)):
             value = ','.join(str(x) for x in value)
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -7252,6 +7252,15 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         self.assertEqual(opts_dict_to_eb_opts(opts_dict), expected)
 
+        # multi-call options
+        opts_dict = {'try-amend': ['a=1', 'b=2', 'c=3']}
+        expected = ['--try-amend=a=1', '--try-amend=b=2', '--try-amend=c=3']
+        self.assertEqual(opts_dict_to_eb_opts(opts_dict), expected)
+
+        opts_dict = {'amend': ['a=1', 'b=2', 'c=3']}
+        expected = ['--amend=a=1', '--amend=b=2', '--amend=c=3']
+        self.assertEqual(opts_dict_to_eb_opts(opts_dict), expected)
+
 
 def suite():
     """ returns all the testcases in this module """


### PR DESCRIPTION
Related to:

- #4643 

This change checks if the option in the easystack belongs to a list of options that allows to be defined multiple times (could be defined in a more generic location) and instead of setting it's value as a list, will set it multiple times to the cli arguments.

Possible breaking change:

- Any currently existing easystack that makes use of a pattern like
  ```
    options:
      - try-amend:
        - opt=1
        - 2
        - 3
  ```
  in order to set `--try-amend=opt=1,2,3`  would not work anymore
