### PR TITLE
Ignore other classes if software specific easyblock class was found 

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -758,7 +758,7 @@ def avail_easyblocks():
     """Return a list of all available easyblocks."""
 
     module_regexp = re.compile(r"^([^_].*)\.py$")
-    class_regex = re.compile(r"^class ([^(]*)\(", re.M)
+    class_regex = re.compile(r"^class ([^(:]*)\(", re.M)
 
     # finish initialisation of the toolchain module (ie set the TC_CONSTANT constants)
     search_toolchain('')

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -58,7 +58,7 @@ from easybuild.tools import LooseVersion
 from easybuild.tools.build_log import EasyBuildError, print_error, print_msg, print_warning
 from easybuild.tools.config import build_option
 from easybuild.tools.environment import restore_env
-from easybuild.tools.filetools import find_easyconfigs, is_generic_easyblock, is_patch_file, locate_files
+from easybuild.tools.filetools import EASYBLOCK_CLASS_PREFIX, find_easyconfigs, is_patch_file, locate_files
 from easybuild.tools.filetools import read_file, resolve_path, which, write_file
 from easybuild.tools.github import GITHUB_EASYCONFIGS_REPO
 from easybuild.tools.github import det_pr_labels, det_pr_title, download_repo, fetch_easyconfigs_from_commit
@@ -795,7 +795,7 @@ def avail_easyblocks():
                         else:
                             # If there is exactly one software specific easyblock we use that
                             sw_specific_class_names = [name for name in class_names
-                                                       if not is_generic_easyblock(name)]
+                                                       if name.startswith(EASYBLOCK_CLASS_PREFIX)]
                         if len(sw_specific_class_names) == 1:
                             class_names = sw_specific_class_names
                     if len(class_names) == 1:

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -58,7 +58,7 @@ from easybuild.tools import LooseVersion
 from easybuild.tools.build_log import EasyBuildError, print_error, print_msg, print_warning
 from easybuild.tools.config import build_option
 from easybuild.tools.environment import restore_env
-from easybuild.tools.filetools import find_easyconfigs, is_patch_file, locate_files
+from easybuild.tools.filetools import find_easyconfigs, is_generic_easyblock, is_patch_file, locate_files
 from easybuild.tools.filetools import read_file, resolve_path, which, write_file
 from easybuild.tools.github import GITHUB_EASYCONFIGS_REPO
 from easybuild.tools.github import det_pr_labels, det_pr_title, download_repo, fetch_easyconfigs_from_commit
@@ -783,6 +783,12 @@ def avail_easyblocks():
                             easyblock_loc = os.path.join(path, fn)
 
                             class_names = class_regex.findall(read_file(easyblock_loc))
+                            if len(class_names) > 1:
+                                # If there is exactly one software specific easyblock we use that
+                                sw_specific_class_names = [name for name in class_names
+                                                           if not is_generic_easyblock(name)]
+                                if len(sw_specific_class_names) == 1:
+                                    class_names = sw_specific_class_names
                             if len(class_names) == 1:
                                 easyblock_class = class_names[0]
                             elif class_names:

--- a/easybuild/scripts/mk_tmpl_easyblock_for.py
+++ b/easybuild/scripts/mk_tmpl_easyblock_for.py
@@ -36,7 +36,7 @@ import os
 import sys
 from optparse import OptionParser
 
-from easybuild.tools.filetools import encode_class_name
+from easybuild.tools.filetools import encode_class_name, EASYBLOCK_CLASS_PREFIX
 
 # parse options
 parser = OptionParser()
@@ -83,8 +83,9 @@ if os.path.exists(easyblock_path):
 # determine parent easyblock class
 parent_import = "from easybuild.framework.easyblock import EasyBlock"
 if not options.parent == "EasyBlock":
