### PR TITLE
Allow templates in `custom_paths` & `custom_commands` sanity-check arguments

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3362,7 +3362,7 @@ class EasyBlock(object):
             # if no sanity_check_paths are specified in easyconfig,
             # we fall back to the ones provided by the easyblock via custom_paths
             if custom_paths:
-                paths = custom_paths
+                paths = self.cfg.resolve_template(custom_paths)
                 self.log.info("Using customized sanity check paths: %s", paths)
             # if custom_paths is empty, we fall back to a generic set of paths:
             # non-empty bin/ + /lib or /lib64 directories
@@ -3412,7 +3412,7 @@ class EasyBlock(object):
             self.log.info("Using (only) sanity check commands specified by easyconfig file: %s", commands)
         else:
             if custom_commands:
-                commands = custom_commands
+                commands = self.cfg.resolve_template(custom_commands)
                 self.log.info("Using customised sanity check commands: %s", commands)
             else:
                 commands = []

--- a/easybuild/tools/include.py
+++ b/easybuild/tools/include.py
@@ -198,10 +198,8 @@ def include_easyblocks(tmpdir, paths):
 
     # hard inject location to included (generic) easyblocks into Python search path
     # only prepending to sys.path is not enough due to 'pkgutil.extend_path' in easybuild/easyblocks/__init__.py
-    new_path = os.path.join(easyblocks_path, 'easybuild', 'easyblocks')
-    easybuild.easyblocks.__path__.insert(0, new_path)
-    new_path = os.path.join(new_path, 'generic')
-    easybuild.easyblocks.generic.__path__.insert(0, new_path)
+    easybuild.easyblocks.__path__.insert(0, easyblocks_dir)
+    easybuild.easyblocks.generic.__path__.insert(0, os.path.join(easyblocks_dir, 'generic'))
 
     # sanity check: verify that included easyblocks can be imported (from expected location)
     for subdir, ebs in [('', included_ebs), ('generic', included_generic_ebs)]:

--- a/test/framework/easyconfigs/test_ecs/p/Python/Python-2.7.15.eb
+++ b/test/framework/easyconfigs/test_ecs/p/Python/Python-2.7.15.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'Python'
+version = '2.7.15'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+more effectively."""
+
+toolchain = SYSTEM
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# This just serves to have a Python as a dependency to test e.g. the Python version templates
+# So all dependencies and extensions are removed
+dependencies = []
+
+osdependencies = []
+
+exts_list = []
+
+moduleclass = 'lang'

--- a/test/framework/easyconfigs/test_ecs/p/Python/Python-3.7.2.eb
+++ b/test/framework/easyconfigs/test_ecs/p/Python/Python-3.7.2.eb
@@ -1,0 +1,23 @@
+easyblock = 'ConfigureMake'
+
+name = 'Python'
+version = '3.7.2'
+
+homepage = 'http://python.org/'
+description = """Python is a programming language that lets you work more quickly and integrate your systems
+more effectively."""
+
+toolchain = SYSTEM
+
+source_urls = ['http://www.python.org/ftp/%(namelower)s/%(version)s/']
+sources = [SOURCE_TGZ]
+
+# This just serves to have a Python as a dependency to test e.g. the Python version templates
+# So all dependencies and extensions are removed
+dependencies = []
+
+osdependencies = []
+
+exts_list = []
+
+moduleclass = 'lang'

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2474,7 +2474,7 @@ class FileToolsTest(EnhancedTestCase):
         # test with specified path with and without trailing '/'s
         for path in [test_ecs, test_ecs + '/', test_ecs + '//']:
             index = ft.create_index(path)
-            self.assertEqual(len(index), 92)
+            self.assertEqual(len(index), 94)
 
             expected = [
                 os.path.join('b', 'bzip2', 'bzip2-1.0.6-GCC-4.9.2.eb'),


### PR DESCRIPTION
E.g. for Python packages we (almost) always want to check for `lib/python%(pyshortver)s` and potentially add additional paths from EasyConfigs.
Currently a workaround is used that sets the parameter in the easyconfig when it isn't set already which is against the semantics of `enhance_sanity_check`.

This change allows this in a trivial way.

The added test just uses `multi_deps` which covers the case without it already, so no need for 2 similar ones.
To make it "realistic" add dummy Python ECs to use as dependencies such that we can use `%(pyshortver)s`

Requires 
- [x] #4677 
- [x] #4678 

I included those PRs here though such that CI passes and either all commits can be reviewed together or just the last one which is the described change.