### PR TITLE
change `Toolchain.get_flag` so it doesn't automatically prepend a dash (`-`) to compiler flags, add deprecation warning for `optarch` value without leading dash, rename `Compiler.COMPILER*_FLAGS` to `Compiler.COMPILER*_OPTIONS`

### DIFF
--- a/easybuild/toolchains/compiler/clang.py
+++ b/easybuild/toolchains/compiler/clang.py
@@ -104,7 +104,7 @@ class Clang(Compiler):
 
     COMPILER_CC = 'clang'
     COMPILER_CXX = 'clang++'
-    COMPILER_C_UNIQUE_FLAGS = []
+    COMPILER_C_UNIQUE_OPTIONS = []
 
     LIB_MULTITHREAD = ['pthread']
     LIB_MATH = ['m']

--- a/easybuild/toolchains/compiler/clang.py
+++ b/easybuild/toolchains/compiler/clang.py
@@ -55,10 +55,10 @@ class Clang(Compiler):
         'basic-block-vectorize': (False, "Basic block vectorization"),
     }
     COMPILER_UNIQUE_OPTION_MAP = {
-        'unroll': 'funroll-loops',
-        'loop-vectorize': ['fvectorize'],
-        'basic-block-vectorize': ['fslp-vectorize'],
-        'optarch': 'march=native',
+        'unroll': '-funroll-loops',
+        'loop-vectorize': ['-fvectorize'],
+        'basic-block-vectorize': ['-fslp-vectorize'],
+        'optarch': '-march=native',
         # Clang's options do not map well onto these precision modes.  The flags enable and disable certain classes of
         # optimizations.
         #
@@ -80,26 +80,26 @@ class Clang(Compiler):
         #
         # 'strict', 'precise' and 'defaultprec' are all ISO C++ and IEEE complaint, but we explicitly specify details
         # flags for strict and precise for robustness against future changes.
-        'strict': ['fno-fast-math'],
-        'precise': ['fno-unsafe-math-optimizations'],
+        'strict': ['-fno-fast-math'],
+        'precise': ['-fno-unsafe-math-optimizations'],
         'defaultprec': [],
-        'loose': ['ffast-math', 'fno-unsafe-math-optimizations'],
-        'veryloose': ['ffast-math'],
-        'vectorize': {False: 'fno-vectorize', True: 'fvectorize'},
+        'loose': ['-ffast-math', '-fno-unsafe-math-optimizations'],
+        'veryloose': ['-ffast-math'],
+        'vectorize': {False: '-fno-vectorize', True: '-fvectorize'},
     }
 
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {
-        (systemtools.POWER, systemtools.POWER): 'mcpu=native',  # no support for march=native on POWER
-        (systemtools.POWER, systemtools.POWER_LE): 'mcpu=native',  # no support for march=native on POWER
-        (systemtools.X86_64, systemtools.AMD): 'march=native',
-        (systemtools.X86_64, systemtools.INTEL): 'march=native',
+        (systemtools.POWER, systemtools.POWER): '-mcpu=native',  # no support for march=native on POWER
+        (systemtools.POWER, systemtools.POWER_LE): '-mcpu=native',  # no support for march=native on POWER
+        (systemtools.X86_64, systemtools.AMD): '-march=native',
+        (systemtools.X86_64, systemtools.INTEL): '-march=native',
     }
     # used with --optarch=GENERIC
     COMPILER_GENERIC_OPTION = {
-        (systemtools.RISCV64, systemtools.RISCV): 'march=rv64gc -mabi=lp64d',  # default for -mabi is system-dependent
-        (systemtools.X86_64, systemtools.AMD): 'march=x86-64 -mtune=generic',
-        (systemtools.X86_64, systemtools.INTEL): 'march=x86-64 -mtune=generic',
+        (systemtools.RISCV64, systemtools.RISCV): '-march=rv64gc -mabi=lp64d',  # default for -mabi is system-dependent
+        (systemtools.X86_64, systemtools.AMD): '-march=x86-64 -mtune=generic',
+        (systemtools.X86_64, systemtools.INTEL): '-march=x86-64 -mtune=generic',
     }
 
     COMPILER_CC = 'clang'

--- a/easybuild/toolchains/compiler/craype.py
+++ b/easybuild/toolchains/compiler/craype.py
@@ -76,8 +76,8 @@ class CrayPECompiler(Compiler):
         # handle shared and dynamic always via $CRAYPE_LINK_TYPE environment variable, don't pass flags to wrapper
         'shared': '',
         'dynamic': '',
-        'verbose': 'craype-verbose',
-        'mpich-mt': 'craympich-mt',
+        'verbose': '-craype-verbose',
+        'mpich-mt': '-craympich-mt',
     }
 
     COMPILER_CC = 'cc'
@@ -98,7 +98,7 @@ class CrayPECompiler(Compiler):
         """Constructor."""
         super(CrayPECompiler, self).__init__(*args, **kwargs)
         # 'register'  additional toolchain options that correspond to a compiler flag
-        self.COMPILER_FLAGS.extend(['dynamic', 'mpich-mt'])
+        self.COMPILER_FLAGS.extend(['-dynamic', '-mpich-mt'])
 
         # use name of PrgEnv module as name of module that provides compiler
         self.COMPILER_MODULE_NAME = ['PrgEnv-%s' % self.PRGENV_MODULE_NAME_SUFFIX]
@@ -163,7 +163,7 @@ class CrayPEPGI(CrayPECompiler):
     def __init__(self, *args, **kwargs):
         """CrayPEPGI constructor."""
         super(CrayPEPGI, self).__init__(*args, **kwargs)
-        self.COMPILER_UNIQUE_OPTION_MAP['openmp'] = 'mp'
+        self.COMPILER_UNIQUE_OPTION_MAP['openmp'] = '-mp'
         for precflag in self.COMPILER_PREC_FLAGS:
             self.COMPILER_UNIQUE_OPTION_MAP[precflag] = Pgi.COMPILER_UNIQUE_OPTION_MAP[precflag]
 
@@ -176,6 +176,6 @@ class CrayPECray(CrayPECompiler):
     def __init__(self, *args, **kwargs):
         """CrayPEIntel constructor."""
         super(CrayPECray, self).__init__(*args, **kwargs)
-        self.COMPILER_UNIQUE_OPTION_MAP['openmp'] = 'homp'
+        self.COMPILER_UNIQUE_OPTION_MAP['openmp'] = '-homp'
         for precflag in self.COMPILER_PREC_FLAGS:
             self.COMPILER_UNIQUE_OPTION_MAP[precflag] = []

--- a/easybuild/toolchains/compiler/craype.py
+++ b/easybuild/toolchains/compiler/craype.py
@@ -98,7 +98,7 @@ class CrayPECompiler(Compiler):
         """Constructor."""
         super(CrayPECompiler, self).__init__(*args, **kwargs)
         # 'register'  additional toolchain options that correspond to a compiler flag
-        self.COMPILER_FLAGS.extend(['-dynamic', '-mpich-mt'])
+        self.COMPILER_OPTIONS.extend(['dynamic', 'mpich-mt'])
 
         # use name of PrgEnv module as name of module that provides compiler
         self.COMPILER_MODULE_NAME = ['PrgEnv-%s' % self.PRGENV_MODULE_NAME_SUFFIX]
@@ -139,7 +139,7 @@ class CrayPEGCC(CrayPECompiler):
     def __init__(self, *args, **kwargs):
         """CrayPEGCC constructor."""
         super(CrayPEGCC, self).__init__(*args, **kwargs)
-        for precflag in self.COMPILER_PREC_FLAGS:
+        for precflag in self.COMPILER_PREC_OPTIONS:
             self.COMPILER_UNIQUE_OPTION_MAP[precflag] = Gcc.COMPILER_UNIQUE_OPTION_MAP[precflag]
 
 
@@ -151,7 +151,7 @@ class CrayPEIntel(CrayPECompiler):
     def __init__(self, *args, **kwargs):
         """CrayPEIntel constructor."""
         super(CrayPEIntel, self).__init__(*args, **kwargs)
-        for precflag in self.COMPILER_PREC_FLAGS:
+        for precflag in self.COMPILER_PREC_OPTIONS:
             self.COMPILER_UNIQUE_OPTION_MAP[precflag] = IntelIccIfort.COMPILER_UNIQUE_OPTION_MAP[precflag]
 
 
@@ -164,7 +164,7 @@ class CrayPEPGI(CrayPECompiler):
         """CrayPEPGI constructor."""
         super(CrayPEPGI, self).__init__(*args, **kwargs)
         self.COMPILER_UNIQUE_OPTION_MAP['openmp'] = '-mp'
-        for precflag in self.COMPILER_PREC_FLAGS:
+        for precflag in self.COMPILER_PREC_OPTIONS:
             self.COMPILER_UNIQUE_OPTION_MAP[precflag] = Pgi.COMPILER_UNIQUE_OPTION_MAP[precflag]
 
 
