### PR TITLE
Add "-" before "DMKL_ILP64" CFLAGS

### DIFF
--- a/easybuild/toolchains/linalg/intelmkl.py
+++ b/easybuild/toolchains/linalg/intelmkl.py
@@ -136,7 +136,7 @@ class IntelMKL(LinAlg):
             # ilp64/i8
             self.BLAS_LIB_MAP.update({"lp64": '_ilp64'})
             # CPP / CFLAGS
-            self.variables.nappend_el('CFLAGS', 'DMKL_ILP64')
+            self.variables.nappend_el('CFLAGS', '-DMKL_ILP64')
 
         # exact paths/linking statements depend on imkl version
         root = self.get_software_root(self.BLAS_MODULE_NAME)[0]


### PR DESCRIPTION
There should be a minus sign "-" before "DMKL_ILP64" in CFLAGS. Without this, it's breaking NWChem build. I'm not sure why this is under the radar for so long. Probably people just gave up on waiting 12 hours to build NWChem. I know modifying this core framework component will require a lot of testing, so take your time to review this pull request.

Currently, these easyconfig files will be affected (based on a simple "grep" pattern of "'i8'" toolchain option in the easyconfig files, and filtering out non-intel toolchain):

NWChem-7.0.2-intel-2021a.eb
NWChem-7.0.2-intel-2022a.eb
NWChem-7.2.2-intel-2023a.eb
NWChem-7.2.3-intel-2024a.eb
DIRAC-22.0-intel-2021a-int64.eb
DIRAC-23.0-intel-2022b-int64.eb
DIRAC-23.0-intel-2023a-int64.eb

