### PR TITLE
enable non-blocking reads for streaming outputs

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -508,9 +508,9 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
 
     if stream_output or qa_patterns:
         # enable non-blocking access to stdout, stderr, stdin
-        channels = [channel for channel in (proc.stdout, proc.stdin, proc.stderr) if channel is not None]
-        for channel in channels:
-            os.set_blocking(channel.fileno(), False)
+        for channel in (proc.stdout, proc.stdin, proc.stderr):
+            if channel is not None:
+                os.set_blocking(channel.fileno(), False)
 
         if stdin:
             proc.stdin.write(stdin)

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -63,7 +63,7 @@ except ImportError:
 
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError, EasyBuildExit, CWD_NOTFOUND_ERROR
-from easybuild.tools.build_log import dry_run_msg, print_msg, time_str_since
+from easybuild.tools.build_log import dry_run_msg, time_str_since
 from easybuild.tools.config import build_option
 from easybuild.tools.hooks import RUN_SHELL_CMD, load_hooks, run_hook
 from easybuild.tools.output import COLOR_RED, COLOR_YELLOW, colorize, print_error
@@ -507,8 +507,6 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
         stdin = stdin.encode()
 
     if stream_output or qa_patterns:
-        print_msg(f"(streaming) output for command '{cmd_str}':")
-
         # enable non-blocking access to stdout, stderr, stdin
         channels = [channel for channel in (proc.stdout, proc.stdin, proc.stderr) if channel is not None]
         for channel in channels:

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -482,9 +482,6 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
     if not hidden:
         _cmd_trace_msg(cmd_str, start_time, work_dir, stdin, tmpdir, thread_id, interactive=interactive)
 
-    if stream_output:
-        print_msg(f"(streaming) output for command '{cmd_str}':")
-
     # use bash as shell instead of the default /bin/sh used by subprocess.run
     # (which could be dash instead of bash, like on Ubuntu, see https://wiki.ubuntu.com/DashAsBinSh)
     # stick to None (default value) when not running command via a shell
@@ -511,6 +508,13 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
         stdin = stdin.encode()
 
     if stream_output or qa_patterns:
+
+        if stream_output:
+            # enable non-blocking reading of output
+            print_msg(f"(streaming) output for command '{cmd_str}':")
+            os.set_blocking(proc.stdout.fileno(), False)
+            if split_stderr:
+                os.set_blocking(proc.stderr.fileno(), False)
 
         if qa_patterns:
             # make stdout, stderr, stdin non-blocking files

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -576,7 +576,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.mock_stdout(False)
 
         self.assertIn("Auto-enabling streaming output", stdout)
-        self.assertIn("== (streaming) output for command 'gcc toy.c -o toy':", stdout)
 
         if os.path.exists(dummylogfn):
             os.remove(dummylogfn)

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -1703,7 +1703,7 @@ class RunTest(EnhancedTestCase):
         self.assertEqual(res.output, expected_output)
 
         self.assertEqual(stderr, '')
-        expected = ("== (streaming) output for command 'echo hello" + '\n' + expected_output).split('\n')
+        expected = ("running shell command:\n\techo hello" + '\n' + expected_output).split('\n')
         for line in expected:
             self.assertIn(line, stdout)
 


### PR DESCRIPTION
This fixes an issue with EB5 on our cluster, running installs with `--logtostdout` hangs after executing `/usr/share/lmod/lmod/libexec/lmod python --terse --show-hidden avail`  in the early stages. However, same installs without `--logtostdout` go fine. An manually executing that `lmod` command also works fine.

Issue seems to be with long/slow commands in streaming mode. The reading action on the output hinders the completion of the command. This PR enables read in non-blocking mode to avoid this issue.

Changelog:
* use same non-blockig mechanism for streaming and QA command runs
* replace fix reads at 128 bytes with `readline`: this does not change functionality as 128 bytes is a (longish) line and this improves readability of logs
* ensure that last piece of output is printed in logs
