### PR TITLE
make sure `type module` is run during a dry run

### DIFF
--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -56,6 +56,7 @@ jobs:
             "eb --show-system-info"
             "eb --check-eb-deps"
             "eb --show-config"
+            "eb -x bzip2-1.0.8.eb"
           )
           for cmd in "${cmds[@]}"; do
               echo ">>> $cmd"

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1367,7 +1367,7 @@ class EnvironmentModules(ModulesTool):
                 out, ec = None, 1
         else:
             cmd = "type _module_raw"
-            res = run_shell_cmd(cmd, fail_on_error=False, in_dry_run=False, hidden=True, output_file=False)
+            res = run_shell_cmd(cmd, fail_on_error=False, in_dry_run=True, hidden=True, output_file=False)
             out, ec = res.output, res.exit_code
 
         if regex is None:

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -308,7 +308,7 @@ class ModulesTool(object):
                 output, exit_code = None, EasyBuildExit.FAIL_SYSTEM_CHECK
         else:
             cmd = "type module"
-            res = run_shell_cmd(cmd, fail_on_error=False, in_dry_run=False, hidden=True, output_file=False)
+            res = run_shell_cmd(cmd, fail_on_error=False, in_dry_run=True, hidden=True, output_file=False)
             output, exit_code = res.output, res.exit_code
 
         if regex is None:


### PR DESCRIPTION
closes #4713

https://github.com/branfosj/easybuild-framework/actions/runs/12279931868/job/34265127454 shows that adding `"eb -x bzip2-1.0.8.eb"` to the end-to-end test fails before the changes in this PR.