### PR TITLE
Fix quoting of command in setup shell script

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -274,7 +274,7 @@ def create_cmd_scripts(cmd_str, work_dir, env, tmpdir, out_file, err_file):
         fid.write('# Run this script to set up a shell environment that EasyBuild used to run the shell command\n')
         fid.write('\n'.join([
             'EB_SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )',
-            f'echo "# Shell for the command: {shlex.quote(cmd_str)}"',
+            f'echo "# Shell for the command: \'"{shlex.quote(cmd_str)}"\'"',
             'echo "# Use command history, exit to stop"',
             # using -i to force interactive shell, so env.sh is also sourced when -c is used to run commands
             'bash --rcfile $EB_SCRIPT_DIR/env.sh -i "$@"',


### PR DESCRIPTION
Avoid that variables are resolved when the `echo` is run. `shlex.quote` outputs a properly escaped string so nothing will be interpreted by the shell. It uses single quotes for that. Putting that inside double quotes means single quotes are used literally and and any variable will be resolved during the echo as shlex.quote put them in single quotes to avoid that.

So end the double-quotes and append the shlex-quoted string. To make it look neither add single quotes around it.

Example before:
```
# Shell for the command: 'export PYTHONPATH=/tmp/easybuild-tmp/eb-u1gfjbyj/tmpzw6qefg8/lib/python3.10/site-packages: &&  cd test && PYTHONUNBUFFERED=1 /software/Python/3.10.8-GCCcore-12.2.0/bin/python run_test.py --continue-through-error  --verbose -x distributed/test_distributed_spawn distributions/test_constraints doctests test_native_mha distributed/rpc/test_tensorpipe_agent'
# Use command history, exit to stop
```

after:
```
# Shell for the command: 'export PYTHONPATH=/tmp/easybuild-tmp/eb-u1gfjbyj/tmpzw6qefg8/lib/python3.10/site-packages:$PYTHONPATH &&  cd test && PYTHONUNBUFFERED=1 /software/Python/3.10.8-GCCcore-12.2.0/bin/python run_test.py --continue-through-error  --verbose -x distributed/test_distributed_spawn distributions/test_constraints doctests test_native_mha distributed/rpc/test_tensorpipe_agent'
# Use command history, exit to stop
```
