### PR TITLE
allow deprecated behaviour when running `test_fetch_sources_git` with Python < 3.9

### DIFF
--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1721,6 +1721,9 @@ class EasyBlockTest(EnhancedTestCase):
         with self.mocked_stdout_stderr():
             eb.fetch_sources(sources, checksums=checksums)
 
+        if sys.version_info[0] >= 3 and sys.version_info[1] < 9:
+            self.disallow_deprecated_behaviour()
+
         self.assertEqual(len(eb.src), 1)
         self.assertEqual(eb.src[0]['name'], "testrepository.tar.xz")
         self.assertExists(eb.src[0]['path'])

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1698,10 +1698,6 @@ class EasyBlockTest(EnhancedTestCase):
     @requires_github_access()
     def test_fetch_sources_git(self):
         """Test fetch_sources method from git repo."""
-        if sys.version_info.minor < 9:
-            print("Skipping test_fetch_sources_git as Python version is < 3.9")
-            return
-
         testdir = os.path.abspath(os.path.dirname(__file__))
         ec = process_easyconfig(os.path.join(testdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb'))[0]
         eb = get_easyblock_instance(ec)
@@ -1717,6 +1713,10 @@ class EasyBlockTest(EnhancedTestCase):
             }
         ]
         checksums = ["00000000"]
+
+        if sys.version_info[0] >= 3 and sys.version_info[1] < 9:
+            self.allow_deprecated_behaviour()
+
         with self.mocked_stdout_stderr():
             eb.fetch_sources(sources, checksums=checksums)
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1717,7 +1717,6 @@ class EasyBlockTest(EnhancedTestCase):
             }
         ]
         checksums = ["00000000"]
-
         with self.mocked_stdout_stderr():
             eb.fetch_sources(sources, checksums=checksums)
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1698,6 +1698,9 @@ class EasyBlockTest(EnhancedTestCase):
     @requires_github_access()
     def test_fetch_sources_git(self):
         """Test fetch_sources method from git repo."""
+        if sys.version_info.minor < 9:
+            print("Skipping test_fetch_sources_git as Python version is < 3.9")
+            return
 
         testdir = os.path.abspath(os.path.dirname(__file__))
         ec = process_easyconfig(os.path.join(testdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb'))[0]
@@ -1714,6 +1717,7 @@ class EasyBlockTest(EnhancedTestCase):
             }
         ]
         checksums = ["00000000"]
+
         with self.mocked_stdout_stderr():
             eb.fetch_sources(sources, checksums=checksums)
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1698,6 +1698,7 @@ class EasyBlockTest(EnhancedTestCase):
     @requires_github_access()
     def test_fetch_sources_git(self):
         """Test fetch_sources method from git repo."""
+
         testdir = os.path.abspath(os.path.dirname(__file__))
         ec = process_easyconfig(os.path.join(testdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb'))[0]
         eb = get_easyblock_instance(ec)


### PR DESCRIPTION
From https://github.com/easybuilders/easybuild-framework/actions/runs/12544709924/job/34977742103

```
======================================================================
ERROR: test_fetch_sources_git (test.framework.easyblock.EasyBlockTest)
Test fetch_sources method from git repo.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/runner/e361bb6a84c200b516a56bf3a0355d38d85acace/lib/python3.7/site-packages/test/framework/easyblock.py", line 1718, in test_fetch_sources_git
    eb.fetch_sources(sources, checksums=checksums)
  File "/tmp/runner/e361bb6a84c200b516a56bf3a0355d38d85acace/lib/python3.7/site-packages/easybuild/framework/easyblock.py", line 511, in fetch_sources
    checksum = self.get_checksum_for(checksums=checksums, filename=source, index=index)
  File "/tmp/runner/e361bb6a84c200b516a56bf3a0355d38d85acace/lib/python3.7/site-packages/easybuild/framework/easyblock.py", line 387, in get_checksum_for
    '6.0'
  File "/tmp/runner/e361bb6a84c200b516a56bf3a0355d38d85acace/lib/python3.7/site-packages/easybuild/tools/build_log.py", line 215, in deprecated
    fancylogger.FancyLogger.deprecated(self, msg, str(CURRENT_VERSION), ver, *args, **kwargs)
  File "/tmp/runner/e361bb6a84c200b516a56bf3a0355d38d85acace/lib/python3.7/site-packages/easybuild/base/fancylogger.py", line 346, in deprecated
    self.raiseException("DEPRECATED (since v%s) functionality used: %s" % (max_ver, msg), exception=exception)
  File "/tmp/runner/e361bb6a84c200b516a56bf3a0355d38d85acace/lib/python3.7/site-packages/easybuild/base/fancylogger.py", line 330, in raiseException
    raise exception(message).with_traceback(tb)
easybuild.tools.build_log.EasyBuildError: 'DEPRECATED (since v6.0) functionality used: Reproducible tarballs of Git repos are only possible when using Python 3.9+ to run EasyBuild. Skipping checksum verification of testrepository.tar.xz since Python < 3.9 is used.; see https://docs.easybuild.io/deprecated-functionality/ for more information'
```