### PR TITLE
set maximum level of parallellism via `parallel` configuration option rather than fixed value for `max_parallel` easyconfig parameter

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2422,8 +2422,8 @@ class EasyBlock(object):
             else:
                 par = min(int(par), int(cfg_par))
 
-        par = det_parallelism(par, maxpar=self.cfg['max_parallel'])
-        self.log.info("Setting parallelism: %s" % par)
+        par = det_parallelism(par=par, maxpar=self.cfg['max_parallel'])
+        self.log.info(f"Setting parallelism: {par}")
         self.cfg.parallel = par
 
     def remove_module_file(self):

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -108,7 +108,7 @@ DEFAULT_CONFIG = {
                        BUILD],
     'hidden': [False, "Install module file as 'hidden' by prefixing its version with '.'", BUILD],
     'installopts': ['', 'Extra options for installation', BUILD],
-    'maxparallel': [16, 'Max degree of parallelism', BUILD],
+    'maxparallel': [None, 'Max degree of parallelism', BUILD],
     'module_only': [False, 'Only generate module file', BUILD],
     'patches': [[], "List of patches to apply", BUILD],
     'prebuildopts': ['', 'Extra options pre-passed to build command.', BUILD],

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -496,8 +496,9 @@ class EasyBuildOptions(GeneralOption):
             'output-style': ("Control output style; auto implies using Rich if available to produce rich output, "
                              "with fallback to basic colored output",
                              'choice', 'store', OUTPUT_STYLE_AUTO, OUTPUT_STYLES),
-            'parallel': ("Specify (maximum) level of parallelism used during build procedure",
-                         'int', 'store', None),
+            'parallel': ("Specify (maximum) level of parallelism used during build procedure "
+                         "(actual value is determined by available cores + 'max_parallel' easyconfig parameter)",
+                         'int', 'store', 16),
             'parallel-extensions-install': ("Install list of extensions in parallel (if supported)",
                                             None, 'store_true', False),
             'pre-create-installdir': ("Create installation directory before submitting build jobs",


### PR DESCRIPTION
Using a fixed value for `maxparallel` (equivalent to `max_parallel`)  easyconfig parameter doesn't allow to easily customize the maximum level of parallelism, while the `--parallel` EasyBuild configuration option does...

follow-up for #4606