### PR TITLE
remove duplication of logs of module commands 

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1012,7 +1012,6 @@ class ModulesTool(object):
         # stdout will contain python code (to change environment etc)
         # stderr will contain text (just like the normal module command)
         stdout, stderr = res.output, res.stderr
-        self.log.debug("Output of module command '%s': stdout: %s; stderr: %s", cmd, stdout, stderr)
 
         # also catch and check exit code
         if kwargs.get('check_exit_code', True) and res.exit_code != EasyBuildExit.SUCCESS:


### PR DESCRIPTION
`run_shell_cmd` already prints at info level the stdout and stderr of those commands