@@ -177,5 +177,5 @@ class CrayPECray(CrayPECompiler):
         """CrayPEIntel constructor."""
         super(CrayPECray, self).__init__(*args, **kwargs)
         self.COMPILER_UNIQUE_OPTION_MAP['openmp'] = '-homp'
-        for precflag in self.COMPILER_PREC_FLAGS:
+        for precflag in self.COMPILER_PREC_OPTIONS:
             self.COMPILER_UNIQUE_OPTION_MAP[precflag] = []

--- a/easybuild/toolchains/compiler/cuda.py
+++ b/easybuild/toolchains/compiler/cuda.py
@@ -98,6 +98,6 @@ class Cuda(Compiler):
 
         # add gencode compiler flags to list of flags for compiler variables
         for gencode_val in self.options.get('cuda_gencode', []):
-            gencode_option = 'gencode %s' % gencode_val
+            gencode_option = '-gencode %s' % gencode_val
             self.variables.nappend('CUDA_CFLAGS', gencode_option)
             self.variables.nappend('CUDA_CXXFLAGS', gencode_option)

--- a/easybuild/toolchains/compiler/cuda.py
+++ b/easybuild/toolchains/compiler/cuda.py
@@ -60,8 +60,8 @@ class Cuda(Compiler):
 
     # always C++ compiler command, even for C!
     COMPILER_CUDA_UNIQUE_OPTION_MAP = {
-        '_opt_CUDA_CC': 'ccbin="%(CXX_base)s"',
-        '_opt_CUDA_CXX': 'ccbin="%(CXX_base)s"',
+        '_opt_CUDA_CC': '-ccbin="%(CXX_base)s"',
+        '_opt_CUDA_CXX': '-ccbin="%(CXX_base)s"',
     }
 
     COMPILER_CUDA_CC = 'nvcc'
@@ -90,8 +90,8 @@ class Cuda(Compiler):
         # note: using $LIBS will yield the use of -lcudart in Xlinker, which is silly, but fine
 
         cuda_flags = [
-            'Xcompiler="%s"' % str(self.variables['CXXFLAGS']),
-            'Xlinker="%s %s"' % (str(self.variables['LDFLAGS']), str(self.variables['LIBS'])),
+            '-Xcompiler="%s"' % str(self.variables['CXXFLAGS']),
+            '-Xlinker="%s %s"' % (str(self.variables['LDFLAGS']), str(self.variables['LIBS'])),
         ]
         self.variables.nextend('CUDA_CFLAGS', cuda_flags)
         self.variables.nextend('CUDA_CXXFLAGS', cuda_flags)

--- a/easybuild/toolchains/compiler/fujitsu.py
+++ b/easybuild/toolchains/compiler/fujitsu.py
@@ -58,23 +58,23 @@ class FujitsuCompiler(Compiler):
     COMPILER_FC = 'frt'
 
     COMPILER_UNIQUE_OPTION_MAP = {
-        DEFAULT_OPT_LEVEL: 'O2',
-        'lowopt': 'O1',
-        'noopt': 'O0',
-        'opt': 'Kfast',  # -O3 -Keval,fast_matmul,fp_contract,fp_relaxed,fz,ilfunc,mfunc,omitfp,simd_packed_promotion
+        DEFAULT_OPT_LEVEL: '-O2',
+        'lowopt': '-O1',
+        'noopt': '-O0',
+        'opt': '-Kfast',  # -O3 -Keval,fast_matmul,fp_contract,fp_relaxed,fz,ilfunc,mfunc,omitfp,simd_packed_promotion
         'optarch': '',  # Fujitsu compiler by default generates code for the arch it is running on
-        'openmp': 'Kopenmp',
-        'unroll': 'funroll-loops',
+        'openmp': '-Kopenmp',
+        'unroll': '-funroll-loops',
         # apparently the -Kfp_precision flag doesn't work in clang mode, will need to look into these later
         # also at strict vs precise and loose vs veryloose
-        'strict': ['Knoeval,nofast_matmul,nofp_contract,nofp_relaxed,noilfunc'],  # ['Kfp_precision'],
-        'precise': ['Knoeval,nofast_matmul,nofp_contract,nofp_relaxed,noilfunc'],  # ['Kfp_precision'],
+        'strict': ['-Knoeval,nofast_matmul,nofp_contract,nofp_relaxed,noilfunc'],  # ['-Kfp_precision'],
+        'precise': ['-Knoeval,nofast_matmul,nofp_contract,nofp_relaxed,noilfunc'],  # ['-Kfp_precision'],
         'defaultprec': [],
-        'loose': ['Kfp_relaxed'],
-        'veryloose': ['Kfp_relaxed'],
+        'loose': ['-Kfp_relaxed'],
+        'veryloose': ['-Kfp_relaxed'],
         # apparently the -K[NO]SVE flags don't work in clang mode
         # SVE is enabled by default, -Knosimd seems to disable it
-        'vectorize': {False: 'Knosimd', True: ''},
+        'vectorize': {False: '-Knosimd', True: ''},
     }
 
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
@@ -109,8 +109,8 @@ class FujitsuCompiler(Compiler):
         super(FujitsuCompiler, self)._set_compiler_vars()
 
         # enable clang compatibility mode
-        self.variables.nappend('CFLAGS', ['Nclang'])
-        self.variables.nappend('CXXFLAGS', ['Nclang'])
+        self.variables.nappend('CFLAGS', ['-Nclang'])
+        self.variables.nappend('CXXFLAGS', ['-Nclang'])
 
         # also add fujitsu module library path to LDFLAGS
         libdir = os.path.join(os.getenv(TC_CONSTANT_MODULE_VAR), 'lib64')

--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -186,8 +186,8 @@ class Gcc(Compiler):
                     break
             if core_types:
                 # On big.LITTLE setups, sort core types to have big core (higher model number) first.
-                # Example: 'mcpu=cortex-a72.cortex-a53' for "ARM Cortex-A53 + Cortex-A72"
-                default_optarch = 'mcpu=%s' % '.'.join([ct[1] for ct in sorted(core_types, reverse=True)])
+                # Example: '-mcpu=cortex-a72.cortex-a53' for "ARM Cortex-A53 + Cortex-A72"
+                default_optarch = '-mcpu=%s' % '.'.join([ct[1] for ct in sorted(core_types, reverse=True)])
                 self.log.debug("Using architecture-specific compiler optimization flag '%s'", default_optarch)
 
         return default_optarch

--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -110,12 +110,12 @@ class Gcc(Compiler):
 
     COMPILER_CC = 'gcc'
     COMPILER_CXX = 'g++'
-    COMPILER_C_UNIQUE_FLAGS = []
+    COMPILER_C_UNIQUE_OPTIONS = []
 
     COMPILER_F77 = 'gfortran'
     COMPILER_F90 = 'gfortran'
     COMPILER_FC = 'gfortran'
-    COMPILER_F_UNIQUE_FLAGS = ['-f2c']
+    COMPILER_F_UNIQUE_OPTIONS = ['f2c']
 
     LIB_MULTITHREAD = ['pthread']
     LIB_MATH = ['m']

--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -55,26 +55,26 @@ class Gcc(Compiler):
         'lto': (False, "Enable Link Time Optimization"),
     }
     COMPILER_UNIQUE_OPTION_MAP = {
-        'i8': 'fdefault-integer-8',
-        'r8': ['fdefault-real-8', 'fdefault-double-8'],
-        'unroll': 'funroll-loops',
-        'f2c': 'ff2c',
-        'loop': ['ftree-switch-conversion', 'floop-interchange', 'floop-strip-mine', 'floop-block'],
-        'lto': 'flto',
-        'ieee': ['mieee-fp', 'fno-trapping-math'],
-        'strict': ['mieee-fp', 'mno-recip'],
-        'precise': ['mno-recip'],
-        'defaultprec': ['fno-math-errno'],
-        'loose': ['fno-math-errno', 'mrecip', 'mno-ieee-fp'],
-        'veryloose': ['fno-math-errno', 'mrecip=all', 'mno-ieee-fp'],
-        'vectorize': {False: 'fno-tree-vectorize', True: 'ftree-vectorize'},
-        DEFAULT_OPT_LEVEL: ['O2', 'ftree-vectorize'],
+        'i8': '-fdefault-integer-8',
+        'r8': ['-fdefault-real-8', '-fdefault-double-8'],
+        'unroll': '-funroll-loops',
+        'f2c': '-ff2c',
+        'loop': ['-ftree-switch-conversion', '-floop-interchange', '-floop-strip-mine', '-floop-block'],
+        'lto': '-flto',
+        'ieee': ['-mieee-fp', '-fno-trapping-math'],
+        'strict': ['-mieee-fp', '-mno-recip'],
+        'precise': ['-mno-recip'],
+        'defaultprec': ['-fno-math-errno'],
+        'loose': ['-fno-math-errno', '-mrecip', '-mno-ieee-fp'],
+        'veryloose': ['-fno-math-errno', '-mrecip=all', '-mno-ieee-fp'],
+        'vectorize': {False: '-fno-tree-vectorize', True: '-ftree-vectorize'},
+        DEFAULT_OPT_LEVEL: ['-O2', '-ftree-vectorize'],
     }
 
     # gcc on aarch64 does not support -mno-recip, -mieee-fp, -mfno-math-errno...
     # https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html
     if systemtools.get_cpu_architecture() == systemtools.AARCH64:
