### PR TITLE
simplify loop in `collect_exts_file_info`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -657,7 +657,12 @@ class EasyBlock:
 
         orig_github_account = self.cfg['github_account']
         for ext in exts_list:
-            if isinstance(ext, (list, tuple)) and ext:
+            if isinstance(ext, str):
+                exts_sources.append({'name': ext})
+            else:
+                if not isinstance(ext, (list, tuple)) or not ext:
+                    raise EasyBuildError("Extension specified in unknown format (not a string/list/tuple)")
+
                 # expected format: (name, version, options (dict))
                 # name and version can use templates, resolved via parent EC
 
@@ -851,12 +856,6 @@ class EasyBlock:
                         self.log.debug('No patches found for extension %s.' % ext_name)
 
                     exts_sources.append(ext_src)
-
-            elif isinstance(ext, str):
-                exts_sources.append({'name': ext})
-
-            else:
-                raise EasyBuildError("Extension specified in unknown format (not a string/list/tuple)")
 
         return exts_sources
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -680,7 +680,7 @@ class EasyBlock:
                 if isinstance(ext_options, dict):
                     ext_options.update(ext[2])
                 else:
-                    raise EasyBuildError("Unexpected type (non-dict) for 3rd element of %s", ext)
+                    raise EasyBuildError(f"Unexpected type (non-dict) for 3rd element of {ext}")
             elif len(ext) > 3:
                 raise EasyBuildError('Extension specified in unknown format (list/tuple too long)')
 
@@ -717,8 +717,8 @@ class EasyBlock:
                     if len(sources) == 1:
                         source = sources[0]
                     else:
-                        error_msg = "'sources' spec for %s in exts_list must be single element list. Is: %s"
-                        raise EasyBuildError(error_msg, ext_name, sources)
+                        raise EasyBuildError(f"'sources' spec for {ext_name} in exts_list must be single element list."
+                                             f" Is: {sources}")
                 else:
                     source = sources
 
@@ -727,8 +727,7 @@ class EasyBlock:
                 if isinstance(source, str):
                     source = {'filename': source}
                 elif not isinstance(source, dict):
-                    raise EasyBuildError("Incorrect value type for source of extension %s: %s",
-                                            ext_name, source)
+                    raise EasyBuildError(f"Incorrect value type for source of extension {ext_name}: {source}")
 
                 # if no custom source URLs are specified in sources spec,
                 # inject the ones specified for this extension
@@ -762,8 +761,8 @@ class EasyBlock:
                         # allow retrying with alternative download_filename
                         is_pypi_source = True
                 elif not isinstance(src_fn, str):
-                    error_msg = "source_tmpl value must be a string! (found value of type '%s'): %s"
-                    raise EasyBuildError(error_msg, type(src_fn).__name__, src_fn)
+                    raise EasyBuildError("source_tmpl value must be a string! "
+                                         f"(found value of type '{type(src_fn).__name__}'): {src_fn}")
 
                 src_fn = resolve_template(src_fn, template_values)
                 ext_src['sources'] = [src_fn]
@@ -785,7 +784,7 @@ class EasyBlock:
                     if src_path:
                         ext_src.update({'src': src_path})
                     else:
-                        raise EasyBuildError("Source for extension %s not found.", ext)
+                        raise EasyBuildError(f"Source for extension {ext} not found.")
 
             # verify checksum for extension sources
             if verify_checksums and 'src' in ext_src:
@@ -802,12 +801,12 @@ class EasyBlock:
                 self.log.debug('Verifying checksums for extension source...')
                 fn_checksum = self.get_checksum_for(checksums, filename=src_fn, index=0)
                 if verify_checksum(src_path, fn_checksum, src_checksums):
-                    self.log.info('Checksum for extension source %s verified', src_fn)
+                    self.log.info(f'Checksum for extension source {src_fn} verified')
                 elif build_option('ignore_checksums'):
-                    print_warning("Ignoring failing checksum verification for %s" % src_fn)
+                    print_warning(f"Ignoring failing checksum verification for {src_fn}")
                 else:
                     raise EasyBuildError(
-                        'Checksum verification for extension source %s failed', src_fn,
+                        f'Checksum verification for extension source {src_fn} failed',
                         exit_code=EasyBuildExit.FAIL_CHECKSUM
                     )
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -659,203 +659,203 @@ class EasyBlock:
         for ext in exts_list:
             if isinstance(ext, str):
                 exts_sources.append({'name': ext})
-            else:
-                if not isinstance(ext, (list, tuple)) or not ext:
-                    raise EasyBuildError("Extension specified in unknown format (not a string/list/tuple)")
+                continue
+            if not isinstance(ext, (list, tuple)) or not ext:
+                raise EasyBuildError("Extension specified in unknown format (not a string/list/tuple)")
 
-                # expected format: (name, version, options (dict))
-                # name and version can use templates, resolved via parent EC
+            # expected format: (name, version, options (dict))
+            # name and version can use templates, resolved via parent EC
 
-                ext_name = resolve_template(ext[0], self.cfg.template_values)
-                if len(ext) == 1:
-                    exts_sources.append({'name': ext_name})
+            ext_name = resolve_template(ext[0], self.cfg.template_values)
+            if len(ext) == 1:
+                exts_sources.append({'name': ext_name})
+                continue
+            ext_version = resolve_template(ext[1], self.cfg.template_values)
+
+            # make sure we grab *raw* dict of default options for extension,
+            # since it may use template values like %(name)s & %(version)s
+            ext_options = copy.deepcopy(self.cfg.get_ref('exts_default_options'))
+
+            if len(ext) == 3:
+                if isinstance(ext_options, dict):
+                    ext_options.update(ext[2])
                 else:
