### PR TITLE
enable `keepsymlinks` by default

### DIFF
--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -154,8 +154,8 @@ DEFAULT_CONFIG = {
                              FILEMANAGEMENT],
     'keeppreviousinstall': [False, ('Boolean to keep the previous installation with identical '
                                     'name. Experts only!'), FILEMANAGEMENT],
-    'keepsymlinks': [False, ('Boolean to determine whether symlinks are to be kept during copying '
-                             'or if the content of the files pointed to should be copied'),
+    'keepsymlinks': [True, ('Boolean to determine whether symlinks are to be kept during copying '
+                            'or if the content of the files pointed to should be copied'),
                      FILEMANAGEMENT],
     'start_dir': [None, ('Path to start the make in. If the path is absolute, use that path. '
                          'If not, this is added to the guessed path.'), FILEMANAGEMENT],

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2610,6 +2610,26 @@ class EasyBlockTest(EnhancedTestCase):
         # Reset mocked value
         del st.det_parallelism._default_parallelism
 
+    def test_keepsymlinks(self):
+        """Test keepsymlinks parameter (default: True)."""
+        topdir = os.path.abspath(os.path.dirname(__file__))
+        toy_ec = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
+        toytxt = read_file(toy_ec)
+
+        test_cases = {
+            '': True,
+            'keepsymlinks = False': False,
+            'keepsymlinks = True': True,
+        }
+
+        for txt, expected in test_cases.items():
+            with self.subTest(ec_params=txt):
+                self.contents = toytxt + '\n' + txt
+                self.writeEC()
+                test_eb = EasyBlock(EasyConfig(self.eb_file))
+                test_eb.post_init()
+                self.assertEqual(test_eb.cfg['keepsymlinks'], expected)
+
     def test_guess_start_dir(self):
         """Test guessing the start dir."""
         test_easyconfigs = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'easyconfigs', 'test_ecs')

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -676,7 +676,7 @@ class EasyConfigTest(EnhancedTestCase):
             'toolchain = {"name": "GCC", "version": "4.6.3"}',
             'patches = %s',
             'maxparallel = 1',
-            'keepsymlinks = True',
+            'keepsymlinks = False',
         ]) % str(patches)
         self.prep()
 
@@ -694,7 +694,7 @@ class EasyConfigTest(EnhancedTestCase):
             'versionsuffix': versuff,
             'toolchain_version': tcver,
             'patches': new_patches,
-            'keepsymlinks': 'True',  # Don't change this
+            'keepsymlinks': 'False',  # Don't change this
             # It should be possible to overwrite values with True/False/None as they often have special meaning
             'runtest': 'False',
             'hidden': 'True',

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-2018a-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-2018a-test.eb
@@ -38,7 +38,7 @@ exts_list = [
         'unknowneasyconfigparameterthatshouldbeignored': 'foo',
         # set boolean value (different from default value) to trigger (now fixed) bug with --inject-checksums
         # cfr. https://github.com/easybuilders/easybuild-framework/pull/3034
-        'keepsymlinks': True,
+        'keepsymlinks': False,
     }),
     ('barbar', '1.2', {
         'start_dir': 'src',

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -6331,7 +6331,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             'patches': [bar_patch, bar_patch_bis],
             'toy_ext_param': "mv anotherbar bar_bis",
             'unknowneasyconfigparameterthatshouldbeignored': 'foo',
-            'keepsymlinks': True,
+            'keepsymlinks': False,
         }))
         self.assertEqual(ec['exts_list'][2], ('barbar', '1.2', {
             'checksums': ['d5bd9908cdefbe2d29c6f8d5b45b2aaed9fd904b5e6397418bb5094fbdb3d838'],


### PR DESCRIPTION
Not keeping symlinks caused surprising behaviour with for example installing Julia using the Tarball easyblock: it gives copies instead of symbolic links for each shared library, when they are symbolic links inside the tarball. This reverses the default behaviour to be less surprising.