### PR TITLE
Allow use of custom delimiter for paths in module generator

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1473,8 +1473,9 @@ class EasyBlock(object):
             allow_abs = self.cfg['allow_prepend_abs_path'] if prepend else self.cfg['allow_append_abs_path']
 
             for (key, value) in self.cfg[name].items():
-                if not isinstance(value, (tuple, list, dict)):
-                    raise EasyBuildError(f'{name} dict value "{value}" (type {type(value)}) is not a list or dict')
+                if not isinstance(value, (tuple, list, dict, str)):
+                    raise EasyBuildError(f'{name} dict value "{value}" (type {type(value)}) is not a '
+                                         'list, dict or str')
                 elif isinstance(value, dict):
                     if 'paths' not in value or 'delimiter' not in value:
                         raise EasyBuildError(f'{name} dict value "{value}" must contain "path" and "delimiter"')

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1474,17 +1474,17 @@ class EasyBlock(object):
 
             for (key, value) in self.cfg[name].items():
                 if not isinstance(value, (tuple, list, dict)):
-                    raise EasyBuildError(f"{name} dict value {value} is not a list or dict")
+                    raise EasyBuildError(f'{name} dict value "{value}" (type {type(value)}) is not a list or dict')
                 elif isinstance(value, dict):
                     if 'paths' not in value or 'delimiter' not in value:
-                        raise EasyBuildError(f"{name} dict value {value} must contain 'path' and 'delimiter'")
+                        raise EasyBuildError(f'{name} dict value "{value}" must contain "path" and "delimiter"')
 
                     paths = value['paths']
                     delim = value['delimiter']
                     if not isinstance(paths, (list, str)):
-                        raise EasyBuildError("modextrapaths dict value {value} path must be list or str")
+                        raise EasyBuildError('modextrapaths dict value "{value}" path must be list or str')
                     if not isinstance(delim, str):
-                        raise EasyBuildError("modextrapaths dict value {value} delimiter must be a str")
+                        raise EasyBuildError('modextrapaths dict value "{value}" delimiter must be a str')
                     lines.append(self.module_generator.update_paths(key, value, prepend=prepend, delim=delim,
                                                                     allow_abs=allow_abs))
                 else:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1486,7 +1486,7 @@ class EasyBlock(object):
                         raise EasyBuildError('modextrapaths dict value "{value}" paths must be list or str')
                     if not isinstance(delim, str):
                         raise EasyBuildError('modextrapaths dict value "{value}" delimiter must be a str')