-                    ext_version = resolve_template(ext[1], self.cfg.template_values)
+                    raise EasyBuildError("Unexpected type (non-dict) for 3rd element of %s", ext)
+            elif len(ext) > 3:
+                raise EasyBuildError('Extension specified in unknown format (list/tuple too long)')
 
-                    # make sure we grab *raw* dict of default options for extension,
-                    # since it may use template values like %(name)s & %(version)s
-                    ext_options = copy.deepcopy(self.cfg.get_ref('exts_default_options'))
+            ext_src = {
+                'name': ext_name,
+                'version': ext_version,
+                'options': ext_options,
+                'github_account': ext_options.get('github_account', orig_github_account),
+                # if a particular easyblock is specified, make sure it's used
+                # (this is picked up by init_ext_instances)
+                'easyblock': ext_options.get('easyblock', None),
+            }
 
-                    if len(ext) == 3:
-                        if isinstance(ext_options, dict):
-                            ext_options.update(ext[2])
-                        else:
-                            raise EasyBuildError("Unexpected type (non-dict) for 3rd element of %s", ext)
-                    elif len(ext) > 3:
-                        raise EasyBuildError('Extension specified in unknown format (list/tuple too long)')
+            # construct dictionary with template values;
+            # inherited from parent, except for name/version templates which are specific to this extension
+            template_values = copy.deepcopy(self.cfg.template_values)
+            template_values.update(template_constant_dict(ext_src))
 
-                    ext_src = {
-                        'name': ext_name,
-                        'version': ext_version,
-                        'options': ext_options,
-                        'github_account': ext_options.get('github_account', orig_github_account),
-                        # if a particular easyblock is specified, make sure it's used
-                        # (this is picked up by init_ext_instances)
-                        'easyblock': ext_options.get('easyblock', None),
-                    }
+            source_urls = resolve_template(ext_options.get('source_urls', []), template_values)
+            checksums = resolve_template(ext_options.get('checksums', []), template_values)
+            ext_src['checksums'] = checksums
 
-                    # construct dictionary with template values;
-                    # inherited from parent, except for name/version templates which are specific to this extension
-                    template_values = copy.deepcopy(self.cfg.template_values)
-                    template_values.update(template_constant_dict(ext_src))
+            download_instructions = resolve_template(ext_options.get('download_instructions'), template_values)
 
-                    source_urls = resolve_template(ext_options.get('source_urls', []), template_values)
-                    checksums = resolve_template(ext_options.get('checksums', []), template_values)
-                    ext_src['checksums'] = checksums
+            if ext_options.get('nosource', None):
+                self.log.debug("No sources for extension %s, as indicated by 'nosource'", ext_name)
 
-                    download_instructions = resolve_template(ext_options.get('download_instructions'), template_values)
+            elif ext_options.get('sources', None):
+                sources = resolve_template(ext_options['sources'], template_values)
 
-                    if ext_options.get('nosource', None):
-                        self.log.debug("No sources for extension %s, as indicated by 'nosource'", ext_name)
-
-                    elif ext_options.get('sources', None):
-                        sources = resolve_template(ext_options['sources'], template_values)
-
-                        # only a single source file is supported for extensions currently,
-                        # see https://github.com/easybuilders/easybuild-framework/issues/3463
-                        if isinstance(sources, list):
-                            if len(sources) == 1:
-                                source = sources[0]
-                            else:
-                                error_msg = "'sources' spec for %s in exts_list must be single element list. Is: %s"
-                                raise EasyBuildError(error_msg, ext_name, sources)
-                        else:
-                            source = sources
-
-                        # always pass source spec as dict value to fetch_source method,
-                        # mostly so we can inject stuff like source URLs
-                        if isinstance(source, str):
-                            source = {'filename': source}
-                        elif not isinstance(source, dict):
-                            raise EasyBuildError("Incorrect value type for source of extension %s: %s",
-                                                 ext_name, source)
-
-                        # if no custom source URLs are specified in sources spec,
-                        # inject the ones specified for this extension
-                        if 'source_urls' not in source:
-                            source['source_urls'] = source_urls
-
-                        if fetch_files:
-                            src = self.fetch_source(source, checksums, extension=True,
-                                                    download_instructions=download_instructions)
-                            ext_src.update({
-                                # keep track of custom extract command (if any)
-                                'extract_cmd': src['cmd'],
-                                # copy 'path' entry to 'src' for use with extensions
-                                'src': src['path'],
-                            })
-                            filename = src['name']
-                        else:
-                            filename = source.get('filename')
-                        if filename is not None:
-                            ext_src['sources'] = [filename]
-
+                # only a single source file is supported for extensions currently,
+                # see https://github.com/easybuilders/easybuild-framework/issues/3463
+                if isinstance(sources, list):
+                    if len(sources) == 1:
+                        source = sources[0]
                     else:
+                        error_msg = "'sources' spec for %s in exts_list must be single element list. Is: %s"
+                        raise EasyBuildError(error_msg, ext_name, sources)
+                else:
+                    source = sources
 