-        no_recip_alternative = ['mno-low-precision-recip-sqrt', 'mno-low-precision-sqrt', 'mno-low-precision-div']
+        no_recip_alternative = ['-mno-low-precision-recip-sqrt', '-mno-low-precision-sqrt', '-mno-low-precision-div']
         COMPILER_UNIQUE_OPTION_MAP['strict'] = no_recip_alternative
         COMPILER_UNIQUE_OPTION_MAP['precise'] = no_recip_alternative
 
@@ -84,28 +84,28 @@ class Gcc(Compiler):
     if systemtools.get_cpu_family() == systemtools.RISCV:
         COMPILER_UNIQUE_OPTION_MAP['strict'] = []
         COMPILER_UNIQUE_OPTION_MAP['precise'] = []
-        COMPILER_UNIQUE_OPTION_MAP['loose'] = ['fno-math-errno']
-        COMPILER_UNIQUE_OPTION_MAP['veryloose'] = ['fno-math-errno']
+        COMPILER_UNIQUE_OPTION_MAP['loose'] = ['-fno-math-errno']
+        COMPILER_UNIQUE_OPTION_MAP['veryloose'] = ['-fno-math-errno']
 
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {
-        (systemtools.AARCH32, systemtools.ARM): 'mcpu=native',  # implies -march=native and -mtune=native
-        (systemtools.AARCH64, systemtools.ARM): 'mcpu=native',  # since GCC 6; implies -march=native and -mtune=native
+        (systemtools.AARCH32, systemtools.ARM): '-mcpu=native',  # implies -march=native and -mtune=native
+        (systemtools.AARCH64, systemtools.ARM): '-mcpu=native',  # since GCC 6; implies -march=native and -mtune=native
         # no support for -march on POWER; implies -mtune=native
-        (systemtools.POWER, systemtools.POWER): 'mcpu=native',
-        (systemtools.POWER, systemtools.POWER_LE): 'mcpu=native',
-        (systemtools.X86_64, systemtools.AMD): 'march=native',  # implies -mtune=native
-        (systemtools.X86_64, systemtools.INTEL): 'march=native',  # implies -mtune=native
+        (systemtools.POWER, systemtools.POWER): '-mcpu=native',
+        (systemtools.POWER, systemtools.POWER_LE): '-mcpu=native',
+        (systemtools.X86_64, systemtools.AMD): '-march=native',  # implies -mtune=native
+        (systemtools.X86_64, systemtools.INTEL): '-march=native',  # implies -mtune=native
     }
     # used with --optarch=GENERIC
     COMPILER_GENERIC_OPTION = {
-        (systemtools.AARCH32, systemtools.ARM): 'mcpu=generic-armv7',  # implies -march=armv7 and -mtune=generic-armv7
-        (systemtools.AARCH64, systemtools.ARM): 'mcpu=generic',       # implies -march=armv8-a and -mtune=generic
-        (systemtools.POWER, systemtools.POWER): 'mcpu=powerpc64',    # no support for -march on POWER
-        (systemtools.POWER, systemtools.POWER_LE): 'mcpu=powerpc64le',    # no support for -march on POWER
-        (systemtools.RISCV64, systemtools.RISCV): 'march=rv64gc -mabi=lp64d',  # default for -mabi is system-dependent
-        (systemtools.X86_64, systemtools.AMD): 'march=x86-64 -mtune=generic',
-        (systemtools.X86_64, systemtools.INTEL): 'march=x86-64 -mtune=generic',
+        (systemtools.AARCH32, systemtools.ARM): '-mcpu=generic-armv7',  # implies -march=armv7 and -mtune=generic-armv7
+        (systemtools.AARCH64, systemtools.ARM): '-mcpu=generic',       # implies -march=armv8-a and -mtune=generic
+        (systemtools.POWER, systemtools.POWER): '-mcpu=powerpc64',    # no support for -march on POWER
+        (systemtools.POWER, systemtools.POWER_LE): '-mcpu=powerpc64le',    # no support for -march on POWER
+        (systemtools.RISCV64, systemtools.RISCV): '-march=rv64gc -mabi=lp64d',  # default for -mabi is system-dependent
+        (systemtools.X86_64, systemtools.AMD): '-march=x86-64 -mtune=generic',
+        (systemtools.X86_64, systemtools.INTEL): '-march=x86-64 -mtune=generic',
     }
 
     COMPILER_CC = 'gcc'
@@ -115,7 +115,7 @@ class Gcc(Compiler):
     COMPILER_F77 = 'gfortran'
     COMPILER_F90 = 'gfortran'
     COMPILER_FC = 'gfortran'
-    COMPILER_F_UNIQUE_FLAGS = ['f2c']
+    COMPILER_F_UNIQUE_FLAGS = ['-f2c']
 
     LIB_MULTITHREAD = ['pthread']
     LIB_MATH = ['m']

--- a/easybuild/toolchains/compiler/intel_compilers.py
+++ b/easybuild/toolchains/compiler/intel_compilers.py
@@ -106,22 +106,22 @@ class IntelCompilers(IntelIccIfort):
 
         if oneapi:
             # fp-model source is not supported by icx but is equivalent to precise
-            self.options.options_map['defaultprec'] = ['fp-speculation=safe', 'fp-model precise']
+            self.options.options_map['defaultprec'] = ['-fp-speculation=safe', '-fp-model precise']
             if LooseVersion(comp_ver) >= LooseVersion('2022'):
-                self.options.options_map['defaultprec'].insert(0, 'ftz')
+                self.options.options_map['defaultprec'].insert(0, '-ftz')
             # icx doesn't like -fp-model fast=1; fp-model fast is equivalent
-            self.options.options_map['loose'] = ['fp-model fast']
+            self.options.options_map['loose'] = ['-fp-model fast']
             # fp-model fast=2 gives "warning: overriding '-ffp-model=fast=2' option with '-ffp-model=fast'"
-            self.options.options_map['veryloose'] = ['fp-model fast']
+            self.options.options_map['veryloose'] = ['-fp-model fast']
             # recommended in porting guide: qopenmp, unlike fiopenmp, works for both classic and oneapi compilers
             # https://www.intel.com/content/www/us/en/developer/articles/guide/porting-guide-for-ifort-to-ifx.html
-            self.options.options_map['openmp'] = ['qopenmp']
+            self.options.options_map['openmp'] = ['-qopenmp']
 
             # -xSSE2 is not supported by Intel oneAPI compilers,
             # so use -march=x86-64 -mtune=generic when using optarch=GENERIC
             self.COMPILER_GENERIC_OPTION = {
-                (systemtools.X86_64, systemtools.AMD): 'march=x86-64 -mtune=generic',
-                (systemtools.X86_64, systemtools.INTEL): 'march=x86-64 -mtune=generic',
+                (systemtools.X86_64, systemtools.AMD): '-march=x86-64 -mtune=generic',
+                (systemtools.X86_64, systemtools.INTEL): '-march=x86-64 -mtune=generic',
             }
 
         # skip IntelIccIfort.set_variables (no longer relevant for recent versions)

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -85,12 +85,12 @@ class IntelIccIfort(Compiler):
 
     COMPILER_CC = 'icc'
     COMPILER_CXX = 'icpc'
-    COMPILER_C_UNIQUE_FLAGS = ['-intel-static', '-no-icc']
+    COMPILER_C_UNIQUE_OPTIONS = ['intel-static', 'no-icc']
 
     COMPILER_F77 = 'ifort'
     COMPILER_F90 = 'ifort'
     COMPILER_FC = 'ifort'
