### PR TITLE
Possible fix to allow `pip install -e .` to work seamlessly with newer pip/setuptools versions

### DIFF
--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -34,6 +34,8 @@ import glob
 import os
 import re
 import sys
+import importlib
+
 from string import ascii_letters, digits
 
 from easybuild.base import fancylogger
@@ -132,9 +134,15 @@ def import_available_modules(namespace):
     :param namespace: The namespace to import modules from.
     """
     modules = []
-    for path in sys.path:
 
-        cand_modpath_glob = os.path.sep.join([path] + namespace.split('.') + ['*.py'])
+    try:
+        mod = importlib.import_module(namespace)
+    except ImportError as err:
+        raise EasyBuildError("import_available_modules: Failed to import %s: %s", namespace, err)
+
+    for path in mod.__path__:
+
+        cand_modpath_glob = os.path.sep.join([path] + ['*.py'])
 
         # if sys.path entry being considered is the empty string
         # (which corresponds to Python packages/modules in current working directory being considered),


### PR DESCRIPTION
Possible fix for 

- #4451 