### PR TITLE
add TODO and warning about non-path variables not being currently handled in module load environment

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1655,14 +1655,23 @@ class EasyBlock(object):
             )
             self.module_load_environment.update(self.make_module_req_guess())
 
-        # Only inject path-like environment variables into module file
-        env_var_requirements = sorted([
-            (envar_name, envar_val) for envar_name, envar_val in self.module_load_environment.items()
+        # Expand and inject path-like environment variables into module file
+        env_var_requirements = {
+            envar_name: envar_val
+            for envar_name, envar_val in sorted(self.module_load_environment.items())
             if envar_val.is_path
-        ])
+        }
         self.log.debug(f"Tentative module environment requirements before path expansion: {env_var_requirements}")
+        # TODO: handle non-path variables in make_module_extra
+        # in the meantime, just report if any is found
+        non_path_envars = set(self.module_load_environment) - set(env_var_requirements)
+        if non_path_envars:
+            self.log.warning(
+                f"Non-path variables found in module load environment: {non_path_envars}."
+                "This is not yet supported by this version of EasyBuild."
+            )
 
-        for env_var, search_paths in env_var_requirements:
+        for env_var, search_paths in env_var_requirements.items():
             if self.dry_run:
                 self.dry_run_msg(f" ${env_var}:{', '.join(search_paths)}")
                 # Don't expand globs or do any filtering for dry run

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -272,6 +272,7 @@ class ModuleLoadEnvironment:
         """
         if name != name.upper():
             raise EasyBuildError(f"Names of ModuleLoadEnvironment attributes must be uppercase, got '{name}'")
+
         try:
             (contents, kwargs) = value
         except ValueError:

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -606,7 +606,7 @@ class EasyBlockTest(EnhancedTestCase):
 
         # Module load environement may contain non-path variables
         # TODO: remove whenever this is properly supported, in the meantime check warning
-        eb.module_load_environment.NONPATH = ('non_path_variable', {'var_type': "STRING"})
+        eb.module_load_environment.NONPATH = ('non_path', {'var_type': "STRING"})
         eb.module_load_environment.PATH = ['bin']
         with self.mocked_stdout_stderr():
             txt = eb.make_module_req()
@@ -615,8 +615,10 @@ class EasyBlockTest(EnhancedTestCase):
 
         if get_module_syntax() == 'Tcl':
             self.assertTrue(re.match(r"^\nprepend-path\s+PATH\s+\$root/bin\n$", txt, re.M))
+            self.assertFalse(re.match(r"^\nprepend-path\s+NONPATH\s+\$root/non_path\n$", txt, re.M))
         elif get_module_syntax() == 'Lua':
             self.assertTrue(re.match(r'^\nprepend_path\("PATH", pathJoin\(root, "bin"\)\)\n$', txt, re.M))
+            self.assertFalse(re.match(r'^\nprepend_path\("NONPATH", pathJoin\(root, "non_path"\)\)\n$', txt, re.M))
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -592,7 +592,8 @@ class EasyBlockTest(EnhancedTestCase):
             full_path = os.path.join(eb.installdir, path, 'subpath')
             os.makedirs(full_path)
             write_file(os.path.join(full_path, 'any.file'), 'test')
-        txt = eb.make_module_req()
+        with eb.module_generator.start_module_creation():
+            txt = eb.make_module_req()
         if get_module_syntax() == 'Tcl':
             self.assertFalse(re.search(r"prepend-path\s+LD_LIBRARY_PATH\s+\$%s\n" % sub_lib_path,
                                        txt, re.M))
@@ -602,6 +603,25 @@ class EasyBlockTest(EnhancedTestCase):
             self.assertFalse(re.search(r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "%s"\)\)\n' % sub_lib_path,
                                        txt, re.M))
             self.assertFalse(re.search(r'prepend_path\("PATH", pathJoin\(root, "%s"\)\)\n' % sub_path_path, txt, re.M))
+
+        # Module load environement may contain non-path variables
+        # TODO: remove whenever this is properly supported, in the meantime check warning
+        eb.module_load_environment.NONPATH = ('non_path_variable', {'var_type': "STRING"})
+        eb.module_load_environment.PATH = ['bin']
+        with self.mocked_stdout_stderr():
+            txt = eb.make_module_req()
+
+        self.assertEqual(list(eb.module_load_environment), ['PATH', 'LD_LIBRARY_PATH', 'NONPATH'])
+
+        if get_module_syntax() == 'Tcl':
+            self.assertTrue(re.match(r"^\nprepend-path\s+PATH\s+\$root/bin\n$", txt, re.M))
+        elif get_module_syntax() == 'Lua':
+            self.assertTrue(re.match(r'^\nprepend_path\("PATH", pathJoin\(root, "bin"\)\)\n$', txt, re.M))
+        else:
+            self.fail("Unknown module syntax: %s" % get_module_syntax())
+
+        logtxt = read_file(eb.logfile)
+        self.assertTrue(re.search(r"WARNING Non-path variables found in module load env.*NONPATH", logtxt, re.M))
 
         # cleanup
         eb.close_log()


### PR DESCRIPTION
Follow-up to discussion in https://github.com/easybuilders/easybuild-framework/pull/4653