### PR TITLE
add support for environment variables in `set_environment` of module generators

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -432,8 +432,10 @@ class ModuleGenerator:
 
     def unpack_setenv_value(self, *args, **kwargs):
         """
+        DEPRECATED method, should not be used.
+        Replaced with (internal) _unpack_setenv_value method.
         """
-        self.log.deprecated("...", '6.0')
+        self.log.deprecated("unpack_setenv_value should not be used directly (replaced by internal method)", '6.0')
         value, use_pushenv, _ = self._unpack_setenv_value(*args, **kwargs)
         return value, use_pushenv
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -462,7 +462,7 @@ class EasyBlockTest(EnhancedTestCase):
         elif get_module_syntax() == 'Lua':
             self.assertTrue(re.search(r'^prepend_path\("CLASSPATH", pathJoin\(root, "bla.jar"\)\)$', guess, re.M))
             self.assertTrue(re.search(r'^prepend_path\("CLASSPATH", pathJoin\(root, "foo.jar"\)\)$', guess, re.M))
-            self.assertTrue(re.search(r'^prepend_path\("MANPATH", pathJoin\(root, "share/man"\)\)$', guess, re.M))
+            self.assertTrue(re.search(r'^prepend_path\("MANPATH", pathJoin\(root, "share", "man"\)\)$', guess, re.M))
             self.assertIn('prepend_path("CMAKE_PREFIX_PATH", root)', guess)
             # bin/ is not added to $PATH if it doesn't include files
             self.assertFalse(re.search(r'^prepend_path\("PATH", pathJoin\(root, "bin"\)\)$', guess, re.M))
@@ -573,12 +573,12 @@ class EasyBlockTest(EnhancedTestCase):
                                        r"prepend-path\s+LD_LIBRARY_PATH\s+\$root/lib/pathA\n",
                                        txt, re.M))
         elif get_module_syntax() == 'Lua':
