### PR TITLE
Avoid processing the same EasyConfig multiple times

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -404,9 +404,15 @@ def parse_easyconfigs(paths, validate=True):
     """
     easyconfigs = []
     generated_ecs = False
+    parsed_paths = []
 
     for (path, generated) in paths:
+        # Avoid processing the same file multiple times
         path = os.path.abspath(path)
+        if any(os.path.samefile(path, p) for p in parsed_paths):
+            continue
+        parsed_paths.append(path)
+
         # keep track of whether any files were generated
         generated_ecs |= generated
         if not os.path.exists(path):

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -737,6 +737,32 @@ class EasyConfigTest(EnhancedTestCase):
         # cleanup
         os.remove(tweaked_fn)
 
+    def test_parse_easyconfig(self):
+        """Test parse_easyconfig function"""
+        self.contents = textwrap.dedent("""
+            easyblock = "ConfigureMake"
+            name = "PI"
+            version = "3.14"
+            homepage = "http://example.com"
+            description = "test easyconfig"
+            toolchain = SYSTEM
+        """)
+        self.prep()
+        ecs, gen_ecs = parse_easyconfigs([(self.eb_file, False)])
+        self.assertEqual(len(ecs), 1)
+        self.assertEqual(ecs[0]['spec'], self.eb_file)
+        self.assertIsInstance(ecs[0]['ec'], EasyConfig)
+        self.assertFalse(gen_ecs)
+        # Passing the same EC multiple times is ignored
+        ecs, gen_ecs = parse_easyconfigs([(self.eb_file, False), (self.eb_file, False)])
+        self.assertEqual(len(ecs), 1)
+        # Similar for symlinks
+        linked_ec = os.path.join(self.test_prefix, 'linked.eb')
+        os.symlink(self.eb_file, linked_ec)
+        ecs, gen_ecs = parse_easyconfigs([(self.eb_file, False), (linked_ec, False)])
+        self.assertEqual(len(ecs), 1)
+        self.assertEqual(ecs[0]['spec'], self.eb_file)
+
     def test_alt_easyconfig_paths(self):
         """Test alt_easyconfig_paths function that collects list of additional paths for easyconfig files."""
 


### PR DESCRIPTION
When passing the same EasyConfig file multiple times on the commandline it will be parsed once and put into a cache.
Every future call will get the same `EasyConfig` instance so any modification to it will be reflected in all future uses of supposedly "freshly parsed EasyConfigs".
This leads to confusing failures when trying to build the same file twice which is likely a mistake anyway, especially when one file is a symlink to another one passed too.
So just make sure each physical file is parsed only once.

I ran into this when building a software using `usempi: True` that errored during configure due to this:
```
== INFO Environment variable CXX set to mpicxx mpicxx (previously undefined)
== INFO Environment variable EBVARCXX set to mpicxx mpicxx (previously undefined)
== INFO Environment variable CXXFLAGS set to -O3 -march=native -fno-math-errno -g -O3 -march=native -O3 -march=native -fno-math-errno -fno-math-errno -g (previously undefined)
```

This is actually a bug introduced by 38361401dd36985c2045f62e19df1dd93319c36e:
- previously `copy.deepcopy` was used which would copy the easyconfig instances contained in the cached dict
- Now only a shallow copy of the dict is made, i.e. there is a separate instance of the dict but not of the keys and values

I don't think this was intentional, the commit message reads
> use copy() method rather than copy.deepcopy on EasyConfig instances

But the operation is done on dict instances not EasyConfig instances. Shall we fix that too @boegel ?   
That would we an alternative to this PR: If we do get independent EC instances then building the same EC twice should work. But I'd prefer this or both.