### PR TITLE
New feature: check if an extension of exts_list is already being installed by a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ dist/
 *egg-info/
 *.swp
 .mypy_cache/
-
+.venv*
 Dockerfile.*
 Singularity.*
 test-reports/

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2927,15 +2927,24 @@ class EasyBlock(object):
         # format the new exts_list to be written to the easyconfig file
         exts_list_formatted = ['exts_list = [']
 
+        # iterate over the new extensions list and format them
         for ext in new_exts_list:
+            # append name and version
             exts_list_formatted.append("%s('%s', '%s', {" % (INDENT_4SPACES, ext['name'], ext['version']))
+
+            # iterate over the options and format them
             for key, value in ext['options'].items():
-                if type(value) == str:
-                    exts_list_formatted.append("%s'%s': '%s'," % (INDENT_4SPACES * 2, key, value))
-                else:
-                    exts_list_formatted.append("%s'%s': %s," % (INDENT_4SPACES * 2, key, value))
+                # if value is a string, then add quotes so they are printed correctly
+                if isinstance(value, str):
+                    value = "'%s'" % value
+
+                # append the key and value of the option
+                exts_list_formatted.append("%s'%s': %s," % (INDENT_4SPACES * 2, key, value))
+
+            # close the extension
             exts_list_formatted.append('%s}),' % (INDENT_4SPACES,))
 
+        # close the exts_list
         exts_list_formatted.append(']\n')
 
         # read the easyconfig file and replace the exts_list with the new one

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -166,7 +166,6 @@ class EasyBlock(object):
 
         # extensions
         self.exts = []
-        self.exts_updated = []
         self.exts_all = None
         self.ext_instances = []
         self.skip = None
@@ -2860,9 +2859,9 @@ class EasyBlock(object):
             pbar_label += "(%d/%d done)" % (idx + 1, exts_cnt)
             self.update_exts_progress_bar(pbar_label)
 
-    def update_exts_list_versions(self):
+    def get_updated_exts_list(self):
         """
-        Update all extensions in exts_list to the latest version.
+        Get a new exts_list with all extensions in exts_list to the latest version.
         """
 
         # aesthetic print
@@ -2872,6 +2871,9 @@ class EasyBlock(object):
         PKG_NAME_OFFSET = 25
         PKG_VERSION_OFFSET = 10
         INFO_OFFSET = 20
+
+        # init variables
+        updated_exts_list = []
 
         # loop over all extensions and update their version
         for ext in self.exts:
@@ -2892,7 +2894,7 @@ class EasyBlock(object):
                 clean_pkg_metadata(pkg)
 
                 # store the updated extension
-                self.exts_updated.append(pkg)
+                updated_exts_list.append(pkg)
 
                 # print message to the user
                 if ext['version'] == pkg['version']:
@@ -2904,7 +2906,7 @@ class EasyBlock(object):
 
             else:
                 # no metadata found, therefore store the original extension
