### PR TITLE
Update fake module for each extension installed

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -56,6 +56,7 @@ import tempfile
 import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from datetime import datetime
 from string import ascii_letters
 from textwrap import indent
@@ -2293,6 +2294,24 @@ class EasyBlock:
     def start_dir(self):
         """Start directory in build directory"""
         return self.cfg['start_dir']
+
+    @contextmanager
+    def fake_module_environment(self):
+        """
+        Load/Unload fake module
+        """
+        # load fake module
+        fake_mod_data = None
+        if not self.dry_run:
+            # load modules for build dependencies as extra modules
+            build_dep_mods = [dep['short_mod_name'] for dep in self.cfg.dependencies(build_only=True)]
+            fake_mod_data = self.load_fake_module(purge=True, extra_modules=build_dep_mods)
+
+        yield
+
+        # cleanup (unload fake module, remove fake module dir)
+        if fake_mod_data:
+            self.clean_up_fake_module(fake_mod_data)
 
     def guess_start_dir(self):
         """

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1637,7 +1637,7 @@ class EasyBlock:
 
         return txt
 
-    def make_module_req(self, fake=False):
+    def make_module_req(self):
         """
         Generate the environment-variables required to run the module.
         """
@@ -1678,11 +1678,10 @@ class EasyBlock:
             mod_lines.append(self.module_generator.comment(note))
 
         for env_var, search_paths in env_var_requirements.items():
-            if self.dry_run or fake:
+            if self.dry_run:
                 # Don't expand globs or do any filtering for dry run
                 mod_req_paths = search_paths
-                if self.dry_run:
-                    self.dry_run_msg(f" ${env_var}:{', '.join(mod_req_paths)}")
+                self.dry_run_msg(f" ${env_var}:{', '.join(mod_req_paths)}")
             else:
                 mod_req_paths = [
                     expanded_path for unexpanded_path in search_paths
@@ -4037,7 +4036,7 @@ class EasyBlock:
             txt += self.make_module_deppaths()
             txt += self.make_module_dep()
             txt += self.make_module_extend_modpath()
-            txt += self.make_module_req(fake=fake)
+            txt += self.make_module_req()
             txt += self.make_module_extra()
             txt += self.make_module_footer()
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1958,10 +1958,11 @@ class EasyBlock:
         if not exts_filter or len(exts_filter) == 0:
             raise EasyBuildError("Skipping of extensions, but no exts_filter set in easyconfig")
 
-        if build_option('parallel_extensions_install'):
-            self.skip_extensions_parallel(exts_filter)
-        else:
-            self.skip_extensions_sequential(exts_filter)
+        with self.fake_module_environment():
+            if build_option('parallel_extensions_install'):
+                self.skip_extensions_parallel(exts_filter)
+            else:
+                self.skip_extensions_sequential(exts_filter)
 
     def skip_extensions_sequential(self, exts_filter):
         """

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2522,6 +2522,7 @@ class EasyBlockTest(EnhancedTestCase):
             exts_list = toy_ec['exts_list']
             exts_list[-1][2]['exts_filter'] = ("thisshouldfail", '')
             toy_ec['exts_list'] = exts_list
+            toy_ec['exts_defaultclass'] = 'DummyExtension'
 
         eb = EB_toy(toy_ec)
         eb.silent = True
@@ -2536,6 +2537,7 @@ class EasyBlockTest(EnhancedTestCase):
         # sanity check commands are checked after checking sanity check paths, so this should work
         toy_ec = EasyConfig(toy_ec_fn)
         toy_ec.update('sanity_check_commands', [("%(installdir)s/bin/toy && rm %(installdir)s/bin/toy", '')])
+        toy_ec['exts_defaultclass'] = 'DummyExtension'
         eb = EB_toy(toy_ec)
         eb.silent = True
         with self.mocked_stdout_stderr():

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-2018a-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-2018a-test.eb
@@ -60,7 +60,7 @@ sanity_check_paths = {
     'dirs': [],
 }
 
-modextrapaths = {'TOY_EXAMPLES': 'examples'}
+modextravars = {'TOY_EXAMPLES': 'examples'}
 
 postinstallcmds = ["echo TOY > %(installdir)s/README"]
 

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-2018a-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-2018a-test.eb
@@ -27,6 +27,7 @@ local_bar_buildopts = " && gcc bar.c -o anotherbar && "
 # used to check whether $TOY_LIBS_PATH is defined even when 'lib' subdirectory doesn't exist yet
 local_bar_buildopts += 'echo "TOY_EXAMPLES=$TOY_EXAMPLES" > %(installdir)s/toy_libs_path.txt'
 
