### PR TITLE
fix environment variable name used in debug log message in `inject_module_extra_paths`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1742,7 +1742,7 @@ class EasyBlock(object):
                 env_var.delimiter = env_var_opts['delimiter']
                 env_var.prepend = env_var_opts['prepend']
                 env_var.type = env_var_opts['var_type']
-                msg = f"Variable ${env_var_name} from '{ec_param}' extended in module load environment with "
+                msg = f"Variable ${existing_env_var} from '{ec_param}' extended in module load environment with "
                 msg += f"delimiter='{env_var.delimiter}', prepend='{env_var.prepend}', type='{env_var.type}' "
                 msg += f"and paths='{env_var}'"
                 self.log.debug(msg)


### PR DESCRIPTION
From log for `cpu_features-0.9.0-GCCcore-12.3.0.eb`:

```
== 2025-03-08 17:22:50,748 easyblock.py:1748 DEBUG Variable $CPP_HEADERS from 'modextrapaths' extended in module load environment with delimiter=':', prepend='True', type='ModEnvVarType.PATH_WITH_FILES' and paths='include:include/cpu_features'
```

Should be `$CPATH`, not `$CPP_HEADERS`.

Becomes even more clear if `eb --` is used:

```
== 2025-03-08 17:27:19,620 easyblock.py:1748 DEBUG Variable $CPP_HEADERS from 'modextrapaths' extended in module load environment with delimiter=':', prepend='True', type='ModEnvVarType.PATH_WITH_FILES' and paths='include:include/cpu_features'
== 2025-03-08 17:27:19,620 easyblock.py:1748 DEBUG Variable $CPP_HEADERS from 'modextrapaths' extended in module load environment with delimiter=':', prepend='True', type='ModEnvVarType.PATH_WITH_FILES' and paths='include:include/cpu_features'
== 2025-03-08 17:27:19,620 easyblock.py:1748 DEBUG Variable $CPP_HEADERS from 'modextrapaths' extended in module load environment with delimiter=':', prepend='True', type='ModEnvVarType.PATH_WITH_FILES' and paths='include:include/cpu_features'
```