### PR TITLE
add support for using list of values in `modulename` in extensions

### DIFF
--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -63,11 +63,12 @@ def get_modulenames(ext, use_name_for_false):
         if isinstance(modulenames, list):
             if not modulenames:
                 raise EasyBuildError(f"Empty modulename list for {ext['name']} is not supported."
-                                     "Use `False` to skip checking the module!")
+                                     "Use `False` to skip checking for module existence!")
         elif modulenames is False:
             return [ext['name']] if use_name_for_false else []
         elif not isinstance(modulenames, str):
-            raise EasyBuildError(f"Wrong type of modulename for {ext['name']}: {type(modulenames)}: {modulenames}")
+            raise EasyBuildError(f"Invalid type for modulename of {ext['name']}. "
+                                 f"Expected False, str, or list, but got {type(modulenames).__name__}: {modulenames}")
         else:
             modulenames = [modulenames]
     return modulenames

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -341,7 +341,7 @@ class Extension:
 
         exts_filer_cmds = construct_exts_filter_cmds(exts_filter, self)
         # allow skipping of sanity check by setting module name to False
-        if exts_filer_cmds is None:
+        if not exts_filer_cmds:
             self.log.info("modulename set to False for '%s' extension, so skipping sanity check", self.name)
         else:
             fail_msgs = []


### PR DESCRIPTION
This changes the allowed types of the `modulename` extension option:
- `False` to skip the sanity check and always install it when `--skip` is used
- `str`: Value for `%(ext_name)s` in the `exts_filter` template
- List of `str`: Multiple names to be used in the `exts_filter` template. All resulting commands must succeed.

This was [previously suggested](https://github.com/Flamefire/easybuild-easyblocks/pull/6#issuecomment-821375228) to allow Perl modules that are part of other Perl modules and hence don't need to be installed multiple times. See https://github.com/easybuilders/easybuild-easyconfigs/pull/12575

It replaces `resolve_exts_filter_template` by
`construct_exts_filter_cmds` as the method now returns a, potentially empty, list which might cause errors if used without expecting a list.

The function is only used internally in framework and not by any easyblocks.