### PR TITLE
Rename `post_install_step` to `post_processing_step` + deprecate use of `post_install_step`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3110,22 +3110,13 @@ class EasyBlock(object):
             print_msg(msg, log=self.log)
 
     def post_install_step(self):
-        """[DEPRECATED] Do some postprocessing."""
-        # this is for easyblocks calling super(EB_xxx, self).post_install_step()
-        # deprecation warning is below, in post_processing_step
-        return self.post_processing_step()
-
-    def post_processing_step(self):
         """
-        Do some postprocessing
+        [DEPRECATED] Do some postprocessing
         - run post install commands if any were specified
         """
-
-        if self.post_install_step.__qualname__ != "EasyBlock.post_install_step":
-            self.log.deprecated(
-                "EasyBlock.post_install_step() is deprecated, use EasyBlock.post_processing_step() instead.",
-                '6.0',
-            )
+        # even though post_install_step is deprecated in easyblocks we need to keep this here until it is
+        # removed in 6.0 for easyblocks calling super(EB_xxx, self).post_install_step()
+        # The deprecation warning for those is below, in post_processing_step().
 
         lib_dir = os.path.join(self.installdir, 'lib')
         lib64_dir = os.path.join(self.installdir, 'lib64')
@@ -3152,6 +3143,21 @@ class EasyBlock(object):
         self.print_post_install_messages()
 
         self.fix_shebang()
+
+    def post_processing_step(self):
+        """
+        Do some postprocessing
+        - run post install commands if any were specified
+        """
+        # if post_install_step() is present in the easyblock print a deprecation warning
+        # with EB 6.0, post_install_step() can be renamed to post_processing_step, and this method deleted.
+
+        if self.post_install_step.__qualname__ != "EasyBlock.post_install_step":
+            self.log.deprecated(
+                "EasyBlock.post_install_step() is deprecated, use EasyBlock.post_processing_step() instead.",
+                '6.0',
+            )
+        return self.post_install_step()
 
     def sanity_check_step(self, *args, **kwargs):
         """

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3110,10 +3110,23 @@ class EasyBlock(object):
             print_msg(msg, log=self.log)
 
     def post_install_step(self):
+        """[DEPRECATED] Do some postprocessing."""
+        # this is for easyblocks calling super(EB_xxx, self).post_install_step()
+        # deprecation warning is below, in post_processing_step
+        return self.post_processing_step()
+
+    def post_processing_step(self):
         """
         Do some postprocessing
         - run post install commands if any were specified
         """
+
+        if self.post_install_step.__qualname__ != "EasyBlock.post_install_step":
+            self.log.deprecated(
+                "EasyBlock.post_install_step() is deprecated, use EasyBlock.post_processing_step() instead.",
+                '6.0',
+            )
+            return self.post_install_step()
 
         lib_dir = os.path.join(self.installdir, 'lib')
         lib64_dir = os.path.join(self.installdir, 'lib64')
@@ -4194,7 +4207,7 @@ class EasyBlock(object):
         # part 3: post-iteration part
         steps_part3 = [
             (POSTITER_STEP, 'restore after iterating', [lambda x: x.post_iter_step], False),
-            (POSTPROC_STEP, 'postprocessing', [lambda x: x.post_install_step], True),
+            (POSTPROC_STEP, 'postprocessing', [lambda x: x.post_processing_step], True),
             (SANITYCHECK_STEP, 'sanity checking', [lambda x: x.sanity_check_step], True),
             (CLEANUP_STEP, 'cleaning up', [lambda x: x.cleanup_step], False),
             (MODULE_STEP, 'creating module', [lambda x: x.make_module_step], False),

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3126,7 +3126,6 @@ class EasyBlock(object):
                 "EasyBlock.post_install_step() is deprecated, use EasyBlock.post_processing_step() instead.",
                 '6.0',
             )
-            return self.post_install_step()
 
         lib_dir = os.path.join(self.installdir, 'lib')
         lib64_dir = os.path.join(self.installdir, 'lib64')

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -64,6 +64,7 @@ LIST_EASYBLOCKS_SIMPLE_TXT = """EasyBlock
 |   |   |-- DeprecatedDummyExtension
 |   |   |   |-- ChildDeprecatedDummyExtension
 |   |-- EB_toy
+|   |   |-- EB_toy_deprecated
 |   |   |-- EB_toy_eula
 |   |   |-- EB_toytoy
 |   |-- Toy_Extension
@@ -78,6 +79,7 @@ Extension
 |   |   |-- DeprecatedDummyExtension
 |   |   |   |-- ChildDeprecatedDummyExtension
 |   |-- EB_toy