-            self.assertTrue(re.search(r'\nprepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib/pathC"\)\)\n' +
-                                      r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib/pathA"\)\)\n' +
-                                      r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib/pathB"\)\)\n',
+            self.assertTrue(re.search(r'\nprepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathC"\)\)\n' +
+                                      r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathA"\)\)\n' +
+                                      r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathB"\)\)\n',
                                       txt, re.M))
-            self.assertFalse(re.search(r'\nprepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib/pathB"\)\)\n' +
-                                       r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib/pathA"\)\)\n',
+            self.assertFalse(re.search(r'\nprepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathB"\)\)\n' +
+                                       r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathA"\)\)\n',
                                        txt, re.M))
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
@@ -651,10 +651,12 @@ class EasyBlockTest(EnhancedTestCase):
             self.assertTrue(re.search(r"^prepend-path\s+LD_LIBRARY_PATH\s+\$root/libraries/intel64_lin$", txt, re.M))
             self.assertTrue(re.search(r"^prepend-path\s+LIBRARY_PATH\s+\$root/libraries/intel64_lin\n$", txt, re.M))
         elif get_module_syntax() == 'Lua':
-            self.assertTrue(re.search(r'^prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "libraries/intel64_lin"\)\)$',
-                                      txt, re.M))
-            self.assertTrue(re.search(r'^prepend_path\("LIBRARY_PATH", pathJoin\(root, "libraries/intel64_lin"\)\)$',
-                                      txt, re.M))
+            self.assertTrue(re.search(
+                r'^prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "libraries", "intel64_lin"\)\)$', txt, re.M
+            ))
+            self.assertTrue(re.search(
+                r'^prepend_path\("LIBRARY_PATH", pathJoin\(root, "libraries", "intel64_lin"\)\)$', txt, re.M
+            ))
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
 
@@ -712,7 +714,7 @@ class EasyBlockTest(EnhancedTestCase):
         expected_patterns = [
             r"^append[-_]path.*TEST_VAR_CUSTOM.*root.*foo.*",
             r"^prepend[-_]path.*CPATH.*root.*include.*",
-            r"^prepend[-_]path.*CPATH.*root.*include/foo.*",
+            r"^prepend[-_]path.*CPATH.*root.*include.*foo.*",
             r"^prepend[-_]path.*LD_LIBRARY_PATH.*root.*lib",
             r"^prepend[-_]path.*LD_LIBRARY_PATH.*root.*foo",
             r"^prepend[-_]path.*TEST_VAR.*root.*foo",

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -870,12 +870,12 @@ class EasyBlockTest(EnhancedTestCase):
             expected_default = re.compile(r'\n'.join([
                 r'setenv\("EBROOTPI", root\)',
                 r'setenv\("EBVERSIONPI", "3.14"\)',
-                r'setenv\("EBDEVELPI", pathJoin\(root, "easybuild/pi-3.14-gompi-2018a-easybuild-devel"\)\)',
+                r'setenv\("EBDEVELPI", pathJoin\(root, "easybuild", "pi-3.14-gompi-2018a-easybuild-devel"\)\)',
             ]))
             expected_alt = re.compile(r'\n'.join([
                 r'setenv\("EBROOTPI", "/opt/software/tau/6.28"\)',
                 r'setenv\("EBVERSIONPI", "6.28"\)',
-                r'setenv\("EBDEVELPI", pathJoin\(root, "easybuild/pi-3.14-gompi-2018a-easybuild-devel"\)\)',
+                r'setenv\("EBDEVELPI", pathJoin\(root, "easybuild", "pi-3.14-gompi-2018a-easybuild-devel"\)\)',
             ]))
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1616,7 +1616,7 @@ class EasyBlockTest(EnhancedTestCase):
                     if val == '':
                         full_val = 'root'
                     else:
-                        full_val = fr'pathJoin\(root, "{val.replace("/",".*")}"\)'
+                        full_val = fr'pathJoin\(root, "{val.replace("/", ".*")}"\)'
                     regex = re.compile(fr'^{placement}_path\("{key}", {full_val}{delim_lua}\)$', re.M)
                 else:
                     self.fail(f"Unknown module syntax: {get_module_syntax()}")

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1616,7 +1616,7 @@ class EasyBlockTest(EnhancedTestCase):
                     if val == '':
                         full_val = 'root'
                     else:
-                        full_val = fr'pathJoin\(root, "{val}"\)'
+                        full_val = fr'pathJoin\(root, "{val.replace("/",".*")}"\)'
                     regex = re.compile(fr'^{placement}_path\("{key}", {full_val}{delim_lua}\)$', re.M)
                 else:
                     self.fail(f"Unknown module syntax: {get_module_syntax()}")

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -983,6 +983,28 @@ class ModuleGeneratorTest(EnhancedTestCase):
             ("/abspath/with/$VAR", True,    'setenv\tkey\t\t"/abspath/with/$::env(VAR)"\n',   'setenv("key", pathJoin("/", "abspath", "with", os.getenv("VAR")))\n'),  # noqa
             ("/abspath/$VAR/dir",  False,   'setenv\tkey\t\t"/abspath/$::env(VAR)/dir"\n',    'setenv("key", "/abspath/" .. os.getenv("VAR") .. "/dir")\n'),  # noqa
             ("/abspath/$VAR/dir",  True,    'setenv\tkey\t\t"/abspath/$::env(VAR)/dir"\n',    'setenv("key", pathJoin("/", "abspath", os.getenv("VAR"), "dir"))\n'),  # noqa
+            # modextravars defined with dicts
+            ({'value': 'value'},    False,  'setenv\tkey\t\t"value"\n',                       'setenv("key", "value")\n'),  # noqa
+            ({'value': 'value',
+              'pushenv': True},     False,  'pushenv\tkey\t\t"value"\n',                      'pushenv("key", "value")\n'),  # noqa
+            ({'value': 'value',
+              'pushenv': False},    False,  'setenv\tkey\t\t"value"\n',                       'setenv("key", "value")\n'),  # noqa
+            ({'value': "$VAR",
+              'shell_vars': True},  False,  'setenv\tkey\t\t"$::env(VAR)"\n',                 'setenv("key", os.getenv("VAR"))\n'),  # noqa
+            ({'value': "$VAR",
+              'shell_vars': True},  True,   'setenv\tkey\t\t"$root/$::env(VAR)"\n',           'setenv("key", pathJoin(root, os.getenv("VAR")))\n'),  # noqa
+            ({'value': "$VAR",
+              'shell_vars': False}, False,  'setenv\tkey\t\t"$VAR"\n',                        'setenv("key", "$VAR")\n'),  # noqa
+            ({'value': "$VAR",
+              'shell_vars': False}, True,   'setenv\tkey\t\t"$root/$VAR"\n',                  'setenv("key", pathJoin(root, "$VAR"))\n'),  # noqa
+            ({'value': "path/$VAR/dir",
+              'shell_vars': True},  False,  'setenv\tkey\t\t"path/$::env(VAR)/dir"\n',        'setenv("key", "path/" .. os.getenv("VAR") .. "/dir")\n'),  # noqa
+            ({'value': "path/$VAR/dir",
+              'shell_vars': True},  True,   'setenv\tkey\t\t"$root/path/$::env(VAR)/dir"\n',  'setenv("key", pathJoin(root, "path", os.getenv("VAR"), "dir"))\n'),  # noqa
+            ({'value': "path/$VAR/dir",
+              'shell_vars': False}, False,  'setenv\tkey\t\t"path/$VAR/dir"\n',               'setenv("key", "path/$VAR/dir")\n'),  # noqa
+            ({'value': "path/$VAR/dir",
+              'shell_vars': False}, True,   'setenv\tkey\t\t"$root/path/$VAR/dir"\n',         'setenv("key", pathJoin(root, "path", "$VAR", "dir"))\n'),  # noqa
         )
         # test set_environment
         for test_value, test_relpath, ref_tcl, ref_lua in collection:

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -953,14 +953,41 @@ class ModuleGeneratorTest(EnhancedTestCase):
 
     def test_env(self):
         """Test setting of environment variables."""
+        collection = (
+            # value,               relpath, Tcl reference,                                    Lua reference
+            ("value",              False,   'setenv\tkey\t\t"value"\n',                       'setenv("key", "value")\n'),  #noqa
+            ('va"lue',             False,   'setenv\tkey\t\t"va\\"lue"\n',                    'setenv("key", \'va"lue\')\n'),  #noqa
+            ("va'lue",             False,   'setenv\tkey\t\t"va\'lue"\n',                     'setenv("key", "va\'lue")\n'),  #noqa
+            ("""va"l'ue""",        False,   'setenv\tkey\t\t"""va"l\'ue"""\n',                'setenv("key", """va"l\'ue""")\n'),  #noqa
+            ("relative/path",      False,   'setenv\tkey\t\t"relative/path"\n',               'setenv("key", "relative/path")\n'),  #noqa
+            ("relative/path",      True,    'setenv\tkey\t\t"$root/relative/path"\n',         'setenv("key", pathJoin(root, "relative", "path"))\n'),  #noqa
+            ("relative/path/",     False,   'setenv\tkey\t\t"relative/path/"\n',              'setenv("key", "relative/path/")\n'),  #noqa
+            ("relative/path/",     True,    'setenv\tkey\t\t"$root/relative/path/"\n',        'setenv("key", pathJoin(root, "relative", "path"))\n'),  #noqa
+            ("",                   False,   'setenv\tkey\t\t""\n',                            'setenv("key", "")\n'),  #noqa
+            ("",                   True,    'setenv\tkey\t\t"$root"\n',                       'setenv("key", root)\n'),  #noqa
+            ("/absolute/path",     False,   'setenv\tkey\t\t"/absolute/path"\n',              'setenv("key", "/absolute/path")\n'),  #noqa
+            ("/absolute/path",     True,    'setenv\tkey\t\t"/absolute/path"\n',              'setenv("key", pathJoin("/", "absolute", "path"))\n'),  #noqa
+            ("/",                  False,   'setenv\tkey\t\t"/"\n',                           'setenv("key", "/")\n'),  #noqa
+            ("/",                  True,    'setenv\tkey\t\t"/"\n',                           'setenv("key", "/")\n'),  #noqa
+            ("$VAR",               False,   'setenv\tkey\t\t"$::env(VAR)"\n',                 'setenv("key", os.getenv("VAR"))\n'),  #noqa
+            ("$VAR",               True,    'setenv\tkey\t\t"$root/$::env(VAR)"\n',           'setenv("key", pathJoin(root, os.getenv("VAR")))\n'),  #noqa
+            ("$VAR/in/path",       False,   'setenv\tkey\t\t"$::env(VAR)/in/path"\n',         'setenv("key", os.getenv("VAR") .. "/in/path")\n'),  #noqa
+            ("$VAR/in/path",       True,    'setenv\tkey\t\t"$root/$::env(VAR)/in/path"\n',   'setenv("key", pathJoin(root, os.getenv("VAR"), "in", "path"))\n'),  #noqa
+            ("path/with/$VAR",     False,   'setenv\tkey\t\t"path/with/$::env(VAR)"\n',       'setenv("key", "path/with/" .. os.getenv("VAR"))\n'),  #noqa
+            ("path/with/$VAR",     True,    'setenv\tkey\t\t"$root/path/with/$::env(VAR)"\n', 'setenv("key", pathJoin(root, "path", "with", os.getenv("VAR")))\n'),  #noqa
+            ("path/$VAR/dir",      False,   'setenv\tkey\t\t"path/$::env(VAR)/dir"\n',        'setenv("key", "path/" .. os.getenv("VAR") .. "/dir")\n'),  #noqa
+            ("path/$VAR/dir",      True,    'setenv\tkey\t\t"$root/path/$::env(VAR)/dir"\n',  'setenv("key", pathJoin(root, "path", os.getenv("VAR"), "dir"))\n'),  #noqa
+            ("/$VAR/in/abspath",   False,   'setenv\tkey\t\t"/$::env(VAR)/in/abspath"\n',     'setenv("key", "/" .. os.getenv("VAR") .. "/in/abspath")\n'),  #noqa
+            ("/$VAR/in/abspath",   True,    'setenv\tkey\t\t"/$::env(VAR)/in/abspath"\n',     'setenv("key", pathJoin("/", os.getenv("VAR"), "in", "abspath"))\n'),  #noqa
+            ("/abspath/with/$VAR", False,   'setenv\tkey\t\t"/abspath/with/$::env(VAR)"\n',   'setenv("key", "/abspath/with/" .. os.getenv("VAR"))\n'),  #noqa
+            ("/abspath/with/$VAR", True,    'setenv\tkey\t\t"/abspath/with/$::env(VAR)"\n',   'setenv("key", pathJoin("/", "abspath", "with", os.getenv("VAR")))\n'),  #noqa
+            ("/abspath/$VAR/dir",  False,   'setenv\tkey\t\t"/abspath/$::env(VAR)/dir"\n',    'setenv("key", "/abspath/" .. os.getenv("VAR") .. "/dir")\n'),  #noqa
+            ("/abspath/$VAR/dir",  True,    'setenv\tkey\t\t"/abspath/$::env(VAR)/dir"\n',    'setenv("key", pathJoin("/", "abspath", os.getenv("VAR"), "dir"))\n'),  #noqa
+        )
         # test set_environment
-        if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
-            self.assertEqual('setenv\tkey\t\t"value"\n', self.modgen.set_environment("key", "value"))
-            self.assertEqual('setenv\tkey\t\t"va\\"lue"\n', self.modgen.set_environment("key", 'va"lue'))
-            self.assertEqual('setenv\tkey\t\t"va\'lue"\n', self.modgen.set_environment("key", "va'lue"))
-            self.assertEqual('setenv\tkey\t\t"""va"l\'ue"""\n', self.modgen.set_environment("key", """va"l'ue"""))
-        else:
-            self.assertEqual('setenv("key", "value")\n', self.modgen.set_environment("key", "value"))
+        for test_value, test_relpath, ref_tcl, ref_lua in collection:
+            reference = ref_tcl if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl else ref_lua
+            self.assertEqual(self.modgen.set_environment("key", test_value, test_relpath), reference)
 
     def test_getenv_cmd(self):
         """Test getting value of environment variable."""

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -955,34 +955,34 @@ class ModuleGeneratorTest(EnhancedTestCase):
         """Test setting of environment variables."""
         collection = (
             # value,               relpath, Tcl reference,                                    Lua reference
-            ("value",              False,   'setenv\tkey\t\t"value"\n',                       'setenv("key", "value")\n'),  #noqa
-            ('va"lue',             False,   'setenv\tkey\t\t"va\\"lue"\n',                    'setenv("key", \'va"lue\')\n'),  #noqa
-            ("va'lue",             False,   'setenv\tkey\t\t"va\'lue"\n',                     'setenv("key", "va\'lue")\n'),  #noqa
-            ("""va"l'ue""",        False,   'setenv\tkey\t\t"""va"l\'ue"""\n',                'setenv("key", """va"l\'ue""")\n'),  #noqa
-            ("relative/path",      False,   'setenv\tkey\t\t"relative/path"\n',               'setenv("key", "relative/path")\n'),  #noqa
-            ("relative/path",      True,    'setenv\tkey\t\t"$root/relative/path"\n',         'setenv("key", pathJoin(root, "relative", "path"))\n'),  #noqa
-            ("relative/path/",     False,   'setenv\tkey\t\t"relative/path/"\n',              'setenv("key", "relative/path/")\n'),  #noqa
-            ("relative/path/",     True,    'setenv\tkey\t\t"$root/relative/path/"\n',        'setenv("key", pathJoin(root, "relative", "path"))\n'),  #noqa
-            ("",                   False,   'setenv\tkey\t\t""\n',                            'setenv("key", "")\n'),  #noqa
-            ("",                   True,    'setenv\tkey\t\t"$root"\n',                       'setenv("key", root)\n'),  #noqa
-            ("/absolute/path",     False,   'setenv\tkey\t\t"/absolute/path"\n',              'setenv("key", "/absolute/path")\n'),  #noqa
-            ("/absolute/path",     True,    'setenv\tkey\t\t"/absolute/path"\n',              'setenv("key", pathJoin("/", "absolute", "path"))\n'),  #noqa
-            ("/",                  False,   'setenv\tkey\t\t"/"\n',                           'setenv("key", "/")\n'),  #noqa
-            ("/",                  True,    'setenv\tkey\t\t"/"\n',                           'setenv("key", "/")\n'),  #noqa
-            ("$VAR",               False,   'setenv\tkey\t\t"$::env(VAR)"\n',                 'setenv("key", os.getenv("VAR"))\n'),  #noqa
-            ("$VAR",               True,    'setenv\tkey\t\t"$root/$::env(VAR)"\n',           'setenv("key", pathJoin(root, os.getenv("VAR")))\n'),  #noqa
-            ("$VAR/in/path",       False,   'setenv\tkey\t\t"$::env(VAR)/in/path"\n',         'setenv("key", os.getenv("VAR") .. "/in/path")\n'),  #noqa
-            ("$VAR/in/path",       True,    'setenv\tkey\t\t"$root/$::env(VAR)/in/path"\n',   'setenv("key", pathJoin(root, os.getenv("VAR"), "in", "path"))\n'),  #noqa
-            ("path/with/$VAR",     False,   'setenv\tkey\t\t"path/with/$::env(VAR)"\n',       'setenv("key", "path/with/" .. os.getenv("VAR"))\n'),  #noqa
-            ("path/with/$VAR",     True,    'setenv\tkey\t\t"$root/path/with/$::env(VAR)"\n', 'setenv("key", pathJoin(root, "path", "with", os.getenv("VAR")))\n'),  #noqa
-            ("path/$VAR/dir",      False,   'setenv\tkey\t\t"path/$::env(VAR)/dir"\n',        'setenv("key", "path/" .. os.getenv("VAR") .. "/dir")\n'),  #noqa
-            ("path/$VAR/dir",      True,    'setenv\tkey\t\t"$root/path/$::env(VAR)/dir"\n',  'setenv("key", pathJoin(root, "path", os.getenv("VAR"), "dir"))\n'),  #noqa
-            ("/$VAR/in/abspath",   False,   'setenv\tkey\t\t"/$::env(VAR)/in/abspath"\n',     'setenv("key", "/" .. os.getenv("VAR") .. "/in/abspath")\n'),  #noqa
-            ("/$VAR/in/abspath",   True,    'setenv\tkey\t\t"/$::env(VAR)/in/abspath"\n',     'setenv("key", pathJoin("/", os.getenv("VAR"), "in", "abspath"))\n'),  #noqa
-            ("/abspath/with/$VAR", False,   'setenv\tkey\t\t"/abspath/with/$::env(VAR)"\n',   'setenv("key", "/abspath/with/" .. os.getenv("VAR"))\n'),  #noqa
-            ("/abspath/with/$VAR", True,    'setenv\tkey\t\t"/abspath/with/$::env(VAR)"\n',   'setenv("key", pathJoin("/", "abspath", "with", os.getenv("VAR")))\n'),  #noqa
-            ("/abspath/$VAR/dir",  False,   'setenv\tkey\t\t"/abspath/$::env(VAR)/dir"\n',    'setenv("key", "/abspath/" .. os.getenv("VAR") .. "/dir")\n'),  #noqa
-            ("/abspath/$VAR/dir",  True,    'setenv\tkey\t\t"/abspath/$::env(VAR)/dir"\n',    'setenv("key", pathJoin("/", "abspath", os.getenv("VAR"), "dir"))\n'),  #noqa
+            ("value",              False,   'setenv\tkey\t\t"value"\n',                       'setenv("key", "value")\n'),  # noqa
+            ('va"lue',             False,   'setenv\tkey\t\t"va\\"lue"\n',                    'setenv("key", \'va"lue\')\n'),  # noqa
+            ("va'lue",             False,   'setenv\tkey\t\t"va\'lue"\n',                     'setenv("key", "va\'lue")\n'),  # noqa
+            ("""va"l'ue""",        False,   'setenv\tkey\t\t"""va"l\'ue"""\n',                'setenv("key", """va"l\'ue""")\n'),  # noqa
+            ("relative/path",      False,   'setenv\tkey\t\t"relative/path"\n',               'setenv("key", "relative/path")\n'),  # noqa
+            ("relative/path",      True,    'setenv\tkey\t\t"$root/relative/path"\n',         'setenv("key", pathJoin(root, "relative", "path"))\n'),  # noqa
+            ("relative/path/",     False,   'setenv\tkey\t\t"relative/path/"\n',              'setenv("key", "relative/path/")\n'),  # noqa
+            ("relative/path/",     True,    'setenv\tkey\t\t"$root/relative/path/"\n',        'setenv("key", pathJoin(root, "relative", "path"))\n'),  # noqa
+            ("",                   False,   'setenv\tkey\t\t""\n',                            'setenv("key", "")\n'),  # noqa
+            ("",                   True,    'setenv\tkey\t\t"$root"\n',                       'setenv("key", root)\n'),  # noqa
+            ("/absolute/path",     False,   'setenv\tkey\t\t"/absolute/path"\n',              'setenv("key", "/absolute/path")\n'),  # noqa
+            ("/absolute/path",     True,    'setenv\tkey\t\t"/absolute/path"\n',              'setenv("key", pathJoin("/", "absolute", "path"))\n'),  # noqa
+            ("/",                  False,   'setenv\tkey\t\t"/"\n',                           'setenv("key", "/")\n'),  # noqa
+            ("/",                  True,    'setenv\tkey\t\t"/"\n',                           'setenv("key", "/")\n'),  # noqa
+            ("$VAR",               False,   'setenv\tkey\t\t"$::env(VAR)"\n',                 'setenv("key", os.getenv("VAR"))\n'),  # noqa
+            ("$VAR",               True,    'setenv\tkey\t\t"$root/$::env(VAR)"\n',           'setenv("key", pathJoin(root, os.getenv("VAR")))\n'),  # noqa
+            ("$VAR/in/path",       False,   'setenv\tkey\t\t"$::env(VAR)/in/path"\n',         'setenv("key", os.getenv("VAR") .. "/in/path")\n'),  # noqa
+            ("$VAR/in/path",       True,    'setenv\tkey\t\t"$root/$::env(VAR)/in/path"\n',   'setenv("key", pathJoin(root, os.getenv("VAR"), "in", "path"))\n'),  # noqa
+            ("path/with/$VAR",     False,   'setenv\tkey\t\t"path/with/$::env(VAR)"\n',       'setenv("key", "path/with/" .. os.getenv("VAR"))\n'),  # noqa
+            ("path/with/$VAR",     True,    'setenv\tkey\t\t"$root/path/with/$::env(VAR)"\n', 'setenv("key", pathJoin(root, "path", "with", os.getenv("VAR")))\n'),  # noqa
+            ("path/$VAR/dir",      False,   'setenv\tkey\t\t"path/$::env(VAR)/dir"\n',        'setenv("key", "path/" .. os.getenv("VAR") .. "/dir")\n'),  # noqa
+            ("path/$VAR/dir",      True,    'setenv\tkey\t\t"$root/path/$::env(VAR)/dir"\n',  'setenv("key", pathJoin(root, "path", os.getenv("VAR"), "dir"))\n'),  # noqa
+            ("/$VAR/in/abspath",   False,   'setenv\tkey\t\t"/$::env(VAR)/in/abspath"\n',     'setenv("key", "/" .. os.getenv("VAR") .. "/in/abspath")\n'),  # noqa
+            ("/$VAR/in/abspath",   True,    'setenv\tkey\t\t"/$::env(VAR)/in/abspath"\n',     'setenv("key", pathJoin("/", os.getenv("VAR"), "in", "abspath"))\n'),  # noqa
+            ("/abspath/with/$VAR", False,   'setenv\tkey\t\t"/abspath/with/$::env(VAR)"\n',   'setenv("key", "/abspath/with/" .. os.getenv("VAR"))\n'),  # noqa
+            ("/abspath/with/$VAR", True,    'setenv\tkey\t\t"/abspath/with/$::env(VAR)"\n',   'setenv("key", pathJoin("/", "abspath", "with", os.getenv("VAR")))\n'),  # noqa
+            ("/abspath/$VAR/dir",  False,   'setenv\tkey\t\t"/abspath/$::env(VAR)/dir"\n',    'setenv("key", "/abspath/" .. os.getenv("VAR") .. "/dir")\n'),  # noqa
+            ("/abspath/$VAR/dir",  True,    'setenv\tkey\t\t"/abspath/$::env(VAR)/dir"\n',    'setenv("key", pathJoin("/", "abspath", os.getenv("VAR"), "dir"))\n'),  # noqa
         )
         # test set_environment
         for test_value, test_relpath, ref_tcl, ref_lua in collection:

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -4461,7 +4461,7 @@ class ToyBuildTest(EnhancedTestCase):
             toy_mod += '.lua'
         toy_mod_txt = read_file(toy_mod)
 
-        pythonpath_regex = re.compile('^prepend.path.*PYTHONPATH.*lib/python3.6/site-packages', re.M)
+        pythonpath_regex = re.compile('^prepend.path.*PYTHONPATH.*lib.*python3.6.*site-packages', re.M)
 
         self.assertTrue(pythonpath_regex.search(toy_mod_txt),
                         f"Pattern '{pythonpath_regex.pattern}' found in: {toy_mod_txt}")

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -428,9 +428,9 @@ class ToyBuildTest(EnhancedTestCase):
             self.assertTrue(re.search(r'^puts stderr "oh hai!"$', toy_module_txt, re.M))
         elif get_module_syntax() == 'Lua':
             self.assertTrue(re.search(r'^setenv\("FOO", "bar"\)', toy_module_txt, re.M))
-            pattern = r'^prepend_path\("SOMEPATH", pathJoin\(root, "foo/bar"\)\)$'
+            pattern = r'^prepend_path\("SOMEPATH", pathJoin\(root, "foo", "bar"\)\)$'
             self.assertTrue(re.search(pattern, toy_module_txt, re.M))
-            pattern = r'^append_path\("SOMEPATH_APPEND", pathJoin\(root, "qux/fred"\)\)$'
+            pattern = r'^append_path\("SOMEPATH_APPEND", pathJoin\(root, "qux", "fred"\)\)$'
             self.assertTrue(re.search(pattern, toy_module_txt, re.M))
             pattern = r'^append_path\("SOMEPATH_APPEND", pathJoin\(root, "thud"\)\)$'
             self.assertTrue(re.search(pattern, toy_module_txt, re.M))
@@ -1647,15 +1647,15 @@ class ToyBuildTest(EnhancedTestCase):
                 r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib"\)\)',
                 r'prepend_path\("LIBRARY_PATH", pathJoin\(root, "lib"\)\)',
                 r'prepend_path\("PATH", pathJoin\(root, "bin"\)\)',
-                r'prepend_path\("SOMEPATH", pathJoin\(root, "foo/bar"\)\)',
+                r'prepend_path\("SOMEPATH", pathJoin\(root, "foo", "bar"\)\)',
                 r'prepend_path\("SOMEPATH", pathJoin\(root, "baz"\)\)',
                 r'prepend_path\("SOMEPATH", root\)',
-                r'append_path\("SOMEPATH_APPEND", pathJoin\(root, "qux/fred"\)\)',
+                r'append_path\("SOMEPATH_APPEND", pathJoin\(root, "qux", "fred"\)\)',
                 r'append_path\("SOMEPATH_APPEND", pathJoin\(root, "thud"\)\)',
                 r'append_path\("SOMEPATH_APPEND", root\)',
                 r'setenv\("EBROOTTOY", root\)',
                 r'setenv\("EBVERSIONTOY", "0.0"\)',
-                r'setenv\("EBDEVELTOY", pathJoin\(root, "easybuild/toy-0.0-tweaked-easybuild-devel"\)\)',
+                r'setenv\("EBDEVELTOY", pathJoin\(root, "easybuild", "toy-0.0-tweaked-easybuild-devel"\)\)',
                 r'',
                 r'setenv\("FOO", "bar"\)',
                 r'',


### PR DESCRIPTION
This PR enhances the `set_environment` methods in module generators to handle contents of variables that have references to shell environment variables (_i.e._ `$ENV_VAR`).

The effects of this PR are better seen in `test_env` in `test/framework/module_generator.py`, which is heavily enhanced to test a lot more cases. See [test/framework/module_generator.py#L956](https://github.com/easybuilders/easybuild-framework/blob/5c594ad603db8ed408a45710979538e159a27fbe/test/framework/module_generator.py#L956)

In practice, this now allows the following in `modextravars`:

```
modextravars = {
    'SOME_VARIABLE_PYTHON': '$EBROOTPYTHON/bin/python',
    'SOME_VARIABLE_CONFIG': '$HOME/.config/file',
}
```

Additionally, in the case of `ModuleGeneratorLua`, the static template `PATH_JOIN_TEMPLATE` used to construct `pathJoin` commands in Lua is replaced with a more powerful `_path_join_cmd` method that properly splits the components of the path:
```
# OLD
pathJoin(root, "foo/bar")
# NEW
pathJoin(root, "foo", "bar")
```

Companion PR in easyconfigs:
* https://github.com/easybuilders/easybuild-easyconfigs/pull/22801
