### PR TITLE
fix download progress bar

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -811,7 +811,7 @@ class EasyBlock:
             srcpaths = source_paths()
 
         # We don't account for the checksums file in the progress bar
-        if filename != 'checksum.json':
+        if filename != 'checksums.json':
             update_progress_bar(PROGRESS_BAR_DOWNLOAD_ALL, label=filename)
 
         if alt_location is None:


### PR DESCRIPTION
before:
```
Fetching files: 100% (4/3) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0:00:00 (nonexisting.patch)
ERROR: Installation of test.eb failed: "Couldn't find file nonexisting.patch anywhere, ...
```

after:
```
Fetching files: 100% (3/3) ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0:00:15 (nonexisting.patch)                                                                             
ERROR: Installation of test.eb failed: "Couldn't find file nonexisting.patch anywhere, ...
```

it still feels a bit weird to me that it shows 100% even though only 2/3 of the files have been obtained, but i'm not 100% sure..
i have a fix for that too, let me know if you want me to add it?