### PR TITLE
don't raise error when required extensions are not found when installing extensions in parallel

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2122,8 +2122,10 @@ class EasyBlock(object):
                     # to avoid getting stuck in an infinite loop!
                     missing_deps = [x for x in required_deps if x not in all_ext_names]
                     if missing_deps:
-                        raise EasyBuildError("Missing required dependencies for %s are not going to be installed: %s",
-                                             ext.name, ', '.join(missing_deps))
+                        msg = f"Missing required extensions for {ext.name} not found "
+                        msg += "in list of extensions being installed, let's assume they are provided by "
+                        msg += "by dependencies and proceed: " + ', '.join(missing_deps)
+                        self.log.info(msg)
                     else:
                         self.log.info("Required dependencies missing for extension %s (%s), adding it back to queue...",
                                       ext.name, ', '.join(pending_deps))

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2118,16 +2118,23 @@ class EasyBlock(object):
                 # if some of the required dependencies are not installed yet, requeue this extension
                 elif pending_deps:
 
-                    # make sure all required dependencies are actually going to be installed,
-                    # to avoid getting stuck in an infinite loop!
+                    # check whether all required dependency extensions are actually going to be installed;
+                    # if not, we assume that they are be provided by dependencies;
                     missing_deps = [x for x in required_deps if x not in all_ext_names]
                     if missing_deps:
                         msg = f"Missing required extensions for {ext.name} not found "
                         msg += "in list of extensions being installed, let's assume they are provided by "
-                        msg += "by dependencies and proceed: " + ', '.join(missing_deps)
+                        msg += "dependencies and proceed: " + ', '.join(missing_deps)
                         self.log.info(msg)
-                    else:
-                        self.log.info("Required dependencies missing for extension %s (%s), adding it back to queue...",
+
+                        msg = f"Pending dependencies for {ext.name} before taking into account missing dependencies: "
+                        self.log.debug(msg + ', '.join(pending_deps))
+                        pending_deps = [x for x in pending_deps if x not in missing_deps]
+                        msg = f"Pending dependencies for {ext.name} after taking into account missing dependencies: "
+                        self.log.debug(msg + ', '.join(pending_deps))
+
+                    if pending_deps:
+                        self.log.info("Required dependencies not installed yet for extension %s (%s), adding it back to queue...",
                                       ext.name, ', '.join(pending_deps))
                         # purposely adding extension back in the queue at Nth place rather than at the end,
                         # since we assume that the required dependencies will be installed soon...

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2119,7 +2119,7 @@ class EasyBlock(object):
                 elif pending_deps:
 
                     # check whether all required dependency extensions are actually going to be installed;
-                    # if not, we assume that they are be provided by dependencies;
+                    # if not, we assume that they are provided by dependencies;
                     missing_deps = [x for x in required_deps if x not in all_ext_names]
                     if missing_deps:
                         msg = f"Missing required extensions for {ext.name} not found "

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -74,7 +74,7 @@ from easybuild.tools.build_log import EasyBuildError, EasyBuildExit, dry_run_msg
 from easybuild.tools.build_log import print_error, print_msg, print_warning
 from easybuild.tools.config import CHECKSUM_PRIORITY_JSON, DEFAULT_ENVVAR_USERS_MODULES, PYTHONPATH, EBPYTHONPREFIXES
 from easybuild.tools.config import FORCE_DOWNLOAD_ALL, FORCE_DOWNLOAD_PATCHES, FORCE_DOWNLOAD_SOURCES
-from easybuild.tools.config import EASYBUILD_SOURCES_URL # noqa
+from easybuild.tools.config import EASYBUILD_SOURCES_URL  # noqa
 from easybuild.tools.config import build_option, build_path, get_log_filename, get_repository, get_repositorypath
 from easybuild.tools.config import install_path, log_path, package_path, source_paths
 from easybuild.tools.environment import restore_env, sanitize_env
@@ -2134,8 +2134,10 @@ class EasyBlock(object):
                         self.log.debug(msg + ', '.join(pending_deps))
 
                     if pending_deps:
-                        self.log.info("Required dependencies not installed yet for extension %s (%s), adding it back to queue...",
-                                      ext.name, ', '.join(pending_deps))
+                        msg = f"Required dependencies not installed yet for extension {ext.name} ("
+                        msg += ', '.join(pending_deps)
+                        msg += "), adding it back to queue..."
+                        self.log.info(msg)
                         # purposely adding extension back in the queue at Nth place rather than at the end,
                         # since we assume that the required dependencies will be installed soon...
                         exts_queue.insert(max_iter, ext)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2142,7 +2142,9 @@ class EasyBlock(object):
                         # since we assume that the required dependencies will be installed soon...
                         exts_queue.insert(max_iter, ext)
 
-                else:
+                # list of pending dependencies may be empty now after taking into account required extensions
+                # that are not being installed above, so extension may be ready to install
+                if not pending_deps:
                     tup = (ext.name, ext.version or '')
                     print_msg("starting installation of extension %s %s..." % tup, silent=self.silent, log=self.log)
 


### PR DESCRIPTION
Raising an error effectively makes it impossible to use `--parallel-extensions-install` on bundle easyconfigs like `R-bundle-CRAN-2024.06-foss-2023b.eb` and `R-bundle-Bioconductor-3.18-foss-2023a-R-4.3.2.eb`.

There's actually no reason to give up when extensions that are required dependencies for an extension that will be installed are not included in `exts_list`, since they're probably provided via a dependency like `R` or `R-bundle-CRAN`.
Note that this is exactly what we do currently when installing extensions sequentially...

If a dependency of a particular extension is totally missing, the installation of that extension will fail as it does when installing sequentially.

Note: for using `--parallel-extensions-install` on `R-bundle-CRAN` (or older `R` easyconfigs that include `Rmpi` and `Rserve`), an additional bug fix is required, see:
* https://github.com/easybuilders/easybuild-easyblocks/pull/3474