### PR TITLE
Feature developer mode

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -80,10 +80,10 @@ from easybuild.tools.config import install_path, log_path, package_path, source_
 from easybuild.tools.environment import restore_env, sanitize_env
 from easybuild.tools.filetools import CHECKSUM_TYPE_SHA256
 from easybuild.tools.filetools import adjust_permissions, apply_patch, back_up_file, change_dir, check_lock
-from easybuild.tools.filetools import compute_checksum, convert_name, copy_file, copy_dir, create_lock, create_patch_info
+from easybuild.tools.filetools import compute_checksum, convert_name, copy_file, create_lock, create_patch_info
 from easybuild.tools.filetools import derive_alt_pypi_url, diff_files, dir_contains_files, download_file
 from easybuild.tools.filetools import encode_class_name, extract_file, find_backup_name_candidate
-from easybuild.tools.filetools import get_cwd, get_source_tarball_from_git, is_alt_pypi_url
+from easybuild.tools.filetools import copy_dir, get_cwd, get_source_tarball_from_git, is_alt_pypi_url
 from easybuild.tools.filetools import is_binary, is_sha256_checksum, mkdir, move_file, move_logs, read_file, remove_dir
 from easybuild.tools.filetools import remove_file, remove_lock, verify_checksum, weld_paths, write_file, symlink
 from easybuild.tools.hooks import BUILD_STEP, CLEANUP_STEP, CONFIGURE_STEP, EXTENSIONS_STEP, FETCH_STEP, INSTALL_STEP
@@ -181,7 +181,7 @@ class EasyBlock(object):
             self.cfg = ec
         else:
             raise EasyBuildError("Value of incorrect type passed to EasyBlock constructor: %s ('%s')", type(ec), ec)
-        
+
         # are we running in developer mode?
         self.developer = build_option('developer')
 
@@ -2676,15 +2676,17 @@ class EasyBlock(object):
             dest = os.path.join(self.builddir, dst_name)
             copy_dir(
                 developer_pth, dest,
-                ignore=lambda pth,elem: [_ for _ in elem if _ in ['.git', '.svn', '.hg']]
+                ignore=lambda pth, elem: [_ for _ in elem if _ in ['.git', '.svn', '.hg']]
             )
             self.cfg['start_dir'] = dest
             self.log.info("Content of develop path %s copied to %s (new start_dir)", developer_pth, dest)
         else:
             for src in self.src:
                 self.log.info("Unpacking source %s" % src['name'])
-                srcdir = extract_file(src['path'], self.builddir, cmd=src['cmd'],
-                                    extra_options=self.cfg['unpack_options'], change_into_dir=False)
+                srcdir = extract_file(
+                    src['path'], self.builddir, cmd=src['cmd'],
+                    extra_options=self.cfg['unpack_options'], change_into_dir=False
+                )
                 change_dir(srcdir)
                 if srcdir:
                     self.src[self.src.index(src)]['finalpath'] = srcdir

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -80,7 +80,7 @@ from easybuild.tools.config import install_path, log_path, package_path, source_
 from easybuild.tools.environment import restore_env, sanitize_env
 from easybuild.tools.filetools import CHECKSUM_TYPE_SHA256
 from easybuild.tools.filetools import adjust_permissions, apply_patch, back_up_file, change_dir, check_lock
-from easybuild.tools.filetools import compute_checksum, convert_name, copy_file, create_lock, create_patch_info
+from easybuild.tools.filetools import compute_checksum, convert_name, copy_file, copy_dir, create_lock, create_patch_info
 from easybuild.tools.filetools import derive_alt_pypi_url, diff_files, dir_contains_files, download_file
 from easybuild.tools.filetools import encode_class_name, extract_file, find_backup_name_candidate
 from easybuild.tools.filetools import get_cwd, get_source_tarball_from_git, is_alt_pypi_url
@@ -181,6 +181,19 @@ class EasyBlock(object):
             self.cfg = ec
         else:
             raise EasyBuildError("Value of incorrect type passed to EasyBlock constructor: %s ('%s')", type(ec), ec)
+        
+        # are we running in developer mode?
+        self.developer = build_option('developer')
+
+        # This is needed in case custom easyblocks do a reparse of the EC file (e.g. quantum espresso)
+        if self.developer and not self.version.endswith('-dev'):
+            old_vers = ec['version']
+            new_vers = old_vers + '-dev'
+            ec['version'] = new_vers
+            for key in ['short_mod_name', 'full_mod_name']:
+                prev = getattr(ec, key)
+                new = prev.replace(f'/{old_vers}', f'/{new_vers}')
+                setattr(ec, key, new)
 
         # modules interface with default MODULEPATH
         self.modules_tool = self.cfg.modules_tool
