### PR TITLE
make `delattr` aware of environment variables in `ModuleLoadEnvironment`

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -335,11 +335,22 @@ class ModuleLoadEnvironment:
         """
         Delete private attributes or public ModuleEnvironmentVariables
         """
+
         if self.regex['private_attr'].match(name):
             del self.__dict__[name]
+            return True
 
         name = self._unmangle_env_var_name(name)
-        del self.__dict__['_env_vars'][name]
+        try:
+            self.__dict__['_env_vars'][name].log.warning(
+                "Please use ModuleLoadEnvironment.remove() instead of 'delattr' to remove environment variables"
+            )
+            del self.__dict__['_env_vars'][name]
+        except KeyError as err:
+            raise EasyBuildError(
+                f"Cannot delete environment variable from ModuleEnvironmentVariable: {name} not found."
+            ) from err
+        return True
 
     def _unmangle_env_var_name(self, name):
         """

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -343,9 +343,6 @@ class ModuleLoadEnvironment:
             return True
 
         name = self._unmangle_env_var_name(name)
-        self._log.warning(
-            f"Please use ModuleLoadEnvironment.remove() instead of 'delattr' to remove environment variable: {name}"
-        )
         try:
             del self.__dict__['_env_vars'][name]
         except KeyError as err:

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -331,6 +331,16 @@ class ModuleLoadEnvironment:
 
         return True
 
+    def __delattr__(self, name):
+        """
+        Delete private attributes or public ModuleEnvironmentVariables
+        """
+        if self.regex['private_attr'].match(name):
+            del self.__dict__[name]
+
+        name = self._unmangle_env_var_name(name)
+        del self.__dict__['_env_vars'][name]
+
     def _unmangle_env_var_name(self, name):
         """
         Unmangle environment variable names that were originally set with a leading double underscore

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -270,6 +270,8 @@ class ModuleLoadEnvironment:
         self.regex['private_attr'] = re.compile('^_[a-z][a-z_]+$')      # private attributes: _var_name
         self.regex['env_var_name'] = re.compile('^[A-Z_]+[A-Z0-9_]+$')  # environment variables: {__}VAR_NAME_00_SUFFIX
 
+        self._log = fancylogger.getLogger(self.__class__.__name__, fname=False)
+
         self._aliases = {}
         if aliases is not None:
             try:
@@ -342,7 +344,7 @@ class ModuleLoadEnvironment:
 
         name = self._unmangle_env_var_name(name)
         try:
