### PR TITLE
correctly deal with easyblocks that still use deprecated `make_module_req_guess` method: remove environment variables if they're not present in guesses

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1681,12 +1681,12 @@ class EasyBlock(object):
 
         if self.make_module_req_guess.__qualname__ != "EasyBlock.make_module_req_guess":
             # Deprecated make_module_req_guess method used in child Easyblock
-            # Update environment with custom make_module_req_guess
+            # adjust environment with custom make_module_req_guess
             self.log.deprecated(
                 "make_module_req_guess() is deprecated, use EasyBlock.module_load_environment instead.",
                 "6.0",
             )
-            self.module_load_environment.update(self.make_module_req_guess())
+            self.module_load_environment.replace(self.make_module_req_guess())
 
         # Expand and inject path-like environment variables into module file
         env_var_requirements = {

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -351,6 +351,13 @@ class ModuleLoadEnvironment:
         except AttributeError as err:
             raise EasyBuildError("Cannot update ModuleLoadEnvironment from a non-dict variable") from err
 
+    def replace(self, new_env):
+        """Replace contents of environment with given dictionary"""
+        env_vars = [e for e in dir(self) if e.isupper()]
+        for env_var in env_vars:
+            self.remove(env_var)
+        self.update(new_env)
+
     def remove(self, var_name):
         """
         Remove ModuleEnvironmentVariable attribute from instance

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -353,9 +353,8 @@ class ModuleLoadEnvironment:
 
     def replace(self, new_env):
         """Replace contents of environment with given dictionary"""
-        env_vars = [e for e in dir(self) if e.isupper()]
-        for env_var in env_vars:
-            self.remove(env_var)
+        for var in self.vars:
+            self.remove(var)
         self.update(new_env)
 
     def remove(self, var_name):

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -1747,6 +1747,19 @@ class ModulesTest(EnhancedTestCase):
         self.assertFalse(hasattr(mod_load_env, 'TEST_VARTYPE'))
         mod_load_env.remove('NONEXISTENT')
 
+        # test replacing of env vars
+        env_vars = sorted(mod_load_env.as_dict.keys())
+        expected = ['ACLOCAL_PATH', 'CLASSPATH', 'CMAKE_LIBRARY_PATH', 'CMAKE_PREFIX_PATH', 'GI_TYPELIB_PATH',
+                    'LD_LIBRARY_PATH', 'LIBRARY_PATH', 'MANPATH', 'PATH', 'PKG_CONFIG_PATH', 'TEST_NEW_VAR',
+                    'TEST_STR', 'TEST_VAR', 'XDG_DATA_DIRS']
+        self.assertEqual(env_vars, expected)
+
+        mod_load_env.replace({'FOO': 'foo', 'BAR': 'bar'})
+        env_vars = sorted(mod_load_env.as_dict.keys())
+        self.assertEqual(env_vars, ['BAR', 'FOO'])
+        self.assertEqual(mod_load_env.BAR.contents, ['bar'])
+        self.assertEqual(mod_load_env.FOO.contents, ['foo'])
+
         # test aliases
         aliases = {
             'ALIAS1': ['ALIAS_VAR11', 'ALIAS_VAR12'],


### PR DESCRIPTION
Some easyblocks (like Conda, Anaconda, XALT) create an entirely new dict in `make_module_req_guess`, which we should respect. If that dict doesn't include environment variables like `PATH` and `LD_LIBRARY_PATH`, it's for a good reason.