-    if options.parent.startswith('EB_'):
-        ebmod = options.parent[3:].lower()  # FIXME: here we should actually decode the encoded class name
+    if options.parent.startswith(EASYBLOCK_CLASS_PREFIX):
+        # FIXME: here we should actually decode the encoded class name
+        ebmod = options.parent[len(EASYBLOCK_CLASS_PREFIX):].lower()
     else:
         ebmod = "generic.%s" % options.parent.lower()
     parent_import = "from easybuild.easyblocks.%s import %s" % (ebmod, options.parent)

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -1317,11 +1317,15 @@ def get_easyblock_classes(package_name):
     modules = import_available_modules(package_name)
 
     for mod in modules:
+        easyblock_found = False
         for name, _ in inspect.getmembers(mod, inspect.isclass):
             eb_class = getattr(mod, name)
             # skip imported classes that are not easyblocks
             if eb_class.__module__.startswith(package_name) and EasyBlock in inspect.getmro(eb_class):
                 easyblocks.add(eb_class)
+                easyblock_found = True
+        if not easyblock_found:
+            raise RuntimeError("No easyblocks found in module: %s", mod.__name__)
 
     return easyblocks
 

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -1313,15 +1313,15 @@ def get_easyblock_classes(package_name):
     """
     Get list of all easyblock classes in specified easyblocks.* package
     """
-    easyblocks = []
+    easyblocks = set()
     modules = import_available_modules(package_name)
 
     for mod in modules:
         for name, _ in inspect.getmembers(mod, inspect.isclass):
             eb_class = getattr(mod, name)
             # skip imported classes that are not easyblocks
-            if eb_class.__module__.startswith(package_name) and eb_class not in easyblocks:
-                easyblocks.append(eb_class)
+            if eb_class.__module__.startswith(package_name) and EasyBlock in inspect.getmro(eb_class):
+                easyblocks.add(eb_class)
 
     return easyblocks
 

--- a/easybuild/tools/include.py
+++ b/easybuild/tools/include.py
@@ -37,7 +37,7 @@ import tempfile
 
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.filetools import expand_glob_paths, read_file, symlink
+from easybuild.tools.filetools import expand_glob_paths, read_file, symlink, EASYBLOCK_CLASS_PREFIX
 # these are imported just to we can reload them later
 import easybuild.tools.module_naming_scheme
 import easybuild.toolchains
@@ -157,7 +157,7 @@ def verify_imports(pymods, pypkg, from_path):
 
 def is_software_specific_easyblock(module):
     """Determine whether Python module at specified location is a software-specific easyblock."""
-    return bool(re.search(r'^class EB_.*\(.*\):\s*$', read_file(module), re.M))
+    return bool(re.search(r'^class %s.*\(.*\):\s*$' % EASYBLOCK_CLASS_PREFIX, read_file(module), re.M))
 
 
 def include_easyblocks(tmpdir, paths):

--- a/easybuild/tools/include.py
+++ b/easybuild/tools/include.py
@@ -157,7 +157,8 @@ def verify_imports(pymods, pypkg, from_path):
 
 def is_software_specific_easyblock(module):
     """Determine whether Python module at specified location is a software-specific easyblock."""
-    return bool(re.search(r'^class %s.*\(.*\):\s*$' % EASYBLOCK_CLASS_PREFIX, read_file(module), re.M))
+    # All software-specific easyblocks start with the prefix and derive from another class, at least EasyBlock
+    return bool(re.search(r"^class %s[^(:]+\([^)]+\):\s*$" % EASYBLOCK_CLASS_PREFIX, read_file(module), re.M))
 
 
 def include_easyblocks(tmpdir, paths):

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -520,7 +520,7 @@ class DocsTest(EnhancedTestCase):
     def test_gen_easyblocks_overview(self):
         """ Test gen_easyblocks_overview_* functions """
         gen_easyblocks_pkg = 'easybuild.easyblocks.generic'
-        modules = import_available_modules(gen_easyblocks_pkg)
+        names = [eb_class.__name__ for eb_class in get_easyblock_classes(gen_easyblocks_pkg)]
         common_params = {
             'ConfigureMake': ['configopts', 'buildopts', 'installopts'],
         }
@@ -564,15 +564,9 @@ class DocsTest(EnhancedTestCase):
         ])
 
         self.assertIn(check_configuremake, ebdoc)
