### PR TITLE
Allow rpath toolchainopt for systemcompiler

### DIFF
--- a/easybuild/toolchains/compiler/systemcompiler.py
+++ b/easybuild/toolchains/compiler/systemcompiler.py
@@ -44,6 +44,8 @@ class SystemCompiler(Compiler):
     # The system compiler does not currently support even the shared options
     # (changing this would require updating set_minimal_build_env() of the toolchain class)
     COMPILER_UNIQUE_OPTS = None
-    COMPILER_SHARED_OPTS = None
+    # only keep the rpath toolchainopt since we want to be able to disable it for
+    # sanity checks in binary-only installations
+    COMPILER_SHARED_OPTS = {k: Compiler.COMPILER_SHARED_OPTS[k] for k in ('rpath',)}
     COMPILER_UNIQUE_OPTION_MAP = None
     COMPILER_SHARED_OPTION_MAP = None

--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -178,7 +178,7 @@ class Compiler(Toolchain):
     def _set_compiler_toolchainoptions(self):
         """Set the compiler related toolchain options"""
         # Initialize default value of debug symbols based on global build option
-        if self.COMPILER_SHARED_OPTS:
+        if self.COMPILER_SHARED_OPTS and 'debug' in self.COMPILER_SHARED_OPTS:
             _, desc = self.COMPILER_SHARED_OPTS['debug']
             self.COMPILER_SHARED_OPTS['debug'] = (build_option('keep_debug_symbols'), desc)
         self.options.add_options(self.COMPILER_SHARED_OPTS, self.COMPILER_SHARED_OPTION_MAP)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3009,14 +3009,15 @@ class ToyBuildTest(EnhancedTestCase):
         self.assertTrue(any(p.startswith(os.getenv('TMPDIR')) for p in rpath_filter_paths))
         self.assertTrue(any(p.startswith(self.test_buildpath) for p in rpath_filter_paths))
 
-        # test use of rpath toolchain option
-        test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
-        toy_ec_txt = read_file(os.path.join(test_ecs, 't', 'toy', 'toy-0.0-gompi-2018a.eb'))
-        toy_ec_txt += "\ntoolchainopts = {'rpath': False}\n"  # overwrites existing toolchainopts
-        toy_ec = os.path.join(self.test_prefix, 'toy.eb')
-        write_file(toy_ec, toy_ec_txt)
-        with self.mocked_stdout_stderr():
-            self._test_toy_build(ec_file=toy_ec, extra_args=['--rpath'], raise_error=True)
+        # test use of rpath toolchain option with SYSTEM and gompi 2018b toolchains
+        for toolchain in ['', '-gompi-2018a']:
+            test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+            toy_ec_txt = read_file(os.path.join(test_ecs, 't', 'toy', f'toy-0.0{toolchain}.eb'))
+            toy_ec_txt += "\ntoolchainopts = {'rpath': False}\n"  # overwrites existing toolchainopts
+            toy_ec = os.path.join(self.test_prefix, 'toy.eb')
+            write_file(toy_ec, toy_ec_txt)
+            with self.mocked_stdout_stderr():
+                self._test_toy_build(ec_file=toy_ec, extra_args=['--rpath'], raise_error=True)
 
     def test_toy_filter_rpath_sanity_libs(self):
         """Test use of --filter-rpath-sanity-libs."""


### PR DESCRIPTION
We need to be able disable RPATH with the SYSTEM toolchain for precompiled binaries using the MakeCp toolchain (e.g. older NCCL).