### PR TITLE
Enhance RPATH sanity check to skip anything whose absolute path resolves to outside the install dir

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3395,6 +3395,13 @@ class EasyBlock:
                 self.log.debug(f"Sanity checking RPATH for files in {dirpath}")
 
                 for path in [os.path.join(dirpath, x) for x in os.listdir(dirpath)]:
+                    # skip the check for any symlinks that resolve to outside the installation directory
+                    if not is_parent_path(self.installdir, path):
+                        msg = f("Skipping RPATH sanity check for {path}, since its absolute path resolves to outside "
+                                "the installation directory")
+                        self.log.debug(msg)
+                        continue
+
                     self.log.debug(f"Sanity checking RPATH for {path}")
 
                     out = get_linked_libs_raw(path)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3397,9 +3397,10 @@ class EasyBlock:
                 for path in [os.path.join(dirpath, x) for x in os.listdir(dirpath)]:
                     # skip the check for any symlinks that resolve to outside the installation directory
                     if not is_parent_path(self.installdir, path):
-                        msg = (f"Skipping RPATH sanity check for {path}, since its absolute path resolves to outside "
-                               "the installation directory")
-                        self.log.debug(msg)
+                        realpath = os.path.realpath(path)
+                        msg = (f"Skipping RPATH sanity check for {path}, since its absolute path {realpath} resolves to"
+                               f" outside the installation directory {self.installdir}")
+                        self.log.info(msg)
                         continue
 
                     self.log.debug(f"Sanity checking RPATH for {path}")

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3398,7 +3398,7 @@ class EasyBlock:
                     # skip the check for any symlinks that resolve to outside the installation directory
                     if not is_parent_path(self.installdir, path):
                         msg = (f"Skipping RPATH sanity check for {path}, since its absolute path resolves to outside "
-                                "the installation directory")
+                               "the installation directory")
                         self.log.debug(msg)
                         continue
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3397,7 +3397,7 @@ class EasyBlock:
                 for path in [os.path.join(dirpath, x) for x in os.listdir(dirpath)]:
                     # skip the check for any symlinks that resolve to outside the installation directory
                     if not is_parent_path(self.installdir, path):
-                        msg = f("Skipping RPATH sanity check for {path}, since its absolute path resolves to outside "
+                        msg = (f"Skipping RPATH sanity check for {path}, since its absolute path resolves to outside "
                                 "the installation directory")
                         self.log.debug(msg)
                         continue


### PR DESCRIPTION
this should solve issues of the kind seen in: https://github.com/easybuilders/easybuild-easyconfigs/issues/22789