### PR TITLE
restore original value for non-list easyconfig parameter values that are considered for iterating over

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2378,16 +2378,11 @@ class EasyBlock(object):
             # handle configure/build/install options that are specified as lists (+ perhaps builddependencies)
             # set first element to be used, keep track of list in self.iter_opts
             # only needs to be done during first iteration, since after that the options won't be lists anymore
-            if self.iter_idx == 0:
+            if self.iter_idx == 0 and self.det_iter_cnt() > 1:
                 # keep track of list, supply first element as first option to handle
-                iter_cnt = self.det_iter_cnt()
-                for opt in self.cfg.iterate_options:
-                    if isinstance(self.cfg[opt], (list, tuple)):
-                        self.iter_opts[opt] = self.cfg[opt]  # copy
-                    elif iter_cnt > 1:
-                        # make iter_cnt copies for every opt since easyblocks can modify them
-                        self.iter_opts[opt] = [self.cfg[opt]] * iter_cnt
-                    self.log.debug("Found list for %s: %s", opt, self.iter_opts[opt])
+                for opt in self.cfg.ITERATE_OPTIONS:
+                    self.iter_opts[opt] = self.cfg[opt]  # copy
+                    self.log.debug("Iterating opt %s: %s", opt, self.iter_opts[opt])
 
             if self.iter_opts:
                 print_msg("starting iteration #%s ..." % self.iter_idx, log=self.log, silent=self.silent)
@@ -2395,7 +2390,9 @@ class EasyBlock(object):
 
             # pop first element from all iterative easyconfig parameters as next value to use
             for opt, value in self.iter_opts.items():
-                if len(value) > self.iter_idx:
+                if opt not in self.cfg.iterate_options:
+                    self.cfg[opt] = value
+                elif len(value) > self.iter_idx:
                     self.cfg[opt] = value[self.iter_idx]
                 else:
                     self.cfg[opt] = ''  # empty list => empty option as next value

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2378,7 +2378,7 @@ class EasyBlock(object):
             # handle configure/build/install options that are specified as lists (+ perhaps builddependencies)
             # set first element to be used, keep track of list in self.iter_opts
             # only needs to be done during first iteration, since after that the options won't be lists anymore
-            if self.iter_idx == 0 and self.det_iter_cnt() > 1:
+            if self.iter_idx == 0 and self.cfg.iterate_options:
                 # keep track of list, supply first element as first option to handle
                 for opt in ITERATE_OPTIONS:
                     self.iter_opts[opt] = self.cfg[opt]  # copy
@@ -2391,6 +2391,9 @@ class EasyBlock(object):
             # pop first element from all iterative easyconfig parameters as next value to use
             for opt, value in self.iter_opts.items():
                 if opt not in self.cfg.iterate_options:
+                    # Use original value even for options that were specified as strings so don't change
+                    # (ie. elements in ITERATE_OPTIONS but not in self.cfg.iterate_options), so they
+                    # are restored after an easyblock such as CMakeMake changes them
                     self.cfg[opt] = value
                 elif len(value) > self.iter_idx:
                     self.cfg[opt] = value[self.iter_idx]

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2380,8 +2380,13 @@ class EasyBlock(object):
             # only needs to be done during first iteration, since after that the options won't be lists anymore
             if self.iter_idx == 0:
                 # keep track of list, supply first element as first option to handle
+                iter_cnt = self.det_iter_cnt()
                 for opt in self.cfg.iterate_options:
-                    self.iter_opts[opt] = self.cfg[opt]  # copy
+                    if isinstance(self.cfg[opt], (list, tuple)):
+                        self.iter_opts[opt] = self.cfg[opt]  # copy
+                    elif iter_cnt > 1:
+                        # make iter_cnt copies for every opt since easyblocks can modify them
+                        self.iter_opts[opt] = [self.cfg[opt]] * iter_cnt
                     self.log.debug("Found list for %s: %s", opt, self.iter_opts[opt])
 
             if self.iter_opts:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2380,7 +2380,7 @@ class EasyBlock(object):
             # only needs to be done during first iteration, since after that the options won't be lists anymore
             if self.iter_idx == 0 and self.det_iter_cnt() > 1:
                 # keep track of list, supply first element as first option to handle
