### PR TITLE
include `data_sources` when checking checksums

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2704,12 +2704,12 @@ class EasyBlock:
         # try to get value with templates resolved, but fall back to not resolving templates;
         # this is better for error reporting that includes names of source files
         try:
-            sources = ent.get('sources', [])
+            sources = ent.get('sources', []) + ent.get('data_sources', [])
             patches = ent.get('patches', []) + ent.get('postinstallpatches', [])
             checksums = ent.get('checksums', [])
         except EasyBuildError:
             if isinstance(ent, EasyConfig):
-                sources = ent.get_ref('sources')
+                sources = ent.get_ref('sources') + ent.get_ref('data_sources')
                 patches = ent.get_ref('patches') + ent.get_ref('postinstallpatches')
                 checksums = ent.get_ref('checksums')
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2704,20 +2704,26 @@ class EasyBlock:
         # try to get value with templates resolved, but fall back to not resolving templates;
         # this is better for error reporting that includes names of source files
         try:
-            sources = ent.get('sources', []) + ent.get('data_sources', [])
+            sources = ent.get('sources', [])
+            data_sources = ent.get('data_sources', [])
             patches = ent.get('patches', []) + ent.get('postinstallpatches', [])
             checksums = ent.get('checksums', [])
         except EasyBuildError:
             if isinstance(ent, EasyConfig):
-                sources = ent.get_ref('sources') + ent.get_ref('data_sources')
+                sources = ent.get_ref('sources')
+                data_sources = ent.get_ref('data_sources')
                 patches = ent.get_ref('patches') + ent.get_ref('postinstallpatches')
                 checksums = ent.get_ref('checksums')
 
         # Single source should be re-wrapped as a list, and checksums with it
         if isinstance(sources, dict):
             sources = [sources]
+        if isinstance(data_sources, dict):
+            data_sources = [data_sources]
         if isinstance(checksums, str):
             checksums = [checksums]
+
+        sources = sources + data_sources
 
         if not checksums:
             checksums_from_json = self.get_checksums_from_json()


### PR DESCRIPTION
Before
```
Checking for SHA256 checksums in 1 easyconfig(s)...

[FAIL] /rds/projects/2017/branfosj-rse/easybuild/src/easybuild-easyconfigs/easybuild/easyconfigs/RFdiffusion-models-1.1.0.eb
Checksums missing for one or more sources/patches in RFdiffusion-models-1.1.0.eb: found 0 sources + 0 patches vs 9 checksums

>> One or more SHA256 checksums checks FAILED!
```

After
```
Checking for SHA256 checksums in 1 easyconfig(s)...

[PASS] /rds/projects/2017/branfosj-rse/easybuild/src/easybuild-easyconfigs/easybuild/easyconfigs/RFdiffusion-models-1.1.0.eb

>> All SHA256 checksums checks PASSed!
```