-        names = []
 
-        for mod in modules:
-            for name, _ in inspect.getmembers(mod, inspect.isclass):
-                eb_class = getattr(mod, name)
-                # skip imported classes that are not easyblocks
-                if eb_class.__module__.startswith(gen_easyblocks_pkg):
-                    self.assertIn(name, ebdoc)
-                    names.append(name)
+        for name in names:
+            self.assertIn(name, ebdoc)
 
         toc = [":ref:`" + n + "`" for n in sorted(set(names))]
         pattern = " - ".join(toc)
@@ -610,17 +604,11 @@ class DocsTest(EnhancedTestCase):
         ])
 
         self.assertIn(check_configuremake, ebdoc)
-        names = []
 
-        for mod in modules:
-            for name, _ in inspect.getmembers(mod, inspect.isclass):
-                eb_class = getattr(mod, name)
-                # skip imported classes that are not easyblocks
-                if eb_class.__module__.startswith(gen_easyblocks_pkg):
-                    self.assertIn(name, ebdoc)
-                    names.append(name)
+        for name in names:
+            self.assertIn(name, ebdoc)
 
-        toc = ["\\[" + n + "\\]\\(#" + n.lower() + "\\)" for n in sorted(set(names))]
+        toc = ["\\[" + n + "\\]\\(#" + n.lower() + "\\)" for n in sorted(names)]
         pattern = " - ".join(toc)
         regex = re.compile(pattern)
         self.assertTrue(re.search(regex, ebdoc), "Pattern %s found in %s" % (regex.pattern, ebdoc))

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -25,7 +25,6 @@
 """
 Unit tests for docs.py.
 """
-import inspect
 import os
 import re
 import sys
@@ -38,7 +37,7 @@ from easybuild.tools.docs import get_easyblock_classes, gen_easyblocks_overview_
 from easybuild.tools.docs import list_easyblocks, list_software, list_toolchains
 from easybuild.tools.docs import md_title_and_table, rst_title_and_table
 from easybuild.tools.options import EasyBuildOptions
-from easybuild.tools.utilities import import_available_modules, mk_md_table, mk_rst_table
+from easybuild.tools.utilities import mk_md_table, mk_rst_table
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
 
 

--- a/test/framework/sandbox/easybuild/easyblocks/f/foofoo.py
+++ b/test/framework/sandbox/easybuild/easyblocks/f/foofoo.py
@@ -32,6 +32,14 @@ from easybuild.easyblocks.foo import EB_foo
 from easybuild.framework.easyconfig import CUSTOM, MANDATORY
 
 
+class dummy1:
+    """Only to verify that unrelated classes in software specific easyblocks are ignored"""
+
+
+class dummy2(dummy1):
+    """Same but with inheritance"""
+
+
 class EB_foofoo(EB_foo):
     """Support for building/installing foofoo."""
 

--- a/test/framework/sandbox/easybuild/easyblocks/generic/bar.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/bar.py
@@ -40,7 +40,7 @@ class dummy2(dummy1):
     """Same but with inheritance"""
 
 
-class dummy1:
+class dummy3:
     """Class without inheritance before the real easyblock to verify the regex not being too greedy"""
 
 

--- a/test/framework/sandbox/easybuild/easyblocks/generic/bar.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/bar.py
@@ -32,6 +32,18 @@ from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig import CUSTOM, MANDATORY
 
 
+class dummy1:
+    """Only to verify that unrelated classes in software specific easyblocks are ignored"""
+
+
+class dummy2(dummy1):
+    """Same but with inheritance"""
+
+
+class dummy1:
+    """Class without inheritance before the real easyblock to verify the regex not being too greedy"""
+
+
 class bar(EasyBlock):
     """Generic support for building/installing bar."""
 


### PR DESCRIPTION
If we have other classes next to a software specific easyblock class in an easyblock file they are likely supplemental.

So ignore them in `avail_easyblocks`.

Also 2 cleanups:
- Use the constant for `EB_` in all places
- Make the loop a bit simpler by reducing the 8-level nesting