+|   |   |-- EB_toy_deprecated
 |   |   |-- EB_toy_eula
 |   |   |-- EB_toytoy
 |   |-- Toy_Extension"""  # noqa
@@ -104,6 +106,7 @@ LIST_EASYBLOCKS_DETAILED_TXT = """EasyBlock (easybuild.framework.easyblock)
 |   |   |-- DeprecatedDummyExtension (easybuild.easyblocks.generic.deprecateddummyextension @ %(topdir)s/generic/deprecateddummyextension.py)
 |   |   |   |-- ChildDeprecatedDummyExtension (easybuild.easyblocks.generic.childdeprecateddummyextension @ %(topdir)s/generic/childdeprecateddummyextension.py)
 |   |-- EB_toy (easybuild.easyblocks.toy @ %(topdir)s/t/toy.py)
+|   |   |-- EB_toy_deprecated (easybuild.easyblocks.toy_deprecated @ %(topdir)s/t/toy_deprecated.py)
 |   |   |-- EB_toy_eula (easybuild.easyblocks.toy_eula @ %(topdir)s/t/toy_eula.py)
 |   |   |-- EB_toytoy (easybuild.easyblocks.toytoy @ %(topdir)s/t/toytoy.py)
 |   |-- Toy_Extension (easybuild.easyblocks.generic.toy_extension @ %(topdir)s/generic/toy_extension.py)
@@ -118,6 +121,7 @@ Extension (easybuild.framework.extension)
 |   |   |-- DeprecatedDummyExtension (easybuild.easyblocks.generic.deprecateddummyextension @ %(topdir)s/generic/deprecateddummyextension.py)
 |   |   |   |-- ChildDeprecatedDummyExtension (easybuild.easyblocks.generic.childdeprecateddummyextension @ %(topdir)s/generic/childdeprecateddummyextension.py)
 |   |-- EB_toy (easybuild.easyblocks.toy @ %(topdir)s/t/toy.py)
+|   |   |-- EB_toy_deprecated (easybuild.easyblocks.toy_deprecated @ %(topdir)s/t/toy_deprecated.py)
 |   |   |-- EB_toy_eula (easybuild.easyblocks.toy_eula @ %(topdir)s/t/toy_eula.py)
 |   |   |-- EB_toytoy (easybuild.easyblocks.toytoy @ %(topdir)s/t/toytoy.py)
 |   |-- Toy_Extension (easybuild.easyblocks.generic.toy_extension @ %(topdir)s/generic/toy_extension.py)"""  # noqa
@@ -157,6 +161,7 @@ LIST_EASYBLOCKS_SIMPLE_RST = """* **EasyBlock**
 
     * EB_toy
 
+      * EB_toy_deprecated
       * EB_toy_eula
       * EB_toytoy
 
