### PR TITLE
Support options for patch command

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2892,9 +2892,10 @@ class EasyBlock:
             srcpathsuffix = patch.get('sourcepath', patch.get('copy', ''))
             # determine whether 'patch' file should be copied rather than applied
             copy_patch = 'copy' in patch and 'sourcepath' not in patch
+            options = patch.get('opts', None)  # Extra options for patch command
 
-            self.log.debug("Source index: %s; patch level: %s; source path suffix: %s; copy patch: %s",
-                           srcind, level, srcpathsuffix, copy_patch)
+            self.log.debug("Source index: %s; patch level: %s; source path suffix: %s; copy patch: %s; options: %s",
+                           srcind, level, srcpathsuffix, copy_patch, options)
 
             if beginpath is None:
                 try:
@@ -2910,7 +2911,7 @@ class EasyBlock:
             src = os.path.abspath(weld_paths(beginpath, srcpathsuffix))
             self.log.debug("Applying patch %s in path %s", patch, src)
 
-            apply_patch(patch['path'], src, copy=copy_patch, level=level)
+            apply_patch(patch['path'], src, copy=copy_patch, level=level, options=options)
 
     def prepare_step(self, start_dir=True, load_tc_deps_modules=True):
         """

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -1894,6 +1894,12 @@ class FileToolsTest(EnhancedTestCase):
         # trying the patch again should fail
         self.assertErrorRegex(EasyBuildError, "Couldn't apply patch file", ft.apply_patch, toy_patch, path)
 
+        # Passing an option works
+        with self.mocked_stdout_stderr():
+            ft.apply_patch(toy_patch_gz, path, options=' --reverse')
+        # Change was really removed
+        self.assertNotIn(pattern, ft.read_file(os.path.join(path, 'toy-0.0', 'toy.source')))
+
         # test copying of files, both to an existing directory and a non-existing location
         test_file = os.path.join(self.test_prefix, 'foo.txt')
         ft.write_file(test_file, '123')


### PR DESCRIPTION
Allow to pass additional arguments to the `patch` command via the `options` dict key for patch specs

This is [documented](https://docs.easybuild.io/patch-files/#including-patches-in-an-easyconfig-file) but not implemented. I couldn't find if it ever was and got removed or never was.

Related: The key checked/used is documented is wrongly: https://github.com/easybuilders/easybuild-docs/pull/322