### PR TITLE
Fix typo in `veryloose` toolchain option for RISC-V

### DIFF
--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -85,7 +85,7 @@ class Gcc(Compiler):
         COMPILER_UNIQUE_OPTION_MAP['strict'] = []
         COMPILER_UNIQUE_OPTION_MAP['precise'] = []
         COMPILER_UNIQUE_OPTION_MAP['loose'] = ['fno-math-errno']
-        COMPILER_UNIQUE_OPTION_MAP['verloose'] = ['fno-math-errno']
+        COMPILER_UNIQUE_OPTION_MAP['veryloose'] = ['fno-math-errno']
 
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {


### PR DESCRIPTION
Just ran into this error:
```
No toolchain option with name verloose defined
```
Apparently, PR #4576 contained a typo. 