@@ -2654,15 +2667,29 @@ class EasyBlock(object):
         """
         Unpack the source files.
         """
-        for src in self.src:
-            self.log.info("Unpacking source %s" % src['name'])
-            srcdir = extract_file(src['path'], self.builddir, cmd=src['cmd'],
-                                  extra_options=self.cfg['unpack_options'], change_into_dir=False)
-            change_dir(srcdir)
-            if srcdir:
-                self.src[self.src.index(src)]['finalpath'] = srcdir
+        developer_pth = self.developer
+        if developer_pth:
+            if self.start_dir:
+                dst_name = self.start_dir
             else:
-                raise EasyBuildError("Unpacking source %s failed", src['name'])
+                dst_name = os.path.basename(developer_pth)
+            dest = os.path.join(self.builddir, dst_name)
+            copy_dir(
+                developer_pth, dest,
+                ignore=lambda pth,elem: [_ for _ in elem if _ in ['.git', '.svn', '.hg']]
+            )
+            self.cfg['start_dir'] = dest
+            self.log.info("Content of develop path %s copied to %s (new start_dir)", developer_pth, dest)
+        else:
+            for src in self.src:
+                self.log.info("Unpacking source %s" % src['name'])
+                srcdir = extract_file(src['path'], self.builddir, cmd=src['cmd'],
+                                    extra_options=self.cfg['unpack_options'], change_into_dir=False)
+                change_dir(srcdir)
+                if srcdir:
+                    self.src[self.src.index(src)]['finalpath'] = srcdir
+                else:
+                    raise EasyBuildError("Unpacking source %s failed", src['name'])
 
     def patch_step(self, beginpath=None, patches=None):
         """
@@ -4036,6 +4063,12 @@ class EasyBlock(object):
         skip_test_step = build_option('skip_test_step')
         skipsteps = self.cfg['skipsteps']
 
+        developer_skip = (
+            FETCH_STEP,
+            PATCH_STEP,
+            EXTENSIONS_STEP,
+        )
+
         # under --skip, sanity check is not skipped
         cli_skip = self.skip and step != SANITYCHECK_STEP
 
@@ -4070,6 +4103,9 @@ class EasyBlock(object):
 
         elif skip_test_step and step == TEST_STEP:
             self.log.info("Skipping %s step as requested via skip-test-step", step)
+            skip = True
+        elif self.developer and step in developer_skip:
+            self.log.info("Skipping %s step because of --developer", step)
             skip = True
 
         else:

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -60,7 +60,7 @@ from easybuild.framework.easyconfig.tools import categorize_files_by_type, dep_g
 from easybuild.framework.easyconfig.tools import det_easyconfig_paths, dump_env_script, get_paths_for
 from easybuild.framework.easyconfig.tools import parse_easyconfigs, review_pr, run_contrib_checks, skip_available
 from easybuild.framework.easyconfig.tweak import obtain_ec_for, tweak
-from easybuild.tools.config import find_last_log, get_repository, get_repositorypath, build_option
+from easybuild.tools.config import find_last_log, get_repository, get_repositorypath, build_option, update_build_option
 from easybuild.tools.containers.common import containerize
 from easybuild.tools.docs import list_software
 from easybuild.tools.environment import restore_env
@@ -690,6 +690,16 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None, pr
         index_fp = dump_index(options.create_index, max_age_sec=options.index_max_age)
         index = load_index(options.create_index)
         print_msg("Index created at %s (%d files)" % (index_fp, len(index)), prefix=False)
+
+    if options.developer:
+        pth = build_option('developer')
+        if not os.path.exists(pth):
+            raise EasyBuildError("Developer mode path %s does not exist" % pth)
+        
+        pth = os.path.abspath(pth)
+        options.developer = pth
+        update_build_option('developer', pth)
+        print_msg("Developer mode running from %s" % build_option('developer'), log=_log)
 
     # non-verbose cleanup after handling GitHub integration stuff or printing terse info
     early_stop_options = [

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -707,7 +707,7 @@ def main(args=None, logfile=None, do_build=None, testing=False, modtool=None, pr
         pth = build_option('developer')
         if not os.path.exists(pth):
             raise EasyBuildError("Developer mode path %s does not exist" % pth)
-        
+
         pth = os.path.abspath(pth)
         options.developer = pth
         update_build_option('developer', pth)

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -445,6 +445,18 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
         options.inject_checksums, options.inject_checksums_to_json, options.sanity_check_only
     ))
 
+    if build_option('developer'):
+        for ec in easyconfigs:
+            _ec = ec['ec']
+            old_vers = _ec['version']
+            new_vers = old_vers + '-dev'
+            _ec['version'] = new_vers
+            for key in ['short_mod_name', 'full_mod_name']:
+                prev = getattr(_ec, key)
+                new = prev.replace(f'/{old_vers}', f'/{new_vers}')
+                ec[key] = new
+                setattr(_ec, key, new)
+
     # skip modules that are already installed unless forced, or unless an option is used that warrants not skipping
     if not keep_available_modules:
         retained_ecs = skip_available(easyconfigs, modtool)

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -218,6 +218,7 @@ BUILD_OPTIONS_CMDLINE = {
         'cuda_cache_dir',
         'cuda_cache_maxsize',
         'cuda_compute_capabilities',
+        'developer',
         'dump_test_report',
         'easyblock',
         'envvars_user_modules',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -265,6 +265,7 @@ class EasyBuildOptions(GeneralOption):
         descr = ("Basic options", "Basic runtime options for EasyBuild.")
 
         opts = OrderedDict({
+            'developer': ("This is a test option", None, 'store_or_None', '.'),
             'dry-run': ("Print build overview incl. dependencies (full paths)", None, 'store_true', False),
             'dry-run-short': ("Print build overview incl. dependencies (short paths)", None, 'store_true', False, 'D'),
             'extended-dry-run': ("Print build environment and (expected) build procedure that will be performed",


### PR DESCRIPTION
Related to:

- https://github.com/easybuilders/easybuild-framework/issues/4394


I am having a crack at implementing this feature.

Right now the user can specify a path using the `--developer` options (arguably would be better as `--source(s)-from`) taken as the current directory by default, to use with an already existing EC file.

The developer mode would append a `-dev` (maybe `.dev` could be better?) to the version originally found in the EC, and the EB will skip the fetch/patch/extension steps and, instead of extracting an existing source during the `extract_step` will copy the content of the specified source path to the build directory.
The name of the copied directory will be set to match `cfg['start_dir']` if set, or will keep its original name and configure its own start directory 

Tested by compiling the develop branch of the following code-bases using the respective 2023a EC file as a base

- QuantumESPRESSO
- zlib
- HDF5

While implementing this, i had several reflections/ideas that will requires some design choices on what we would want this feature to enable and potential problems with the current implementation

- EC with multiple sources
  - this could still work but it would require the user to have all projects in the directory pointed at with `--developer` (and possibly some minor changes to how `start_dir` is being handled.
- Bundles
  - will not work without mocking `self.src` that should be set by the fetch_step
  - will also have similar problems as the `EC with multiple sources`

The `-dev` suffix to the version will make the version appear as greater then the modified one but lower then the next numerically higher one, so it should not screw up with version checks in the easyblock (and i think having the develop version appear as greater should be the default behavior for this scenario).

I was thinking the most general way to avoid this problem might be to:

- Extend the EC source syntax to add a `develop` options to point to the dir to be copied
- Run al step as normal up to the `extract_step`
- Run the extraction (or implement a dryrun version) to get the name of the extracted folder and than remove/replace it with a copy of the folder pointed by `develop`
- Would also remove the need to handle the `-dev` prefix as the developer could just set his own `versionsuffix`

The current implementation is probably the easiest for the developer perspective (they would only need to add `--developer` to the command, but this might be limited and not work in many scenario.

The more complete approach might add a level of difficulty in that the developer will need to understand the EC file and add the relevant parts.
There is also the fact that this build process would need to download some existing sources without using them just to get the information to reproduce the expected `builddir` layout (not sure if there is a way around this).

An intermediate approach could be to allow `--developer` to define a list of paths and each of them would replace one source in the same order as they are defined in the EC (would act at the level of the `fetch_step`.
The downside would be that the developer would need to be careful about the order of the specified sources

I am not sure which would be the best way to move forward (or if there is some other solution I have not tried/thought of) so I am leaving this as a draft for discussion