-    COMPILER_F_UNIQUE_FLAGS = ['-intel-static']
+    COMPILER_F_UNIQUE_OPTIONS = ['intel-static']
 
     LINKER_TOGGLE_STATIC_DYNAMIC = {
         'static': '-Bstatic',

--- a/easybuild/toolchains/compiler/inteliccifort.py
+++ b/easybuild/toolchains/compiler/inteliccifort.py
@@ -57,40 +57,40 @@ class IntelIccIfort(Compiler):
     }
 
     COMPILER_UNIQUE_OPTION_MAP = {
-        'i8': 'i8',
-        'r8': 'r8',
-        'optarch': 'xHost',
-        'ieee': 'fltconsistency',
-        'strict': ['fp-speculation=strict', 'fp-model strict'],
-        'precise': ['fp-model precise'],
-        'defaultprec': ['ftz', 'fp-speculation=safe', 'fp-model source'],
-        'loose': ['fp-model fast=1'],
-        'veryloose': ['fp-model fast=2'],
-        'vectorize': {False: 'no-vec', True: 'vec'},
-        'intel-static': 'static-intel',
-        'no-icc': 'no-icc',
-        'error-unknown-option': 'we10006',  # error at warning #10006: ignoring unknown option
+        'i8': '-i8',
+        'r8': '-r8',
+        'optarch': '-xHost',
+        'ieee': '-fltconsistency',
+        'strict': ['-fp-speculation=strict', '-fp-model strict'],
+        'precise': ['-fp-model precise'],
+        'defaultprec': ['-ftz', '-fp-speculation=safe', '-fp-model source'],
+        'loose': ['-fp-model fast=1'],
+        'veryloose': ['-fp-model fast=2'],
+        'vectorize': {False: '-no-vec', True: '-vec'},
+        'intel-static': '-static-intel',
+        'no-icc': '-no-icc',
+        'error-unknown-option': '-we10006',  # error at warning #10006: ignoring unknown option
     }
 
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {
-        (systemtools.X86_64, systemtools.AMD): 'xHost',
-        (systemtools.X86_64, systemtools.INTEL): 'xHost',
+        (systemtools.X86_64, systemtools.AMD): '-xHost',
+        (systemtools.X86_64, systemtools.INTEL): '-xHost',
     }
     # used with --optarch=GENERIC
     COMPILER_GENERIC_OPTION = {
-        (systemtools.X86_64, systemtools.AMD): 'xSSE2',
-        (systemtools.X86_64, systemtools.INTEL): 'xSSE2',
+        (systemtools.X86_64, systemtools.AMD): '-xSSE2',
+        (systemtools.X86_64, systemtools.INTEL): '-xSSE2',
     }
 
     COMPILER_CC = 'icc'
     COMPILER_CXX = 'icpc'
-    COMPILER_C_UNIQUE_FLAGS = ['intel-static', 'no-icc']
+    COMPILER_C_UNIQUE_FLAGS = ['-intel-static', '-no-icc']
 
     COMPILER_F77 = 'ifort'
     COMPILER_F90 = 'ifort'
     COMPILER_FC = 'ifort'
-    COMPILER_F_UNIQUE_FLAGS = ['intel-static']
+    COMPILER_F_UNIQUE_FLAGS = ['-intel-static']
 
     LINKER_TOGGLE_STATIC_DYNAMIC = {
         'static': '-Bstatic',
@@ -135,6 +135,6 @@ class IntelIccIfort(Compiler):
         # -fopenmp is not supported in old versions (11.x)
         icc_version, _ = self.get_software_version(self.COMPILER_MODULE_NAME)[0:2]
         if LooseVersion(icc_version) < LooseVersion('12'):
-            self.options.options_map['openmp'] = 'openmp'
+            self.options.options_map['openmp'] = '-openmp'
 
         super(IntelIccIfort, self).set_variables()

--- a/easybuild/toolchains/compiler/nvhpc.py
+++ b/easybuild/toolchains/compiler/nvhpc.py
@@ -60,28 +60,28 @@ class NVHPC(Compiler):
     # http://www.pgroup.com/products/freepgi/freepgi_ref/ch02.html#Mfprelaxed
     # http://www.pgroup.com/products/freepgi/freepgi_ref/ch02.html#Mfpapprox
     COMPILER_UNIQUE_OPTION_MAP = {
-        'i8': 'i8',
-        'r8': 'r8',
+        'i8': '-i8',
+        'r8': '-r8',
         'optarch': '',  # PGI by default generates code for the arch it is running on!
-        'openmp': 'mp',
-        'ieee': 'Kieee',
-        'strict': ['Mnoflushz', 'Kieee'],
-        'precise': ['Mnoflushz'],
-        'defaultprec': ['Mflushz'],
-        'loose': ['Mfprelaxed'],
-        'veryloose': ['Mfprelaxed=div,order,intrinsic,recip,sqrt,rsqrt', 'Mfpapprox'],
-        'vectorize': {False: 'Mnovect', True: 'Mvect'},
+        'openmp': '-mp',
+        'ieee': '-Kieee',
+        'strict': ['-Mnoflushz', '-Kieee'],
+        'precise': ['-Mnoflushz'],
+        'defaultprec': ['-Mflushz'],
+        'loose': ['-Mfprelaxed'],
+        'veryloose': ['-Mfprelaxed=div,order,intrinsic,recip,sqrt,rsqrt', 'Mfpapprox'],
+        'vectorize': {False: '-Mnovect', True: '-Mvect'},
     }
 
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {
-        (systemtools.X86_64, systemtools.AMD): 'tp=host',
-        (systemtools.X86_64, systemtools.INTEL): 'tp=host',
+        (systemtools.X86_64, systemtools.AMD): '-tp=host',
+        (systemtools.X86_64, systemtools.INTEL): '-tp=host',
     }
     # used with --optarch=GENERIC
     COMPILER_GENERIC_OPTION = {
-        (systemtools.X86_64, systemtools.AMD): 'tp=px',
-        (systemtools.X86_64, systemtools.INTEL): 'tp=px',
+        (systemtools.X86_64, systemtools.AMD): '-tp=px',
+        (systemtools.X86_64, systemtools.INTEL): '-tp=px',
     }
 
     COMPILER_CC = 'nvc'

--- a/easybuild/toolchains/compiler/pgi.py
+++ b/easybuild/toolchains/compiler/pgi.py
@@ -56,17 +56,17 @@ class Pgi(Compiler):
     # http://www.pgroup.com/products/freepgi/freepgi_ref/ch02.html#Mfprelaxed
     # http://www.pgroup.com/products/freepgi/freepgi_ref/ch02.html#Mfpapprox
     COMPILER_UNIQUE_OPTION_MAP = {
-        'i8': 'i8',
-        'r8': 'r8',
+        'i8': '-i8',
+        'r8': '-r8',
         'optarch': '',  # PGI by default generates code for the arch it is running on!
-        'openmp': 'mp',
-        'ieee': 'Kieee',
-        'strict': ['Mnoflushz', 'Kieee'],
-        'precise': ['Mnoflushz'],
-        'defaultprec': ['Mflushz'],
-        'loose': ['Mfprelaxed'],
-        'veryloose': ['Mfprelaxed=div,order,intrinsic,recip,sqrt,rsqrt', 'Mfpapprox'],
-        'vectorize': {False: 'Mnovect', True: 'Mvect'},
+        'openmp': '-mp',
+        'ieee': '-Kieee',
+        'strict': ['-Mnoflushz', '-Kieee'],
+        'precise': ['-Mnoflushz'],
+        'defaultprec': ['-Mflushz'],
+        'loose': ['-Mfprelaxed'],
+        'veryloose': ['-Mfprelaxed=div,order,intrinsic,recip,sqrt,rsqrt', '-Mfpapprox'],
+        'vectorize': {False: '-Mnovect', True: '-Mvect'},
     }
 
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
@@ -76,8 +76,8 @@ class Pgi(Compiler):
     }
     # used with --optarch=GENERIC
     COMPILER_GENERIC_OPTION = {
-        (systemtools.X86_64, systemtools.AMD): 'tp=x64',
-        (systemtools.X86_64, systemtools.INTEL): 'tp=x64',
+        (systemtools.X86_64, systemtools.AMD): '-tp=x64',
+        (systemtools.X86_64, systemtools.INTEL): '-tp=x64',
     }
 
     COMPILER_CC = 'pgcc'

--- a/easybuild/toolchains/mpi/intelmpi.py
+++ b/easybuild/toolchains/mpi/intelmpi.py
@@ -97,6 +97,6 @@ class IntelMPI(Mpich2):
         super(IntelMPI, self).set_variables()
         # add -mt_mpi flag to ensure linking against thread-safe MPI library when OpenMP is enabled
         if self.options.get('openmp', None) and self.options.get('usempi', None):
