### PR TITLE
mark support for installing extensions in parallel as being mature, since it's no longer experimental

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1877,7 +1877,6 @@ class EasyBlock(object):
         Skip already installed extensions (checking in parallel),
         by removing them from list of Extension instances to install (self.ext_instances).
         """
-        self.log.experimental("Skipping installed extensions in parallel")
         print_msg("skipping installed extensions (in parallel)", log=self.log)
 
         installed_exts_ids = []
@@ -1934,13 +1933,12 @@ class EasyBlock(object):
         self.log.debug("List of loaded modules: %s", self.modules_tool.list())
 
         if build_option('parallel_extensions_install'):
-            self.log.experimental("installing extensions in parallel")
             try:
                 self.install_extensions_parallel(install=install)
             except NotImplementedError:
                 # If parallel extension install is not supported for this type of extension then install sequentially
                 msg = "Parallel extensions install not supported for %s - using sequential install" % self.name
-                self.log.experimental(msg)
+                self.log.info(msg)
                 self.install_extensions_sequential(install=install)
         else:
             self.install_extensions_sequential(install=install)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -948,10 +948,6 @@ class EasyBuildOptions(GeneralOption):
         # set tmpdir
         self.tmpdir = set_tmpdir(self.options.tmpdir)
 
-        # early check for opt-in to installing extensions in parallel (experimental feature)
-        if self.options.parallel_extensions_install:
-            self.log.experimental("installing extensions in parallel")
-
         # take --include options into account (unless instructed otherwise)
         if self.with_include:
             self._postprocess_include()


### PR DESCRIPTION
Requires:
* [x] https://github.com/easybuilders/easybuild-framework/pull/4671
* [x] https://github.com/easybuilders/easybuild-easyblocks/pull/3474
* [x] https://github.com/easybuilders/easybuild-easyblocks/pull/3490