### PR TITLE
clean up use get_source_tarball_from_git` to use same checkout mechanism for creating tarball for Git repos with tags and commits

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2700,11 +2700,13 @@ def get_source_tarball_from_git(filename, target_dir, git_config):
     # prepare target directory and clone repository
     mkdir(target_dir, parents=True)
 
+    # compose base git command
+    git_cmd = 'git'
+    if extra_config_params is not None:
+        git_cmd_params = [f"-c {param}" for param in extra_config_params]
+        git_cmd += f" {' '.join(git_cmd_params)}"
+
     # compose 'git clone' command, and run it
-    if extra_config_params:
-        git_cmd = 'git ' + ' '.join(['-c %s' % param for param in extra_config_params])
-    else:
-        git_cmd = 'git'
     clone_cmd = [git_cmd, 'clone']
 
     if not keep_git_dir and not commit:


### PR DESCRIPTION
This PR is an extensive code cleanup of `get_source_tarball_from_git` (+25 -61). There are no changes in behaviour and one little bugfix.

Follow-up to the issues investigated in #4793 

Motivation:
* We got into a situation where the code checking out sources from git tags and commits is very different, but git tags and commits are the same thing. So there is no reason for such a difference, this PR unifies both checkouts to work in the same exact way. The unified procedure is the same currently used for commits:
  1. `git clone --no-checkout {repo}`
  2. `git checkout {tag/commit}`
  3. (if submodules) `git submodules update --init ...`
* Sometimes `git clone` is shallow (with `--depth 1`), but in all such cases we end up unshallowing the repo. So there is no speed gain in any case. And this is expected, since we only checkout specific tags or commits (that's required), we cannot know how old those are, so we always have to fetch the full history of the repo. So this PR removes shallow clones in all cases.
* There is a bunch of logic handling branches which is unnecessary. To checkout tags or commits, it doesn't matter how many branches has the repo, or which one is the active one. So this PR removes all logic related to branches.
* The `git_config` option `recurse-submodules` is currently broken. The git option `--recurse-submodules` can only be used with a list of _pathspecs_ in `git clone`, not in `git submodule` as it is currently done. The fix is rather simple, we can pass those _pathspecs_ in the same way directly to `git submodule` without any `--recurse-submodules`

This PR adds several new tests to `test_github_get_source_tarball_from_git` to tests all these features with a test repo. Currently most of these features are not tested at all beyond checking the git command generated by `get_source_tarball_from_git`.

The new tests need a companion PR to https://github.com/easybuilders/testrepository

_update_: companion PR ready
* [ ] https://github.com/easybuilders/testrepository/pull/5