### PR TITLE
Fix unbound variable in error case in `build_and_install_software`

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -172,10 +172,10 @@ def build_and_install_software(ecs, init_session_state, exit_on_failure=True):
                 adjust_permissions(parent_dir, stat.S_IWUSR, add=False, recursive=False)
 
         if not ec_res['success'] and exit_on_failure:
-            if not isinstance(ec_res['err'], EasyBuildError):
-                raise ec_res['err']
-            else:
-                raise EasyBuildError(test_msg, exit_code=err_code)
+            error = ec_res['err']
+            if isinstance(error, EasyBuildError):
+                error = EasyBuildError(test_msg, exit_code=error.exit_code)
+            raise error
 
         res.append((ec, ec_res))
 


### PR DESCRIPTION
@dagonzalezfo Can you please double check this is what you intended in https://github.com/easybuilders/easybuild-framework/pull/4534/files#diff-7ee72a681a6748afac9e6e8e3ff33fd2b76c661eff64435388ec03895cf8a767R177

The bug results in this crash:
```
== cleaning up...
EasyBuild crashed! Please consider reporting a bug, this should not happen...

Traceback (most recent call last):
  File "/usr/lib64/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Easybuild-5.0.0/lib/python3.8/site-packages/easybuild/main.py", line 804, in <module>
    main_with_hooks()
  File "/Easybuild-5.0.0/lib/python3.8/site-packages/easybuild/main.py", line 790, in main_with_hooks
    main(args=args, prepared_cfg_data=(init_session_state, eb_go, cfg_settings))
  File "/Easybuild-5.0.0/lib/python3.8/site-packages/easybuild/main.py", line 746, in main
    hooks, do_build)
  File "/Easybuild-5.0.0/lib/python3.8/site-packages/easybuild/main.py", line 570, in process_eb_args
    exit_on_failure=exit_on_failure)
  File "/Easybuild-5.0.0/lib/python3.8/site-packages/easybuild/main.py", line 178, in build_and_install_software
    raise EasyBuildError(test_msg, exit_code=err_code)
UnboundLocalError: local variable 'err_code' referenced before assignment
```

We have 3 cases:
1. build_and_install_one finishes but failed -> 'err' is an EasyBuildError with err_code set
2. build_and_install_one failed with an EasyBuildError -> 'err'  is set to an EasyBuildError, err_code is not
3. build_and_install_one failed with another exception -> 'err'  is set to that, err_code is not

How I understood the intended logic:
- When we have an EasyBuildError exit with the code of that but use `test_msg` as the message. I.e. just rewrite the EasyBuildError message
- Otherwise just throw that that unknown/unexpected exception

Maybe we should rather:
- If 'err' is an EasyBuildError, we replace `error.msg = test_msg` (not create a new instance which would be logged)
- Otherwise create a new EasyBuildError with `test_msg` and the default exit code