-                        # if no sources are specified via 'sources', fall back to 'source_tmpl'
-                        src_fn = ext_options.get('source_tmpl')
-                        is_pypi_source = False
-                        if src_fn is None:
-                            # use default template for name of source file if none is specified
-                            src_fn = '%(name)s-%(version)s.tar.gz'
-                            if len(source_urls) == 1 and PYPI_PKG_URL_PATTERN in source_urls[0]:
-                                # allow retrying with alternative download_filename
-                                is_pypi_source = True
-                        elif not isinstance(src_fn, str):
-                            error_msg = "source_tmpl value must be a string! (found value of type '%s'): %s"
-                            raise EasyBuildError(error_msg, type(src_fn).__name__, src_fn)
+                # always pass source spec as dict value to fetch_source method,
+                # mostly so we can inject stuff like source URLs
+                if isinstance(source, str):
+                    source = {'filename': source}
+                elif not isinstance(source, dict):
+                    raise EasyBuildError("Incorrect value type for source of extension %s: %s",
+                                            ext_name, source)
 
-                        src_fn = resolve_template(src_fn, template_values)
-                        ext_src['sources'] = [src_fn]
+                # if no custom source URLs are specified in sources spec,
+                # inject the ones specified for this extension
+                if 'source_urls' not in source:
+                    source['source_urls'] = source_urls
 
-                        if fetch_files:
-                            src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,
-                                                        force_download=force_download,
-                                                        download_instructions=download_instructions,
-                                                        warning_only=is_pypi_source)
-                            if not src_path and is_pypi_source:
-                                # retry with alternative download_filename
-                                alt_name = resolve_template('%(name)s', template_values).replace("-", "_")
-                                src_version = resolve_template('%(version)s', template_values)
-                                alt_download_fn = f'{alt_name}-{src_version}.tar.gz'
-                                src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,
-                                                            force_download=force_download,
-                                                            download_instructions=download_instructions,
-                                                            download_filename=alt_download_fn)
-                            if src_path:
-                                ext_src.update({'src': src_path})
-                            else:
-                                raise EasyBuildError("Source for extension %s not found.", ext)
+                if fetch_files:
+                    src = self.fetch_source(source, checksums, extension=True,
+                                            download_instructions=download_instructions)
+                    ext_src.update({
+                        # keep track of custom extract command (if any)
+                        'extract_cmd': src['cmd'],
+                        # copy 'path' entry to 'src' for use with extensions
+                        'src': src['path'],
+                    })
+                    filename = src['name']
+                else:
+                    filename = source.get('filename')
+                if filename is not None:
+                    ext_src['sources'] = [filename]
 
-                    # verify checksum for extension sources
-                    if verify_checksums and 'src' in ext_src:
-                        src_path = ext_src['src']
-                        src_fn = os.path.basename(src_path)
+            else:
 
-                        src_checksums = {}
+                # if no sources are specified via 'sources', fall back to 'source_tmpl'
+                src_fn = ext_options.get('source_tmpl')
+                is_pypi_source = False
+                if src_fn is None:
+                    # use default template for name of source file if none is specified
+                    src_fn = '%(name)s-%(version)s.tar.gz'
+                    if len(source_urls) == 1 and PYPI_PKG_URL_PATTERN in source_urls[0]:
+                        # allow retrying with alternative download_filename
+                        is_pypi_source = True
+                elif not isinstance(src_fn, str):
+                    error_msg = "source_tmpl value must be a string! (found value of type '%s'): %s"
+                    raise EasyBuildError(error_msg, type(src_fn).__name__, src_fn)
+
+                src_fn = resolve_template(src_fn, template_values)
+                ext_src['sources'] = [src_fn]
+
+                if fetch_files:
+                    src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,
+                                                force_download=force_download,
+                                                download_instructions=download_instructions,
+                                                warning_only=is_pypi_source)
+                    if not src_path and is_pypi_source:
+                        # retry with alternative download_filename
+                        alt_name = resolve_template('%(name)s', template_values).replace("-", "_")
+                        src_version = resolve_template('%(version)s', template_values)
+                        alt_download_fn = f'{alt_name}-{src_version}.tar.gz'
+                        src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,
+                                                    force_download=force_download,
+                                                    download_instructions=download_instructions,
+                                                    download_filename=alt_download_fn)
+                    if src_path:
+                        ext_src.update({'src': src_path})
+                    else:
+                        raise EasyBuildError("Source for extension %s not found.", ext)
+
+            # verify checksum for extension sources
+            if verify_checksums and 'src' in ext_src:
+                src_path = ext_src['src']
+                src_fn = os.path.basename(src_path)
+
+                src_checksums = {}
+                for checksum_type in [CHECKSUM_TYPE_SHA256]:
+                    src_checksum = compute_checksum(src_path, checksum_type=checksum_type)
+                    src_checksums[checksum_type] = src_checksum
+                    self.log.info("%s checksum for %s: %s", checksum_type, src_path, src_checksum)
+
+                # verify checksum (if provided)
+                self.log.debug('Verifying checksums for extension source...')
+                fn_checksum = self.get_checksum_for(checksums, filename=src_fn, index=0)
+                if verify_checksum(src_path, fn_checksum, src_checksums):
+                    self.log.info('Checksum for extension source %s verified', src_fn)
+                elif build_option('ignore_checksums'):
+                    print_warning("Ignoring failing checksum verification for %s" % src_fn)
+                else:
+                    raise EasyBuildError(
+                        'Checksum verification for extension source %s failed', src_fn,
+                        exit_code=EasyBuildExit.FAIL_CHECKSUM
+                    )
+
+            # locate extension patches (if any), and verify checksums
+            ext_patch_specs = resolve_template((
+                ext_options.get('patches', []),
+                ext_options.get(ALTERNATIVE_EASYCONFIG_PARAMETERS['post_install_patches'],
+                                ext_options.get('post_install_patches', []))
+                ), template_values)
+            if fetch_files:
+                ext_patches = self.fetch_patches(patch_specs=ext_patch_specs, extension=True)
+            else:
+                ext_patches = [create_patch_info(p) for p in itertools.chain.from_iterable(ext_patch_specs)]
+
+            if ext_patches:
+                self.log.debug('Found patches for extension %s: %s', ext_name, ext_patches)
+                ext_src.update({'patches': ext_patches})
+
+                if verify_checksums:
+                    computed_checksums = {}
+                    for patch in ext_patches:
+                        patch = patch['path']
+                        computed_checksums[patch] = {}
                         for checksum_type in [CHECKSUM_TYPE_SHA256]:
