### PR TITLE
Small improvements to `ModuleLoadEnvironment`

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -152,18 +152,15 @@ class ModuleEnvironmentVariable:
     Contents of environment variable is a list of unique strings
     """
 
-    def __init__(self, contents, var_type=None, delim=os.pathsep):
+    def __init__(self, contents, var_type=ModEnvVarType.PATH_WITH_FILES, delim=os.pathsep):
         """
         Initialize new environment variable
         Actual contents of the environment variable are held in self.contents
-        By default, environment variable is a (list of) paths with files in them
+        By default, the environment variable is a list of paths with files in them
         Existence of paths and their contents are not checked at init
         """
         self.contents = contents
         self.delim = delim
-
-        if var_type is None:
-            var_type = ModEnvVarType.PATH_WITH_FILES
         self.type = var_type
 
         self.log = fancylogger.getLogger(self.__class__.__name__, fname=False)
@@ -283,7 +280,7 @@ class ModuleLoadEnvironment:
 
         # special variables that require files in their top directories
         if name in ('LD_LIBRARY_PATH', 'PATH'):
-            kwargs.update({'var_type': ModEnvVarType.PATH_WITH_TOP_FILES})
+            kwargs['var_type'] = ModEnvVarType.PATH_WITH_TOP_FILES
 
         return super().__setattr__(name, ModuleEnvironmentVariable(contents, **kwargs))
 

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -294,8 +294,7 @@ class ModuleLoadEnvironment:
         - key = attribute name
         - value = its "contents" attribute
         """
-        for attr in self.__dict__:
-            yield attr, getattr(self, attr)
+        return self.__dict__.items()
 
     def update(self, new_env):
         """Update contents of environment from given dictionary"""
@@ -318,10 +317,7 @@ class ModuleLoadEnvironment:
         Return dict with mapping of ModuleEnvironmentVariables names with their contents
         Equivalent in shape to os.environ
         """
-        mapping = {}
-        for envar_name, envar_contents in self.items():
-            mapping.update({envar_name: str(envar_contents)})
-        return mapping
+        return {envar_name: str(envar_contents) for envar_name, envar_contents in self.items()}
 
 
 class ModulesTool(object):

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -439,7 +439,7 @@ class EasyBlockTest(EnhancedTestCase):
         for path in ('bin', ('bin', 'testdir'), 'sbin', 'share', ('share', 'man'), 'lib', 'lib64'):
             path_components = (path, ) if isinstance(path, str) else path
             os.mkdir(os.path.join(eb.installdir, *path_components))
-        eb.install_lib_symlink = LibSymlink.NEITHER
+        eb.check_install_lib_symlink()
 
         write_file(os.path.join(eb.installdir, 'foo.jar'), 'foo.jar')
         write_file(os.path.join(eb.installdir, 'bla.jar'), 'bla.jar')
@@ -505,7 +505,7 @@ class EasyBlockTest(EnhancedTestCase):
         write_file(os.path.join(eb.installdir, 'lib', 'libfoo.so'), 'test')
         shutil.rmtree(os.path.join(eb.installdir, 'lib64'))
         os.symlink('lib', os.path.join(eb.installdir, 'lib64'))
-        eb.install_lib_symlink = LibSymlink.LIB64_TO_LIB
+        eb.check_install_lib_symlink()
         with eb.module_generator.start_module_creation():
             guess = eb.make_module_req()
         if get_module_syntax() == 'Tcl':
@@ -3215,7 +3215,6 @@ class EasyBlockTest(EnhancedTestCase):
         write_file(os.path.join(eb.installdir, 'dir_full_subdirs', 'subdir1', 'file12.txt'), 'test file 1.2')
         write_file(os.path.join(eb.installdir, 'dir_full_subdirs', 'subdir2', 'file21.txt'), 'test file 2.1')
 
-        self.assertEqual(eb.install_lib_symlink, LibSymlink.UNKNOWN)
         eb.check_install_lib_symlink()
         self.assertEqual(eb.install_lib_symlink, LibSymlink.NEITHER)
 


### PR DESCRIPTION
I just checked https://github.com/easybuilders/easybuild-framework/pull/4653 and found a few possible improvements:

1. Using an "unknown" state and requiring callers to update that is error-prone. Comparing `self.install_lib_symlink == LibSymlink.LIB64_TO_LIB` might silently fail if it is forgotten. Use a property with auto-init instead
2. Isn't `def __init__(... var_type=ModEnvVarType.PATH_WITH_FILES...)` clearer in what the default is instead of using and checking for `None`?
3. `for attr in self.__dict__: yield attr, getattr(self, attr)` can be made simpler and faster by using `yield from self.__dict__.items()` or just returning the latter
4. `environ` can use a dict-comprehension for brevity and speed to avoid repeated `update` calls

Do those make sense? @lexming @boegel 