### PR TITLE
change semantics of `--dry-run`, so it doesn't imply `--robot`

### DIFF
--- a/easybuild/tools/robot.py
+++ b/easybuild/tools/robot.py
@@ -242,7 +242,7 @@ def dry_run(easyconfigs, modtool, short=False):
     :param short: use short format for overview: use a variable for common prefixes
     """
     lines = []
-    if build_option('robot_path') is None:
+    if build_option('robot') is None:
         lines.append("Dry run: printing build status of easyconfigs")
         all_specs = easyconfigs
     else:

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3747,6 +3747,7 @@ class EasyConfigTest(EnhancedTestCase):
         args = [
             ec_file,
             '--dry-run',
+            '--robot',
         ]
         outtxt = self.eb_main(args, raise_error=True)
         self.assertTrue(re.search(r'module: GCC/\.4\.9\.2', outtxt))

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1564,12 +1564,15 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     def test_dry_run(self):
         """Test dry run (long format)."""
+
+        # first test with --robot
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 
         args = [
             'gzip-1.4-GCC-4.6.3.eb',
-            '--dry-run',  # implies enabling dependency resolution
+            '--dry-run',
+            '--robot',  # implies enabling dependency resolution
             '--unittest-file=%s' % self.logfile,
         ]
         with self.mocked_stdout_stderr():
@@ -1585,6 +1588,24 @@ class CommandLineOptionsTest(EnhancedTestCase):
         for ec, mod, mark in ecs_mods:
             regex = re.compile(r" \* \[%s\] \S+%s \(module: %s\)" % (mark, ec, mod), re.M)
             self.assertTrue(regex.search(logtxt), "Found match for pattern %s in '%s'" % (regex.pattern, logtxt))
+
+        # next test without --robot
+        fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
+        os.close(fd)
+
+        args = [
+            'gzip-1.4-GCC-4.6.3.eb',
+            '--dry-run',
+            '--unittest-file=%s' % self.logfile,
+        ]
+        self.eb_main(args, logfile=dummylogfn)
+        logtxt = read_file(self.logfile)
+
+        info_msg = r"Dry run: printing build status of easyconfigs"
+        self.assertTrue(re.search(info_msg, logtxt, re.M), "Info message dry running in '%s'" % logtxt)
+        ec, mod, mark = ("gzip-1.4-GCC-4.6.3.eb", "gzip/1.4-GCC-4.6.3", ' ')
+        regex = re.compile(r" \* \[%s\] \S+%s \(module: %s\)" % (mark, ec, mod), re.M)
+        self.assertTrue(regex.search(logtxt), "Found match for pattern %s in '%s'" % (regex.pattern, logtxt))
 
     def test_missing(self):
         """Test use of --missing/-M."""
@@ -1740,6 +1761,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             gzip_ec,
             '--try-toolchain=iccifort,2016.1.150-GCC-4.9.3-2.25',
             '--dry-run',
+            '--robot',
         ]
 
         # by default, toolchain mapping is enabled
@@ -1796,6 +1818,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--try-toolchain-version=6.4.0-2.28',
             '--try-update-deps',
             '-D',
+            '--robot',
         ]
 
         with self.mocked_stdout_stderr():
@@ -1880,6 +1903,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             'gzip-1.5-foss-2018a.eb',
             'OpenMPI-2.1.2-GCC-6.4.0-2.28.eb',
             '--dry-run',
+            '--robot',
             '--unittest-file=%s' % self.logfile,
             '--module-naming-scheme=HierarchicalMNS',
             '--ignore-osdeps',
@@ -1921,6 +1945,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             'gzip-1.5-foss-2018a.eb',
             'OpenMPI-2.1.2-GCC-6.4.0-2.28.eb',
             '--dry-run',
+            '--robot',
             '--unittest-file=%s' % self.logfile,
             '--module-naming-scheme=CategorizedHMNS',
             '--ignore-osdeps',
@@ -2232,6 +2257,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args = [
             '--from-commit=%s' % test_commit,
             '--dry-run',
+            '--robot',
             '--tmpdir=%s' % tmpdir,
             '--include-easyblocks=' + os.path.join(self.test_prefix, 'easyblocks', '*.py'),
         ]
@@ -3098,6 +3124,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         args = [
             ec_file,
             '--dry-run',
+            '--robot',
             '--hide-toolchains=GCC',
         ]
         with self.mocked_stdout_stderr():
@@ -4362,6 +4389,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--minimal-toolchains',
             '--module-naming-scheme=HierarchicalMNS',
             '--dry-run',
+            '--robot',
         ]
         self.mock_stdout(True)
         self.eb_main(args, do_build=True, raise_error=True, testing=False)


### PR DESCRIPTION
`--dry-run` without `--robot` should only show info about the easyconfig itself, not the dependencies.
