### PR TITLE
simplify code for determining the PYTHONPATH module entries

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1429,9 +1429,9 @@ class EasyBlock(object):
 
         if use_ebpythonprefixes:
             path = ''  # EBPYTHONPREFIXES are relative to the install dir
-            lines = self.module_generator.prepend_paths(EBPYTHONPREFIXES, path)
+            lines = self.module_generator.prepend_paths(EBPYTHONPREFIXES, path, warn_exists=False)
         else:
-            lines = self.module_generator.prepend_paths(PYTHONPATH, python_paths)
+            lines = self.module_generator.prepend_paths(PYTHONPATH, python_paths, warn_exists=False)
         return [lines] if lines else []
 
     def make_module_extra(self, altroot=None, altversion=None):

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -241,7 +241,7 @@ class ModuleGenerator(object):
                 filtered_paths = None
         return filtered_paths
 
-    def append_paths(self, key, paths, allow_abs=False, expand_relpaths=True, delim=':'):
+    def append_paths(self, key, paths, allow_abs=False, expand_relpaths=True, delim=':', warn_exists=True):
         """
         Generate append-path statements for the given list of paths.
 
@@ -250,8 +250,9 @@ class ModuleGenerator(object):
         :param allow_abs: allow providing of absolute paths
         :param expand_relpaths: expand relative paths into absolute paths (by prefixing install dir)
         :param delim: delimiter used between paths
+        :param warn_exists: Show a warning if any path was already added to the variable
         """
-        paths = self._filter_paths(key, paths)
+        paths = self._filter_paths(key, paths, warn_exists=warn_exists)
         if paths is None:
             return ''
         return self.update_paths(key, paths, prepend=False, allow_abs=allow_abs, expand_relpaths=expand_relpaths,

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -206,8 +206,12 @@ class ModuleGenerator(object):
 
         return os.path.join(mod_path, mod_path_suffix)
 
-    def _filter_paths(self, key, paths):
-        """Filter out paths already added to key and return the remaining ones"""
+    def _filter_paths(self, key, paths, warn_exists=True):
+        """
+        Filter out paths already added to key and return the remaining ones
+
+        :param warn_exists: Show a warning for paths already added to the key
+        """
         if self.added_paths_per_key is None:
             # For compatibility this is only a warning for now and we don't filter any paths
             print_warning('Module creation has not been started. Call start_module_creation first!')
@@ -227,10 +231,12 @@ class ModuleGenerator(object):
                 paths = list(paths)
             filtered_paths = [x for x in paths if x not in added_paths and not added_paths.add(x)]
         if filtered_paths != paths:
-            removed_paths = paths if filtered_paths is None else [x for x in paths if x not in filtered_paths]
-            print_warning("Suppressed adding the following path(s) to $%s of the module as they were already added: %s",
-                          key, removed_paths,
-                          log=self.log)
+            if warn_exists:
+                removed_paths = paths if filtered_paths is None else [x for x in paths if x not in filtered_paths]
+                print_warning("Suppressed adding the following path(s) to $%s of the module "
+                              "as they were already added: %s",
+                              key, removed_paths,
+                              log=self.log)
             if not filtered_paths:
                 filtered_paths = None
         return filtered_paths
@@ -251,7 +257,7 @@ class ModuleGenerator(object):
         return self.update_paths(key, paths, prepend=False, allow_abs=allow_abs, expand_relpaths=expand_relpaths,
                                  delim=delim)
 
-    def prepend_paths(self, key, paths, allow_abs=False, expand_relpaths=True, delim=':'):
+    def prepend_paths(self, key, paths, allow_abs=False, expand_relpaths=True, delim=':', warn_exists=True):
         """
         Generate prepend-path statements for the given list of paths.
 
@@ -260,8 +266,9 @@ class ModuleGenerator(object):
         :param allow_abs: allow providing of absolute paths
         :param expand_relpaths: expand relative paths into absolute paths (by prefixing install dir)
         :param delim: delimiter used between paths
+        :param warn_exists: Show a warning if any path was already added to the variable
         """
-        paths = self._filter_paths(key, paths)
+        paths = self._filter_paths(key, paths, warn_exists=warn_exists)
         if paths is None:
             return ''
         return self.update_paths(key, paths, prepend=True, allow_abs=allow_abs, expand_relpaths=expand_relpaths,

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -782,13 +782,16 @@ class ModuleGeneratorTest(EnhancedTestCase):
         # check for warning that is printed when same path is added multiple times
         with self.modgen.start_module_creation():
             self.modgen.append_paths('TEST', 'path1')
-            self.mock_stderr(True)
-            self.modgen.append_paths('TEST', 'path1')
-            stderr = self.get_stderr()
-            self.mock_stderr(False)
+            with self.mocked_stdout_stderr():
+                self.modgen.append_paths('TEST', 'path1')
+                stderr = self.get_stderr()
             expected_warning = "\nWARNING: Suppressed adding the following path(s) to $TEST of the module "
             expected_warning += "as they were already added: path1\n\n"
             self.assertEqual(stderr, expected_warning)
+            with self.mocked_stdout_stderr():
+                self.modgen.append_paths('TEST', 'path1', warn_exists=False)
+                stderr = self.get_stderr()
+            self.assertEqual(stderr, '')
 
     def test_module_extensions(self):
         """test the extensions() for extensions"""

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -882,13 +882,17 @@ class ModuleGeneratorTest(EnhancedTestCase):
         # check for warning that is printed when same path is added multiple times
         with self.modgen.start_module_creation():
             self.modgen.prepend_paths('TEST', 'path1')
-            self.mock_stderr(True)
-            self.modgen.prepend_paths('TEST', 'path1')
-            stderr = self.get_stderr()
-            self.mock_stderr(False)
+            with self.mocked_stdout_stderr():
+                self.modgen.prepend_paths('TEST', 'path1')
+                stderr = self.get_stderr()
             expected_warning = "\nWARNING: Suppressed adding the following path(s) to $TEST of the module "
             expected_warning += "as they were already added: path1\n\n"
             self.assertEqual(stderr, expected_warning)
+
+            with self.mocked_stdout_stderr():
+                self.modgen.prepend_paths('TEST', 'path1', warn_exists=False)
+                stderr = self.get_stderr()
+            self.assertEqual(stderr, '')
 
     def test_det_user_modpath(self):
         """Test for generic det_user_modpath method."""


### PR DESCRIPTION
The check whether the path(s) have already been added is redundant as that is done in the module_generator class.

The whole code with all the checks is superflous if there are no python paths to add.

To avoid excessive indentation return early with an empty list in that case and same for Python installations for consistency.

`prepend_paths` can return an empty string when everything is filtered. As we return a list here (we might be better of returning a string instead) return an empty list to avoid empty lines being written if `'\n'` was used. -> TODO for later

Best to view with whitespace changes ignored