### PR TITLE
also pass value of `fail_on_error` and `hidden` options of `run_shell_cmd` call down to pre/post `run_shell_cmd` hook

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -424,6 +424,8 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
         kwargs = {
             'interactive': interactive,
             'work_dir': work_dir,
+            'fail_on_error': fail_on_error,
+            'hidden': hidden,
         }
         hook_res = run_hook(RUN_SHELL_CMD, hooks, pre_step_hook=True, args=[cmd], kwargs=kwargs)
         if hook_res:
@@ -597,6 +599,8 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
             'stderr': res.stderr,
             'work_dir': res.work_dir,
             'shell_cmd_result': res,
+            'fail_on_error': fail_on_error,
+            'hidden': hidden,
         }
         run_hook(RUN_SHELL_CMD, hooks, post_step_hook=True, args=[cmd], kwargs=run_hook_kwargs)
 

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -2068,6 +2068,8 @@ class RunTest(EnhancedTestCase):
                     print("pre-run hook '%s' in %s" % (cmd, work_dir))
                     import sys
                     sys.stderr.write('pre-run hook done\\n')
+                print("command is allowed to fail: %s" % kwargs.get('fail_on_error', 'NOT AVAILABLE'))
+                print("command is hidden: %s" % kwargs.get('hidden', 'NOT AVAILABLE'))
                 if cmd != 'false' and not cmd.startswith('echo'):
                     cmds = cmd.split(';')
                     return '; '.join(cmds[:-1] + ["echo " + cmds[-1].lstrip()])
@@ -2081,6 +2083,8 @@ class RunTest(EnhancedTestCase):
                 else:
                     msg = "post-run hook '%s'" % cmd
                 msg += " (exit code: %s, output: '%s')" % (exit_code, output)
+                msg += "\\ncommand was allowed to fail: %s" % kwargs.get('fail_on_error', 'NOT AVAILABLE')
+                msg += "\\ncommand was hidden: %s" % kwargs.get('hidden', 'NOT AVAILABLE')
                 print(msg)
         """)
         write_file(hooks_file, hooks_file_txt)
@@ -2095,7 +2099,11 @@ class RunTest(EnhancedTestCase):
 
         expected_stdout = '\n'.join([
             f"pre-run hook 'make' in {cwd}",
+            "command is allowed to fail: True",
+            "command is hidden: False",
             "post-run hook 'echo make' (exit code: 0, output: 'make\n')",
+            "command was allowed to fail: True",
+            "command was hidden: False",
             '',
         ])
         self.assertEqual(stdout, expected_stdout)
@@ -2109,6 +2117,8 @@ class RunTest(EnhancedTestCase):
 
         expected_stdout = '\n'.join([
             "pre-run hook 'make' in %s" % cwd,
+            "command is allowed to fail: True",
+            "command is hidden: False",
             '  running shell command "echo make"',
             '  (in %s)' % cwd,
             '',
@@ -2135,8 +2145,14 @@ class RunTest(EnhancedTestCase):
                 pass
             stdout = self.get_stdout()
 
-        expected_last_line = "\npost-run hook 'false' (exit code: 1, output: '')\n"
-        self.assertTrue(stdout.endswith(expected_last_line), f"Stdout should end with '{expected_last_line}': {stdout}")
+        expected_end = '\n'.join([
+            '',
+            "post-run hook 'false' (exit code: 1, output: '')",
+            "command was allowed to fail: True",
+            "command was hidden: False",
+            '',
+        ])
+        self.assertTrue(stdout.endswith(expected_end), f"Stdout should end with '{expected_end}': {stdout}")
 
     def test_run_shell_cmd_delete_cwd(self):
         """


### PR DESCRIPTION
EasyBuild runs several "hidden" commands, and also sometimes runs commands that are allowed to fail.

Discriminating between these commands and "normal" commands like the ones that are part of an installation procedure could be interesting in `run_shell_cmd` hooks.