### PR TITLE
Use more robust mechanism for unsetting environment variables

### DIFF
--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -294,7 +294,8 @@ class RunTest(EnhancedTestCase):
         env_script = os.path.join(cmd_tmpdir, 'env.sh')
         self.assertExists(env_script)
         env_script_txt = read_file(env_script)
-        self.assertTrue(env_script_txt.startswith('unset -f $('))
+        self.assertIn('unset "$var"', env_script_txt)
+        self.assertIn('unset -f "$func"', env_script_txt)
         self.assertIn('\nexport FOOBAR=foobar\nexport PATH', env_script_txt)
 
         cmd_script = os.path.join(cmd_tmpdir, 'cmd.sh')


### PR DESCRIPTION
Parsing the output of "env" can be fragile for certain complex environment.
Using compgen should be safer.