-                for opt in self.cfg.ITERATE_OPTIONS:
+                for opt in ITERATE_OPTIONS:
                     self.iter_opts[opt] = self.cfg[opt]  # copy
                     self.log.debug("Iterating opt %s: %s", opt, self.iter_opts[opt])
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1037,8 +1037,14 @@ class EasyConfig(object):
     def start_iterating(self):
         """Start iterative mode."""
 
-        # builddependencies is already handled, see __init__
-        self.iterate_options.extend([opt for opt in ITERATE_OPTIONS if opt != 'builddependencies'])
+        for opt in ITERATE_OPTIONS:
+            # builddpendencies is already handled, see __init__
+            if opt == 'builddependencies':
+                continue
+
+            # list of values indicates that this is a value to iterate over
+            if isinstance(self[opt], (list, tuple)):
+                self.iterate_options.append(opt)
 
         # keep track of when we're iterating (used by builddependencies())
         self.iterating = True

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1037,14 +1037,8 @@ class EasyConfig(object):
     def start_iterating(self):
         """Start iterative mode."""
 
-        for opt in ITERATE_OPTIONS:
-            # builddpendencies is already handled, see __init__
-            if opt == 'builddependencies':
-                continue
-
-            # list of values indicates that this is a value to iterate over
-            if isinstance(self[opt], (list, tuple)):
-                self.iterate_options.append(opt)
+        # builddependencies is already handled, see __init__
+        self.iterate_options.extend([opt for opt in ITERATE_OPTIONS if opt != 'builddependencies'])
 
         # keep track of when we're iterating (used by builddependencies())
         self.iterating = True

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1187,6 +1187,8 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(eb.cfg.iterating, True)
         self.assertEqual(eb.cfg.iterate_options, ['configopts'])
         self.assertEqual(eb.cfg['configopts'], "--opt1 --anotheropt")
+        # mimic easyblock that changes this in-place
+        eb.cfg['preconfigopts'] = "FOO=bar "
         self.assertEqual(eb.iter_opts, expected_iter_opts)
 
         # when next iteration is start, iteration index gets bumped
@@ -1198,6 +1200,8 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(stdout, "== starting iteration #1 ...\n")
         self.assertEqual(eb.cfg.iterating, True)
         self.assertEqual(eb.cfg.iterate_options, ['configopts'])
+        # preconfigopts should have been restored (https://github.com/easybuilders/easybuild-framework/pull/4848)
+        self.assertEqual(eb.cfg['preconfigopts'], "")
         self.assertEqual(eb.cfg['configopts'], "--opt2")
         self.assertEqual(eb.iter_opts, expected_iter_opts)
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -44,7 +44,7 @@ import easybuild.tools.systemtools as st
 from easybuild.base import fancylogger
 from easybuild.framework.easyblock import EasyBlock, get_easyblock_instance
 from easybuild.framework.easyconfig import CUSTOM
-from easybuild.framework.easyconfig.easyconfig import EasyConfig
+from easybuild.framework.easyconfig.easyconfig import EasyConfig, ITERATE_OPTIONS
 from easybuild.framework.easyconfig.tools import avail_easyblocks, process_easyconfig
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools import LooseVersion, config
@@ -1173,7 +1173,9 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(eb.cfg.iterate_options, [])
         self.assertEqual(eb.cfg['configopts'], ["--opt1 --anotheropt", "--opt2", "--opt3 --optbis"])
 
-        expected_iter_opts = {'configopts': ["--opt1 --anotheropt", "--opt2", "--opt3 --optbis"]}
+        expected_iter_opts = dict.fromkeys(ITERATE_OPTIONS, "")
+        expected_iter_opts['builddependencies'] = []
+        expected_iter_opts['configopts'] = ["--opt1 --anotheropt", "--opt2", "--opt3 --optbis"]
 
         # once iteration mode is set, we're still in iteration #0
         self.mock_stdout(True)


### PR DESCRIPTION
Since some easyblocks, e.g. `CMakeMake` modify `self.cfg['configopts']` it's safer to start afresh for every iteration. This PR implements this by turning options like these, if not already lists, into lists with identical element copies, e.g.
`[self.cfg['configopts']] * <number_of_iterations>`

This modification does not affect the logic of iterative `builddependencies` itself since it is used in some other places in the code.