-            self.__dict__['_env_vars'][name].log.warning(
+            self._log.warning(
                 f"Please use ModuleLoadEnvironment.remove() instead of 'delattr' to remove environment variable: {name}"
             )
             del self.__dict__['_env_vars'][name]

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -336,6 +336,7 @@ class ModuleLoadEnvironment:
     def __delattr__(self, name):
         """
         Delete private attributes or public ModuleEnvironmentVariables
+        Fails on missing attributes
         """
 
         if self.regex['private_attr'].match(name):

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -343,7 +343,7 @@ class ModuleLoadEnvironment:
         name = self._unmangle_env_var_name(name)
         try:
             self.__dict__['_env_vars'][name].log.warning(
-                "Please use ModuleLoadEnvironment.remove() instead of 'delattr' to remove environment variables"
+                f"Please use ModuleLoadEnvironment.remove() instead of 'delattr' to remove environment variable: {name}"
             )
             del self.__dict__['_env_vars'][name]
         except KeyError as err:

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -343,10 +343,10 @@ class ModuleLoadEnvironment:
             return True
 
         name = self._unmangle_env_var_name(name)
+        self._log.warning(
+            f"Please use ModuleLoadEnvironment.remove() instead of 'delattr' to remove environment variable: {name}"
+        )
         try:
-            self._log.warning(
-                f"Please use ModuleLoadEnvironment.remove() instead of 'delattr' to remove environment variable: {name}"
-            )
             del self.__dict__['_env_vars'][name]
         except KeyError as err:
             raise EasyBuildError(

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -1755,16 +1755,35 @@ class ModulesTest(EnhancedTestCase):
         self.assertEqual(mod_load_env.TEST_STR.contents, ['some/path'])
 
         # test removal of envars
-        mod_load_env.remove('TEST_VARTYPE')
-        self.assertFalse('TEST_VARTYPE' in mod_load_env.vars)
+        mod_load_env.REMOVABLE_VAR = test_contents
+        self.assertTrue('REMOVABLE_VAR' in mod_load_env.vars)
+        mod_load_env.remove('REMOVABLE_VAR')
+        self.assertFalse('REMOVABLE_VAR' in mod_load_env.vars)
+        self.assertFalse('NONEXISTENT' in mod_load_env.vars)
         mod_load_env.remove('NONEXISTENT')
+        self.assertFalse('NONEXISTENT' in mod_load_env.vars)
+
+        # test removal with delattr
+        mod_load_env.REMOVABLE_VAR = test_contents
+        self.assertTrue('REMOVABLE_VAR' in mod_load_env.vars)
+        delattr(mod_load_env, 'REMOVABLE_VAR')
+        self.assertFalse('REMOVABLE_VAR' in mod_load_env.vars)
+        mod_load_env._REMOVABLE_VAR = test_contents
+        self.assertTrue('_REMOVABLE_VAR' in mod_load_env.vars)
+        delattr(mod_load_env, '_REMOVABLE_VAR')
+        self.assertFalse('_REMOVABLE_VAR' in mod_load_env.vars)
+        mod_load_env.__REMOVABLE_VAR = test_contents
+        self.assertTrue('__REMOVABLE_VAR' in mod_load_env.vars)
+        delattr(mod_load_env, '__REMOVABLE_VAR')
+        self.assertFalse('__REMOVABLE_VAR' in mod_load_env.vars)
+        self.assertRaises(KeyError, delattr, mod_load_env, 'NONEXISTENT')
 
         # test replacing of env vars
         env_vars = sorted(mod_load_env.as_dict.keys())
         expected = ['ACLOCAL_PATH', 'CLASSPATH', 'CMAKE_LIBRARY_PATH', 'CMAKE_PREFIX_PATH', 'GI_TYPELIB_PATH',
                     'LD_LIBRARY_PATH', 'LIBRARY_PATH', 'MANPATH', 'PATH', 'PKG_CONFIG_PATH', 'TEST_NEW_VAR',
-                    'TEST_STR', 'TEST_VAR', 'XDG_DATA_DIRS', '_UNDERSCORE_VAR', '__DOUBLE_UNDERSCORE_VAR',
-                    '___TRIPLE__UNDERSCORE_VAR']
+                    'TEST_STR', 'TEST_VAR', 'TEST_VARTYPE', 'XDG_DATA_DIRS', '_UNDERSCORE_VAR',
+                    '__DOUBLE_UNDERSCORE_VAR', '___TRIPLE__UNDERSCORE_VAR']
         self.assertEqual(env_vars, expected)
 
         mod_load_env.replace({'FOO': 'foo', 'BAR': 'bar'})

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -1776,7 +1776,7 @@ class ModulesTest(EnhancedTestCase):
         self.assertTrue('__REMOVABLE_VAR' in mod_load_env.vars)
         delattr(mod_load_env, '__REMOVABLE_VAR')
         self.assertFalse('__REMOVABLE_VAR' in mod_load_env.vars)
-        self.assertRaises(KeyError, delattr, mod_load_env, 'NONEXISTENT')
+        self.assertRaises(EasyBuildError, delattr, mod_load_env, 'NONEXISTENT')
 
         # test replacing of env vars
         env_vars = sorted(mod_load_env.as_dict.keys())


### PR DESCRIPTION
There are two ways to remove attributes from `ModuleLoadEnvironment`:
* `ModuleLoadEnvironment.remove("ENV_VAR")` will ignore missing attributes
* `delattr(ModuleLoadEnvironment, "ENV_VAR")` will error on missing attributes