-            mt_mpi_option = ['mt_mpi']
+            mt_mpi_option = ['-mt_mpi']
             for flags_var, _ in COMPILER_FLAGS:
                 self.variables.nappend(flags_var, mt_mpi_option)

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -398,7 +398,7 @@ class EasyBuildOptions(GeneralOption):
                                           "for example: 3.5,5.0,7.2", 'strlist', 'extend', None),
             'debug-lmod': ("Run Lmod modules tool commands in debug module", None, 'store_true', False),
             'default-opt-level': ("Specify default optimisation level", 'choice', 'store', DEFAULT_OPT_LEVEL,
-                                  Compiler.COMPILER_OPT_FLAGS),
+                                  Compiler.COMPILER_OPT_OPTIONS),
             'deprecated': ("Run pretending to be (future) version, to test removal of deprecated code.",
                            None, 'store', None),
             'detect-loaded-modules': ("Detect loaded EasyBuild-generated modules, act accordingly; "

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -33,7 +33,7 @@ Authors:
 * Damian Alvarez (Forschungszentrum Juelich GmbH)
 """
 from easybuild.tools import systemtools
-from easybuild.tools.build_log import EasyBuildError, print_warning
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import build_option
 from easybuild.tools.toolchain.constants import COMPILER_VARIABLES
 from easybuild.tools.toolchain.toolchain import Toolchain
@@ -299,7 +299,7 @@ class Compiler(Toolchain):
                 extraflags = self.options.option(extra)
                 if not extraflags or extraflags[0] != '-':
                     raise EasyBuildError("toolchainopts %s: '%s' must start with a '-'." % (extra, extraflags))
-                self.variables.nappend_el(var, extraflags[1:])
+                self.variables.nappend_el(var, extraflags)
 
     def _set_optimal_architecture(self, default_optarch=None):
         """
@@ -356,8 +356,8 @@ class Compiler(Toolchain):
             optarch = self.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(self.arch, self.cpu_family)]
 
         if optarch is not None:
-            if not optarch.startswith('-'):
-                print_warning(f'Specifying optarch "{optarch}" without initial dash is deprecated in EasyBuild 5.')
+            if optarch and not optarch.startswith('-'):
+                self.log.deprecated(f'Specifying optarch "{optarch}" without initial dash is deprecated.', '6.0')
                 # Add flags for backwards compatibility
                 optarch = '-' + optarch
 

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -33,7 +33,7 @@ Authors:
 * Damian Alvarez (Forschungszentrum Juelich GmbH)
 """
 from easybuild.tools import systemtools
-from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option
 from easybuild.tools.toolchain.constants import COMPILER_VARIABLES
 from easybuild.tools.toolchain.toolchain import Toolchain
@@ -356,6 +356,11 @@ class Compiler(Toolchain):
             optarch = self.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(self.arch, self.cpu_family)]
 
         if optarch is not None:
+            if not optarch.startswith('-'):
+                print_warning(f'Specifying optarch "{optarch}" without initial dash is deprecated in EasyBuild 5.')
+                # Add flags for backwards compatibility
+                optarch = '-' + optarch
+
             optarch_log_str = optarch or 'no flags'
             self.log.info("_set_optimal_architecture: using %s as optarch for %s/%s.",
                           optarch_log_str, self.arch, self.cpu_family)

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -38,7 +38,7 @@ from easybuild.tools.config import build_option
 from easybuild.tools.toolchain.constants import COMPILER_VARIABLES
 from easybuild.tools.toolchain.toolchain import Toolchain
 
-# default optimization 'level' (see COMPILER_SHARED_OPTION_MAP/COMPILER_OPT_FLAGS)
+# default optimization 'level' (see COMPILER_SHARED_OPTION_MAP/COMPILER_OPT_OPTIONS)
 DEFAULT_OPT_LEVEL = 'defaultopt'
 
 # 'GENERIC' can  be used to enable generic compilation instead of optimized compilation (which is the default)
@@ -127,20 +127,20 @@ class Compiler(Toolchain):
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = None
     COMPILER_GENERIC_OPTION = None
 
-    COMPILER_FLAGS = ['debug', 'ieee', 'openmp', 'pic', 'shared', 'static', 'unroll', 'verbose']  # any compiler
-    COMPILER_OPT_FLAGS = ['noopt', 'lowopt', DEFAULT_OPT_LEVEL, 'opt']  # optimisation args, ordered !
-    COMPILER_PREC_FLAGS = ['strict', 'precise', 'defaultprec', 'loose', 'veryloose']  # precision flags, ordered !
+    COMPILER_OPTIONS = ['debug', 'ieee', 'openmp', 'pic', 'shared', 'static', 'unroll', 'verbose']  # any compiler
+    COMPILER_OPT_OPTIONS = ['noopt', 'lowopt', DEFAULT_OPT_LEVEL, 'opt']  # optimisation args, ordered !
+    COMPILER_PREC_OPTIONS = ['strict', 'precise', 'defaultprec', 'loose', 'veryloose']  # precision flags, ordered !
 
     COMPILER_CC = None
     COMPILER_CXX = None
-    COMPILER_C_FLAGS = ['-cstd']
-    COMPILER_C_UNIQUE_FLAGS = []
+    COMPILER_C_OPTIONS = ['cstd']
+    COMPILER_C_UNIQUE_OPTIONS = []
 
     COMPILER_F77 = None
     COMPILER_F90 = None
     COMPILER_FC = None
-    COMPILER_F_FLAGS = ['-i8', '-r8']
-    COMPILER_F_UNIQUE_FLAGS = []
+    COMPILER_F_OPTIONS = ['i8', 'r8']
+    COMPILER_F_UNIQUE_OPTIONS = []
 
     LINKER_TOGGLE_STATIC_DYNAMIC = None
     LINKER_TOGGLE_START_STOP_GROUP = {
@@ -245,20 +245,20 @@ class Compiler(Toolchain):
     def _set_compiler_flags(self):
         """Collect the flags set, and add them as variables too"""
 
-        flags = [self.options.option(x) for x in self.COMPILER_FLAGS if self.options.get(x, False)]
-        cflags = [self.options.option(x) for x in self.COMPILER_C_FLAGS + self.COMPILER_C_UNIQUE_FLAGS
+        flags = [self.options.option(x) for x in self.COMPILER_OPTIONS if self.options.get(x, False)]
+        cflags = [self.options.option(x) for x in self.COMPILER_C_OPTIONS + self.COMPILER_C_UNIQUE_OPTIONS
                   if self.options.get(x, False)]
-        fflags = [self.options.option(x) for x in self.COMPILER_F_FLAGS + self.COMPILER_F_UNIQUE_FLAGS
+        fflags = [self.options.option(x) for x in self.COMPILER_F_OPTIONS + self.COMPILER_F_UNIQUE_OPTIONS
                   if self.options.get(x, False)]
 
         # Allow a user-defined default optimisation
         default_opt_level = build_option('default_opt_level')
-        if default_opt_level not in self.COMPILER_OPT_FLAGS:
+        if default_opt_level not in self.COMPILER_OPT_OPTIONS:
             raise EasyBuildError("Unknown value for default optimisation: %s (possibilities are %s)" %
-                                 (default_opt_level, self.COMPILER_OPT_FLAGS))
+                                 (default_opt_level, self.COMPILER_OPT_OPTIONS))
 
         # 1st one is the one to use. add default at the end so len is at least 1
-        optflags = ([self.options.option(x) for x in self.COMPILER_OPT_FLAGS if self.options.get(x, False)] +
+        optflags = ([self.options.option(x) for x in self.COMPILER_OPT_OPTIONS if self.options.get(x, False)] +
                     [self.options.option(default_opt_level)])[:1]
 
         # only apply if the vectorize toolchainopt is explicitly set
@@ -280,7 +280,7 @@ class Compiler(Toolchain):
         elif self.options.get('optarch', False):
             optarchflags.append(self.options.option('optarch'))
 
-        precflags = [self.options.option(x) for x in self.COMPILER_PREC_FLAGS if self.options.get(x, False)] + \
+        precflags = [self.options.option(x) for x in self.COMPILER_PREC_OPTION if self.options.get(x, False)] + \
                     [self.options.option('defaultprec')]
 
         self.variables.nextend('OPTFLAGS', optflags + optarchflags)

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -105,18 +105,18 @@ class Compiler(Toolchain):
 
     COMPILER_UNIQUE_OPTION_MAP = None
     COMPILER_SHARED_OPTION_MAP = {
-        DEFAULT_OPT_LEVEL: 'O2',
-        'cstd': 'std=%(value)s',
-        'debug': 'g',
-        'lowopt': 'O1',
-        'noopt': 'O0',
-        'openmp': 'fopenmp',
-        'opt': 'O3',
-        'pic': 'fPIC',
-        'shared': 'shared',
-        'static': 'static',
-        'unroll': 'unroll',
-        'verbose': 'v',
+        DEFAULT_OPT_LEVEL: '-O2',
+        'cstd': '-std=%(value)s',
+        'debug': '-g',
+        'lowopt': '-O1',
+        'noopt': '-O0',
+        'openmp': '-fopenmp',
+        'opt': '-O3',
+        'pic': '-fPIC',
+        'shared': '-shared',
+        'static': '-static',
+        'unroll': '-unroll',
+        'verbose': '-v',
         'extra_cflags': '%(value)s',
         'extra_cxxflags': '%(value)s',
         'extra_fflags': '%(value)s',
@@ -133,13 +133,13 @@ class Compiler(Toolchain):
 
     COMPILER_CC = None
     COMPILER_CXX = None
-    COMPILER_C_FLAGS = ['cstd']
+    COMPILER_C_FLAGS = ['-cstd']
     COMPILER_C_UNIQUE_FLAGS = []
 
     COMPILER_F77 = None
     COMPILER_F90 = None
     COMPILER_FC = None
-    COMPILER_F_FLAGS = ['i8', 'r8']
+    COMPILER_F_FLAGS = ['-i8', '-r8']
     COMPILER_F_UNIQUE_FLAGS = []
 
     LINKER_TOGGLE_STATIC_DYNAMIC = None

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -280,7 +280,7 @@ class Compiler(Toolchain):
         elif self.options.get('optarch', False):
             optarchflags.append(self.options.option('optarch'))
 
-        precflags = [self.options.option(x) for x in self.COMPILER_PREC_OPTION if self.options.get(x, False)] + \
+        precflags = [self.options.option(x) for x in self.COMPILER_PREC_OPTIONS if self.options.get(x, False)] + \
                     [self.options.option('defaultprec')]
 
         self.variables.nextend('OPTFLAGS', optflags + optarchflags)

--- a/easybuild/tools/toolchain/constants.py
+++ b/easybuild/tools/toolchain/constants.py
@@ -31,9 +31,9 @@ Authors:
 * Kenneth Hoste (Ghent University)
 """
 
