### PR TITLE
resolve template values when getting checksums for extensions

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -614,7 +614,7 @@ class EasyBlock(object):
                     template_values.update(template_constant_dict(ext_src))
 
                     source_urls = resolve_template(ext_options.get('source_urls', []), template_values)
-                    checksums = ext_options.get('checksums', [])
+                    checksums = resolve_template(ext_options.get('checksums', []), template_values)
 
                     download_instructions = resolve_template(ext_options.get('download_instructions'), template_values)
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -494,8 +494,11 @@ class EasyConfigTest(EnhancedTestCase):
                    "checksums": [
                        # SHA256 checksum for source (gzip-1.4.eb)
                        "6a5abcab719cefa95dca4af0db0d2a9d205d68f775a33b452ec0f2b75b6a3a45",
-                       # SHA256 checksum for 'patch' (toy-0.0.eb)
-                       "177b34bcdfa1abde96f30354848a01894ebc9c24913bc5145306cd30f78fc8ad",
+                       # SHA256 checksum for 'patch' (toy-0.0.eb);
+                       # using dict value with key that has a template value,
+                       # to make sure that works as expected...
+                       {"toy-0.%(version_minor)s.eb":
+                        "177b34bcdfa1abde96f30354848a01894ebc9c24913bc5145306cd30f78fc8ad"},
                    ],
                }),
                # Can use templates in name and version
@@ -519,7 +522,8 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(exts_sources[1]['version'], '2.0')
         self.assertEqual(exts_sources[1]['options'], {
             'checksums': ['6a5abcab719cefa95dca4af0db0d2a9d205d68f775a33b452ec0f2b75b6a3a45',
-                          '177b34bcdfa1abde96f30354848a01894ebc9c24913bc5145306cd30f78fc8ad'],
+                          {'toy-0.%(version_minor)s.eb':
+                           '177b34bcdfa1abde96f30354848a01894ebc9c24913bc5145306cd30f78fc8ad'}],
             'patches': [('toy-0.0.eb', '.')],
             'source_tmpl': 'gzip-1.4.eb',
             'source_urls': [('http://example.com', 'suffix')],


### PR DESCRIPTION
With the fix, the enhanced test fails with:
```
ERROR: test_exts_list (test.framework.easyconfig.EasyConfigTest.test_exts_list)
Test handling of list of extensions.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Volumes/work/easybuild-framework/easybuild/tools/filetools.py", line 1305, in verify_checksum
    checksum = checksum[filename]
               ~~~~~~~~^^^^^^^^^^
KeyError: 'toy-0.0.eb'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Volumes/work/easybuild-framework/test/framework/easyconfig.py", line 512, in test_exts_list
    exts_sources = eb.collect_exts_file_info()
  File "/Volumes/work/easybuild-framework/easybuild/framework/easyblock.py", line 735, in collect_exts_file_info
    if verify_checksum(patch, checksum, computed_checksums[patch]):
       ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Volumes/work/easybuild-framework/easybuild/tools/filetools.py", line 1307, in verify_checksum
    raise EasyBuildError("Missing checksum for %s in %s", filename, checksum)
easybuild.tools.build_log.EasyBuildError: "Missing checksum for toy-0.0.eb in {'toy-0.%(version_minor)s.eb': '177b34bcdfa1abde96f30354848a01894ebc9c24913bc5145306cd30f78fc8ad'}"
```

This reproduces the problem reported in https://github.com/easybuilders/easybuild-easyconfigs/issues/22090

edit: This is fallout from #4516, where templates are being resolved for `sources` in `EasyBlock.collect_exts_file_info`, but not in `checksums`.