-                            src_checksum = compute_checksum(src_path, checksum_type=checksum_type)
-                            src_checksums[checksum_type] = src_checksum
-                            self.log.info("%s checksum for %s: %s", checksum_type, src_path, src_checksum)
+                            checksum = compute_checksum(patch, checksum_type=checksum_type)
+                            computed_checksums[patch][checksum_type] = checksum
+                            self.log.info("%s checksum for %s: %s", checksum_type, patch, checksum)
 
-                        # verify checksum (if provided)
-                        self.log.debug('Verifying checksums for extension source...')
-                        fn_checksum = self.get_checksum_for(checksums, filename=src_fn, index=0)
-                        if verify_checksum(src_path, fn_checksum, src_checksums):
-                            self.log.info('Checksum for extension source %s verified', src_fn)
+                    # verify checksum (if provided)
+                    self.log.debug('Verifying checksums for extension patches...')
+                    for idx, patch in enumerate(ext_patches):
+                        patch = patch['path']
+                        patch_fn = os.path.basename(patch)
+
+                        checksum = self.get_checksum_for(checksums, filename=patch_fn, index=idx+1)
+                        if verify_checksum(patch, checksum, computed_checksums[patch]):
+                            self.log.info('Checksum for extension patch %s verified', patch_fn)
                         elif build_option('ignore_checksums'):
-                            print_warning("Ignoring failing checksum verification for %s" % src_fn)
+                            print_warning("Ignoring failing checksum verification for %s" % patch_fn)
                         else:
                             raise EasyBuildError(
-                                'Checksum verification for extension source %s failed', src_fn,
+                                "Checksum verification for extension patch %s failed", patch_fn,
                                 exit_code=EasyBuildExit.FAIL_CHECKSUM
                             )
+            else:
+                self.log.debug('No patches found for extension %s.' % ext_name)
 
-                    # locate extension patches (if any), and verify checksums
-                    ext_patch_specs = resolve_template((
-                        ext_options.get('patches', []),
-                        ext_options.get(ALTERNATIVE_EASYCONFIG_PARAMETERS['post_install_patches'],
-                                        ext_options.get('post_install_patches', []))
-                        ), template_values)
-                    if fetch_files:
-                        ext_patches = self.fetch_patches(patch_specs=ext_patch_specs, extension=True)
-                    else:
-                        ext_patches = [create_patch_info(p) for p in itertools.chain.from_iterable(ext_patch_specs)]
-
-                    if ext_patches:
-                        self.log.debug('Found patches for extension %s: %s', ext_name, ext_patches)
-                        ext_src.update({'patches': ext_patches})
-
-                        if verify_checksums:
-                            computed_checksums = {}
-                            for patch in ext_patches:
-                                patch = patch['path']
-                                computed_checksums[patch] = {}
-                                for checksum_type in [CHECKSUM_TYPE_SHA256]:
-                                    checksum = compute_checksum(patch, checksum_type=checksum_type)
-                                    computed_checksums[patch][checksum_type] = checksum
-                                    self.log.info("%s checksum for %s: %s", checksum_type, patch, checksum)
-
-                            # verify checksum (if provided)
-                            self.log.debug('Verifying checksums for extension patches...')
-                            for idx, patch in enumerate(ext_patches):
-                                patch = patch['path']
-                                patch_fn = os.path.basename(patch)
-
-                                checksum = self.get_checksum_for(checksums, filename=patch_fn, index=idx+1)
-                                if verify_checksum(patch, checksum, computed_checksums[patch]):
-                                    self.log.info('Checksum for extension patch %s verified', patch_fn)
-                                elif build_option('ignore_checksums'):
-                                    print_warning("Ignoring failing checksum verification for %s" % patch_fn)
-                                else:
-                                    raise EasyBuildError(
-                                        "Checksum verification for extension patch %s failed", patch_fn,
-                                        exit_code=EasyBuildExit.FAIL_CHECKSUM
-                                    )
-                    else:
-                        self.log.debug('No patches found for extension %s.' % ext_name)
-
-                    exts_sources.append(ext_src)
+            exts_sources.append(ext_src)
 
         return exts_sources
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -689,7 +689,7 @@ class EasyBlock:
                 if isinstance(ext_options, dict):
                     ext_options.update(ext[2])
                 else:
-                    raise EasyBuildError("Unexpected type (non-dict) for 3rd element of %s", ext)
+                    raise EasyBuildError(f"Unexpected type (non-dict) for 3rd element of {ext}")
             elif len(ext) > 3:
                 raise EasyBuildError('Extension specified in unknown format (list/tuple too long)')
 