-from easybuild.tools.toolchain.variables import CommandFlagList, CommaSharedLibs, CommaStaticLibs, FlagList
-from easybuild.tools.toolchain.variables import IncludePaths, LibraryList, LinkLibraryPaths, SearchPaths
-from easybuild.tools.variables import AbsPathList
+from easybuild.tools.toolchain.variables import CommaSharedLibs, CommaStaticLibs
+from easybuild.tools.toolchain.variables import IncludePaths, LibraryList, LinkLibraryPaths
+from easybuild.tools.variables import AbsPathList, StrList
 
 
 COMPILER_VARIABLES = [
@@ -53,10 +53,10 @@ COMPILER_FLAGS = [
 ]
 
 COMPILER_MAP_CLASS = {
-    FlagList: [
+    StrList: [
         ('OPTFLAGS', 'Optimization flags'),
         ('PRECFLAGS', 'FP precision flags'),
-    ] + COMPILER_FLAGS,
+    ] + COMPILER_FLAGS + COMPILER_VARIABLES,
     LibraryList: [
         ('LIBS', 'Libraries'),  # -l options to pass to the linker (C/C++/Fortran)
         ('FLIBS', 'Fortran libraries'),  # linker flags (e.g. -L and -l) for Fortran libraries
@@ -74,18 +74,15 @@ COMPILER_MAP_CLASS = {
         ('OBJC_INCLUDE_PATH', 'Location of Objective C header files'),
         ('LIBRARY_PATH', 'Location of linker files'),
     ],
-    CommandFlagList: COMPILER_VARIABLES,
 }
 
 CO_COMPILER_MAP_CLASS = {
-    CommandFlagList: [
+    StrList: [
         ('CUDA_CC', 'CUDA C compiler command'),
         ('CUDA_CXX', 'CUDA C++ compiler command'),
         ('CUDA_F77', 'CUDA Fortran 77 compiler command'),
         ('CUDA_F90', 'CUDA Fortran 90 compiler command'),
         ('CUDA_FC', 'CUDA Fortran 77/90 compiler command'),
-    ],
-    FlagList: [
         ('CUDA_CFLAGS', 'CUDA C compiler flags'),
         ('CUDA_CXXFLAGS', 'CUDA C++ compiler flags'),
         ('CUDA_FCFLAGS', 'CUDA Fortran 77/90 compiler flags'),
@@ -110,7 +107,7 @@ MPI_MAP_CLASS = {
         ('MPI_LIB_DIR', 'MPI library directory'),
         ('MPI_INC_DIR', 'MPI include directory'),
     ],
-    CommandFlagList: MPI_COMPILER_VARIABLES + SEQ_COMPILER_VARIABLES,
+    StrList: MPI_COMPILER_VARIABLES + SEQ_COMPILER_VARIABLES,
 }
 
 BLAS_MAP_CLASS = {

--- a/easybuild/tools/toolchain/constants.py
+++ b/easybuild/tools/toolchain/constants.py
@@ -32,7 +32,7 @@ Authors:
 """
 
 from easybuild.tools.toolchain.variables import CommaSharedLibs, CommaStaticLibs
-from easybuild.tools.toolchain.variables import IncludePaths, LibraryList, LinkLibraryPaths
+from easybuild.tools.toolchain.variables import IncludePaths, LibraryList, LinkLibraryPaths, SearchPaths
 from easybuild.tools.variables import AbsPathList, StrList
 
 

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -1173,7 +1173,7 @@ class Toolchain(object):
     def get_flag(self, name):
         """Get compiler flag(s) for a certain option."""
         if isinstance(self.options.option(name), list):
-            return " ".join(list(self.options.option(name)))
+            return " ".join(self.options.option(name))
         else:
             return self.options.option(name)
 

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -1173,9 +1173,9 @@ class Toolchain(object):
     def get_flag(self, name):
         """Get compiler flag(s) for a certain option."""
         if isinstance(self.options.option(name), list):
-            return " ".join("-%s" % x for x in list(self.options.option(name)))
+            return " ".join(list(self.options.option(name)))
         else:
-            return "-%s" % self.options.option(name)
+            return self.options.option(name)
 
     def toolchain_family(self):
         """Return toolchain family for this toolchain."""

--- a/easybuild/tools/toolchain/toolchainvariables.py
+++ b/easybuild/tools/toolchain/toolchainvariables.py
@@ -33,7 +33,8 @@ Authors:
 
 from easybuild.tools.variables import Variables, join_map_class
 from easybuild.tools.toolchain.constants import ALL_MAP_CLASSES
-from easybuild.tools.toolchain.variables import LinkerFlagList, FlagList
+from easybuild.tools.toolchain.variables import LinkerFlagList
+from easybuild.tools.variables import StrList
 
 
 class ToolchainVariables(Variables):
@@ -42,7 +43,7 @@ class ToolchainVariables(Variables):
     in context of compilers (i.e. the generated string are e.g. compiler options or link flags)
     """
     MAP_CLASS = join_map_class(ALL_MAP_CLASSES)  # join_map_class strips explanation
-    DEFAULT_CLASS = FlagList
+    DEFAULT_CLASS = StrList
     LINKER_TOGGLE_START_STOP_GROUP = None
     LINKER_TOGGLE_STATIC_DYNAMIC = None
 

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -3228,21 +3228,6 @@ class ToolchainTest(EnhancedTestCase):
         expected = {}
         self.assertEqual(res, expected)
 
-    def test_get_flag(self):
-        """Test get_flag function"""
-        tc = self.get_toolchain('gompi', version='2018a')
-
-        checks = {
-            '-a': 'a',
-            '-openmp': 'openmp',
-            '-foo': ['foo'],
-            '-foo -bar': ['foo', 'bar'],
-        }
-
-        for flagstring, flags in checks.items():
-            tc.options.options_map['openmp'] = flags
-            self.assertEqual(tc.get_flag('openmp'), flagstring)
-
 
 def suite():
     """ return all the tests"""

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -682,7 +682,7 @@ class ToolchainTest(EnhancedTestCase):
     def test_override_optarch(self):
         """Test whether overriding the optarch flag works."""
         flag_vars = ['CFLAGS', 'CXXFLAGS', 'FCFLAGS', 'FFLAGS', 'F90FLAGS']
-        for optarch_var in ['march=lovelylovelysandybridge', None]:
+        for optarch_var in ['-march=lovelylovelysandybridge', None]:
             init_config(build_options={'optarch': optarch_var, 'silent': True})
             for enable in [True, False]:
                 tc = self.get_toolchain('foss', version='2018a')
@@ -761,7 +761,7 @@ class ToolchainTest(EnhancedTestCase):
         tc.set_options({})
         with self.mocked_stdout_stderr():
             tc.prepare()
-        self.assertEqual(tc.options.options_map['optarch'], 'mcpu=cortex-a53')
+        self.assertEqual(tc.options.options_map['optarch'], '-mcpu=cortex-a53')
         self.assertIn('-mcpu=cortex-a53', os.environ['CFLAGS'])
         self.modtool.purge()
 
@@ -769,7 +769,7 @@ class ToolchainTest(EnhancedTestCase):
         tc.set_options({})
         with self.mocked_stdout_stderr():
             tc.prepare()
-        self.assertEqual(tc.options.options_map['optarch'], 'mcpu=native')
+        self.assertEqual(tc.options.options_map['optarch'], '-mcpu=native')
         self.assertIn('-mcpu=native', os.environ['CFLAGS'])
         self.modtool.purge()
 
@@ -778,16 +778,16 @@ class ToolchainTest(EnhancedTestCase):
         tc.set_options({})
         with self.mocked_stdout_stderr():
             tc.prepare()
-        self.assertEqual(tc.options.options_map['optarch'], 'mcpu=cortex-a72.cortex-a53')
+        self.assertEqual(tc.options.options_map['optarch'], '-mcpu=cortex-a72.cortex-a53')
         self.assertIn('-mcpu=cortex-a72.cortex-a53', os.environ['CFLAGS'])
         self.modtool.purge()
 
     def test_compiler_dependent_optarch(self):
         """Test whether specifying optarch on a per compiler basis works."""
         flag_vars = ['CFLAGS', 'CXXFLAGS', 'FCFLAGS', 'FFLAGS', 'F90FLAGS']
-        intel_options = [('intelflag', 'intelflag'), ('GENERIC', 'xSSE2'), ('', '')]
-        gcc_options = [('gccflag', 'gccflag'), ('march=nocona', 'march=nocona'), ('', '')]
-        gcccore_options = [('gcccoreflag', 'gcccoreflag'), ('GENERIC', 'march=x86-64 -mtune=generic'), ('', '')]
+        intel_options = [('intelflag', 'intelflag'), ('GENERIC', '-xSSE2'), ('', '')]
+        gcc_options = [('gccflag', 'gccflag'), ('-march=nocona', '-march=nocona'), ('', '')]
+        gcccore_options = [('gcccoreflag', 'gcccoreflag'), ('GENERIC', '-march=x86-64 -mtune=generic'), ('', '')]
 
         tc_intel = ('iccifort', '2018.1.163')
         tc_gcc = ('GCC', '6.4.0-2.28')
@@ -849,8 +849,8 @@ class ToolchainTest(EnhancedTestCase):
                     gcc_options[1][1],
                     gcccore_options[0][1],
                     gcccore_options[1][1],
-                    'xHost',  # default optimal for Intel
-                    'march=native',  # default optimal for GCC
+                    '-xHost',  # default optimal for Intel
+                    '-march=native',  # default optimal for GCC
                 ]
             else:
                 blacklist = [flags]
@@ -880,16 +880,16 @@ class ToolchainTest(EnhancedTestCase):
         toy_txt = read_file(eb_file)
 
         # check that an optarch map raises an error
-        write_file(test_ec, toy_txt + "\ntoolchainopts = {'optarch': 'GCC:march=sandrybridge;Intel:xAVX'}")
+        write_file(test_ec, toy_txt + "\ntoolchainopts = {'optarch': 'GCC:-march=sandrybridge;Intel:-xAVX'}")
         msg = "syntax is not allowed"
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, msg, self.eb_main, [test_ec], raise_error=True, do_build=True)
 
         # check that setting optarch flags work
-        write_file(test_ec, toy_txt + "\ntoolchainopts = {'optarch': 'march=sandybridge'}")
+        write_file(test_ec, toy_txt + "\ntoolchainopts = {'optarch': '-march=sandybridge'}")
         with self.mocked_stdout_stderr():
             out = self.eb_main([test_ec], raise_error=True, do_build=True)
-        regex = re.compile("_set_optimal_architecture: using march=sandybridge as optarch for x86_64")
+        regex = re.compile("_set_optimal_architecture: using -march=sandybridge as optarch for x86_64")
         self.assertTrue(regex.search(out), "Pattern '%s' found in: %s" % (regex.pattern, out))
 
     def test_misc_flags_unique_fortran(self):

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -785,9 +785,9 @@ class ToolchainTest(EnhancedTestCase):
     def test_compiler_dependent_optarch(self):
         """Test whether specifying optarch on a per compiler basis works."""
         flag_vars = ['CFLAGS', 'CXXFLAGS', 'FCFLAGS', 'FFLAGS', 'F90FLAGS']
-        intel_options = [('intelflag', 'intelflag'), ('GENERIC', '-xSSE2'), ('', '')]
-        gcc_options = [('gccflag', 'gccflag'), ('-march=nocona', '-march=nocona'), ('', '')]
-        gcccore_options = [('gcccoreflag', 'gcccoreflag'), ('GENERIC', '-march=x86-64 -mtune=generic'), ('', '')]
+        intel_options = [('intelflag', '-intelflag'), ('GENERIC', '-xSSE2'), ('', '')]
+        gcc_options = [('gccflag', '-gccflag'), ('-march=nocona', '-march=nocona'), ('', '')]
+        gcccore_options = [('gcccoreflag', '-gcccoreflag'), ('GENERIC', '-march=x86-64 -mtune=generic'), ('', '')]
 
         tc_intel = ('iccifort', '2018.1.163')
         tc_gcc = ('GCC', '6.4.0-2.28')
@@ -1356,7 +1356,7 @@ class ToolchainTest(EnhancedTestCase):
     def test_fosscuda(self):
         """Test whether fosscuda is handled properly."""
         tc = self.get_toolchain("fosscuda", version="2018a")
-        opts = {'cuda_gencode': ['arch=compute_35,code=sm_35', 'arch=compute_10,code=compute_10'], 'openmp': True}
+        opts = {'cuda_gencode': ['-arch=compute_35,code=sm_35', 'a-rch=compute_10,code=compute_10'], 'openmp': True}
         tc.set_options(opts)
         with self.mocked_stdout_stderr():
             tc.prepare()

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -937,7 +937,7 @@ class ToolchainTest(EnhancedTestCase):
         precs = ['strict', 'precise', 'loose', 'veryloose']
         prec_flags = {}
         for prec in precs:
-            prec_flags[prec] = ' '.join('-%s' % x for x in Gcc.COMPILER_UNIQUE_OPTION_MAP[prec])
+            prec_flags[prec] = ' '.join(Gcc.COMPILER_UNIQUE_OPTION_MAP[prec])
 
         for prec in prec_flags:
             for enable in [True, False]:

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -2274,7 +2274,7 @@ class ToolchainTest(EnhancedTestCase):
         """Test independency of toolchain instances."""
 
         # tweaking --optarch is required for Cray toolchains (craypre-<optarch> module must be available)
-        custom_optarchs = ['test', '-test']  # specifying without initial - is deprecated but should still work
+        custom_optarchs = ['test', '-test']  # specifying without initial "-" is deprecated but should still work
         for custom_optarch in custom_optarchs:
             init_config(build_options={'optarch': custom_optarch, 'silent': True})
 
@@ -2288,13 +2288,16 @@ class ToolchainTest(EnhancedTestCase):
             }
 
             toolchains = [
-                ('CrayCCE', '2015.06-XC'),
-                ('CrayGNU', '2015.06-XC'),
-                ('CrayIntel', '2015.06-XC'),
                 ('GCC', '6.4.0-2.28'),
                 ('iccifort', '2018.1.163'),
                 ('intel-compilers', '2022.1.0'),
             ]
+            if custom_optarchs == 'test':  # optarch is not used as a flag for Cray
+                toolchains += [
+                    ('CrayCCE', '2015.06-XC'),
+                    ('CrayGNU', '2015.06-XC'),
+                    ('CrayIntel', '2015.06-XC'),
+                ]
 
             # purposely obtain toolchains several times in a row, value for $CFLAGS should not change
             for _ in range(3):

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -795,6 +795,7 @@ class ToolchainTest(EnhancedTestCase):
         tc_pgi = ('PGI', '16.7-GCC-5.4.0-2.26')
         enabled = [True, False]
 
+        self.allow_deprecated_behaviour()  # when testing optarch flags without initial "-" (remove in EB 6.0)
         test_cases = []
         for i, (tc, options) in enumerate(zip((tc_intel, tc_gcc, tc_gcccore),
                                               (intel_options, gcc_options, gcccore_options))):
@@ -2298,7 +2299,7 @@ class ToolchainTest(EnhancedTestCase):
                     ('CrayGNU', '2015.06-XC'),
                     ('CrayIntel', '2015.06-XC'),
                 ]
-                self.allow_deprecated_behaviour()  # test will be automatically converted to -test
+                self.allow_deprecated_behaviour()  # test will be automatically converted to -test (remove in 6.0)
             else:
                 self.disallow_deprecated_behaviour()
 

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -2298,6 +2298,9 @@ class ToolchainTest(EnhancedTestCase):
                     ('CrayGNU', '2015.06-XC'),
                     ('CrayIntel', '2015.06-XC'),
                 ]
