### PR TITLE
fix `fake_module_environment` context manager: make sure that cleanup of fake module is always done, even if an error was raised

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2289,11 +2289,12 @@ class EasyBlock:
 
         fake_mod_data = self.load_fake_module(purge=True, extra_modules=extra_modules)
 
-        yield
-
-        # cleanup (unload fake module, remove fake module dir)
-        if fake_mod_data:
-            self.clean_up_fake_module(fake_mod_data)
+        try:
+            yield
+        finally:
+            # cleanup (unload fake module, remove fake module dir)
+            if fake_mod_data:
+                self.clean_up_fake_module(fake_mod_data)
 
     def guess_start_dir(self):
         """


### PR DESCRIPTION
This fixes a problem when `--parallel-extensions-install` is used when extensions are involved that can't actually be installed in parallel, like with `Perl-5.34.1-GCCcore-11.3.0.eb`:
```
$ eb Perl-5.34.1-GCCcore-11.3.0.eb --parallel-extensions-install
== installing extension File::Listing 6.15 (2/383)...
== ... (took 1 min 8 secs)
== FAILED: Installation ended unsuccessfully: Module command '/usr/share/lmod/lmod/libexec/lmod python load Perl/5.34.1-GCCcore-11.3.0' failed with exit code 1; stderr: Lmod has detected the following error: These module(s) or extension(s) exist but cannot be loaded as requested: "Perl/5.34.1-GCCcore-11.3.0"
   Try: "module spider Perl/5.34.1-GCCcore-11.3.0" to see how to load the module(s).

If you don't understand the warning or error, contact the helpdesk at hpc@ugent.be
```

EasyBuild will naively always try to install extensions in parallel when the `--parallel-extensions-install` configuration setting is enabled, and only give up on that when a `NotImplementedError` is raised; see `EasyBlock.install_all_extensions`.
A `NotImplementedError` will be raised by the `install_extension_async` method for extensions other than R packages.

We should probably look into changing that, and only start installing extensions in parallel (via `EasyBlock.install_extensions_parallel`) if *all* extensions that should be installed actually support it. If not, the extensions should just be installed sequentially (via `EasyBlock.install_extensions_sequential`).
Doing that correctly requires additional work though, probably an extra method in `Extension` that declares whether installing in parallel is supported, or not.

The acute problem here is that this leaves the environment in an inconsistent state, because the fake module that was loaded when the asynchronous installation of the 1st extension was being launched will not be cleaned up.

This makes Lmod quite unhappy as soon as an attempt is made to prepare the environment for the installation of the 2nd extension, see error above.

This fix in this PR makes sure that the fake module that was loaded is correctly cleaned up, and then there's no problem when the extensions are being installed.

edit: opened two issues to follow-up on things that were uncovered while working out this fix:
* #4896
* #4897