### PR TITLE
add BOTH_TO_DIR state to LibSymlink

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -133,8 +133,9 @@ class LibSymlink(Enum):
     - LIB_TO_LIB64: 'lib' is a symlink to 'lib64'
     - LIB64_TO_LIB: 'lib64' is a symlink to 'lib'
     - NEITHER: neither 'lib' is a symlink to 'lib64', nor 'lib64' is a symlink to 'lib'
+    - BOTH_TO_DIR: 'lib' and 'lib64' are symlinks to some other directory
     - """
-    LIB_TO_LIB64, LIB64_TO_LIB, NEITHER = range(3)
+    LIB_TO_LIB64, LIB64_TO_LIB, NEITHER, BOTH_TO_DIR = range(4)
 
 
 class EasyBlock(object):
@@ -1760,7 +1761,9 @@ class EasyBlock(object):
 
         self._install_lib_symlink = LibSymlink.NEITHER
         if os.path.exists(lib_dir) and os.path.exists(lib64_dir):
-            if os.path.islink(lib_dir) and os.path.samefile(lib_dir, lib64_dir):
+            if os.path.islink(lib_dir) and os.path.islink(lib64_dir):
+                self._install_lib_symlink = LibSymlink.BOTH_TO_DIR
+            elif os.path.islink(lib_dir) and os.path.samefile(lib_dir, lib64_dir):
                 self._install_lib_symlink = LibSymlink.LIB_TO_LIB64
             elif os.path.islink(lib64_dir) and os.path.samefile(lib_dir, lib64_dir):
                 self._install_lib_symlink = LibSymlink.LIB64_TO_LIB

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -3312,6 +3312,25 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(test_emsp("lib*", ModEnvVarType.PATH_WITH_FILES), ["lib64"])
         self.assertEqual(test_emsp("lib*", ModEnvVarType.PATH_WITH_TOP_FILES), ["lib64"])
 
+        # test both lib and lib64 symlinked to some other folder
+        remove_dir(os.path.join(eb.installdir, "lib64"))
+        remove_file(os.path.join(eb.installdir, "lib"))
+        os.mkdir(os.path.join(eb.installdir, "random_lib_dir"))
+        write_file(os.path.join(eb.installdir, "random_lib_dir", "libtest.so"), "not actually a lib")
+        os.symlink("random_lib_dir", os.path.join(eb.installdir, "lib"))
+        os.symlink("random_lib_dir", os.path.join(eb.installdir, "lib64"))
+        eb.check_install_lib_symlink()
+        self.assertEqual(eb.install_lib_symlink, LibSymlink.BOTH_TO_DIR)
+        self.assertEqual(test_emsp("lib", ModEnvVarType.PATH), ["lib"])
+        self.assertEqual(test_emsp("lib", ModEnvVarType.PATH_WITH_FILES), ["lib"])
+        self.assertEqual(test_emsp("lib", ModEnvVarType.PATH_WITH_TOP_FILES), ["lib"])
+        self.assertEqual(test_emsp("lib64", ModEnvVarType.PATH), ["lib64"])
+        self.assertEqual(test_emsp("lib64", ModEnvVarType.PATH_WITH_FILES), ["lib64"])
+        self.assertEqual(test_emsp("lib64", ModEnvVarType.PATH_WITH_TOP_FILES), ["lib64"])
+        self.assertEqual(test_emsp("lib*", ModEnvVarType.PATH), ["lib", "lib64"])
+        self.assertEqual(test_emsp("lib*", ModEnvVarType.PATH_WITH_FILES), ["lib", "lib64"])
+        self.assertEqual(test_emsp("lib*", ModEnvVarType.PATH_WITH_TOP_FILES), ["lib", "lib64"])
+
 
 def suite():
     """ return all the tests in this file """

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -3364,9 +3364,9 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(test_emsp("lib64", ModEnvVarType.PATH), ["lib64"])
         self.assertEqual(test_emsp("lib64", ModEnvVarType.PATH_WITH_FILES), ["lib64"])
         self.assertEqual(test_emsp("lib64", ModEnvVarType.PATH_WITH_TOP_FILES), ["lib64"])
-        self.assertEqual(test_emsp("lib*", ModEnvVarType.PATH), ["lib", "lib64"])
-        self.assertEqual(test_emsp("lib*", ModEnvVarType.PATH_WITH_FILES), ["lib", "lib64"])
-        self.assertEqual(test_emsp("lib*", ModEnvVarType.PATH_WITH_TOP_FILES), ["lib", "lib64"])
+        self.assertEqual(sorted(test_emsp("lib*", ModEnvVarType.PATH)), ["lib", "lib64"])
+        self.assertEqual(sorted(test_emsp("lib*", ModEnvVarType.PATH_WITH_FILES)), ["lib", "lib64"])
+        self.assertEqual(sorted(test_emsp("lib*", ModEnvVarType.PATH_WITH_TOP_FILES)), ["lib", "lib64"])
 
 
 def suite():


### PR DESCRIPTION
This covers cases where both `lib` and `lib64` are symlinks to some other directory