### PR TITLE
fall back to getting values with unresolved templates in `EasyBlock.check_checksums_for`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2584,23 +2584,17 @@ class EasyBlock(object):
         ec_fn = os.path.basename(self.cfg.path)
         checksum_issues = []
 
-        if isinstance(ent, EasyConfig):
-            # try to get value with templates resolved, but fall back to not resolving templates;
-            # this is better for error reporting that includes names of source files
-            try:
-                sources = ent.get('sources', [])
-                patches = ent.get('patches', []) + ent.get('postinstallpatches', [])
-                checksums = ent.get('checksums', [])
-            except EasyBuildError:
-                sources = ent.get_ref('sources')
-                patches = ent.get_ref('patches') + ent.get_ref('postinstallpatches')
-                checksums = ent.get_ref('checksums')
-        elif isinstance(ent, dict):
+        # try to get value with templates resolved, but fall back to not resolving templates;
+        # this is better for error reporting that includes names of source files
+        try:
             sources = ent.get('sources', [])
             patches = ent.get('patches', []) + ent.get('postinstallpatches', [])
             checksums = ent.get('checksums', [])
-        else:
-            raise EasyBuildError(f"Unexpected value type in EasyBlock.check_checksums_for: {type(ent)}")
+        except EasyBuildError:
+            if isinstance(ent, EasyConfig):
+                sources = ent.get_ref('sources')
+                patches = ent.get_ref('patches') + ent.get_ref('postinstallpatches')
+                checksums = ent.get_ref('checksums')
 
         # Single source should be re-wrapped as a list, and checksums with it
         if isinstance(sources, dict):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2584,9 +2584,24 @@ class EasyBlock(object):
         ec_fn = os.path.basename(self.cfg.path)
         checksum_issues = []
 
-        sources = ent.get('sources', [])
-        patches = ent.get('patches', []) + ent.get('postinstallpatches', [])
-        checksums = ent.get('checksums', [])
+        if isinstance(ent, EasyConfig):
+            # try to get value with templates resolved, but fall back to not resolving templates;
+            # this is better for error reporting that includes names of source files
+            try:
+                sources = ent.get('sources', [])
+                patches = ent.get('patches', []) + ent.get('postinstallpatches', [])
+                checksums = ent.get('checksums', [])
+            except EasyBuildError:
+                sources = ent.get_ref('sources')
+                patches = ent.get_ref('patches') + ent.get_ref('postinstallpatches')
+                checksums = ent.get_ref('checksums')
+        elif isinstance(ent, dict):
+            sources = ent.get('sources', [])
+            patches = ent.get('patches', []) + ent.get('postinstallpatches', [])
+            checksums = ent.get('checksums', [])
+        else:
+            raise EasyBuildError(f"Unexpected value type in EasyBlock.check_checksums_for: {type(ent)}")
+
         # Single source should be re-wrapped as a list, and checksums with it
         if isinstance(sources, dict):
             sources = [sources]

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2906,6 +2906,20 @@ class EasyBlockTest(EnhancedTestCase):
         eb.json_checksums = None
         self.assertEqual(eb.check_checksums(), [])
 
+        # more checks for check_checksums_for method, which also takes regular dict as input
+        self.assertEqual(eb.check_checksums_for({}), [])
+        expected = "Checksums missing for one or more sources/patches in test.eb: "
+        expected += "found 1 sources + 0 patches vs 0 checksums"
+        self.assertEqual(eb.check_checksums_for({'sources': ['test.tar.gz']}), [expected])
+
+        # example from QuantumESPRESSO easyconfig, template used in extract_cmd should not cause trouble
+        eb.cfg['sources'] = [{
+            'filename': 'q-e-qe-%(version)s.tar.gz',
+            'extract_cmd': 'mkdir -p %(builddir)s/qe-%(version)s && tar xzvf %s --strip-components=1 -C $_',
+            'source_urls': ['https://gitlab.com/QEF/q-e/-/archive/qe-%(version)s'],
+        }]
+        res = eb.check_checksums_for(eb.cfg)
+
     def test_this_is_easybuild(self):
         """Test 'this_is_easybuild' function (and get_git_revision function used by it)."""
         # make sure both return a non-Unicode string


### PR DESCRIPTION
Fix for problems that arise with for example `QuantumESPRESSO-7.3-intel-2023a.eb` in the easyconfigs test suite:
```
Failed to resolve all templates in "mkdir -p %(builddir)s/qe-%(version)s && tar xzvf %%s --strip-components=1 -C $_" using template dictionary: {...}
```

That's because the `%(builddir)s` template can not be resolved yet when checking checksums for sources/patches, but since that's part of `extract_cmd` there's no reason for concern here:

```python
sources = [
    {
        'filename': 'q-e-qe-%(version)s.tar.gz',
        'extract_cmd': 'mkdir -p %(builddir)s/qe-%(version)s && tar xzvf %s --strip-components=1 -C $_',
        'source_urls': ['https://gitlab.com/QEF/q-e/-/archive/qe-%(version)s']
    },
...
```

Falling back to grabbing values without resolving templates via `get_ref` fixes this issue, only small downside is that it leads to using `q-e-qe-%(version)s.tar.gz` in any potential error messages in case of incorrect checksum.

edit: fallout from changes in https://github.com/easybuilders/easybuild-framework/pull/4516