### PR TITLE
always honor keeppreviousinstall setting

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1132,8 +1132,8 @@ class EasyBlock:
                 raise EasyBuildError("self.builddir not set, make sure gen_builddir() is called first!")
             self.log.debug("Creating the build directory %s (cleanup: %s)", self.builddir, self.cfg['cleanupoldbuild'])
         else:
-            self.log.info("Overriding 'cleanupoldinstall' (to False), 'cleanupoldbuild' (to True) "
-                          "and 'keeppreviousinstall' because we're building in the installation directory.")
+            self.log.info("Overriding 'cleanupoldinstall' (to False) and 'cleanupoldbuild' (to True) "
+                          "because we're building in the installation directory.")
             # force cleanup before installation
             if build_option('module_only') or self.cfg['module_only']:
                 self.log.debug("Disabling cleanupoldbuild because we run as module-only")
@@ -1141,7 +1141,10 @@ class EasyBlock:
             else:
                 self.cfg['cleanupoldbuild'] = True
 
-            self.cfg['keeppreviousinstall'] = False
+            if self.cfg['keeppreviousinstall']:
+                self.log.warning("Both keepppreviousinstall and buildininstalldir are set to True before creating the "
+                                 "build directory, hopefully you know what you are doing!")
+
             # avoid cleanup after installation
             self.cfg['cleanupoldinstall'] = False
 


### PR DESCRIPTION
needed for installing software in a bwrap namespace, where we bind mount the software installdir (name/version) of each software that will be installed by EB.

this in turn requires setting `keeppreviousinstall` to `True`, because removing a bind mounted directory is not possible. we currently set this in the parse hook (would be useful to have a build option for this).

EB currently hard sets `keeppreviousinstall` to `False` if `buildininstalldir` is `True`, which breaks the bwrap installation. this PR prints a big warning instead of changing `keeppreviousinstall`.

see also https://github.com/easybuilders/easybuild-framework/issues/4110