### PR TITLE
Fix tests after removal of 5.0.x branch

### DIFF
--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -406,17 +406,16 @@ class GithubTest(EnhancedTestCase):
             'pr_target_account': gh.GITHUB_EB_MAIN,
         })
 
-        # TODO: no 5.x PRs for new easyblocks
         # PR with new easyblock plus non-easyblock file
-        # all_ebs_pr1964 = ['lammps.py']
+        all_ebs_pr1964 = ['lammps.py']
 
         # PR with changed easyblock
-        all_ebs_pr3631 = ['root.py']
+        all_ebs_pr3674 = ['llvm.py']
 
         # PR with more than one easyblock
         all_ebs_pr3596 = ['wps.py', 'wrf.py']
 
-        for pr, all_ebs in [(3631, all_ebs_pr3631), (3596, all_ebs_pr3596)]:
+        for pr, all_ebs in [(1964, all_ebs_pr1964), (3674, all_ebs_pr3674), (3596, all_ebs_pr3596)]:
             try:
                 tmpdir = os.path.join(self.test_prefix, 'pr%s' % pr)
                 with self.mocked_stdout_stderr():


### PR DESCRIPTION
Use PRs against develop and change ECs removed/archived.

- test_github_preview_pr fixed in #4827
- test_github_fetch_easyblocks_from_pr
- test_github_xxx_include_easyblocks_from_pr
- test_github_new_update_pr
- test_github_new_pr_delete
- test_github_empty_pr