### PR TITLE
replace full trace message for extension check command with simple pass/fail message

### DIFF
--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -319,7 +319,7 @@ class Extension:
 
             msg = f"Extension sanity check command '{cmd}': "
             if cmd_res.exit_code == EasyBuildExit.SUCCESS:
-                trace_msg(msg + 'PASS')
+                trace_msg(msg + 'OK')
             else:
                 trace_msg(msg + 'FAIL')
                 if stdin:

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -43,6 +43,7 @@ from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_EASYBLOCK_RU
 from easybuild.tools.build_log import EasyBuildError, EasyBuildExit, raise_nosupport
 from easybuild.tools.filetools import change_dir
 from easybuild.tools.run import run_shell_cmd
+from easybuild.tools.utilities import trace_msg
 
 
 def resolve_exts_filter_template(exts_filter, ext):
@@ -314,9 +315,13 @@ class Extension:
             self.log.info("modulename set to False for '%s' extension, so skipping sanity check", self.name)
         elif exts_filter:
             cmd, stdin = resolve_exts_filter_template(exts_filter, self)
-            cmd_res = run_shell_cmd(cmd, fail_on_error=False, stdin=stdin)
+            cmd_res = run_shell_cmd(cmd, fail_on_error=False, stdin=stdin, hidden=True)
 
-            if cmd_res.exit_code != EasyBuildExit.SUCCESS:
+            msg = f"Extension sanity check command '{cmd}': "
+            if cmd_res.exit_code == EasyBuildExit.SUCCESS:
+                trace_msg(msg + 'PASS')
+            else:
+                trace_msg(msg + 'FAIL')
                 if stdin:
                     fail_msg = 'command "%s" (stdin: "%s") failed' % (cmd, stdin)
                 else:


### PR DESCRIPTION
This makes the output of the sanity check step of whole lot easier to digest.

For example, for `matplotlib-3.9.2-gfbf-2024a.eb`, instead of:
```
>> running shell command:
        /user/gent/400/vsc40023/eb_arcaninescratch/RHEL9/zen2-ib/software/Python/3.12.3-GCCcore-13.3.0/bin/python -c "import fontTools"
        [started at: 2025-05-23 09:15:17]
        [working dir: /arcanine/scratch/gent/vo/000/gvo00002/vsc40023/easybuild_tests/RHEL9/zen2-ib/software/matplotlib/3.9.2-gfbf-2024a]
        [output and state saved to /tmp/eb-sec1umjh/run-shell-cmd-output/python-khf3qko_]
  >> command completed: exit 0, ran in < 1s
  >> running shell command:
        /user/gent/400/vsc40023/eb_arcaninescratch/RHEL9/zen2-ib/software/Python/3.12.3-GCCcore-13.3.0/bin/python -c "import cycler"
        [started at: 2025-05-23 09:15:17]
        [working dir: /arcanine/scratch/gent/vo/000/gvo00002/vsc40023/easybuild_tests/RHEL9/zen2-ib/software/matplotlib/3.9.2-gfbf-2024a]
        [output and state saved to /tmp/eb-sec1umjh/run-shell-cmd-output/python-m_236t9m]
  >> command completed: exit 0, ran in < 1s
  >> running shell command:
        /user/gent/400/vsc40023/eb_arcaninescratch/RHEL9/zen2-ib/software/Python/3.12.3-GCCcore-13.3.0/bin/python -c "import kiwisolver"
        [started at: 2025-05-23 09:15:18]
        [working dir: /arcanine/scratch/gent/vo/000/gvo00002/vsc40023/easybuild_tests/RHEL9/zen2-ib/software/matplotlib/3.9.2-gfbf-2024a]
        [output and state saved to /tmp/eb-sec1umjh/run-shell-cmd-output/python-iqsl5h7s]
  >> command completed: exit 0, ran in < 1s
  >> running shell command:
        /user/gent/400/vsc40023/eb_arcaninescratch/RHEL9/zen2-ib/software/Python/3.12.3-GCCcore-13.3.0/bin/python -c "import contourpy"
        [started at: 2025-05-23 09:15:18]
        [working dir: /arcanine/scratch/gent/vo/000/gvo00002/vsc40023/easybuild_tests/RHEL9/zen2-ib/software/matplotlib/3.9.2-gfbf-2024a]
        [output and state saved to /tmp/eb-sec1umjh/run-shell-cmd-output/python-ug535xt5]
  >> command completed: exit 0, ran in < 1s
  >> running shell command:
        /user/gent/400/vsc40023/eb_arcaninescratch/RHEL9/zen2-ib/software/Python/3.12.3-GCCcore-13.3.0/bin/python -c "import matplotlib"
        [started at: 2025-05-23 09:15:19]
        [working dir: /arcanine/scratch/gent/vo/000/gvo00002/vsc40023/easybuild_tests/RHEL9/zen2-ib/software/matplotlib/3.9.2-gfbf-2024a]
        [output and state saved to /tmp/eb-sec1umjh/run-shell-cmd-output/python-kdjcjjbe]
  >> command completed: exit 0, ran in < 1s
```

we now get:
```
  >> Extension sanity check command '/user/gent/400/vsc40023/eb_arcaninescratch/RHEL9/zen2-ib/software/Python/3.12.3-GCCcore-13.3.0/bin/python -c "import fontTools"': OK
  >> Extension sanity check command '/user/gent/400/vsc40023/eb_arcaninescratch/RHEL9/zen2-ib/software/Python/3.12.3-GCCcore-13.3.0/bin/python -c "import cycler"': OK
  >> Extension sanity check command '/user/gent/400/vsc40023/eb_arcaninescratch/RHEL9/zen2-ib/software/Python/3.12.3-GCCcore-13.3.0/bin/python -c "import kiwisolver"': OK
  >> Extension sanity check command '/user/gent/400/vsc40023/eb_arcaninescratch/RHEL9/zen2-ib/software/Python/3.12.3-GCCcore-13.3.0/bin/python -c "import contourpy"': OK
  >> Extension sanity check command '/user/gent/400/vsc40023/eb_arcaninescratch/RHEL9/zen2-ib/software/Python/3.12.3-GCCcore-13.3.0/bin/python -c "import matplotlib"': OK
```