### PR TITLE
use `develop` branch for PRs that target removed `5.0.x` branch in `fetch_files_from_pr`

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -538,7 +538,12 @@ def fetch_files_from_pr(pr, path=None, github_user=None, github_account=None, gi
     pr_closed = pr_data['state'] == GITHUB_STATE_CLOSED and not pr_merged
 
     pr_target_branch = pr_data['base']['ref']
-    _log.info("Target branch for PR #%s: %s", pr, pr_target_branch)
+    _log.info(f"Target branch for PR #{pr}: {pr_target_branch}")
+    # 5.0.x branch was collapsed into develop branch and then removed shortly after release of EasyBuild v5.0.0,
+    # so for PRs targeting the 5.0.x branch use develop branch instead
+    if pr_target_branch == '5.0.x':
+        pr_target_branch = GITHUB_DEVELOP_BRANCH
+        _log.info(f"Using {pr_target_branch} instead of 5.0.x branch (since that branch was removed)")
 
     # download target branch of PR so we can try and apply the PR patch on top of it
     repo_target_branch = download_repo(repo=github_repo, account=github_account, branch=pr_target_branch,


### PR DESCRIPTION
The long-lived `5.0.x` branch that was used for preparing EasyBuild v5.0.0 was collapsed into the `develop` branch and removed shortly after the release of EasyBuild v5.0.0.

That causes trouble when `--from-pr` or `--include-easyblocks-from-pr` is used on PRs that were targeting the `5.0.x` branch, for example:

```
$ eb --from-pr 22227 -Dr
== Temporary log file in case of crash /tmp/eb-w6t5qm45/easybuild-a07fthw5.log
pr_target_branch='5.0.x'
ERROR: No branch with name 5.0.x found in repo easybuilders/easybuild-easyconfigs: auto_merge_prs, develop, dual_serial_mpi, main, ocaisa-patch-1
```

Since `5.0.x` was collapsed into `develop`, we can easily fix this by using `develop` instead