@@ -730,8 +730,8 @@ class EasyBlock:
                     if len(sources) == 1:
                         source = sources[0]
                     else:
-                        error_msg = "'sources' spec for %s in exts_list must be single element list. Is: %s"
-                        raise EasyBuildError(error_msg, ext_name, sources)
+                        raise EasyBuildError(f"'sources' spec for {ext_name} in exts_list must be single element list."
+                                             f" Is: {sources}")
                 else:
                     source = sources
 
@@ -740,8 +740,7 @@ class EasyBlock:
                 if isinstance(source, str):
                     source = {'filename': source}
                 elif not isinstance(source, dict):
-                    raise EasyBuildError("Incorrect value type for source of extension %s: %s",
-                                            ext_name, source)
+                    raise EasyBuildError(f"Incorrect value type for source of extension {ext_name}: {source}")
 
                 # if no custom source URLs are specified in sources spec,
                 # inject the ones specified for this extension
@@ -775,8 +774,8 @@ class EasyBlock:
                         # allow retrying with alternative download_filename
                         is_pypi_source = True
                 elif not isinstance(src_fn, str):
-                    error_msg = "source_tmpl value must be a string! (found value of type '%s'): %s"
-                    raise EasyBuildError(error_msg, type(src_fn).__name__, src_fn)
+                    raise EasyBuildError("source_tmpl value must be a string! "
+                                         f"(found value of type '{type(src_fn).__name__}'): {src_fn}")
 
                 src_fn = resolve_template(src_fn, template_values)
                 ext_src['sources'] = [src_fn]
@@ -798,7 +797,7 @@ class EasyBlock:
                     if src_path:
                         ext_src.update({'src': src_path})
                     else:
-                        raise EasyBuildError("Source for extension %s not found.", ext)
+                        raise EasyBuildError(f"Source for extension {ext} not found.")
 
             # verify checksum for extension sources
             if verify_checksums and 'src' in ext_src:
@@ -815,12 +814,12 @@ class EasyBlock:
                 self.log.debug('Verifying checksums for extension source...')
                 fn_checksum = self.get_checksum_for(checksums, filename=src_fn, index=0)
                 if verify_checksum(src_path, fn_checksum, src_checksums):
-                    self.log.info('Checksum for extension source %s verified', src_fn)
+                    self.log.info(f'Checksum for extension source {src_fn} verified')
                 elif build_option('ignore_checksums'):
-                    print_warning("Ignoring failing checksum verification for %s" % src_fn)
+                    print_warning(f"Ignoring failing checksum verification for {src_fn}")
                 else:
                     raise EasyBuildError(
-                        'Checksum verification for extension source %s failed', src_fn,
+                        f'Checksum verification for extension source {src_fn} failed',
                         exit_code=EasyBuildExit.FAIL_CHECKSUM
                     )
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -668,207 +668,207 @@ class EasyBlock:
         for ext in exts_list:
             if isinstance(ext, str):
                 exts_sources.append({'name': resolve_template(ext, self.cfg.template_values)})
-            else:
-                if not isinstance(ext, (list, tuple)) or not ext:
-                    raise EasyBuildError("Extension specified in unknown format (not a string/list/tuple)")
+                continue
+            if not isinstance(ext, (list, tuple)) or not ext:
+                raise EasyBuildError("Extension specified in unknown format (not a string/list/tuple)")
 
-                # expected format: (name, version, options (dict))
-                # name and version can use templates, resolved via parent EC
+            # expected format: (name, version, options (dict))
+            # name and version can use templates, resolved via parent EC
 
-                ext_name = resolve_template(ext[0], self.cfg.template_values)
-                if len(ext) == 1:
-                    exts_sources.append({'name': ext_name})
+            ext_name = resolve_template(ext[0], self.cfg.template_values)
+            if len(ext) == 1:
+                exts_sources.append({'name': ext_name})
+                continue
+            ext_version = resolve_template(ext[1], self.cfg.template_values)
+
+            # make sure we grab *raw* dict of default options for extension,
+            # since it may use template values like %(name)s & %(version)s
+            ext_options = copy.deepcopy(self.cfg.get_ref('exts_default_options'))
+
+            if len(ext) == 3:
+                if isinstance(ext_options, dict):
+                    ext_options.update(ext[2])
                 else:
-                    ext_version = resolve_template(ext[1], self.cfg.template_values)
+                    raise EasyBuildError("Unexpected type (non-dict) for 3rd element of %s", ext)
+            elif len(ext) > 3:
+                raise EasyBuildError('Extension specified in unknown format (list/tuple too long)')
 
-                    # make sure we grab *raw* dict of default options for extension,
-                    # since it may use template values like %(name)s & %(version)s
-                    ext_options = copy.deepcopy(self.cfg.get_ref('exts_default_options'))
+            ext_src = {
+                'name': ext_name,
+                'version': ext_version,
+                'options': ext_options,
+                'github_account': ext_options.get('github_account', orig_github_account),
+                # if a particular easyblock is specified, make sure it's used
+                # (this is picked up by init_ext_instances)
+                'easyblock': ext_options.get('easyblock'),
+            }
 
-                    if len(ext) == 3:
-                        if isinstance(ext_options, dict):
-                            ext_options.update(ext[2])
-                        else:
-                            raise EasyBuildError("Unexpected type (non-dict) for 3rd element of %s", ext)
-                    elif len(ext) > 3:
-                        raise EasyBuildError('Extension specified in unknown format (list/tuple too long)')
+            # construct dictionary with template values;
+            # inherited from parent, except for name/version templates which are specific to this extension
+            template_values = copy.deepcopy(self.cfg.template_values)
+            template_values.update(template_constant_dict(ext_src))
 
