### PR TITLE
Adapt `module show` command run to cope with non-zero exit code for non-existing module (required for Environment Modules v5.5+ and Lmod 8.7.56+)

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -709,7 +709,8 @@ class ModulesTool(object):
             ans = MODULE_SHOW_CACHE[key]
             self.log.debug("Found cached result for 'module show %s' with key '%s': %s", mod_name, key, ans)
         else:
-            ans = self.run_module('show', mod_name, check_output=False, return_stderr=True)
+            ans = self.run_module('show', mod_name, check_output=False, return_stderr=True,
+                                  check_exit_code=False)
             MODULE_SHOW_CACHE[key] = ans
             self.log.debug("Cached result for 'module show %s' with key '%s': %s", mod_name, key, ans)
 

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -122,10 +122,12 @@ class ModulesTest(EnhancedTestCase):
             error_pattern = "Module command '.*thisdoesnotmakesense' failed with exit code [1-9]"
             self.assertErrorRegex(EasyBuildError, error_pattern, self.modtool.run_module, 'thisdoesnotmakesense')
 
-            # we need to use a different error pattern here with Environment Modules,
-            # because a load of a non-existing module doesnt' trigger a non-zero exit code...
-            # it will still fail though, just differently
-            if isinstance(self.modtool, EnvironmentModulesC) or isinstance(self.modtool, EnvironmentModules):
+            # we need to use a different error pattern here with EnvironmentModulesC and
+            # EnvironmentModules  <5.5, because a load of a non-existing module doesnt' trigger a
+            # non-zero exit code. it will still fail though, just differently
+            version = LooseVersion(self.modtool.version)
+            if (isinstance(self.modtool, EnvironmentModulesC)
+                    or (isinstance(self.modtool, EnvironmentModules) and version < '5.5')):
                 error_pattern = "Unable to locate a modulefile for 'nosuchmodule/1.2.3'"
             else:
                 error_pattern = "Module command '.*load nosuchmodule/1.2.3' failed with exit code [1-9]"


### PR DESCRIPTION
The `module show` command is used by ModulesTool `exist` method to test the existence of a modulefile. Running `module show` against a non-existing modulefile will make `modulecmd.tcl` script to produce a non-zero exit code starting Modules v5.5.

With this change, the exit code check when running `module show` is disabled. It should not harm the module existence check as it relies on the analysis of the obtained stderr output.
    
Note that Lmod (as of version 8.7.55) does not set a non-zero exit code when running `module show` against a non-existing modulefile when `LMOD_QUIET` environment variable is set. If this behavior is changed in the future, this change will also benefit to Lmod.
