### PR TITLE
Fix missed message in trivial equal-asserts

### DIFF
--- a/easybuild/base/testing.py
+++ b/easybuild/base/testing.py
@@ -86,7 +86,7 @@ class TestCase(OrigTestCase):
         """Make assertEqual always print useful messages"""
 
         try:
-            super(TestCase, self).assertEqual(a, b, msg)
+            super(TestCase, self).assertEqual(a, b, msg=msg)
         except AssertionError as e:
             if not self._is_diffable(a) or not self._is_diffable(b):
                 raise

--- a/easybuild/base/testing.py
+++ b/easybuild/base/testing.py
@@ -86,7 +86,7 @@ class TestCase(OrigTestCase):
         """Make assertEqual always print useful messages"""
 
         try:
-            super(TestCase, self).assertEqual(a, b)
+            super(TestCase, self).assertEqual(a, b, msg)
         except AssertionError as e:
             if not self._is_diffable(a) or not self._is_diffable(b):
                 raise

--- a/easybuild/framework/easyconfig/format/version.py
+++ b/easybuild/framework/easyconfig/format/version.py
@@ -499,7 +499,6 @@ class ToolchainVersionOperator(VersionOperator):
         Initialise each search_toolchain request, save in module constant TOOLCHAIN_NAMES.
         :param search_string: passed to search_toolchain function.
         """
-        global TOOLCHAIN_NAMES
         if search_string not in TOOLCHAIN_NAMES:
             _, all_tcs = search_toolchain(search_string)
             self.log.debug('Found all toolchains for "%s" to %s' % (search_string, all_tcs))

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -240,8 +240,6 @@ def process_easystack(easystack_path, args, logfile, testing, init_session_state
     # keep copy of original environment, so we can restore it for every easystack entry
     init_env = copy.deepcopy(os.environ)
 
-    global _log
-
     # TODO: insert fast loop that validates if all command line options are valid. If there are errors in options,
     # we want to know early on, and this loop potentially builds a lot of packages and could take very long
     # for path in orig_paths:
@@ -311,6 +309,9 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
     options = eb_go.options
 
     global _log
+    # Unpack cfg_settings
+    (build_specs, _log, logfile, robot_path, search_query, eb_tmpdir, try_to_generate,
+     from_pr_list, tweaked_ecs_paths) = cfg_settings
 
     # determine easybuild-easyconfigs package install path
     easyconfigs_pkg_paths = get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR)
@@ -324,10 +325,6 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
         else:
             eb_file = find_easybuild_easyconfig()
             eb_args.append(eb_file)
-
-    # Unpack cfg_settings
-    (build_specs, _log, logfile, robot_path, search_query, eb_tmpdir, try_to_generate,
-     from_pr_list, tweaked_ecs_paths) = cfg_settings
 
     if options.copy_ec:
         # figure out list of files to copy + target location (taking into account --from-pr)


### PR DESCRIPTION
The default error is raised for trivial types but the message was not passed along and is missing in that case.