### PR TITLE
also ignore errors raised during test step when `--ignore-test-failure` is used

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2995,6 +2995,8 @@ class EasyBlock:
         """Run the test_step and handles failures"""
         try:
             self.test_step()
+        except EasyBuildError as err:
+            self.report_test_failure(f"An error was raised during test step: {err}")
         except RunShellCmdError as err:
             err.print()
             ec_path = os.path.basename(self.cfg.path)

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -132,6 +132,13 @@ class EB_toy(ExtensionEasyBlock):
         if res.exit_code:
             print_warning("Command '%s' failed, but we'll ignore it..." % cmd)
 
+    def test_step(self, *args, **kwargs):
+        """Test toy."""
+        if self.cfg['runtest'] == 'RAISE_ERROR':
+            raise EasyBuildError("TOY_TEST_FAIL")
+        else:
+            super().test_step(*args, **kwargs)
+
     def install_step(self, name=None):
         """Install toy."""
         if name is None:

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -53,7 +53,7 @@ from easybuild.framework.easyconfig.easyconfig import EasyConfig
 from easybuild.framework.easyconfig.parser import EasyConfigParser
 from easybuild.main import main_with_hooks
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import get_module_syntax, get_repositorypath, update_build_option
+from easybuild.tools.config import get_module_syntax, get_repositorypath
 from easybuild.tools.environment import modify_env
 from easybuild.tools.filetools import adjust_permissions, change_dir, copy_file, mkdir, move_file
 from easybuild.tools.filetools import read_file, remove_dir, remove_file, which, write_file


### PR DESCRIPTION
This fixes a regression in EasyBuild v5.0.0, see the changes that were made in `EasyBlock._test_step` in:
* #4383

While `--ignore-test-failure` worked with EasyBuild 4.x to let an installation of PyTorch complete even when too many failing tests were found, it doesn't work anymore with EasyBuild v5.0.0 because the custom easyblock for PyTorch raises an `EasyBuildError` (since it goes way beyond just a running a shell command in the test step).

`test_toy_failing_test_step` was enhanced to verify the fix