### PR TITLE
Improve test failure output for `assertEqual`

### DIFF
--- a/easybuild/base/testing.py
+++ b/easybuild/base/testing.py
@@ -55,15 +55,12 @@ def nicediff(txta, txtb, offset=5):
     """
     diff = list(difflib.ndiff(txta.splitlines(1), txtb.splitlines(1)))
     different_idx = [idx for idx, line in enumerate(diff) if not line.startswith(' ')]
-    res_idx = []
+    res_idx = set()
     # very bruteforce
     for didx in different_idx:
-        for idx in range(max(didx - offset, 0), min(didx + offset, len(diff) - 1)):
-            if idx not in res_idx:
-                res_idx.append(idx)
-    res_idx.sort()
+        res_idx.update(range(max(didx - offset, 0), min(didx + offset, len(diff))))
     # insert linenumbers too? what are the linenumbers in ndiff?
-    newdiff = [diff[idx] for idx in res_idx]
+    newdiff = [diff[idx] for idx in sorted(res_idx)]
 
     return newdiff
 

--- a/easybuild/base/testing.py
+++ b/easybuild/base/testing.py
@@ -73,10 +73,21 @@ class TestCase(OrigTestCase):
     ASSERT_MAX_DIFF = 100
     DIFF_OFFSET = 5  # lines of text around changes
 
-    # pylint: disable=arguments-differ
+    def _is_diffable(self, x):
+        """Test if it makes sense to show a diff for x"""
+        if isinstance(x, (int, float, bool, type(None))):
+            return False
+        if isinstance(x, str) and '\n' not in x:
+            return False
+        return True
+
+    # pylint: disable=arguments-differ,arguments-renamed
     def assertEqual(self, a, b, msg=None):
         """Make assertEqual always print useful messages"""
 
+        if not self._is_diffable(a) or not self._is_diffable(b):
+            super(TestCase, self).assertEqual(a, b, msg)
+            return
         try:
             super(TestCase, self).assertEqual(a, b)
         except AssertionError as e:

--- a/easybuild/base/testing.py
+++ b/easybuild/base/testing.py
@@ -85,12 +85,12 @@ class TestCase(OrigTestCase):
     def assertEqual(self, a, b, msg=None):
         """Make assertEqual always print useful messages"""
 
-        if not self._is_diffable(a) or not self._is_diffable(b):
-            super(TestCase, self).assertEqual(a, b, msg)
-            return
         try:
             super(TestCase, self).assertEqual(a, b)
         except AssertionError as e:
+            if not self._is_diffable(a) or not self._is_diffable(b):
+                raise
+
             if msg is None:
                 msg = str(e)
             else:

--- a/easybuild/base/testing.py
+++ b/easybuild/base/testing.py
@@ -83,7 +83,7 @@ class TestCase(OrigTestCase):
             if msg is None:
                 msg = str(e)
             else:
-                msg = "%s: %s" % (msg, e)
+                msg = "%s: %s" % (msg, str(e))
 
             if isinstance(a, str):
                 txta = a

--- a/easybuild/base/testing.py
+++ b/easybuild/base/testing.py
@@ -111,7 +111,7 @@ class TestCase(OrigTestCase):
             else:
                 limit = ''
 
-            raise AssertionError("%s:\nDIFF%s:\n%s" % (msg, limit, ''.join(diff[:self.ASSERT_MAX_DIFF])))
+            raise AssertionError("%s:\nDIFF%s:\n%s" % (msg, limit, ''.join(diff[:self.ASSERT_MAX_DIFF]))) from None
 
     def assertExists(self, path, msg=None):
         """Assert the given path exists"""


### PR DESCRIPTION
Improve the readability when a test fails:

- The `DIFF:` message had an off-by-one error that missed the last line of the diff
- When raising our enhanced failure message we included the original stacktrace as "During handling of the above exception, another exception occurred: [...]" added by Python and the string `"AssertionError"` by the formatting of the original message which is just noise.
- There is no need for a DIFF for numbers, True/False/None or single-line strings as the diff is trivial and already contained as `a != b`, so don't do our custom handling there
- Also a small refactoring converting "loop x: if x not in list then add to list" to a set using a generator