-                self.exts_updated.append(ext)
+                updated_exts_list.append(ext)
 
                 # print message to the user
                 print_msg(
@@ -2912,6 +2914,8 @@ class EasyBlock(object):
 
         # aesthetic print
         print()
+
+        return updated_exts_list
 
     def write_new_easyconfig_exts_list(self, new_exts_list):
         """
@@ -4952,7 +4956,7 @@ def update_exts_list(ecs):
 
         # update the extensions in the exts_list to their latest version
         print_msg("Updating extension list...", log=_log)
-        app.update_exts_list_versions()
+        updated_exts_list = app.get_updated_exts_list()
 
         # Write the new easyconfig file
         ec_backup = back_up_file(ec['spec'], backup_extension='bak_update')
@@ -4960,7 +4964,7 @@ def update_exts_list(ecs):
 
         # Write the new easyconfig file
         print_msg('Writing updated EasyConfig file...', log=_log)
-        app.write_new_easyconfig_exts_list(app.exts_updated)
+        app.write_new_easyconfig_exts_list(updated_exts_list)
 
         # Print success message
         print_msg('New easyConfig file written successfully!\n', log=_log)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4905,24 +4905,20 @@ def get_updated_exts_list(exts_defaultclass, exts_list, bioconductor_version=Non
             new_ext = get_pkg_as_extension(exts_defaultclass, metadata)
 
             # print message to the user
-            if ext_version is None:
-                ext_version = "_"
             if ext_version == new_ext['version']:
                 print_msg(
-                    f"Package {ext_name:<{PKG_NAME_OFFSET}} v{ext_version:<{PKG_VERSION_OFFSET}} {'up-to-date':<{INFO_OFFSET}}", log=_log)
+                    f"Package {ext_name:<{PKG_NAME_OFFSET}} v{('_' if ext_version is None else ext_version):<{PKG_VERSION_OFFSET}} {'up-to-date':<{INFO_OFFSET}}", log=_log)
             else:
                 print_msg(
-                    f"Package {ext_name:<{PKG_NAME_OFFSET}} v{ext_version:<{PKG_VERSION_OFFSET}} updated to v{new_ext['version']:<{INFO_OFFSET}}", log=_log)
+                    f"Package {ext_name:<{PKG_NAME_OFFSET}} v{('_' if ext_version is None else ext_version):<{PKG_VERSION_OFFSET}} updated to v{new_ext['version']:<{INFO_OFFSET}}", log=_log)
 
         else:
             # no metadata found, therefore store the original extension
             new_ext = {"name": ext_name, "version": ext_version,  "options": ext_options}
 
             # print message to the user
-            if ext_version is None:
-                ext_version = "_"
             print_msg(
-                f"Package {ext_name:<{PKG_NAME_OFFSET}} v{ext_version:<{PKG_VERSION_OFFSET}} {'info not found':<{INFO_OFFSET}}", log=_log)
+                f"Package {ext_name:<{PKG_NAME_OFFSET}} v{('_' if ext_version is None else ext_version):<{PKG_VERSION_OFFSET}} {'info not found':<{INFO_OFFSET}}", log=_log)
 
         # store the new extension
         updated_exts_list.append(new_ext)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2868,6 +2868,11 @@ class EasyBlock(object):
         # aesthetic print
         print()
 
+        # offsets for printing the package information
+        PKG_NAME_OFFSET = 25
+        PKG_VERSION_OFFSET = 10
+        INFO_OFFSET = 20
+
         # loop over all extensions and update their version
         for ext in self.exts:
 
@@ -2891,17 +2896,19 @@ class EasyBlock(object):
 
                 # print message to the user
                 if ext['version'] == pkg['version']:
-                    print_msg(f"Package {ext['name']:<{25}} v{ext['version']:<{10}} {'up-to-date':<{20}}", log=_log)
+                    print_msg(
+                        f"Package {ext['name']:<{PKG_NAME_OFFSET}} v{ext['version']:<{PKG_VERSION_OFFSET}} {'up-to-date':<{INFO_OFFSET}}", log=_log)
                 else:
                     print_msg(
-                        f"Package {ext['name']:<{25}} v{ext['version']:<{10}} updated to {pkg['version']:<{20}}", log=_log)
+                        f"Package {ext['name']:<{PKG_NAME_OFFSET}} v{ext['version']:<{PKG_VERSION_OFFSET}} updated to {pkg['version']:<{INFO_OFFSET}}", log=_log)
 
             else:
                 # no metadata found, therefore store the original extension
                 self.exts_updated.append(ext)
 
                 # print message to the user
-                print_msg(f"Package {ext['name']:<{20}} v{ext['version']:<{10}} {'info not found':<{20}}", log=_log)
+                print_msg(
+                    f"Package {ext['name']:<{PKG_NAME_OFFSET}} v{ext['version']:<{PKG_VERSION_OFFSET}} {'info not found':<{INFO_OFFSET}}", log=_log)
 
         # aesthetic print
         print()

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -959,7 +959,7 @@ def get_pkg_metadata(pkg_class, pkg_name, pkg_version=None):
         url = "%s/%s/json" % (PYPI_URL, pkg_name)
 
     else:
-        raise NotImplementedError
+        raise EasyBuildError("exts_defaultclass %s not supported" % pkg_class)
 
     try:
         # get the package's metadata from the database
@@ -984,7 +984,7 @@ def get_pkg_metadata(pkg_class, pkg_name, pkg_version=None):
             checksum = get_python_package_checksum(pkg_metadata, version)
 
         else:
-            raise NotImplementedError
+            raise EasyBuildError("exts_defaultclass %s not supported" % pkg_class)
 
         pkg_metadata = {"name": name, "version": version, "checksum": checksum}
 

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -49,7 +49,8 @@ import traceback
 #  expect missing log output when this not the case!
 from easybuild.tools.build_log import EasyBuildError, print_error, print_msg, print_warning, stop_logging
 
-from easybuild.framework.easyblock import build_and_install_one, inject_checksums, inject_checksums_to_json, update_exts_list
+from easybuild.framework.easyblock import build_and_install_one, inject_checksums, inject_checksums_to_json
+from easybuild.framework.easyblock import update_exts_list
 from easybuild.framework.easyconfig import EASYCONFIGS_PKG_SUBDIR
 from easybuild.framework.easyconfig import easyconfig
 from easybuild.framework.easystack import parse_easystack
@@ -550,7 +551,7 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
         _log.info("Creating dependency graph %s" % options.dep_graph)
         dep_graph(options.dep_graph, ordered_ecs)
         return True
-    
+
     # update all extensions in exts_list to the latest version and exit
     if options.update_exts_list:
         update_exts_list(ordered_ecs)

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -49,7 +49,7 @@ import traceback
 #  expect missing log output when this not the case!
 from easybuild.tools.build_log import EasyBuildError, print_error, print_msg, print_warning, stop_logging
 
-from easybuild.framework.easyblock import build_and_install_one, inject_checksums, inject_checksums_to_json
+from easybuild.framework.easyblock import build_and_install_one, inject_checksums, inject_checksums_to_json, update_exts_list
 from easybuild.framework.easyconfig import EASYCONFIGS_PKG_SUBDIR
 from easybuild.framework.easyconfig import easyconfig
 from easybuild.framework.easystack import parse_easystack
@@ -549,6 +549,11 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
     if options.dep_graph:
         _log.info("Creating dependency graph %s" % options.dep_graph)
         dep_graph(options.dep_graph, ordered_ecs)
+        return True
+    
+    # update all extensions in exts_list to the latest version and exit
+    if options.update_exts_list:
+        update_exts_list(ordered_ecs)
         return True
 
     # submit build as job(s), clean up and exit

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -50,7 +50,7 @@ import traceback
 from easybuild.tools.build_log import EasyBuildError, print_error, print_msg, print_warning, stop_logging
 
 from easybuild.framework.easyblock import build_and_install_one, inject_checksums, inject_checksums_to_json
-from easybuild.framework.easyblock import update_exts_list
+from easybuild.framework.easyblock import update_exts_list, check_installed_exts
 from easybuild.framework.easyconfig import EASYCONFIGS_PKG_SUBDIR
 from easybuild.framework.easyconfig import easyconfig
 from easybuild.framework.easystack import parse_easystack
@@ -345,7 +345,7 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
         'sync_pr_with_develop',
         'update_branch_github',
         'update_pr',
-        ) if getattr(options, opt)
+    ) if getattr(options, opt)
     ]
     any_pr_option_set = len(set_pr_options) > 0
     if len(set_pr_options) > 1:
@@ -555,6 +555,11 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
     # update all extensions in exts_list to the latest version and exit
     if options.update_exts_list:
         update_exts_list(ordered_ecs)
+        return True
+
+    # check the extensions already being installed by dependencies and exit
+    if options.check_installed_exts:
+        check_installed_exts(ordered_ecs)
         return True
 
     # submit build as job(s), clean up and exit

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -693,7 +693,7 @@ class EasyBuildOptions(GeneralOption):
             'show-full-config': ("Show current EasyBuild configuration (all settings)", None, 'store_true', False),
             'show-system-info': ("Show system information relevant to EasyBuild", None, 'store_true', False),
             'terse': ("Terse output (machine-readable)", None, 'store_true', False),
-            'update-exts-list': ("Update the exts_list of an easyconfig file", None ,'store_true', False),
+            'update-exts-list': ("Update the exts_list of an easyconfig file", None, 'store_true', False),
             'easystack': ("Path to easystack file in YAML format, specifying details of a software stack",
                           None, 'store', None),
         })

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -693,6 +693,7 @@ class EasyBuildOptions(GeneralOption):
             'show-full-config': ("Show current EasyBuild configuration (all settings)", None, 'store_true', False),
             'show-system-info': ("Show system information relevant to EasyBuild", None, 'store_true', False),
             'terse': ("Terse output (machine-readable)", None, 'store_true', False),
+            'update-exts-list': ("Update the exts_list of an easyconfig file", None ,'store_true', False),
             'easystack': ("Path to easystack file in YAML format, specifying details of a software stack",
                           None, 'store', None),
         })

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -694,6 +694,7 @@ class EasyBuildOptions(GeneralOption):
             'show-system-info': ("Show system information relevant to EasyBuild", None, 'store_true', False),
             'terse': ("Terse output (machine-readable)", None, 'store_true', False),
             'update-exts-list': ("Update the exts_list of an easyconfig file", None, 'store_true', False),
+            'check-installed-exts': ("Check if an extensions is already being installed by a dependency", None, 'store_true', False),
             'easystack': ("Path to easystack file in YAML format, specifying details of a software stack",
                           None, 'store', None),
         })


### PR DESCRIPTION
Steps to reproduce:

git clone -b easybuild-update-integration https://github.com/HPCNow/easybuild-framework_2024.git
cd easybuild-framework_2024
python3 -m venv .venv
. .venv/bin/activate
pip install -r requirements.txt
pip install easybuild-easyblocks easybuild-easyconfigs
pip install -e .
python3 easybuild/main.py "your-eb-recipie-path" --check-installed-exts
