### PR TITLE
use `enumerate` where applicable + fix for `ModuleGenerator._generate_multi_deps_list`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1381,8 +1381,7 @@ class EasyBlock(object):
             multi_dep_mod_names = {}
             for deplist in self.cfg.multi_deps:
                 for dep in deplist:
-                    multi_dep_mod_names.setdefault(dep['name'], [])
-                    multi_dep_mod_names[dep['name']].append(dep['short_mod_name'])
+                    multi_dep_mod_names.setdefault(dep['name'], []).append(dep['short_mod_name'])
 
             multi_dep_load_defaults = []
             for _, depmods in sorted(multi_dep_mod_names.items()):

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1494,13 +1494,13 @@ class EasyConfig(object):
             # all multi_deps entries should be listed in builddependencies (if not, something is very wrong)
             if isinstance(builddeps, list) and all(isinstance(x, list) for x in builddeps):
 
-                for iter_id in range(len(builddeps)):
+                for iter_id, current_builddeps in enumerate(builddeps):
 
                     # only build dependencies that correspond to multi_deps entries should be loaded as extra modules
                     # (other build dependencies should not be required to make sanity check pass for this iteration)
                     iter_deps = []
                     for key in self['multi_deps']:
-                        hits = [d for d in builddeps[iter_id] if d['name'] == key]
+                        hits = [d for d in current_builddeps if d['name'] == key]
                         if len(hits) == 1:
                             iter_deps.append(hits[0])
                         else:

--- a/easybuild/tools/configobj.py
+++ b/easybuild/tools/configobj.py
@@ -876,31 +876,24 @@ class Section(dict):
         """
         out = {}
         # scalars first
-        for i in range(len(self.scalars)):
-            entry = self.scalars[i]
+        for i, entry in enumerate(self.scalars):
             try:
                 val = function(self, entry, **keywargs)
-                # bound again in case name has changed
-                entry = self.scalars[i]
-                out[entry] = val
             except Exception:
                 if raise_errors:
                     raise
-                else:
-                    entry = self.scalars[i]
-                    out[entry] = False
+                val = False
+            # bound again in case name has changed
+            entry = self.scalars[i]
+            out[entry] = val
         # then sections
-        for i in range(len(self.sections)):
-            entry = self.sections[i]
+        for i, entry in enumerate(self.sections):
             if call_on_sections:
                 try:
                     function(self, entry, **keywargs)
                 except Exception:
                     if raise_errors:
                         raise
-                    else:
-                        entry = self.sections[i]
-                        out[entry] = False
                 # bound again in case name has changed
                 entry = self.sections[i]
             # previous result is discarded

--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -36,15 +36,16 @@ Authors:
 * Damian Alvarez (Forschungszentrum Juelich GmbH)
 """
 import copy
+import itertools
 import os
 import re
 import tempfile
 from collections import defaultdict
 from contextlib import contextmanager
-from easybuild.tools import LooseVersion
 from textwrap import wrap
 
 from easybuild.base import fancylogger
+from easybuild.tools import LooseVersion
 from easybuild.tools.build_log import EasyBuildError, print_warning
 from easybuild.tools.config import build_option, get_module_syntax, install_path
 from easybuild.tools.filetools import convert_name, mkdir, read_file, remove_file, resolve_path, symlink, write_file
@@ -680,21 +681,13 @@ class ModuleGenerator(object):
         """
         multi_deps = []
         if self.app.cfg['multi_deps']:
-            for key in sorted(self.app.cfg['multi_deps'].keys()):
-                mod_list = []
-                txt = ''
-                vlist = self.app.cfg['multi_deps'].get(key)
-                for idx, version in enumerate(vlist):
-                    for deplist in self.app.cfg.multi_deps:
-                        for dep in deplist:
-                            if dep['name'] == key and dep['version'] == version:
-                                modname = dep['short_mod_name']
-                                # indicate which version is loaded by default (unless that's disabled)
-                                if idx == 0 and self.app.cfg['multi_deps_load_default']:
-                                    modname += ' (default)'
-                                mod_list.append(modname)
-                txt += ', '.join(mod_list)
-                multi_deps.append(txt)
+            for name in sorted(self.app.cfg['multi_deps']):
+                mod_list = [dep['short_mod_name'] for dep in itertools.chain.from_iterable(self.app.cfg.multi_deps)
+                            if dep['name'] == name]
+                # indicate that the first version is loaded by default if enabled
+                if self.app.cfg['multi_deps_load_default']:
+                    mod_list[0] += ' (default)'
+                multi_deps.append(', '.join(mod_list))
 
         return multi_deps
 


### PR DESCRIPTION
PyLint found uses of `range(len(...))` where the index was then used to access an element.

Using `enumerate` yields the value together with the index making the intention clearer (and the code likely faster).

This also led to a nice simplification possibility in make_module_dep, get_parsed_multi_deps and configobj.walk and a possible bugfix in _generate_multi_deps_list:

The code generating the load statement uses the first module of each name in `self.app.cfg.multi_deps` but the code generating the help text has an additional version check. We don't need that and it can possibly be wrong if the order of the versions was different somehow.   
I simply collect all modules with the given name using a (fast) list comprehension and mark the first as the default