+                self.allow_deprecated_behaviour()  # test will be automatically converted to -test
+            else:
+                self.disallow_deprecated_behaviour()
 
             # purposely obtain toolchains several times in a row, value for $CFLAGS should not change
             for _ in range(3):

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -583,7 +583,7 @@ class ToolchainTest(EnhancedTestCase):
             tc.prepare()
         for var in flag_vars:
             flags = tc.get_variable(var)
-            flag = '-%s' % tc.COMPILER_SHARED_OPTION_MAP['lowopt']
+            flag = tc.COMPILER_SHARED_OPTION_MAP['lowopt']
             self.assertIn(flag, flags)
         self.modtool.purge()
 
@@ -593,7 +593,7 @@ class ToolchainTest(EnhancedTestCase):
             tc.prepare()
         for var in flag_vars:
             flags = tc.get_variable(var)
-            flag = '-%s' % tc.COMPILER_SHARED_OPTION_MAP['noopt']
+            flag = tc.COMPILER_SHARED_OPTION_MAP['noopt']
             self.assertIn(flag, flags)
         self.modtool.purge()
 
@@ -603,7 +603,7 @@ class ToolchainTest(EnhancedTestCase):
             tc.prepare()
         for var in flag_vars:
             flags = tc.get_variable(var)
-            flag = '-%s' % tc.COMPILER_SHARED_OPTION_MAP['noopt']
+            flag = tc.COMPILER_SHARED_OPTION_MAP['noopt']
             self.assertIn(flag, flags)
 
     def test_misc_flags_shared(self):
