### PR TITLE
Allow test case filtering by class name

### DIFF
--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -430,7 +430,8 @@ class TestLoaderFiltered(unittest.TestLoader):
         retained_test_names = []
         if len(filters) > 0:
             for test_case_name in test_case_names:
-                if any(filt in test_case_name for filt in filters):
+                full_test_case_name = '%s.%s' % (test_case_class.__name__, test_case_name)
+                if any(filt in full_test_case_name for filt in filters):
                     retained_test_names.append(test_case_name)
 
             retained_tests = ', '.join(retained_test_names)


### PR DESCRIPTION
It sometimes is useful to run either all tests from a class or a specific test from a class where the name might also be used in another class.
Use the common convention of `'<class>.<test>'` and match against that allowing e.g. "TypeCheckingTest.test_check_type" as a filter.