### PR TITLE
Allow empty string in `modextrapaths`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1716,7 +1716,11 @@ class EasyBlock(object):
             }
 
             try:
-                env_var_opts.update(extra_opts)
+                # make sure paths is added for empty string
+                if extra_opts == '':
+                    env_var_opts['paths'] = extra_opts
+                else:
+                    env_var_opts.update(extra_opts)
             except ValueError:
                 # no options provided, so must be only a list of string values specifying paths
                 env_var_opts['paths'] = extra_opts

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1715,19 +1715,14 @@ class EasyBlock(object):
                 'prepend': True,
             }
 
-            try:
-                # make sure paths is added for empty string
-                if extra_opts == '':
-                    env_var_opts['paths'] = extra_opts
-                else:
-                    env_var_opts.update(extra_opts)
-            except ValueError:
-                # no options provided, so must be only a list of string values specifying paths
-                env_var_opts['paths'] = extra_opts
-            else:
-                if 'paths' not in env_var_opts:
-                    error_msg = f"'paths' key not set for ${env_var_name} in '{ec_param}' easyconfig parameter"
-                    raise EasyBuildError(error_msg)
+            if not isinstance(extra_opts, dict):
+                extra_opts = {'paths': extra_opts}
+
+            env_var_opts.update(extra_opts)
+
+            if 'paths' not in env_var_opts:
+                error_msg = f"'paths' key not set for ${env_var_name} in '{ec_param}' easyconfig parameter"
+                raise EasyBuildError(error_msg)
 
             # make sure that we have a list of paths, even if there's only one
             if isinstance(env_var_opts['paths'], str):


### PR DESCRIPTION
After PR #4774, when empty string is used in `modextrapaths`, for example `modextrapaths = {'PATH': ''}` in `dotNET-Core-8.0.302.eb`, easybuild does not add `paths` key into `env_var_opts` and fails silently. This induces error when checking `paths` key existence. This PR tries to make sure `paths` is added when empty string is used.