-                    ext_src = {
-                        'name': ext_name,
-                        'version': ext_version,
-                        'options': ext_options,
-                        'github_account': ext_options.get('github_account', orig_github_account),
-                        # if a particular easyblock is specified, make sure it's used
-                        # (this is picked up by init_ext_instances)
-                        'easyblock': ext_options.get('easyblock'),
-                    }
+            # Resolve this here where we have the template values available
+            if 'extension_name' in ext_options:
+                ext_options['extension_name'] = resolve_template(ext_options['extension_name'], template_values)
 
-                    # construct dictionary with template values;
-                    # inherited from parent, except for name/version templates which are specific to this extension
-                    template_values = copy.deepcopy(self.cfg.template_values)
-                    template_values.update(template_constant_dict(ext_src))
+            source_urls = resolve_template(ext_options.get('source_urls', []), template_values)
+            checksums = resolve_template(ext_options.get('checksums', []), template_values)
+            ext_src['checksums'] = checksums
 
-                    # Resolve this here where we have the template values available
-                    if 'extension_name' in ext_options:
-                        ext_options['extension_name'] = resolve_template(ext_options['extension_name'], template_values)
+            download_instructions = resolve_template(ext_options.get('download_instructions'), template_values)
 
-                    source_urls = resolve_template(ext_options.get('source_urls', []), template_values)
-                    checksums = resolve_template(ext_options.get('checksums', []), template_values)
-                    ext_src['checksums'] = checksums
+            if ext_options.get('nosource', None):
+                self.log.debug("No sources for extension %s, as indicated by 'nosource'", ext_name)
 
-                    download_instructions = resolve_template(ext_options.get('download_instructions'), template_values)
+            elif ext_options.get('sources', None):
+                sources = resolve_template(ext_options['sources'], template_values)
 
-                    if ext_options.get('nosource', None):
-                        self.log.debug("No sources for extension %s, as indicated by 'nosource'", ext_name)
-
-                    elif ext_options.get('sources', None):
-                        sources = resolve_template(ext_options['sources'], template_values)
-
-                        # only a single source file is supported for extensions currently,
-                        # see https://github.com/easybuilders/easybuild-framework/issues/3463
-                        if isinstance(sources, list):
-                            if len(sources) == 1:
-                                source = sources[0]
-                            else:
-                                error_msg = "'sources' spec for %s in exts_list must be single element list. Is: %s"
-                                raise EasyBuildError(error_msg, ext_name, sources)
-                        else:
-                            source = sources
-
-                        # always pass source spec as dict value to fetch_source method,
-                        # mostly so we can inject stuff like source URLs
-                        if isinstance(source, str):
-                            source = {'filename': source}
-                        elif not isinstance(source, dict):
-                            raise EasyBuildError("Incorrect value type for source of extension %s: %s",
-                                                 ext_name, source)
-
-                        # if no custom source URLs are specified in sources spec,
-                        # inject the ones specified for this extension
-                        if 'source_urls' not in source:
-                            source['source_urls'] = source_urls
-
-                        if fetch_files:
-                            src = self.fetch_source(source, checksums, extension=True,
-                                                    download_instructions=download_instructions)
-                            ext_src.update({
-                                # keep track of custom extract command (if any)
-                                'extract_cmd': src['cmd'],
-                                # copy 'path' entry to 'src' for use with extensions
-                                'src': src['path'],
-                            })
-                            filename = src['name']
-                        else:
-                            filename = source.get('filename')
-                        if filename is not None:
-                            ext_src['sources'] = [filename]
-
+                # only a single source file is supported for extensions currently,
+                # see https://github.com/easybuilders/easybuild-framework/issues/3463
+                if isinstance(sources, list):
+                    if len(sources) == 1:
+                        source = sources[0]
                     else:
+                        error_msg = "'sources' spec for %s in exts_list must be single element list. Is: %s"
+                        raise EasyBuildError(error_msg, ext_name, sources)
+                else:
+                    source = sources
 
-                        # if no sources are specified via 'sources', fall back to 'source_tmpl'
-                        src_fn = ext_options.get('source_tmpl')
-                        is_pypi_source = False
-                        if src_fn is None:
-                            # use default template for name of source file if none is specified
-                            src_fn = '%(name)s-%(version)s.tar.gz'
-                            if len(source_urls) == 1 and PYPI_PKG_URL_PATTERN in source_urls[0]:
-                                # allow retrying with alternative download_filename
-                                is_pypi_source = True
-                        elif not isinstance(src_fn, str):
-                            error_msg = "source_tmpl value must be a string! (found value of type '%s'): %s"
-                            raise EasyBuildError(error_msg, type(src_fn).__name__, src_fn)
+                # always pass source spec as dict value to fetch_source method,
+                # mostly so we can inject stuff like source URLs
+                if isinstance(source, str):
+                    source = {'filename': source}
+                elif not isinstance(source, dict):
+                    raise EasyBuildError("Incorrect value type for source of extension %s: %s",
+                                            ext_name, source)
 
-                        src_fn = resolve_template(src_fn, template_values)
-                        ext_src['sources'] = [src_fn]
+                # if no custom source URLs are specified in sources spec,
+                # inject the ones specified for this extension
+                if 'source_urls' not in source:
+                    source['source_urls'] = source_urls
 
