### PR TITLE
fix dry-run output when using `multi_deps`

### DIFF
--- a/easybuild/tools/include.py
+++ b/easybuild/tools/include.py
@@ -198,10 +198,8 @@ def include_easyblocks(tmpdir, paths):
 
     # hard inject location to included (generic) easyblocks into Python search path
     # only prepending to sys.path is not enough due to 'pkgutil.extend_path' in easybuild/easyblocks/__init__.py
-    new_path = os.path.join(easyblocks_path, 'easybuild', 'easyblocks')
-    easybuild.easyblocks.__path__.insert(0, new_path)
-    new_path = os.path.join(new_path, 'generic')
-    easybuild.easyblocks.generic.__path__.insert(0, new_path)
+    easybuild.easyblocks.__path__.insert(0, easyblocks_dir)
+    easybuild.easyblocks.generic.__path__.insert(0, os.path.join(easyblocks_dir, 'generic'))
 
     # sanity check: verify that included easyblocks can be imported (from expected location)
     for subdir, ebs in [('', included_ebs), ('generic', included_generic_ebs)]:


### PR DESCRIPTION
When using `multi_deps` the dry-run sanity check step should be run multiple times just as is done in the real build.
However the decision which method to call is made before calling `_sanity_check_step_multi_deps` and that doesn't check for dry-run.

Factor out a dispatch method that can be called during the iteration of the multiple dependencies and use that in both cases.