### PR TITLE
count the `data_sources`

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -835,7 +835,7 @@ class EasyConfig:
 
         # No need to resolve templates as we only need a count not the names
         with self.disable_templating():
-            cnt = len(self['sources']) + len(self['patches'])
+            cnt = len(self['sources']) + len(self['data_sources']) + len(self['patches'])
             exts = self['exts_list']
 
         for ext in exts:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -835,7 +835,7 @@ class EasyConfig:
 
         # No need to resolve templates as we only need a count not the names
         with self.disable_templating():
-            cnt = len(self['sources']) + len(self['data_sources']) + len(self['patches'])
+            cnt = sum(len(self[k]) for k in ['data_sources', 'sources', 'patches'])
             exts = self['exts_list']
 
         for ext in exts:


### PR DESCRIPTION
fix for #4474 - `100.0` files to download.

If `count_files()` returns `0` then the Rich progress bar defaults to percentage - so `100.0` for the total.

```
Downloading Base_epoch8_ckpt.pt_v12fc204edeae5b57713c5ad7dcb97d39 ━━━━━━━━━━━━━━━━━━━━━━━━╺━━━━━━━━━━━━━━━ 294.6/483.6 MB 7.6 MB/s 0:00:25
Fetching files:   7% (7/100.0) ━━╸━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0:00:38 (Base_epoch8_ckpt.pt_v12fc204edeae5b57713c5ad7dcb97d39)
```