-                    lines.append(self.module_generator.update_paths(key, value, prepend=prepend, delim=delim,
+                    lines.append(self.module_generator.update_paths(key, paths, prepend=prepend, delim=delim,
                                                                     allow_abs=allow_abs))
                 else:
                     if isinstance(value, str):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1478,12 +1478,12 @@ class EasyBlock(object):
                                          'list, dict or str')
                 elif isinstance(value, dict):
                     if 'paths' not in value or 'delimiter' not in value:
-                        raise EasyBuildError(f'{name} dict value "{value}" must contain "path" and "delimiter"')
+                        raise EasyBuildError(f'{name} dict value "{value}" must contain "paths" and "delimiter"')
 
                     paths = value['paths']
                     delim = value['delimiter']
                     if not isinstance(paths, (list, str)):
-                        raise EasyBuildError('modextrapaths dict value "{value}" path must be list or str')
+                        raise EasyBuildError('modextrapaths dict value "{value}" paths must be list or str')
                     if not isinstance(delim, str):
                         raise EasyBuildError('modextrapaths dict value "{value}" delimiter must be a str')
                     lines.append(self.module_generator.update_paths(key, value, prepend=prepend, delim=delim,

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -1016,7 +1016,7 @@ class ModuleGeneratorTcl(ModuleGenerator):
             else:
                 abspaths.append(path)
 
-        delim_opt = '' if delim != ':' else f' -d "{delim}"'
+        delim_opt = '' if delim == ':' else f' -d "{delim}"'
         statements = [f'{update_type}-path{delim_opt}\t{key}\t\t{p}\n' for p in abspaths]
         return ''.join(statements)
 

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -1016,10 +1016,8 @@ class ModuleGeneratorTcl(ModuleGenerator):
             else:
                 abspaths.append(path)
 
-        if delim != ':':
-            statements = ['%s-path -d "%s"\t%s\t\t%s\n' % (update_type, delim, key, p) for p in abspaths]
-        else:
-            statements = ['%s-path\t%s\t\t%s\n' % (update_type, key, p) for p in abspaths]
+        delim_opt = '' if delim != ':' else f' -d "{delim}"'
+        statements = [f'{update_type}-path{delim_opt}\t{key}\t\t{p}\n' for p in abspaths]
         return ''.join(statements)
 
     def set_alias(self, key, value):

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -1017,7 +1017,7 @@ class ModuleGeneratorTcl(ModuleGenerator):
                 abspaths.append(path)
 
         if delim != ':':
-            statements = ['%s-path -d "%s"\t%s\t\t%s \n' % (update_type, delim, key, p) for p in abspaths]
+            statements = ['%s-path -d "%s"\t%s\t\t%s\n' % (update_type, delim, key, p) for p in abspaths]
         else:
             statements = ['%s-path\t%s\t\t%s\n' % (update_type, key, p) for p in abspaths]
         return ''.join(statements)

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -235,7 +235,7 @@ class ModuleGenerator(object):
                 filtered_paths = None
         return filtered_paths
 
-    def append_paths(self, key, paths, allow_abs=False, expand_relpaths=True):
+    def append_paths(self, key, paths, allow_abs=False, expand_relpaths=True, delim=':'):
         """
         Generate append-path statements for the given list of paths.
 
@@ -243,13 +243,15 @@ class ModuleGenerator(object):
         :param paths: list of paths to append
         :param allow_abs: allow providing of absolute paths
         :param expand_relpaths: expand relative paths into absolute paths (by prefixing install dir)
+        :param delim: delimiter used between paths
         """
         paths = self._filter_paths(key, paths)
         if paths is None:
             return ''
-        return self.update_paths(key, paths, prepend=False, allow_abs=allow_abs, expand_relpaths=expand_relpaths)
+        return self.update_paths(key, paths, prepend=False, allow_abs=allow_abs, expand_relpaths=expand_relpaths,
+                                 delim=delim)
 
-    def prepend_paths(self, key, paths, allow_abs=False, expand_relpaths=True):
+    def prepend_paths(self, key, paths, allow_abs=False, expand_relpaths=True, delim=':'):
         """
         Generate prepend-path statements for the given list of paths.
 
@@ -257,11 +259,13 @@ class ModuleGenerator(object):
         :param paths: list of paths to append
         :param allow_abs: allow providing of absolute paths
         :param expand_relpaths: expand relative paths into absolute paths (by prefixing install dir)
+        :param delim: delimiter used between paths
         """
         paths = self._filter_paths(key, paths)
         if paths is None:
             return ''
-        return self.update_paths(key, paths, prepend=True, allow_abs=allow_abs, expand_relpaths=expand_relpaths)
+        return self.update_paths(key, paths, prepend=True, allow_abs=allow_abs, expand_relpaths=expand_relpaths,
+                                 delim=delim)
 
     def _modulerc_check_module_version(self, module_version):
         """
@@ -552,15 +556,16 @@ class ModuleGenerator(object):
         """
         raise NotImplementedError
 
-    def update_paths(self, key, paths, prepend=True, allow_abs=False, expand_relpaths=True):
+    def update_paths(self, key, paths, prepend=True, allow_abs=False, expand_relpaths=True, delim=':'):
         """
         Generate prepend-path or append-path statements for the given list of paths.
 
         :param key: environment variable to prepend/append paths to
-        :param paths: list of paths to prepend
+        :param paths: list of paths to prepend/append
         :param prepend: whether to prepend (True) or append (False) paths
         :param allow_abs: allow providing of absolute paths
         :param expand_relpaths: expand relative paths into absolute paths (by prefixing install dir)
+        :param delim: delimiter used between paths
         """
         raise NotImplementedError
 
@@ -970,15 +975,16 @@ class ModuleGeneratorTcl(ModuleGenerator):
         print_cmd = "puts stderr %s" % quote_str(msg, tcl=True)
         return '\n'.join(['', self.conditional_statement("module-info mode unload", print_cmd, indent=False)])
 
-    def update_paths(self, key, paths, prepend=True, allow_abs=False, expand_relpaths=True):
+    def update_paths(self, key, paths, prepend=True, allow_abs=False, expand_relpaths=True, delim=':'):
         """
         Generate prepend-path or append-path statements for the given list of paths.
 
         :param key: environment variable to prepend/append paths to
-        :param paths: list of paths to prepend
+        :param paths: list of paths to prepend/append
         :param prepend: whether to prepend (True) or append (False) paths
         :param allow_abs: allow providing of absolute paths
         :param expand_relpaths: expand relative paths into absolute paths (by prefixing install dir)
+        :param delim: delimiter used between paths
         """
         if prepend:
             update_type = 'prepend'
@@ -1010,7 +1016,10 @@ class ModuleGeneratorTcl(ModuleGenerator):
             else:
                 abspaths.append(path)
 
-        statements = ['%s-path\t%s\t\t%s\n' % (update_type, key, p) for p in abspaths]
+        if delim != ':':
+            statements = ['%s-path -d "%s"\t%s\t\t%s \n' % (update_type, delim, key, p) for p in abspaths]
+        else:
+            statements = ['%s-path\t%s\t\t%s\n' % (update_type, key, p) for p in abspaths]
         return ''.join(statements)
 
     def set_alias(self, key, value):
@@ -1161,6 +1170,7 @@ class ModuleGeneratorLua(ModuleGenerator):
 
     PATH_JOIN_TEMPLATE = 'pathJoin(root, "%s")'
     UPDATE_PATH_TEMPLATE = '%s_path("%s", %s)'
+    UPDATE_PATH_TEMPLATE_DELIM = '%s_path {"%s", delim="%s")'
 
     START_STR = '[==['
     END_STR = ']==]'
@@ -1422,7 +1432,7 @@ class ModuleGeneratorLua(ModuleGenerator):
         return super(ModuleGeneratorLua, self).modulerc(module_version=module_version, filepath=filepath,
                                                         modulerc_txt=modulerc_txt)
 
-    def update_paths(self, key, paths, prepend=True, allow_abs=False, expand_relpaths=True):
+    def update_paths(self, key, paths, prepend=True, allow_abs=False, expand_relpaths=True, delim=':'):
         """
         Generate prepend_path or append_path statements for the given list of paths
 
@@ -1431,6 +1441,7 @@ class ModuleGeneratorLua(ModuleGenerator):
         :param prepend: whether to prepend (True) or append (False) paths
         :param allow_abs: allow providing of absolute paths
         :param expand_relpaths: expand relative paths into absolute paths (by prefixing install dir)
+        :param delim: delimiter used between paths
         """
         if prepend:
             update_type = 'prepend'
@@ -1463,7 +1474,10 @@ class ModuleGeneratorLua(ModuleGenerator):
                 else:
                     abspaths.append('root')
 
-        statements = [self.UPDATE_PATH_TEMPLATE % (update_type, key, p) for p in abspaths]
+        if delim != ':':
+            statements = [self.UPDATE_PATH_TEMPLATE_DELIM % (update_type, key, p, delim) for p in abspaths]
+        else:
+            statements = [self.UPDATE_PATH_TEMPLATE % (update_type, key, p) for p in abspaths]
         statements.append('')
         return '\n'.join(statements)
 

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -1170,7 +1170,7 @@ class ModuleGeneratorLua(ModuleGenerator):
 
     PATH_JOIN_TEMPLATE = 'pathJoin(root, "%s")'
     UPDATE_PATH_TEMPLATE = '%s_path("%s", %s)'
-    UPDATE_PATH_TEMPLATE_DELIM = '%s_path {"%s", delim="%s")'
+    UPDATE_PATH_TEMPLATE_DELIM = '%s_path("%s", %s, "%s")'
 
     START_STR = '[==['
     END_STR = ']==]'

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1334,11 +1334,11 @@ class EasyBlockTest(EnhancedTestCase):
             self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
 
         for (key, vals) in modextrapaths.items():
-            if isinstance(vals, str):
-                vals = [vals]
             if isinstance(vals, dict):
                 delim = vals['delimiter']
                 paths = vals['paths']
+                if isinstance(paths, str):
+                    paths = [paths]
 
                 for val in paths:
                     if get_module_syntax() == 'Tcl':
@@ -1352,6 +1352,9 @@ class EasyBlockTest(EnhancedTestCase):
                     num_prepends = len(regex.findall(txt))
                     self.assertEqual(num_prepends, 1, "Expected exactly 1 %s command in %s" % (regex.pattern, txt))
             else:
+                if isinstance(vals, str):
+                    vals = [vals]
+
                 for val in vals:
                     if get_module_syntax() == 'Tcl':
                         regex = re.compile(fr'^prepend-path\s+{key}\s+\$root/{val}$', re.M)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1340,7 +1340,7 @@ class EasyBlockTest(EnhancedTestCase):
                 if get_module_syntax() == 'Tcl':
                     regex = re.compile(r'^prepend-path\s+(-d ".")?%s\s+\$root/%s$' % (key, val), re.M)
                 elif get_module_syntax() == 'Lua':
-                    regex = re.compile(r'^prepend_path\("%s", pathJoin\(root, "%s"\)(, ".")\)$' % (key, val), re.M)
+                    regex = re.compile(r'^prepend_path\("%s", pathJoin\(root, "%s"\)(, ".")?\)$' % (key, val), re.M)
                 else:
                     self.fail("Unknown module syntax: %s" % get_module_syntax())
                 self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
@@ -1355,7 +1355,7 @@ class EasyBlockTest(EnhancedTestCase):
                 if get_module_syntax() == 'Tcl':
                     regex = re.compile(r'^append-path\s+(-d ".")?%s\s+\$root/%s$' % (key, val), re.M)
                 elif get_module_syntax() == 'Lua':
-                    regex = re.compile(r'^append_path\("%s", pathJoin\(root, "%s"\)(, ".")\)$' % (key, val), re.M)
+                    regex = re.compile(r'^append_path\("%s", pathJoin\(root, "%s"\)(, ".")?\)$' % (key, val), re.M)
                 else:
                     self.fail("Unknown module syntax: %s" % get_module_syntax())
                 self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1336,17 +1336,33 @@ class EasyBlockTest(EnhancedTestCase):
         for (key, vals) in modextrapaths.items():
             if isinstance(vals, str):
                 vals = [vals]
-            for val in vals:
-                if get_module_syntax() == 'Tcl':
-                    regex = re.compile(r'^prepend-path\s+(-d "."\s+)?%s\s+\$root/%s$' % (key, val), re.M)
-                elif get_module_syntax() == 'Lua':
-                    regex = re.compile(r'^prepend_path\("%s", pathJoin\(root, "%s"\)(, ".")?\)$' % (key, val), re.M)
-                else:
-                    self.fail("Unknown module syntax: %s" % get_module_syntax())
-                self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
-                # Check for duplicates
-                num_prepends = len(regex.findall(txt))
-                self.assertEqual(num_prepends, 1, "Expected exactly 1 %s command in %s" % (regex.pattern, txt))
+            if type(vals) == dict:
+                delim = vals['delimiter']
+                paths = vals['paths']
+
+                for val in paths:
+                    if get_module_syntax() == 'Tcl':
+                        regex = re.compile(fr'^prepend-path\s+-d\s+"{delim}"\s+{key}\s+\$root/{val}$', re.M)
+                    elif get_module_syntax() == 'Lua':
+                        regex = re.compile(fr'^prepend_path\("{key}", pathJoin\(root, "{val}"\), "{delim}"\)$', re.M)
+                    else:
+                        self.fail("Unknown module syntax: %s" % get_module_syntax())
+                    self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
+                    # Check for duplicates
+                    num_prepends = len(regex.findall(txt))
+                    self.assertEqual(num_prepends, 1, "Expected exactly 1 %s command in %s" % (regex.pattern, txt))
+            else:
+                for val in vals:
+                    if get_module_syntax() == 'Tcl':
+                        regex = re.compile(fr'^prepend-path\s+{key}\s+\$root/{val}$', re.M)
+                    elif get_module_syntax() == 'Lua':
+                        regex = re.compile(fr'^prepend_path\("{key}", pathJoin\(root, "{val}"\)\)$', re.M)
+                    else:
+                        self.fail("Unknown module syntax: %s" % get_module_syntax())
+                    self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
+                    # Check for duplicates
+                    num_prepends = len(regex.findall(txt))
+                    self.assertEqual(num_prepends, 1, "Expected exactly 1 %s command in %s" % (regex.pattern, txt))
 
         for (key, vals) in modextrapaths_append.items():
             if isinstance(vals, str):

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1259,6 +1259,7 @@ class EasyBlockTest(EnhancedTestCase):
         modextrapaths = {
             'PATH': ('xbin', 'pibin'),
             'CPATH': 'pi/include',
+            'TCLLIBPATH': {'path': 'pi', 'delimiter': ' '},
         }
         modextrapaths_append = {'APPEND_PATH': 'append_path'}
         self.contents = '\n'.join([

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1338,9 +1338,9 @@ class EasyBlockTest(EnhancedTestCase):
                 vals = [vals]
             for val in vals:
                 if get_module_syntax() == 'Tcl':
-                    regex = re.compile(r'^prepend-path\s+%s\s+\$root/%s$' % (key, val), re.M)
+                    regex = re.compile(r'^prepend-path\s+(-d ".")?%s\s+\$root/%s$' % (key, val), re.M)
                 elif get_module_syntax() == 'Lua':
-                    regex = re.compile(r'^prepend_path\("%s", pathJoin\(root, "%s"\)\)$' % (key, val), re.M)
+                    regex = re.compile(r'^prepend_path\("%s", pathJoin\(root, "%s"\)(, ".")\)$' % (key, val), re.M)
                 else:
                     self.fail("Unknown module syntax: %s" % get_module_syntax())
                 self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
@@ -1353,9 +1353,9 @@ class EasyBlockTest(EnhancedTestCase):
                 vals = [vals]
             for val in vals:
                 if get_module_syntax() == 'Tcl':
-                    regex = re.compile(r'^append-path\s+%s\s+\$root/%s$' % (key, val), re.M)
+                    regex = re.compile(r'^append-path\s+(-d ".")?%s\s+\$root/%s$' % (key, val), re.M)
                 elif get_module_syntax() == 'Lua':
-                    regex = re.compile(r'^append_path\("%s", pathJoin\(root, "%s"\)\)$' % (key, val), re.M)
+                    regex = re.compile(r'^append_path\("%s", pathJoin\(root, "%s"\)(, ".")\)$' % (key, val), re.M)
                 else:
                     self.fail("Unknown module syntax: %s" % get_module_syntax())
                 self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1259,7 +1259,7 @@ class EasyBlockTest(EnhancedTestCase):
         modextrapaths = {
             'PATH': ('xbin', 'pibin'),
             'CPATH': 'pi/include',
-            'TCLLIBPATH': {'path': 'pi', 'delimiter': ' '},
+            'TCLLIBPATH': {'paths': 'pi', 'delimiter': ' '},
         }
         modextrapaths_append = {'APPEND_PATH': 'append_path'}
         self.contents = '\n'.join([

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1338,7 +1338,7 @@ class EasyBlockTest(EnhancedTestCase):
                 vals = [vals]
             for val in vals:
                 if get_module_syntax() == 'Tcl':
-                    regex = re.compile(r'^prepend-path\s+(-d ".")?%s\s+\$root/%s$' % (key, val), re.M)
+                    regex = re.compile(r'^prepend-path\s+(-d "."\s+)?%s\s+\$root/%s$' % (key, val), re.M)
                 elif get_module_syntax() == 'Lua':
                     regex = re.compile(r'^prepend_path\("%s", pathJoin\(root, "%s"\)(, ".")?\)$' % (key, val), re.M)
                 else:

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1336,7 +1336,7 @@ class EasyBlockTest(EnhancedTestCase):
         for (key, vals) in modextrapaths.items():
             if isinstance(vals, str):
                 vals = [vals]
-            if type(vals) == dict:
+            if isinstance(vals, dict):
                 delim = vals['delimiter']
                 paths = vals['paths']
 


### PR DESCRIPTION
This is the straight forward option that we definitely should expose.
It would allow any easyblock to use this at least, though in practice, we should also enable some way for easyconfigs to chose this when specifying modextrapaths.

I left that out for this initial PR, since we need to introduce some new syntax. Maybe good to mark that for 5.0.x.

Various ideas have been thrown out:

```python
modextrapaths = {
    'PATH': 'some_path',    # Normal : delimited paths continue to be either a string
    'PATH': ['some_path', 'other_path'],    # or a list of strings
    'FOO': ('foo', ';'), # Using a tuple indicates second argument is delimiter ; in this case
    'FOO': (['foo', 'bar'], ';'), # same with multiple paths, the string is replaced by a list.
    'BAR': {'paths': 'foo', 'delimiter': ';'}, # more explicit option
    'BAR': {'paths': ['foo', 'bar'], 'delimiter': ';'}, # and with multiple strings
}
```

That's about all the options I can think of. I would be against doing

```python
modextrapaths = {
    'FOO': [('foo', ';'), ('bar', ';')], # not good
}
```

since it could allow for different separators to be used for the same variable, which doesn't make any sense.

Needs tests.

