### PR TITLE
fix color tags set by colorize when rich is available

### DIFF
--- a/easybuild/tools/output.py
+++ b/easybuild/tools/output.py
@@ -74,9 +74,9 @@ def colorize(txt, color):
     """
     if color in KNOWN_COLORS:
         if use_rich():
-            coltxt = '[bold %s]%s[/bold %s]' % (color, txt, color)
-        else:
             coltxt = KNOWN_COLORS[color] + txt + COLOR_END
+        else:
+            coltxt = '[bold %s]%s[/bold %s]' % (color, txt, color)
     else:
         raise EasyBuildError("Unknown color: %s", color)
 


### PR DESCRIPTION
This has to be reversed for colorize to work as intended.

I have `rich` installed and I'm getting colorless string tags:
```
[bold red]ERROR: Shell command failed![/bold red]
```