-                        if fetch_files:
-                            src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,
-                                                        force_download=force_download,
-                                                        download_instructions=download_instructions,
-                                                        warning_only=is_pypi_source)
-                            if not src_path and is_pypi_source:
-                                # retry with alternative download_filename
-                                alt_name = resolve_template('%(name)s', template_values).replace("-", "_")
-                                src_version = resolve_template('%(version)s', template_values)
-                                alt_download_fn = f'{alt_name}-{src_version}.tar.gz'
-                                src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,
-                                                            force_download=force_download,
-                                                            download_instructions=download_instructions,
-                                                            download_filename=alt_download_fn)
-                            if src_path:
-                                ext_src.update({'src': src_path})
-                            else:
-                                raise EasyBuildError("Source for extension %s not found.", ext)
+                if fetch_files:
+                    src = self.fetch_source(source, checksums, extension=True,
+                                            download_instructions=download_instructions)
+                    ext_src.update({
+                        # keep track of custom extract command (if any)
+                        'extract_cmd': src['cmd'],
+                        # copy 'path' entry to 'src' for use with extensions
+                        'src': src['path'],
+                    })
+                    filename = src['name']
+                else:
+                    filename = source.get('filename')
+                if filename is not None:
+                    ext_src['sources'] = [filename]
 
-                    # verify checksum for extension sources
-                    if verify_checksums and 'src' in ext_src:
-                        src_path = ext_src['src']
-                        src_fn = os.path.basename(src_path)
+            else:
 
-                        src_checksums = {}
+                # if no sources are specified via 'sources', fall back to 'source_tmpl'
+                src_fn = ext_options.get('source_tmpl')
+                is_pypi_source = False
+                if src_fn is None:
+                    # use default template for name of source file if none is specified
+                    src_fn = '%(name)s-%(version)s.tar.gz'
+                    if len(source_urls) == 1 and PYPI_PKG_URL_PATTERN in source_urls[0]:
+                        # allow retrying with alternative download_filename
+                        is_pypi_source = True
+                elif not isinstance(src_fn, str):
+                    error_msg = "source_tmpl value must be a string! (found value of type '%s'): %s"
+                    raise EasyBuildError(error_msg, type(src_fn).__name__, src_fn)
+
+                src_fn = resolve_template(src_fn, template_values)
+                ext_src['sources'] = [src_fn]
+
+                if fetch_files:
+                    src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,
+                                                force_download=force_download,
+                                                download_instructions=download_instructions,
+                                                warning_only=is_pypi_source)
+                    if not src_path and is_pypi_source:
+                        # retry with alternative download_filename
+                        alt_name = resolve_template('%(name)s', template_values).replace("-", "_")
+                        src_version = resolve_template('%(version)s', template_values)
+                        alt_download_fn = f'{alt_name}-{src_version}.tar.gz'
+                        src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,
+                                                    force_download=force_download,
+                                                    download_instructions=download_instructions,
+                                                    download_filename=alt_download_fn)
+                    if src_path:
+                        ext_src.update({'src': src_path})
+                    else:
+                        raise EasyBuildError("Source for extension %s not found.", ext)
+
+            # verify checksum for extension sources
+            if verify_checksums and 'src' in ext_src:
+                src_path = ext_src['src']
+                src_fn = os.path.basename(src_path)
+
+                src_checksums = {}
+                for checksum_type in [CHECKSUM_TYPE_SHA256]:
+                    src_checksum = compute_checksum(src_path, checksum_type=checksum_type)
+                    src_checksums[checksum_type] = src_checksum
+                    self.log.info("%s checksum for %s: %s", checksum_type, src_path, src_checksum)
+
+                # verify checksum (if provided)
+                self.log.debug('Verifying checksums for extension source...')
+                fn_checksum = self.get_checksum_for(checksums, filename=src_fn, index=0)
+                if verify_checksum(src_path, fn_checksum, src_checksums):
+                    self.log.info('Checksum for extension source %s verified', src_fn)
+                elif build_option('ignore_checksums'):
+                    print_warning("Ignoring failing checksum verification for %s" % src_fn)
+                else:
+                    raise EasyBuildError(
+                        'Checksum verification for extension source %s failed', src_fn,
+                        exit_code=EasyBuildExit.FAIL_CHECKSUM
+                    )
+
+            # locate extension patches (if any), and verify checksums
+            ext_patch_specs = resolve_template((
+                ext_options.get('patches', []),
+                ext_options.get(ALTERNATIVE_EASYCONFIG_PARAMETERS['post_install_patches'],
+                                ext_options.get('post_install_patches', []))
+                ), template_values)
+            if fetch_files:
+                ext_patches = self.fetch_patches(patch_specs=ext_patch_specs, extension=True)
+            else:
+                ext_patches = [create_patch_info(p) for p in itertools.chain.from_iterable(ext_patch_specs)]
+
+            if ext_patches:
+                self.log.debug('Found patches for extension %s: %s', ext_name, ext_patches)
+                ext_src.update({'patches': ext_patches})
+
+                if verify_checksums:
+                    computed_checksums = {}
+                    for patch in ext_patches:
+                        patch = patch['path']
+                        computed_checksums[patch] = {}
                         for checksum_type in [CHECKSUM_TYPE_SHA256]:
