### PR TITLE
add support for `%(rpath_enabled)s` template value

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -101,7 +101,7 @@ TEMPLATE_NAMES_DYNAMIC = [
     ('cuda_sm_space_sep', "Space-separated list of sm_* values that correspond with CUDA compute capabilities"),
     ('mpi_cmd_prefix', "Prefix command for running MPI programs (with default number of ranks)"),
     # can't be a boolean (True/False), must be a string value since it's a string template
-    ('rpath', "String value indicating whether or not RPATH linking is used ('true' or 'false')"),
+    ('rpath_enabled', "String value indicating whether or not RPATH linking is used ('true' or 'false')"),
     ('software_commit', "Git commit id to use for the software as specified by --software-commit command line option"),
     ('sysroot', "Location root directory of system, prefix for standard paths like /usr/lib and /usr/include"
      "as specified by the --sysroot configuration option"),
@@ -211,7 +211,7 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
     template_values['arch'] = platform.uname()[4]
 
     # set 'rpath' template based on 'rpath' configuration option, using empty string as fallback
-    template_values['rpath'] = 'true' if build_option('rpath') else 'false'
+    template_values['rpath_enabled'] = 'true' if build_option('rpath') else 'false'
 
     # set 'sysroot' template based on 'sysroot' configuration option, using empty string as fallback
     template_values['sysroot'] = build_option('sysroot') or ''

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -101,7 +101,7 @@ TEMPLATE_NAMES_DYNAMIC = [
     ('cuda_sm_space_sep', "Space-separated list of sm_* values that correspond with CUDA compute capabilities"),
     ('mpi_cmd_prefix', "Prefix command for running MPI programs (with default number of ranks)"),
     # can't be a boolean (True/False), must be a string value since it's a string template
-    ('rpath', "String value indicating whether or not RPATH linking is used ('yes' or 'no')"),
+    ('rpath', "String value indicating whether or not RPATH linking is used ('true' or 'false')"),
     ('software_commit', "Git commit id to use for the software as specified by --software-commit command line option"),
     ('sysroot', "Location root directory of system, prefix for standard paths like /usr/lib and /usr/include"
      "as specified by the --sysroot configuration option"),
@@ -211,7 +211,7 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
     template_values['arch'] = platform.uname()[4]
 
     # set 'rpath' template based on 'rpath' configuration option, using empty string as fallback
-    template_values['rpath'] = 'yes' if build_option('rpath') else 'no'
+    template_values['rpath'] = 'true' if build_option('rpath') else 'false'
 
     # set 'sysroot' template based on 'sysroot' configuration option, using empty string as fallback
     template_values['sysroot'] = build_option('sysroot') or ''

--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -100,6 +100,8 @@ TEMPLATE_NAMES_DYNAMIC = [
     ('cuda_sm_comma_sep', "Comma-separated list of sm_* values that correspond with CUDA compute capabilities"),
     ('cuda_sm_space_sep', "Space-separated list of sm_* values that correspond with CUDA compute capabilities"),
     ('mpi_cmd_prefix', "Prefix command for running MPI programs (with default number of ranks)"),
+    # can't be a boolean (True/False), must be a string value since it's a string template
+    ('rpath', "String value indicating whether or not RPATH linking is used ('yes' or 'no')"),
     ('software_commit', "Git commit id to use for the software as specified by --software-commit command line option"),
     ('sysroot', "Location root directory of system, prefix for standard paths like /usr/lib and /usr/include"
      "as specified by the --sysroot configuration option"),
@@ -207,6 +209,9 @@ def template_constant_dict(config, ignore=None, skip_lower=None, toolchain=None)
 
     # set 'arch' for system architecture based on 'machine' (4th) element of platform.uname() return value
     template_values['arch'] = platform.uname()[4]
+
+    # set 'rpath' template based on 'rpath' configuration option, using empty string as fallback
+    template_values['rpath'] = 'yes' if build_option('rpath') else 'no'
 
     # set 'sysroot' template based on 'sysroot' configuration option, using empty string as fallback
     template_values['sysroot'] = build_option('sysroot') or ''

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1434,18 +1434,18 @@ class EasyConfigTest(EnhancedTestCase):
         write_file(test_ec, test_ec_txt)
 
         ec = EasyConfig(test_ec)
-        expected = '--with-rpath=yes' if get_os_name() == 'Linux' else '--with-rpath=no'
+        expected = '--with-rpath=true' if get_os_name() == 'Linux' else '--with-rpath=false'
         self.assertEqual(ec['configopts'], expected)
 
         # force True
         update_build_option('rpath', True)
         ec = EasyConfig(test_ec)
-        self.assertEqual(ec['configopts'], "--with-rpath=yes")
+        self.assertEqual(ec['configopts'], "--with-rpath=true")
 
         # force False
         update_build_option('rpath', False)
         ec = EasyConfig(test_ec)
-        self.assertEqual(ec['configopts'], "--with-rpath=no")
+        self.assertEqual(ec['configopts'], "--with-rpath=false")
 
     def test_sysroot_template(self):
         """Test the %(sysroot)s template"""
@@ -3389,7 +3389,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         arch_regex = re.compile('^[a-z0-9_]+$')
 
-        rpath = 'yes' if get_os_name() == 'Linux' else 'no'
+        rpath = 'true' if get_os_name() == 'Linux' else 'false'
 
         expected = {
             'bitbucket_account': 'gzip',

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1430,7 +1430,7 @@ class EasyConfigTest(EnhancedTestCase):
 
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         test_ec_txt = read_file(toy_ec)
-        test_ec_txt += "configopts = '--with-rpath=%(rpath)s'"
+        test_ec_txt += "configopts = '--with-rpath=%(rpath_enabled)s'"
         write_file(test_ec, test_ec_txt)
 
         ec = EasyConfig(test_ec)
@@ -3400,7 +3400,7 @@ class EasyConfigTest(EnhancedTestCase):
             'nameletter': 'g',
             'nameletterlower': 'g',
             'parallel': None,
-            'rpath': rpath,
+            'rpath_enabled': rpath,
             'software_commit': '',
             'sysroot': '',
             'toolchain_name': 'foss',
@@ -3484,7 +3484,7 @@ class EasyConfigTest(EnhancedTestCase):
             'pyminver': '7',
             'pyshortver': '3.7',
             'pyver': '3.7.2',
-            'rpath': rpath,
+            'rpath_enabled': rpath,
             'software_commit': '',
             'sysroot': '',
             'version': '0.01',
@@ -3551,7 +3551,7 @@ class EasyConfigTest(EnhancedTestCase):
             'namelower': 'foo',
             'nameletter': 'f',
             'nameletterlower': 'f',
-            'rpath': rpath,
+            'rpath_enabled': rpath,
             'software_commit': '',
             'sysroot': '',
             'version': '1.2.3',

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1423,6 +1423,30 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertIn('start_dir in extension configure is %s &&' % ext_start_dir, logtxt)
         self.assertIn('start_dir in extension build is %s &&' % ext_start_dir, logtxt)
 
+    def test_rpath_template(self):
+        """Test the %(rpath)s template"""
+        test_easyconfigs = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'easyconfigs', 'test_ecs')
+        toy_ec = os.path.join(test_easyconfigs, 't', 'toy', 'toy-0.0.eb')
+
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        test_ec_txt = read_file(toy_ec)
+        test_ec_txt += "configopts = '--with-rpath=%(rpath)s'"
+        write_file(test_ec, test_ec_txt)
+
+        ec = EasyConfig(test_ec)
+        expected = '--with-rpath=yes' if get_os_name() == 'Linux' else '--with-rpath=no'
+        self.assertEqual(ec['configopts'], expected)
+
+        # force True
+        update_build_option('rpath', True)
+        ec = EasyConfig(test_ec)
+        self.assertEqual(ec['configopts'], "--with-rpath=yes")
+
+        # force False
+        update_build_option('rpath', False)
+        ec = EasyConfig(test_ec)
+        self.assertEqual(ec['configopts'], "--with-rpath=no")
+
     def test_sysroot_template(self):
         """Test the %(sysroot)s template"""
 
@@ -3365,6 +3389,8 @@ class EasyConfigTest(EnhancedTestCase):
 
         arch_regex = re.compile('^[a-z0-9_]+$')
 
+        rpath = 'yes' if get_os_name() == 'Linux' else 'no'
+
         expected = {
             'bitbucket_account': 'gzip',
             'github_account': 'gzip',
@@ -3374,6 +3400,7 @@ class EasyConfigTest(EnhancedTestCase):
             'nameletter': 'g',
             'nameletterlower': 'g',
             'parallel': None,
+            'rpath': rpath,
             'software_commit': '',
             'sysroot': '',
             'toolchain_name': 'foss',
@@ -3457,6 +3484,7 @@ class EasyConfigTest(EnhancedTestCase):
             'pyminver': '7',
             'pyshortver': '3.7',
             'pyver': '3.7.2',
+            'rpath': rpath,
             'software_commit': '',
             'sysroot': '',
             'version': '0.01',
@@ -3523,6 +3551,7 @@ class EasyConfigTest(EnhancedTestCase):
             'namelower': 'foo',
             'nameletter': 'f',
             'nameletterlower': 'f',
+            'rpath': rpath,
             'software_commit': '',
             'sysroot': '',
             'version': '1.2.3',


### PR DESCRIPTION
There are situations where we should be able to detect in an easyconfig file whether or not RPATH linking is used.

This can be leveraged in easyconfigs where pre-built binaries or libraries are included, like (for example):

```python
postinstallcmds = [
    "if %(rpath_enabled)s; then patchelf %(installdir)s/...; fi",
]