### PR TITLE
Add `required` argument to `get_cuda_cc_template_value`

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1968,17 +1968,22 @@ class EasyConfig:
                 res[key] = value
         return res
 
-    def get_cuda_cc_template_value(self, key):
+    def get_cuda_cc_template_value(self, key, required=True):
         """
         Get template value based on --cuda-compute-capabilities EasyBuild configuration option
         and cuda_compute_capabilities easyconfig parameter.
         Returns user-friendly error message in case neither are defined,
         or if an unknown key is used.
+
+        :param required: If False and the key is not found, return an empty string instead of raising an error.
         """
         if key.startswith('cuda_') and any(x == key for x in TEMPLATE_NAMES_DYNAMIC):
             try:
                 return self.template_values[key]
             except KeyError:
+                if not required:
+                    self.log.debug(f'Key {key} not found in template values, returning empty value')
+                    return ''
                 error_msg = "Template value '%s' is not defined!\n"
                 error_msg += "Make sure that either the --cuda-compute-capabilities EasyBuild configuration "
                 error_msg += "option is set, or that the cuda_compute_capabilities easyconfig parameter is defined."

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -5090,6 +5090,7 @@ class EasyConfigTest(EnhancedTestCase):
         }
         for key in cuda_template_values:
             self.assertErrorRegex(EasyBuildError, error_pattern % key, ec.get_cuda_cc_template_value, key)
+            self.assertEqual(ec.get_cuda_cc_template_value(key, required=False), '')
 
         update_build_option('cuda_compute_capabilities', ['6.5', '7.0'])
         ec = EasyConfig(self.eb_file)


### PR DESCRIPTION
In many places it isn't an error to have no CUDA compute capabilities. Having a parameter to handle this case allows to avoid having to check the EC parameter and the build option in every case causing potential inconsistencies.

With this we can do replacements like:
```diff
-        # list of CUDA compute capabilities to use can be specifed in two ways (where (2) overrules (1)):
-        # (1) in the easyconfig file, via the custom cuda_compute_capabilities;
-        # (2) in the EasyBuild configuration, via --cuda-compute-capabilities configuration option;
-        cuda_cc_list = build_option('cuda_compute_capabilities') or self.cfg['cuda_compute_capabilities'] or []
+        cuda_cc_list = self.cfg.get_cuda_cc_template_value("cuda_cc_space_sep", required=False).split()
```