### PR TITLE
Fix GitHub Actions for CentOS 7.9 container

### DIFF
--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -18,10 +18,17 @@ jobs:
       fail-fast: false
     container:
       image: ghcr.io/easybuilders/${{ matrix.container }}-amd64
-    env: {ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true} # Allow using Node16 actions
+      volumes:
+        - /node20217:/node20217:rw,rshared
+        - ${{ matrix.container == 'centos-7.9' && '/node20217:/__e/node20:ro,rshared' || ' ' }}
     steps:
+      - name: install nodejs20glibc2.17
+        if: ${{ matrix.container == 'centos-7.9' }}
+        run: |
+          curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz
+          tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: download and unpack easyblocks and easyconfigs repositories
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -195,7 +195,7 @@ jobs:
             IGNORE_PATTERNS+="|skipping SvnRepository test"
             IGNORE_PATTERNS+="|requires Lmod as modules tool"
             IGNORE_PATTERNS+="|stty: 'standard input': Inappropriate ioctl for device"
-            IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 3.[56]"
+            IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 3.[567]"
             IGNORE_PATTERNS+="|from cryptography.* import "
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 2"
             IGNORE_PATTERNS+="|Blowfish"

--- a/.github/workflows/unit_tests_python2.yml
+++ b/.github/workflows/unit_tests_python2.yml
@@ -16,9 +16,16 @@ jobs:
       # CentOS 7.9 container that already includes Lmod & co,
       # see https://github.com/easybuilders/easybuild-containers
       image: ghcr.io/easybuilders/centos-7.9-amd64
-    env: {ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true} # Allow using Node16 actions
+      volumes:
+        - '/node20217:/node20217:rw,rshared'
+        - '/node20217:/__e/node20:ro,rshared'
     steps:
-    - uses: actions/checkout@v3
+    - name: install nodejs20glibc2.17
+      run: |
+        curl -LO https://unofficial-builds.nodejs.org/download/release/v20.9.0/node-v20.9.0-linux-x64-glibc-217.tar.xz
+        tar -xf node-v20.9.0-linux-x64-glibc-217.tar.xz --strip-components 1 -C /node20217
+
+    - uses: actions/checkout@v4
 
     - name: install Python packages
       run: |


### PR DESCRIPTION
Node 16 support is removed and Node 20 requires a newer GLibc. Install an unofficial Node 20 that is build against GLibc 2.17

@boegel 