### PR TITLE
check whether `exts_defaultclass` is set after call to `prepare_for_extensions`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3176,13 +3176,13 @@ class EasyBlock:
             self.log.debug("No extensions in exts_list")
             return
 
-        # we really need a default class
-        if not self.cfg['exts_defaultclass'] and install:
-            raise EasyBuildError("ERROR: No default extension class set for %s", self.name)
-
         start_progress_bar(PROGRESS_BAR_EXTENSIONS, len(self.cfg.get_ref('exts_list')))
 
         self.prepare_for_extensions()
+
+        # we really need a default class
+        if not self.cfg['exts_defaultclass'] and install:
+            raise EasyBuildError("ERROR: No default extension class set for %s", self.name)
 
         if fetch:
             self.update_exts_progress_bar("fetching extension sources/patches")

--- a/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-2018a-test.eb
+++ b/test/framework/easyconfigs/test_ecs/t/toy/toy-0.0-gompi-2018a-test.eb
@@ -27,7 +27,6 @@ local_bar_buildopts = " && gcc bar.c -o anotherbar && "
 # used to check whether $TOY_LIBS_PATH is defined even when 'lib' subdirectory doesn't exist yet
 local_bar_buildopts += 'echo "TOY_EXAMPLES=$TOY_EXAMPLES" > %(installdir)s/toy_libs_path.txt'
 
-exts_defaultclass = 'DummyExtension'
 exts_list = [
     'ulimit',  # extension that is part of "standard library"
     ('bar', '0.0', {


### PR DESCRIPTION
fix for a regression introduced in #4868

building a Perl easyconfig fails with:
```
No default extension class set for Perl
```

because the check on `exts_defaultclass` was moved before the call to `prepare_for_extensions`