### PR TITLE
replace deprecation warning about reproducible tarballs on Python older than 3.9 to a regular warning

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -423,10 +423,9 @@ class EasyBlock:
             # ignore any checksum for given filename due to changes in https://github.com/python/cpython/issues/90021
             # tarballs made for git repos are not reproducible when created with Python < 3.9
             if sys.version_info[0] >= 3 and sys.version_info[1] < 9:
-                self.log.deprecated(
+                print_warning(
                     "Reproducible tarballs of Git repos are only possible when using Python 3.9+ to run EasyBuild. "
-                    f"Skipping checksum verification of {chksum_input} since Python < 3.9 is used.",
-                    '6.0'
+                    f"Skipping checksum verification of {chksum_input} since Python < 3.9 is used."
                 )
                 return None
             # not all archives formats of git repos are reproducible


### PR DESCRIPTION
As discussed in Slack, this deprecation warning causes issues with boegelbot because the easyconfigs in our repo use reproducible tarballs, but we still need to test with Python 3.6 as it is a supported version.