### PR TITLE
fix `test_modulerc` by taking into account that wrapper module may also be shown as being loaded

### DIFF
--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -589,10 +589,9 @@ class ModuleGeneratorTest(EnhancedTestCase):
 
         # loading of module with symbolic version works
         self.modtool.load(['test/1.2.3'])
-        # test/1.2.3.4.5 is actually loaded (rather than test/1.2.3)
+        # test/1.2.3.4.5 is actually loaded
         res = self.modtool.list()
-        self.assertEqual(len(res), 1)
-        self.assertEqual(res[0]['mod_name'], 'test/1.2.3.4.5')
+        self.assertTrue(any(x['mod_name'] == 'test/1.2.3.4.5' for x in res))
 
         # if same symbolic version is added again, nothing changes
         self.modgen.modulerc(mod_ver_spec, filepath=modulerc_path)


### PR DESCRIPTION
This relaxes `test_modulerc` a little bit, taking into account that recent Lmod versions will show both the wrapper module and the actual module as being loaded (for example `Java/11` and `Java/11.0.20`)