### PR TITLE
limit output included in sanity check failure message for missing RPATH section in output of '`readelf -d`' + fix regex used to look for `'(RPATH)'`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3349,7 +3349,7 @@ class EasyBlock(object):
 
         not_found_regex = re.compile(r'(\S+)\s*\=\>\s*not found')
         lib_path_regex = re.compile(r'\S+\s*\=\>\s*(\S+)')
-        readelf_rpath_regex = re.compile('(RPATH)', re.M)
+        readelf_rpath_regex = re.compile(r'\(RPATH\)', re.M)
 
         # List of libraries that should be exempt from the RPATH sanity check;
         # For example, libcuda.so.1 should never be RPATH-ed by design,
@@ -3413,7 +3413,7 @@ class EasyBlock(object):
                             if res.exit_code != EasyBuildExit.SUCCESS:
                                 fail_msg = f"Failed to run 'readelf -d {path}': {res.output}"
                             elif not readelf_rpath_regex.search(res.output):
-                                fail_msg = f"No '(RPATH)' found in 'readelf -d' output for {path}: {out}"
+                                fail_msg = f"No '(RPATH)' found in 'readelf -d' output for {path}"
 
                             if fail_msg:
                                 self.log.warning(fail_msg)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3031,7 +3031,7 @@ class ToyBuildTest(EnhancedTestCase):
 
         libtoy_libdir = os.path.join(self.test_installpath, 'software', 'libtoy', '0.0', 'lib')
         toyapp_bin = os.path.join(self.test_installpath, 'software', 'toy-app', '0.0', 'bin', 'toy-app')
-        rpath_regex = re.compile(r"RPATH.*" + libtoy_libdir, re.M)
+        rpath_regex = re.compile(r"\(RPATH\).*" + libtoy_libdir, re.M)
         with self.mocked_stdout_stderr():
             res = run_shell_cmd(f"readelf -d {toyapp_bin}")
         self.assertTrue(rpath_regex.search(res.output),


### PR DESCRIPTION
fixes #4572