### PR TITLE
add warning about possible checksum verification failure on non-reproducible sources

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -399,16 +399,24 @@ class EasyBlock(object):
             self.log.debug("Cannot get checksum without a file name")
             return None
 
-        if sys.version_info[0] >= 3 and sys.version_info[1] < 9:
+        if chksum_input_git is not None:
             # ignore any checksum for given filename due to changes in https://github.com/python/cpython/issues/90021
             # tarballs made for git repos are not reproducible when created with Python < 3.9
-            if chksum_input_git is not None:
+            if sys.version_info[0] >= 3 and sys.version_info[1] < 9:
                 self.log.deprecated(
                     "Reproducible tarballs of Git repos are only possible when using Python 3.9+ to run EasyBuild. "
                     f"Skipping checksum verification of {chksum_input} since Python < 3.9 is used.",
                     '6.0'
                 )
                 return None
+            # not all archives formats of git repos are reproducible
+            # warn users that checksum might fail for non-reproducible archives
+            _, file_ext = os.path.splitext(chksum_input)
+            if file_ext not in ['', '.tar', '.txz', '.xz']:
+                print_warning(
+                    f"Checksum verification may fail! Archive file '{chksum_input}' contains sources of a git repo "
+                    "in a non-reproducible format. Please re-create that archive with XZ compression instead."
+                )
 
         checksum = None
         # if checksums are provided as a dict, lookup by source filename as key


### PR DESCRIPTION
Verification of checksums can fail for sources of git repos in non-reproducible format (i.e. `.tar.gz`). This is known, but it can be confusing when those fail as there is no clue that this is the reason:

```
== FAILED: Installation ended unsuccessfully: Checksum verification for /user/brussel/101/vsc10122/easybuild/install/skylake/sources/p/polars/jsonpath_lib-0.3.0-24eaf0b4416edff38a4d1b6b17bc4b9f3f047b4b.tar.gz using {'jsonpath_lib-0.3.0-24eaf0b4416edff38a4d1b6b17bc4b9f3f047b4b.tar.gz': 'dfb5eb7f47b5b5a7b35262f7b41787a785958001a23ff039cdae926396c6af96'} failed. (took 3 secs)
== Results of the build can be found in the log file(s) /tmp/eb-ubv_m0gz/easybuild-polars-0.20.2-20250306.134946.tPBiI.log
ERROR: Installation of polars-0.20.2-gfbf-2023a.eb failed: "Checksum verification for /user/brussel/101/vsc10122/easybuild/install/skylake/sources/p/polars/jsonpath_lib-0.3.0-24eaf0b4416edff38a4d1b6b17bc4b9f3f047b4b.tar.gz using {'jsonpath_lib-0.3.0-24eaf0b4416edff38a4d1b6b17bc4b9f3f047b4b.tar.gz': 'dfb5eb7f47b5b5a7b35262f7b41787a785958001a23ff039cdae926396c6af96'} failed."
```

Unfortunately, it is not trivial to add specific information in that error, because at that point the knowledge that the failed tarball is from a git repo is already lost.

So this PR adds a big warning message whenever such a tarball is found in the list of sources.