### PR TITLE
enhance `get_software_libdir` to return full paths if requested

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1697,7 +1697,7 @@ def get_software_root(name, with_env_var=False):
     return res
 
 
-def get_software_libdir(name, only_one=True, fs=None):
+def get_software_libdir(name, only_one=True, fs=None, full_path=False):
     """
     Find library subdirectories for the specified software package.
 
@@ -1708,30 +1708,35 @@ def get_software_libdir(name, only_one=True, fs=None):
     :param name: name of the software package
     :param only_one: indicates whether only one lib path is expected to be found
     :param fs: only retain library subdirs that contain one of the files in this list
+    :param full_path: Include the software root in the returned path, or just return the subfolder found
     """
     lib_subdirs = ['lib', 'lib64']
     root = get_software_root(name)
-    res = []
+    found_subdirs = []
     if root:
         for lib_subdir in lib_subdirs:
             lib_dir_path = os.path.join(root, lib_subdir)
             if os.path.exists(lib_dir_path):
                 # take into account that lib64 could be a symlink to lib (or vice versa)
                 # see https://github.com/easybuilders/easybuild-framework/issues/3139
-                if any(os.path.samefile(lib_dir_path, os.path.join(root, x)) for x in res):
+                if any(os.path.samefile(lib_dir_path, os.path.join(root, x)) for x in found_subdirs):
                     _log.debug("%s is the same as one of the other paths, so skipping it", lib_dir_path)
 
                 elif fs is None or any(os.path.exists(os.path.join(lib_dir_path, f)) for f in fs):
                     _log.debug("Retaining library subdir '%s' (found at %s)", lib_subdir, lib_dir_path)
-                    res.append(lib_subdir)
+                    found_subdirs.append(lib_subdir)
 
             elif build_option('extended_dry_run'):
-                res.append(lib_subdir)
+                found_subdirs.append(lib_subdir)
                 break
 
         # if no library subdir was found, return None
-        if not res:
+        if not found_subdirs:
             return None
+        if full_path:
+            res = [os.path.join(root, subdir) for subdir in found_subdirs]
+        else:
+            res = found_subdirs
         if only_one:
             if len(res) == 1:
                 res = res[0]
@@ -1740,14 +1745,15 @@ def get_software_libdir(name, only_one=True, fs=None):
                     # if both lib and lib64 were found, check if only one (exactly) has libraries;
                     # this is needed for software with library archives in lib64 but other files/directories in lib
                     lib_glob = ['*.%s' % ext for ext in ['a', get_shared_lib_ext()]]
-                    has_libs = [any(glob.glob(os.path.join(root, subdir, f)) for f in lib_glob) for subdir in res]
+                    has_libs = [any(glob.glob(os.path.join(root, subdir, f)) for f in lib_glob)
+                                for subdir in found_subdirs]
                     if has_libs[0] and not has_libs[1]:
                         return res[0]
-                    elif has_libs[1] and not has_libs[0]:
+                    if has_libs[1] and not has_libs[0]:
                         return res[1]
 
                 raise EasyBuildError("Multiple library subdirectories found for %s in %s: %s",
-                                     name, root, ', '.join(res))
+                                     name, root, ', '.join(found_subdirs))
         return res
     else:
         # return None if software package root could not be determined


### PR DESCRIPTION
This avoids the need to do something like `os.path.join(get_software_root(foo), get_software_libdir(foo))`

Also removed an extra indent for readability: The `if root: <long codeblock> else: return None` gets easier to read when swapped avoiding the `else`