+exts_defaultclass = 'DummyExtension'
 exts_list = [
     'ulimit',  # extension that is part of "standard library"
     ('bar', '0.0', {

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -6731,6 +6731,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         test_ec_txt += '\n' + '\n'.join([
             "sanity_check_commands = ['barbar', 'toy']",
             "sanity_check_paths = {'files': ['bin/barbar', 'bin/toy'], 'dirs': ['bin']}",
+            "exts_defaultclass = 'DummyExtension'",
             "exts_list = [",
             "    ('barbar', '0.0', {",
             "        'start_dir': 'src',",

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1224,7 +1224,7 @@ class ToyBuildTest(EnhancedTestCase):
         toy_libs_path = os.path.join(toy_installdir, 'toy_libs_path.txt')
         self.assertTrue(os.path.exists(toy_libs_path))
         txt = read_file(toy_libs_path)
-        regex = re.compile('^TOY_EXAMPLES=.*/examples$')
+        regex = re.compile('^TOY_EXAMPLES=examples$')
         self.assertTrue(regex.match(txt), f"Pattern '{regex.pattern}' should match in: {txt}")
 
     def test_toy_advanced_filter_deps(self):

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3488,6 +3488,7 @@ class ToyBuildTest(EnhancedTestCase):
                 loaded_mod_names = [x['mod_name'] for x in self.modtool.list()]
                 self.assertNotIn('toy/0.0', loaded_mod_names)
                 self.assertIn('GCC/7.3.0-2.30', loaded_mod_names)
+                self.modtool.unload(['GCC/7.3.0-2.30'])
             else:
                 # just undo
                 self.modtool.unload(['toy/0.0', 'GCC/7.3.0-2.30'])

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1357,6 +1357,7 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         test_ec_txt = '\n'.join([
             toy_ec_txt,
+            'exts_defaultclass = "DummyExtension"',
             'exts_list = [',
             '   ("bar", "0.0", {',
             '       "buildopts": " && ls -l test.txt",',
@@ -1405,6 +1406,7 @@ class ToyBuildTest(EnhancedTestCase):
             # test use of single-element list in 'sources' with just the filename
             test_ec_txt = '\n'.join([
                 toy_ec_txt,
+                'exts_defaultclass = "DummyExtension"',
                 'exts_list = [',
                 '   ("bar", "0.0", {',
                 '       "sources": %s,' % bar_sources_spec,
@@ -1432,6 +1434,7 @@ class ToyBuildTest(EnhancedTestCase):
 
             test_ec_txt = '\n'.join([
                 toy_ec_txt,
+                'exts_defaultclass = "DummyExtension"',
                 'exts_list = [',
                 '   ("bar", "0.0", {',
                 '       "source_urls": ["file://%s"],' % test_source_path,
@@ -1447,6 +1450,7 @@ class ToyBuildTest(EnhancedTestCase):
             # check that checksums are picked up and verified
             test_ec_txt = '\n'.join([
                 toy_ec_txt,
+                'exts_defaultclass = "DummyExtension"',
                 'exts_list = [',
                 '   ("bar", "0.0", {',
                 '       "source_urls": ["file://%s"],' % test_source_path,
@@ -1470,6 +1474,7 @@ class ToyBuildTest(EnhancedTestCase):
             # test again with correct checksum for bar-0.0.tar.gz, but faulty checksum for patch file
             test_ec_txt = '\n'.join([
                 toy_ec_txt,
+                'exts_defaultclass = "DummyExtension"',
                 'exts_list = [',
                 '   ("bar", "0.0", {',
                 '       "source_urls": ["file://%s"],' % test_source_path,
@@ -1493,6 +1498,7 @@ class ToyBuildTest(EnhancedTestCase):
             # test again with correct checksums
             test_ec_txt = '\n'.join([
                 toy_ec_txt,
+                'exts_defaultclass = "DummyExtension"',
                 'exts_list = [',
                 '   ("bar", "0.0", {',
                 '       "source_urls": ["file://%s"],' % test_source_path,
@@ -1518,6 +1524,7 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         test_ec_txt = '\n'.join([
             toy_ec_txt,
+            'exts_defaultclass = "DummyExtension"',
             'exts_list = [',
             '   ("bar", "0.0", {',
             # deliberately incorrect custom extract command, just to verify that it's picked up
@@ -1556,6 +1563,7 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec_txt = '\n'.join([
             toy_ec_txt,
             'prebuildopts = "echo \\\"%s\\\" > %s && ",' % (ext_code, ext_cfile),
+            'exts_defaultclass = "DummyExtension"',
             'exts_list = [',
             '   ("exts-git", "0.0", {',
             '       "buildopts": "&& ls -l %s %s",' % (ext_tarball, ext_tarfile),
@@ -1924,6 +1932,7 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec_txt += '\n' + '\n'.join([
             "sanity_check_commands = ['barbar', 'toy']",
             "sanity_check_paths = {'files': ['bin/barbar', 'bin/toy'], 'dirs': ['bin']}",
+            "exts_defaultclass = 'DummyExtension'",
             "exts_list = [",
             "    ('barbar', '0.0', {",
             "        'start_dir': 'src',",
@@ -1993,6 +2002,7 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         test_ec_txt = read_file(toy_ec)
         test_ec_txt += '\n' + '\n'.join([
+            "exts_defaultclass = 'DummyExtension'",
             "exts_list = [",
             "    ('ls'),",
             "    ('bar', '0.0'),",
@@ -2373,6 +2383,7 @@ class ToyBuildTest(EnhancedTestCase):
         ec1 = os.path.join(self.test_prefix, 'toy1.eb')
         ec1_txt = '\n'.join([
             toy_ec_txt,
+            "exts_defaultclass = 'DummyExtension'",
             "exts_list = [('barbar', '1.2', {'start_dir': 'src'})]",
             "",
         ])
@@ -3220,7 +3231,10 @@ class ToyBuildTest(EnhancedTestCase):
         """Test use of --hooks."""
         toy_ec = os.path.join(os.path.dirname(__file__), 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
         test_ec = os.path.join(self.test_prefix, 'test.eb')
-        test_ec_txt = read_file(toy_ec) + "\nexts_list = [('bar', '0.0'), ('toy', '0.0')]"
+        test_ec_txt = read_file(toy_ec) + '\n'.join([
+            "exts_list = [('bar', '0.0'), ('toy', '0.0')]",
+            "exts_defaultclass = 'DummyExtension'",
+        ])
         write_file(test_ec, test_ec_txt)
 
         hooks_file = os.path.join(self.test_prefix, 'my_hooks.py')
@@ -3364,6 +3378,7 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec = os.path.join(self.test_prefix, 'test.eb')
 
         # also inject (minimal) list of extensions to test iterative installation of extensions
+        test_ec_txt += "\nexts_defaultclass = 'DummyExtension'"
         test_ec_txt += "\nexts_list = [('barbar', '1.2', {'start_dir': 'src'})]"
 
         test_ec_txt += "\nmulti_deps = {'GCC': ['4.6.3', '7.3.0-2.30']}"

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3342,14 +3342,15 @@ class ToyBuildTest(EnhancedTestCase):
             ' gcc toy.c -o toy  && copy_toy_file toy copy_of_toy' command failed (exit code 127), but I fixed it!
             in post-install hook for toy v0.0
             bin, lib
+            toy 0.0
+            ['%(name)s-%(version)s.tar.gz']
+            echo toy
+            toy 0.0
+            ['%(name)s-%(version)s.tar.gz']
+            echo toy
             in module-write hook hook for {mod_name}
-            toy 0.0
-            ['%(name)s-%(version)s.tar.gz']
-            echo toy
-            toy 0.0
-            ['%(name)s-%(version)s.tar.gz']
-            echo toy
             installing of extension bar is done!
+            in module-write hook hook for {mod_name}
             pre_run_shell_cmd_hook triggered for ' gcc toy.c -o toy '
             ' gcc toy.c -o toy  && copy_toy_file toy copy_of_toy' command failed (exit code 127), but I fixed it!
             installing of extension toy is done!


### PR DESCRIPTION
The extension step generates a single fake module before the first extension is installed and uses that same fake module across the installation of all extensions.

This break the installations of easyconfigs with extensions that rely on files installed by previous extensions in the same easyconfig and that make use of search paths to find those files. Since the resolution of paths in `module_load_environment` only happens before extensions are installed, no search paths are added to the fake module as those paths/globs are empty.

We added a quick workaround in https://github.com/easybuilders/easybuild-framework/pull/4809 that skips path resolution for fake modules to avoid this issue. However, this workaround has broken installation of easyconfigs that have search paths with globs that must be expanded in their sanity checks. One example is [MATSim-15.0-Java-17.eb](https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/m/MATSim/MATSim-15.0-Java-17.eb), which has `modextrapaths = {'CLASSPATH': 'libs/*'}`.

```
== sanity checking...
  >> file 'matsim-15.0.jar' found: OK
  >> (non-empty) directory 'libs' found: OK
  >> (non-empty) directory 'examples' found: OK
  >> loading modules: MATSim/15.0-Java-17...
  >> running command 'java org.matsim.run.ReleaseInfo' ...
  >> result for command 'java org.matsim.run.ReleaseInfo': FAILED
== ... (took 3 secs)
== FAILED: Installation ended unsuccessfully: Sanity check failed: sanity check command java org.matsim.run.ReleaseInfo failed with exit code 1 (output: Error: Could not find or load main class org.matsim.run.ReleaseInfo
Caused by: java.lang.ClassNotFoundException: org.matsim.run.ReleaseInfo
) (took 9 secs)
```

This PR fixes this issue for good by generating a new fake module for each extension installed. This ensures that path/glob resolution can happen and new files from previous extensions will be accounted.

Moreover, I'm adding a new context manager to handle fake modules and a new unit test to test this particular case.
