### PR TITLE
add support for `check_readelf_rpath` easyconfig parameter to optionally skip RPATH checks

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3740,7 +3740,7 @@ class EasyBlock:
         self.log.info("Checking RPATH linkage for binaries/libraries...")
 
         fails = []
-        
+
         # Configure RPATH checking by readelf using easyconfig variable 'check_readelf_rpath' (default True)
         if check_readelf_rpath is None:
             check_readelf_rpath = self.cfg["check_readelf_rpath"]

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3742,13 +3742,11 @@ class EasyBlock:
         fails = []
 
         # Configure RPATH checking by readelf using easyconfig variable 'check_readelf_rpath' (default True)
-        if check_readelf_rpath is None:
-            check_readelf_rpath = self.cfg["check_readelf_rpath"]
-            (
-                self.log.info("RPATH checking by readelf is enabled")
-                if check_readelf_rpath
-                else self.log.info("RPATH checking by readelf is disabled")
-            )
+        check_readelf_rpath = self.cfg["check_readelf_rpath"]
+        if check_readelf_rpath:
+            self.log.info("Checks on RPATH section of binaries/libraries (via 'readelf -d') enabled")
+        else:
+            self.log.info("Checks on RPATH section of binaries/libraries (via 'readelf -d') disabled")
 
         if build_option('strict_rpath_sanity_check'):
             self.log.info("Unsetting $LD_LIBRARY_PATH since strict RPATH sanity check is enabled...")

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3741,8 +3741,10 @@ class EasyBlock:
 
         fails = []
 
-        # Configure RPATH checking by readelf using easyconfig variable 'check_readelf_rpath' (default True)
-        check_readelf_rpath = self.cfg["check_readelf_rpath"]
+        if check_readelf_rpath is None:
+            # Configure RPATH checking by readelf using easyconfig variable 'check_readelf_rpath' (default True)
+            check_readelf_rpath = self.cfg["check_readelf_rpath"]
+
         if check_readelf_rpath:
             self.log.info("Checks on RPATH section of binaries/libraries (via 'readelf -d') enabled")
         else:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3734,12 +3734,21 @@ class EasyBlock:
 
         return fail_msgs
 
-    def sanity_check_rpath(self, rpath_dirs=None, check_readelf_rpath=True):
+    def sanity_check_rpath(self, rpath_dirs=None, check_readelf_rpath=None):
         """Sanity check binaries/libraries w.r.t. RPATH linking."""
 
         self.log.info("Checking RPATH linkage for binaries/libraries...")
 
         fails = []
+        
+        # Configure RPATH checking by readelf using easyconfig variable 'check_readelf_rpath' (default True)
+        if check_readelf_rpath is None:
+            check_readelf_rpath = self.cfg["check_readelf_rpath"]
+            (
+                self.log.info("RPATH checking by readelf is enabled")
+                if check_readelf_rpath
+                else self.log.info("RPATH checking by readelf is disabled")
+            )
 
         if build_option('strict_rpath_sanity_check'):
             self.log.info("Unsetting $LD_LIBRARY_PATH since strict RPATH sanity check is enabled...")

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -236,6 +236,7 @@ DEFAULT_CONFIG = {
                           "and will be archived in the next major release of EasyBuild", OTHER],
     'build_info_msg': [None, "String with information to be printed to stdout and logged during the building "
                              "of the easyconfig", OTHER],
+    'check_readelf_rpath': [True, "If False, it won't check the RPATH by readelf even with the --rpath flag", OTHER],
 }
 
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3034,7 +3034,7 @@ class ToyBuildTest(EnhancedTestCase):
             write_file(toy_ec, toy_ec_txt)
             with self.mocked_stdout_stderr():
                 self._test_toy_build(ec_file=toy_ec, extra_args=['--rpath'], raise_error=True)
-        
+
         # test check_readelf_rpath easyconfig parameter
         test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         toy_ec_txt = read_file(os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb'))

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3034,6 +3034,15 @@ class ToyBuildTest(EnhancedTestCase):
             write_file(toy_ec, toy_ec_txt)
             with self.mocked_stdout_stderr():
                 self._test_toy_build(ec_file=toy_ec, extra_args=['--rpath'], raise_error=True)
+        
+        # test check_readelf_rpath easyconfig parameter
+        test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+        toy_ec_txt = read_file(os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb'))
+        toy_ec_txt += "\ncheck_readelf_rpath = False\n"
+        toy_ec = os.path.join(self.test_prefix, 'toy.eb')
+        write_file(toy_ec, toy_ec_txt)
+        with self.mocked_stdout_stderr():
+            self._test_toy_build(ec_file=toy_ec, extra_args=['--rpath'], raise_error=True)
 
     def test_toy_filter_rpath_sanity_libs(self):
         """Test use of --filter-rpath-sanity-libs."""


### PR DESCRIPTION
This commit adds a new easyconfig variable named 'check_readelf_rpath'.  When set to False, RPATH checks by readelf are skipped even if the --rpath flag is present. This provides more flexible control over RPATH validation in specialized build scenarios (as git-lfs).

resolves https://github.com/vscentrum/vsc-software-stack/issues/502
resolves https://github.com/easybuilders/easybuild-easyconfigs/issues/17516