@@ -183,6 +188,7 @@ LIST_EASYBLOCKS_SIMPLE_RST = """* **EasyBlock**
 
     * EB_toy
 
+      * EB_toy_deprecated
       * EB_toy_eula
       * EB_toytoy
 
@@ -225,6 +231,7 @@ LIST_EASYBLOCKS_DETAILED_RST = """* **EasyBlock** (easybuild.framework.easyblock
 
     * EB_toy (easybuild.easyblocks.toy @ %(topdir)s/t/toy.py)
 
+      * EB_toy_deprecated (easybuild.easyblocks.toy_deprecated @ %(topdir)s/t/toy_deprecated.py)
       * EB_toy_eula (easybuild.easyblocks.toy_eula @ %(topdir)s/t/toy_eula.py)
       * EB_toytoy (easybuild.easyblocks.toytoy @ %(topdir)s/t/toytoy.py)
 
@@ -251,6 +258,7 @@ LIST_EASYBLOCKS_DETAILED_RST = """* **EasyBlock** (easybuild.framework.easyblock
 
     * EB_toy (easybuild.easyblocks.toy @ %(topdir)s/t/toy.py)
 
+      * EB_toy_deprecated (easybuild.easyblocks.toy_deprecated @ %(topdir)s/t/toy_deprecated.py)
       * EB_toy_eula (easybuild.easyblocks.toy_eula @ %(topdir)s/t/toy_eula.py)
       * EB_toytoy (easybuild.easyblocks.toytoy @ %(topdir)s/t/toytoy.py)
 
@@ -280,6 +288,7 @@ LIST_EASYBLOCKS_SIMPLE_MD = """- **EasyBlock**
       - DeprecatedDummyExtension
         - ChildDeprecatedDummyExtension
     - EB_toy
+      - EB_toy_deprecated
       - EB_toy_eula
       - EB_toytoy
     - Toy_Extension
@@ -294,6 +303,7 @@ LIST_EASYBLOCKS_SIMPLE_MD = """- **EasyBlock**
       - DeprecatedDummyExtension
         - ChildDeprecatedDummyExtension
     - EB_toy
+      - EB_toy_deprecated
       - EB_toy_eula
       - EB_toytoy
     - Toy_Extension"""  # noqa
@@ -320,6 +330,7 @@ LIST_EASYBLOCKS_DETAILED_MD = """- **EasyBlock** (easybuild.framework.easyblock)
       - DeprecatedDummyExtension (easybuild.easyblocks.generic.deprecateddummyextension @ %(topdir)s/generic/deprecateddummyextension.py)
         - ChildDeprecatedDummyExtension (easybuild.easyblocks.generic.childdeprecateddummyextension @ %(topdir)s/generic/childdeprecateddummyextension.py)
     - EB_toy (easybuild.easyblocks.toy @ %(topdir)s/t/toy.py)
+      - EB_toy_deprecated (easybuild.easyblocks.toy_deprecated @ %(topdir)s/t/toy_deprecated.py)
       - EB_toy_eula (easybuild.easyblocks.toy_eula @ %(topdir)s/t/toy_eula.py)
       - EB_toytoy (easybuild.easyblocks.toytoy @ %(topdir)s/t/toytoy.py)
     - Toy_Extension (easybuild.easyblocks.generic.toy_extension @ %(topdir)s/generic/toy_extension.py)
@@ -334,6 +345,7 @@ LIST_EASYBLOCKS_DETAILED_MD = """- **EasyBlock** (easybuild.framework.easyblock)
       - DeprecatedDummyExtension (easybuild.easyblocks.generic.deprecateddummyextension @ %(topdir)s/generic/deprecateddummyextension.py)
         - ChildDeprecatedDummyExtension (easybuild.easyblocks.generic.childdeprecateddummyextension @ %(topdir)s/generic/childdeprecateddummyextension.py)
     - EB_toy (easybuild.easyblocks.toy @ %(topdir)s/t/toy.py)
+      - EB_toy_deprecated (easybuild.easyblocks.toy_deprecated @ %(topdir)s/t/toy_deprecated.py)
       - EB_toy_eula (easybuild.easyblocks.toy_eula @ %(topdir)s/t/toy_eula.py)
       - EB_toytoy (easybuild.easyblocks.toytoy @ %(topdir)s/t/toytoy.py)
     - Toy_Extension (easybuild.easyblocks.generic.toy_extension @ %(topdir)s/generic/toy_extension.py)"""  # noqa

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1062,10 +1062,12 @@ class EasyBlockTest(EnhancedTestCase):
         toy_ec = EasyConfig(toy_ec_fn)
         eb = EB_toy_deprecated(toy_ec)
         eb.silent = True
-        with self.mocked_stdout_stderr() as (_, stderr):
+        with self.mocked_stdout_stderr() as (stdout, stderr):
             eb.run_all_steps(True)
 
             regex = re.compile(depr_msg, re.M)
+            stdout = stdout.getvalue()
+            self.assertTrue("This step is deprecated.\n" in stdout)
             stderr = stderr.getvalue()
             self.assertTrue(regex.search(stderr), f"Pattern {regex.pattern} found in: {stderr}")
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1025,8 +1025,9 @@ class EasyBlockTest(EnhancedTestCase):
         test_ecs_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'easyconfigs', 'test_ecs')
         toy_ec_fn = os.path.join(test_ecs_dir, 't', 'toy', 'toy-0.0-gompi-2018a-test.eb')
 
-        # this import only works here, since EB_toy is a test easyblock
-        from easybuild.easyblocks.toy import EB_toy, EB_toy_deprecated
+        # these imports only work here, since EB_toy is a test easyblock
+        from easybuild.easyblocks.toy import EB_toy
+        from easybuild.easyblocks.toy_deprecated import EB_toy_deprecated
 
         cwd = os.getcwd()
         toy_ec = EasyConfig(toy_ec_fn)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1018,6 +1018,32 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(eb.cfg.iterating, False)
         self.assertEqual(eb.cfg['configopts'], ["--opt1 --anotheropt", "--opt2", "--opt3 --optbis"])
 
+    def test_post_processing_step(self):
+        """Test post_processing_step and deprecated post_install_step."""
+        init_config(build_options={'silent': True})
+
+        test_ecs_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'easyconfigs', 'test_ecs')
+        toy_ec_fn = os.path.join(test_ecs_dir, 't', 'toy', 'toy-0.0-gompi-2018a-test.eb')
+
+        # this import only works here, since EB_toy is a test easyblock
+        from easybuild.easyblocks.toy import EB_toy, EB_toy_deprecated
+
+        cwd = os.getcwd()
+        toy_ec = EasyConfig(toy_ec_fn)
+        eb = EB_toy_deprecated(toy_ec)
+        eb.silent = True
+        expected_error = r"DEPRECATED \(since v6.0\).*use EasyBlock.post_processing_step\(\) instead.*"
+        with self.mocked_stdout_stderr():
+            self.assertErrorRegex(EasyBuildError, expected_error, eb.run_all_steps, True)
+
+        change_dir(cwd)
+        toy_ec = EasyConfig(toy_ec_fn)
+        eb = EB_toy(toy_ec)
+        eb.silent = True
+        with self.mocked_stdout_stderr():
+            eb.run_all_steps(True)
+        assert os.path.exists(os.path.join(eb.installdir, 'lib', 'libtoy_post.a'))
+
     def test_extensions_step(self):
         """Test the extensions_step"""
         init_config(build_options={'silent': True})

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -142,6 +142,12 @@ class EB_toy(ExtensionEasyBlock):
         mkdir(libdir, parents=True)
         write_file(os.path.join(libdir, 'lib%s.a' % name), name.upper())
 
+    def post_processing_step(self):
+        """Any postprocessing for toy"""
+        libdir = os.path.join(self.installdir, 'lib')
+        write_file(os.path.join(libdir, 'lib%s_post.a' % self.name), self.name.upper())
+        super(EB_toy, self).post_processing_step()
+
     @property
     def required_deps(self):
         """Return list of required dependencies for this extension."""
@@ -192,3 +198,11 @@ class EB_toy(ExtensionEasyBlock):
         txt = super(EB_toy, self).make_module_extra()
         txt += self.module_generator.set_environment('TOY', os.getenv('TOY', '<TOY_env_var_not_defined>'))
         return txt
+
+
+class EB_toy_deprecated(EB_toy):
+    """Support for building/installing toy with deprecated post_install step."""
+
+    def post_install_step(self):
+        """Any postprocessing for toy (deprecated)"""
+        super(EB_toy, self).post_install_step(*arg)

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -198,11 +198,3 @@ class EB_toy(ExtensionEasyBlock):
         txt = super(EB_toy, self).make_module_extra()
         txt += self.module_generator.set_environment('TOY', os.getenv('TOY', '<TOY_env_var_not_defined>'))
         return txt
-
-
-class EB_toy_deprecated(EB_toy):
-    """Support for building/installing toy with deprecated post_install step."""
-
-    def post_install_step(self):
-        """Any postprocessing for toy (deprecated)"""
-        super(EB_toy, self).post_install_step()

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -205,4 +205,4 @@ class EB_toy_deprecated(EB_toy):
 
     def post_install_step(self):
         """Any postprocessing for toy (deprecated)"""
-        super(EB_toy, self).post_install_step(*arg)
+        super(EB_toy, self).post_install_step()

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy_deprecated.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy_deprecated.py
@@ -1,0 +1,39 @@
+##
+# Copyright 2009-2024 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+(deprecated) EasyBuild support for building and installing toy, implemented as an easyblock
+
+@author: Bart Oldeman (McGill University, Calcul Quebec, Digital Research Alliance of Canada)
+"""
+
+from easybuild.easyblocks.toy import EB_toy
+
+
+class EB_toy_deprecated(EB_toy):
+    """Support for building/installing toy with deprecated post_install step."""
+
+    def post_install_step(self):
+        """Any postprocessing for toy (deprecated)"""
+        super(EB_toy, self).post_install_step()

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy_deprecated.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy_deprecated.py
@@ -36,4 +36,5 @@ class EB_toy_deprecated(EB_toy):
 
     def post_install_step(self):
         """Any postprocessing for toy (deprecated)"""
+        print("This step is deprecated.")
         super(EB_toy, self).post_install_step()

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2460,8 +2460,8 @@ class ToyBuildTest(EnhancedTestCase):
             "rm -f %(installdir)s/lib64",
             # create empty lib64 dir
             "mkdir %(installdir)s/lib64",
-            # move libtoy.a
-            "mv %(installdir)s/lib/libtoy.a %(installdir)s/lib64/libtoy.a",
+            # move libtoy*.a
+            "mv %(installdir)s/lib/libtoy*.a %(installdir)s/lib64/",
         ])
         ectxt = re.sub("postinstallcmds.*", "postinstallcmds = ['%s']" % postinstallcmd, ectxt)
 


### PR DESCRIPTION
This deprecates post_install_step.
Fixes #4656