-                            src_checksum = compute_checksum(src_path, checksum_type=checksum_type)
-                            src_checksums[checksum_type] = src_checksum
-                            self.log.info("%s checksum for %s: %s", checksum_type, src_path, src_checksum)
+                            checksum = compute_checksum(patch, checksum_type=checksum_type)
+                            computed_checksums[patch][checksum_type] = checksum
+                            self.log.info("%s checksum for %s: %s", checksum_type, patch, checksum)
 
-                        # verify checksum (if provided)
-                        self.log.debug('Verifying checksums for extension source...')
-                        fn_checksum = self.get_checksum_for(checksums, filename=src_fn, index=0)
-                        if verify_checksum(src_path, fn_checksum, src_checksums):
-                            self.log.info('Checksum for extension source %s verified', src_fn)
+                    # verify checksum (if provided)
+                    self.log.debug('Verifying checksums for extension patches...')
+                    for idx, patch in enumerate(ext_patches):
+                        patch = patch['path']
+                        patch_fn = os.path.basename(patch)
+
+                        checksum = self.get_checksum_for(checksums, filename=patch_fn, index=idx+1)
+                        if verify_checksum(patch, checksum, computed_checksums[patch]):
+                            self.log.info('Checksum for extension patch %s verified', patch_fn)
                         elif build_option('ignore_checksums'):
-                            print_warning("Ignoring failing checksum verification for %s" % src_fn)
+                            print_warning("Ignoring failing checksum verification for %s" % patch_fn)
                         else:
                             raise EasyBuildError(
-                                'Checksum verification for extension source %s failed', src_fn,
+                                "Checksum verification for extension patch %s failed", patch_fn,
                                 exit_code=EasyBuildExit.FAIL_CHECKSUM
                             )
+            else:
+                self.log.debug('No patches found for extension %s.' % ext_name)
 
-                    # locate extension patches (if any), and verify checksums
-                    ext_patch_specs = resolve_template((
-                        ext_options.get('patches', []),
-                        ext_options.get(ALTERNATIVE_EASYCONFIG_PARAMETERS['post_install_patches'],
-                                        ext_options.get('post_install_patches', []))
-                        ), template_values)
-                    if fetch_files:
-                        ext_patches = self.fetch_patches(patch_specs=ext_patch_specs, extension=True)
-                    else:
-                        ext_patches = [create_patch_info(p) for p in itertools.chain.from_iterable(ext_patch_specs)]
-
-                    if ext_patches:
-                        self.log.debug('Found patches for extension %s: %s', ext_name, ext_patches)
-                        ext_src.update({'patches': ext_patches})
-
-                        if verify_checksums:
-                            computed_checksums = {}
-                            for patch in ext_patches:
-                                patch = patch['path']
-                                computed_checksums[patch] = {}
-                                for checksum_type in [CHECKSUM_TYPE_SHA256]:
-                                    checksum = compute_checksum(patch, checksum_type=checksum_type)
-                                    computed_checksums[patch][checksum_type] = checksum
-                                    self.log.info("%s checksum for %s: %s", checksum_type, patch, checksum)
-
-                            # verify checksum (if provided)
-                            self.log.debug('Verifying checksums for extension patches...')
-                            for idx, patch in enumerate(ext_patches):
-                                patch = patch['path']
-                                patch_fn = os.path.basename(patch)
-
-                                checksum = self.get_checksum_for(checksums, filename=patch_fn, index=idx+1)
-                                if verify_checksum(patch, checksum, computed_checksums[patch]):
-                                    self.log.info('Checksum for extension patch %s verified', patch_fn)
-                                elif build_option('ignore_checksums'):
-                                    print_warning("Ignoring failing checksum verification for %s" % patch_fn)
-                                else:
-                                    raise EasyBuildError(
-                                        "Checksum verification for extension patch %s failed", patch_fn,
-                                        exit_code=EasyBuildExit.FAIL_CHECKSUM
-                                    )
-                    else:
-                        self.log.debug('No patches found for extension %s.' % ext_name)
-
-                    exts_sources.append(ext_src)
+            exts_sources.append(ext_src)
 
         return exts_sources
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -666,7 +666,12 @@ class EasyBlock:
 
         orig_github_account = self.cfg['github_account']
         for ext in exts_list:
-            if isinstance(ext, (list, tuple)) and ext:
+            if isinstance(ext, str):
+                exts_sources.append({'name': resolve_template(ext, self.cfg.template_values)})
+            else:
+                if not isinstance(ext, (list, tuple)) or not ext:
+                    raise EasyBuildError("Extension specified in unknown format (not a string/list/tuple)")
+
                 # expected format: (name, version, options (dict))
                 # name and version can use templates, resolved via parent EC
 
@@ -864,11 +869,6 @@ class EasyBlock:
                         self.log.debug('No patches found for extension %s.' % ext_name)
 
                     exts_sources.append(ext_src)
-
-            elif isinstance(ext, str):
-                exts_sources.append({'name': resolve_template(ext, self.cfg.template_values)})
-            else:
-                raise EasyBuildError("Extension specified in unknown format (not a string/list/tuple)")
 
         return exts_sources
 


### PR DESCRIPTION
The loop over `exts_list` uses an excessive amount of branches and hence indentation making it hard to read.

We have 3 simple cases:

1. Extension is a string -> use it as the name and do nothing else
2. extension is neither a string, list nor dict -> Error out
3. extension is a list of only a name -> use as the name and do nothing else

Moving the type check to the top of the loop makes it instantly visible which types are accepted, the `elif`s at the bottom are hard to find after all the indents.

Using `continue` after handling the simple cases reduces the indentation by 2 levels and makes it clear, that nothing else is done for those.