@@ -619,7 +619,7 @@ class ToolchainTest(EnhancedTestCase):
                 with self.mocked_stdout_stderr():
                     tc.prepare()
                 # we need to make sure we check for flags, not letter (e.g. 'v' vs '-v')
-                flag = '-%s' % tc.COMPILER_SHARED_OPTION_MAP[opt]
+                flag = tc.COMPILER_SHARED_OPTION_MAP[opt]
                 for var in flag_vars:
                     flags = tc.get_variable(var).split()
                     if enable:
@@ -672,8 +672,7 @@ class ToolchainTest(EnhancedTestCase):
                     option = {True: option}
                 for var in flag_vars:
                     flags = tc.get_variable(var)
-                    for key, value in option.items():
-                        flag = "-%s" % value
+                    for key, flag in option.items():
                         if enable == key:
                             self.assertIn(flag, flags, "%s: %s means %s in %s" % (opt, enable, flag, flags))
                         else:
@@ -692,7 +691,7 @@ class ToolchainTest(EnhancedTestCase):
                     tc.prepare()
                 flag = None
                 if optarch_var is not None:
-                    flag = '-%s' % optarch_var
+                    flag = optarch_var
                 else:
                     # default optarch flag
                     flag = tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(tc.arch, tc.cpu_family)]
@@ -907,9 +906,9 @@ class ToolchainTest(EnhancedTestCase):
                     tc.prepare()
                 flag = tc.COMPILER_UNIQUE_OPTION_MAP[opt]
                 if isinstance(flag, list):
-                    flag = ' '.join('-%s' % x for x in flag)
+                    flag = ' '.join(flag)
                 else:
-                    flag = '-%s' % flag
+                    flag = flag
                 for var in flag_vars:
                     flags = tc.get_variable(var)
                     if enable:
@@ -1363,7 +1362,7 @@ class ToolchainTest(EnhancedTestCase):
             tc.prepare()
 
         archflags = tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(tc.arch, tc.cpu_family)]
-        optflags = "-O2 -ftree-vectorize -%s -fno-math-errno -g -fopenmp" % archflags
+        optflags = "-O2 -ftree-vectorize %s -fno-math-errno -g -fopenmp" % archflags
         nvcc_flags = r' '.join([
             r'-Xcompiler="%s"' % optflags,
             # the use of -lcudart in -Xlinker is a bit silly but hard to avoid

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -3237,6 +3237,21 @@ class ToolchainTest(EnhancedTestCase):
         expected = {}
         self.assertEqual(res, expected)
 
+    def test_get_flag(self):
+        """Test get_flag function"""
+        tc = self.get_toolchain('gompi', version='2018a')
+
+        checks = {
+            '-a': '-a',
+            '-openmp': '-openmp',
+            '-foo': ['-foo'],
+            '-foo -bar': ['-foo', '-bar'],
+        }
+
+        for flagstring, flags in checks.items():
+            tc.options.options_map['openmp'] = flags
+            self.assertEqual(tc.get_flag('openmp'), flagstring)
+
 
 def suite():
     """ return all the tests"""

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1356,7 +1356,7 @@ class ToolchainTest(EnhancedTestCase):
     def test_fosscuda(self):
         """Test whether fosscuda is handled properly."""
         tc = self.get_toolchain("fosscuda", version="2018a")
-        opts = {'cuda_gencode': ['-arch=compute_35,code=sm_35', 'a-rch=compute_10,code=compute_10'], 'openmp': True}
+        opts = {'cuda_gencode': ['-arch=compute_35,code=sm_35', '-arch=compute_10,code=compute_10'], 'openmp': True}
         tc.set_options(opts)
         with self.mocked_stdout_stderr():
             tc.prepare()

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -2293,7 +2293,7 @@ class ToolchainTest(EnhancedTestCase):
                 ('iccifort', '2018.1.163'),
                 ('intel-compilers', '2022.1.0'),
             ]
-            if custom_optarchs == 'test':  # optarch is not used as a flag for Cray
+            if custom_optarch == 'test':  # optarch is not used as a flag for Cray
                 toolchains += [
                     ('CrayCCE', '2015.06-XC'),
                     ('CrayGNU', '2015.06-XC'),

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -1356,7 +1356,7 @@ class ToolchainTest(EnhancedTestCase):
     def test_fosscuda(self):
         """Test whether fosscuda is handled properly."""
         tc = self.get_toolchain("fosscuda", version="2018a")
-        opts = {'cuda_gencode': ['-arch=compute_35,code=sm_35', '-arch=compute_10,code=compute_10'], 'openmp': True}
+        opts = {'cuda_gencode': ['arch=compute_35,code=sm_35', 'arch=compute_10,code=compute_10'], 'openmp': True}
         tc.set_options(opts)
         with self.mocked_stdout_stderr():
             tc.prepare()

--- a/test/framework/toolchainvariables.py
+++ b/test/framework/toolchainvariables.py
@@ -62,16 +62,16 @@ class ToolchainVariablesTest(EnhancedTestCase):
         tcv.join('MPICC', 'CC')
         self.assertEqual(str(tcv['MPICC']), "gcc")
 
-        tcv['F90'] = ['gfortran', 'foo', 'bar']
-        self.assertEqual(tcv['F90'].__repr__(), "[['gfortran', 'foo', 'bar']]")
+        tcv['F90'] = ['gfortran', '-foo', '-bar']
+        self.assertEqual(tcv['F90'].__repr__(), "[['gfortran', '-foo', '-bar']]")
         self.assertEqual(str(tcv['F90']), "gfortran -foo -bar")
 
-        tcv.nappend('FLAGS', ['one', 'two'])
-        x = tcv.nappend('FLAGS', ['three', 'four'])
+        tcv.nappend('FLAGS', ['-one', '-two'])
+        x = tcv.nappend('FLAGS', ['-three', '-four'])
         x.POSITION = -5  # sanitize will reorder, default POSITION is 0
-        self.assertEqual(tcv['FLAGS'].__repr__(), "[['one', 'two'], ['three', 'four']]")
+        self.assertEqual(tcv['FLAGS'].__repr__(), "[['-one', '-two'], ['-three', '-four']]")
         tcv['FLAGS'].sanitize()  # sort on position, called by __str__ also
-        self.assertEqual(tcv['FLAGS'].__repr__(), "[['three', 'four'], ['one', 'two']]")
+        self.assertEqual(tcv['FLAGS'].__repr__(), "[['-three', '-four'], ['-one', '-two']]")
         self.assertEqual(str(tcv['FLAGS']), "-three -four -one -two")
 
         # LIBBLAS is a LibraryList

--- a/test/framework/toolchainvariables.py
+++ b/test/framework/toolchainvariables.py
@@ -159,7 +159,7 @@ class ToolchainVariablesTest(EnhancedTestCase):
 
         tcv.nappend('MPICH_CC', 'icc', var_class=CommandFlagList)
         self.assertEqual(str(tcv['MPICH_CC']), "icc")
-        tcv.nappend('MPICH_CC', 'test')
+        tcv.nappend('MPICH_CC', '-test')
         self.assertEqual(str(tcv['MPICH_CC']), "icc -test")
 
 


### PR DESCRIPTION
Fixes #4269

It was extremely difficult to read this code, partly because a bunch of variables like:
```
COMPILER_F_UNIQUE_FLAGS = []
```
were, in fact, not flags, but options. I renamed these variables because it was so misleading. To add to this, we also have two COMPILER_FLAGS used for different things (neither of them are flags)