### PR TITLE
add EB configuration option to ignore unversioned (0.0.0) python packages

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -498,6 +498,8 @@ class EasyBuildOptions(GeneralOption):
             'ignore-checksums': ("Ignore failing checksum verification", None, 'store_true', False),
             'ignore-test-failure': ("Ignore a failing test step", None, 'store_true', False),
             'ignore-osdeps': ("Ignore any listed OS dependencies", None, 'store_true', False),
+            'ignore-pip-unversioned-pkgs': ("List of installed unversioned (0.0.0) python packages to ignore in the "
+                                            "sanity check", 'strlist', 'store', []),
             'insecure-download': ("Don't check the server certificate against the available certificate authorities.",
                                   None, 'store_true', False),
             'install-latest-eb-release': ("Install latest known version of easybuild", None, 'store_true', False),


### PR DESCRIPTION
useful when your OS has some packages installed that report a version of `0.0.0` (e.g. `kiwisolver` or `mpmath` in debian 12/ubuntu 24.04)

- [] companion PR: https://github.com/easybuilders/easybuild-easyblocks/pull/3753

needs tests adding