### PR TITLE
make EasyBuild plugin-able through entrypoints

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -65,7 +65,7 @@ from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconf
 from easybuild.framework.easyconfig.templates import ALTERNATIVE_EASYCONFIG_TEMPLATES, DEPRECATED_EASYCONFIG_TEMPLATES
 from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS, TEMPLATE_NAMES_DYNAMIC, template_constant_dict
 from easybuild.tools import LooseVersion
-from easybuild.tools.entrypoints import get_easyblock_entrypoints, validate_easyblock_entrypoints
+from easybuild.tools.entrypoints import EntrypointEasyblock
 from easybuild.tools.build_log import EasyBuildError, EasyBuildExit, print_warning, print_msg
 from easybuild.tools.config import GENERIC_EASYBLOCK_PKG, LOCAL_VAR_NAMING_CHECK_ERROR, LOCAL_VAR_NAMING_CHECK_LOG
 from easybuild.tools.config import LOCAL_VAR_NAMING_CHECK_WARN
@@ -2041,9 +2041,15 @@ def get_easyblock_class(easyblock, name=None, error_on_failed_import=True, error
                           class_name, modulepath)
                 cls = get_class_for(modulepath, class_name)
             else:
-                modulepath = get_module_path(easyblock)
-                cls = get_class_for(modulepath, class_name)
-                _log.info("Derived full easyblock module path for %s: %s" % (class_name, modulepath))
+                eb_from_eps = EntrypointEasyblock.get_entrypoints(name=easyblock)
+                if eb_from_eps:
+                    ep = eb_from_eps[0]
+                    cls = ep.wrapped
+                    _log.info("Obtained easyblock class '%s' from entrypoint '%s'", easyblock, str(ep))
+                else:
+                    modulepath = get_module_path(easyblock)
+                    cls = get_class_for(modulepath, class_name)
+                    _log.info("Derived full easyblock module path for %s: %s" % (class_name, modulepath))
         else:
             # if no easyblock specified, try to find if one exists
             if name is None:
@@ -2129,14 +2135,6 @@ def get_module_path(name, generic=None, decode=True):
 
     if generic is None:
         generic = filetools.is_generic_easyblock(name)
-
-    invalid_eps = validate_easyblock_entrypoints()
-    if invalid_eps:
-        _log.warning("Invalid easyblock entrypoints found: %s", invalid_eps)
-        raise EasyBuildError("Invalid easyblock entrypoints found: %s", invalid_eps)
-    eb_from_eps = get_easyblock_entrypoints(name)
-    if eb_from_eps:
-        return list(eb_from_eps.keys())[0]
 
     # example: 'EB_VSC_minus_tools' should result in 'vsc_tools'
     if decode:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -2132,7 +2132,7 @@ def get_module_path(name, generic=None, decode=True):
 
     invalid_eps = validate_easyblock_entrypoints()
     if invalid_eps:
-        _log.error("Invalid easyblock entrypoints found: %s", invalid_eps)
+        _log.warning("Invalid easyblock entrypoints found: %s", invalid_eps)
         raise EasyBuildError("Invalid easyblock entrypoints found: %s", invalid_eps)
     eb_from_eps = get_easyblock_entrypoints(name)
     if eb_from_eps:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -2041,7 +2041,7 @@ def get_easyblock_class(easyblock, name=None, error_on_failed_import=True, error
                           class_name, modulepath)
                 cls = get_class_for(modulepath, class_name)
             else:
-                eb_from_eps = EntrypointEasyblock.get_entrypoints(name=easyblock)
+                eb_from_eps = EntrypointEasyblock.get_loaded_entrypoints(name=easyblock)
                 if eb_from_eps:
                     ep = eb_from_eps[0]
                     cls = ep.wrapped

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -65,6 +65,7 @@ from easybuild.framework.easyconfig.parser import fetch_parameters_from_easyconf
 from easybuild.framework.easyconfig.templates import ALTERNATIVE_EASYCONFIG_TEMPLATES, DEPRECATED_EASYCONFIG_TEMPLATES
 from easybuild.framework.easyconfig.templates import TEMPLATE_CONSTANTS, TEMPLATE_NAMES_DYNAMIC, template_constant_dict
 from easybuild.tools import LooseVersion
+from easybuild.tools.entrypoints import get_easyblock_entrypoints, validate_easyblock_entrypoints
 from easybuild.tools.build_log import EasyBuildError, EasyBuildExit, print_warning, print_msg
 from easybuild.tools.config import GENERIC_EASYBLOCK_PKG, LOCAL_VAR_NAMING_CHECK_ERROR, LOCAL_VAR_NAMING_CHECK_LOG
 from easybuild.tools.config import LOCAL_VAR_NAMING_CHECK_WARN
@@ -2128,6 +2129,14 @@ def get_module_path(name, generic=None, decode=True):
 
     if generic is None:
         generic = filetools.is_generic_easyblock(name)
+
+    invalid_eps = validate_easyblock_entrypoints()
+    if invalid_eps:
+        _log.error("Invalid easyblock entrypoints found: %s", invalid_eps)
+        raise EasyBuildError("Invalid easyblock entrypoints found: %s", invalid_eps)
+    eb_from_eps = get_easyblock_entrypoints(name)
+    if eb_from_eps:
+        return list(eb_from_eps.keys())[0]
 
     # example: 'EB_VSC_minus_tools' should result in 'vsc_tools'
     if decode:

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -54,6 +54,7 @@ from easybuild.framework.easyconfig.easyconfig import create_paths, det_file_inf
 from easybuild.framework.easyconfig.easyconfig import process_easyconfig
 from easybuild.framework.easyconfig.style import cmdline_easyconfigs_style_check
 from easybuild.tools import LooseVersion
+from easybuild.tools.entrypoints import validate_easyblock_entrypoints, get_easyblock_entrypoints
 from easybuild.tools.build_log import EasyBuildError, EasyBuildExit, print_error, print_msg, print_warning
 from easybuild.tools.config import build_option
 from easybuild.tools.environment import restore_env
@@ -798,6 +799,12 @@ def avail_easyblocks():
                                              easyblock_loc, class_names)
                     else:
                         raise EasyBuildError("Failed to determine easyblock class name for %s", easyblock_loc)
+
+    invalid_eps = validate_easyblock_entrypoints()
+    if invalid_eps:
+        _log.error("Found invalid easyblock entry points: %s", invalid_eps)
+        raise EasyBuildError("Found invalid easyblock entry points: %s", invalid_eps)
+    easyblocks.update(get_easyblock_entrypoints())
 
     return easyblocks
 

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -802,7 +802,7 @@ def avail_easyblocks():
 
     invalid_eps = validate_easyblock_entrypoints()
     if invalid_eps:
-        _log.error("Found invalid easyblock entry points: %s", invalid_eps)
+        _log.warning("Found invalid easyblock entry points: %s", invalid_eps)
         raise EasyBuildError("Found invalid easyblock entry points: %s", invalid_eps)
     easyblocks.update(get_easyblock_entrypoints())
 

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -800,7 +800,7 @@ def avail_easyblocks():
                     else:
                         raise EasyBuildError("Failed to determine easyblock class name for %s", easyblock_loc)
 
-    ept_eb_lst = EntrypointEasyblock.get_entrypoints()
+    ept_eb_lst = EntrypointEasyblock.get_loaded_entrypoints()
 
     for ept_eb in ept_eb_lst:
         easyblocks[ept_eb.module] = {

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -54,7 +54,7 @@ from easybuild.framework.easyconfig.easyconfig import create_paths, det_file_inf
 from easybuild.framework.easyconfig.easyconfig import process_easyconfig
 from easybuild.framework.easyconfig.style import cmdline_easyconfigs_style_check
 from easybuild.tools import LooseVersion
-from easybuild.tools.entrypoints import validate_easyblock_entrypoints, get_easyblock_entrypoints
+from easybuild.tools.entrypoints import EntrypointEasyblock
 from easybuild.tools.build_log import EasyBuildError, EasyBuildExit, print_error, print_msg, print_warning
 from easybuild.tools.config import build_option
 from easybuild.tools.environment import restore_env
@@ -800,11 +800,13 @@ def avail_easyblocks():
                     else:
                         raise EasyBuildError("Failed to determine easyblock class name for %s", easyblock_loc)
 
-    invalid_eps = validate_easyblock_entrypoints()
-    if invalid_eps:
-        _log.warning("Found invalid easyblock entry points: %s", invalid_eps)
-        raise EasyBuildError("Found invalid easyblock entry points: %s", invalid_eps)
-    easyblocks.update(get_easyblock_entrypoints())
+    ept_eb_lst = EntrypointEasyblock.get_entrypoints()
+
+    for ept_eb in ept_eb_lst:
+        easyblocks[ept_eb.module] = {
+            'class': ept_eb.name,
+            'loc': ept_eb.file,
+        }
 
     return easyblocks
 

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -353,6 +353,7 @@ BUILD_OPTIONS_CMDLINE = {
         'upload_test_report',
         'update_modules_tool_cache',
         'use_ccache',
+        'use_entrypoints',
         'use_existing_modules',
         'use_f90cache',
         'wait_on_lock_limit',

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -66,6 +66,7 @@ from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME, is_system
 from easybuild.tools.toolchain.utilities import search_toolchain
 from easybuild.tools.utilities import INDENT_2SPACES, INDENT_4SPACES
 from easybuild.tools.utilities import import_available_modules, mk_md_table, mk_rst_table, nub, quote_str
+from easybuild.tools.entrypoints import EASYBLOCK_ENTRYPOINT_MARK
 
 
 _log = fancylogger.getLogger('tools.docs')
@@ -724,6 +725,9 @@ def gen_list_easyblocks(list_easyblocks, format_strings):
     def add_class(classes, cls):
         """Add a new class, and all of its subclasses."""
         children = cls.__subclasses__()
+        # Filter out possible sublcasses coming from entrypoints as they will be readded letter
+        if not build_option('use_entrypoints', default=False):
+            children = [c for c in children if not hasattr(c, EASYBLOCK_ENTRYPOINT_MARK)]
         classes.update({cls.__name__: {
             'module': cls.__module__,
             'children': sorted([c.__name__ for c in children], key=lambda x: x.lower())

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -66,7 +66,6 @@ from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME, is_system
 from easybuild.tools.toolchain.utilities import search_toolchain
 from easybuild.tools.utilities import INDENT_2SPACES, INDENT_4SPACES
 from easybuild.tools.utilities import import_available_modules, mk_md_table, mk_rst_table, nub, quote_str
-from easybuild.tools.entrypoints import EASYBLOCK_ENTRYPOINT_MARK
 
 
 _log = fancylogger.getLogger('tools.docs')
@@ -725,9 +724,9 @@ def gen_list_easyblocks(list_easyblocks, format_strings):
     def add_class(classes, cls):
         """Add a new class, and all of its subclasses."""
         children = cls.__subclasses__()
-        # Filter out possible sublcasses coming from entrypoints as they will be readded letter
-        if not build_option('use_entrypoints', default=False):
-            children = [c for c in children if not hasattr(c, EASYBLOCK_ENTRYPOINT_MARK)]
+        # Filter out possible sublcasses coming from entrypoints based on build option
+        # if not build_option('use_entrypoints', default=False):
+        #     children = [c for c in children if not hasattr(c, EASYBLOCK_ENTRYPOINT_MARK)]
         classes.update({cls.__name__: {
             'module': cls.__module__,
             'children': sorted([c.__name__ for c in children], key=lambda x: x.lower())

--- a/easybuild/tools/docs.py
+++ b/easybuild/tools/docs.py
@@ -724,9 +724,6 @@ def gen_list_easyblocks(list_easyblocks, format_strings):
     def add_class(classes, cls):
         """Add a new class, and all of its subclasses."""
         children = cls.__subclasses__()
-        # Filter out possible sublcasses coming from entrypoints based on build option
-        # if not build_option('use_entrypoints', default=False):
-        #     children = [c for c in children if not hasattr(c, EASYBLOCK_ENTRYPOINT_MARK)]
         classes.update({cls.__name__: {
             'module': cls.__module__,
             'children': sorted([c.__name__ for c in children], key=lambda x: x.lower())

--- a/easybuild/tools/entrypoints.py
+++ b/easybuild/tools/entrypoints.py
@@ -47,11 +47,9 @@ def get_group_entrypoints(group: str):
                 _log.debug("`get_group_entrypoints` called before BuildOptions initialized, with python < 3.8")
         else:
             if HAVE_ENTRY_POINTS_CLS:
-                eps = entry_points(group=group)
-                res = set(eps)
+                res = set(entry_points(group=group))
             else:
-                eps = entry_points()
-                res = set(eps.get(group, []))
+                res = set(entry_points().get(group, []))
 
     return res
 

--- a/easybuild/tools/entrypoints.py
+++ b/easybuild/tools/entrypoints.py
@@ -78,7 +78,7 @@ class EasybuildEntrypoint:
             check = False
             try:
                 check = isinstance(wrap, self.expected_type) or issubclass(wrap, self.expected_type)
-            except:
+            except Exception:
                 pass
             if not check:
                 raise EasyBuildError(
@@ -176,6 +176,7 @@ class EntrypointHook(EasybuildEntrypoint):
             msg = f"Attempting to register unknown hook '{hook_name}'"
             _log.warning(msg)
             raise EasyBuildError(msg)
+
 
 class EntrypointEasyblock(EasybuildEntrypoint):
     """Class to represent an easyblock entrypoint."""

--- a/easybuild/tools/entrypoints.py
+++ b/easybuild/tools/entrypoints.py
@@ -7,7 +7,6 @@ Authors:
 import sys
 import importlib
 from easybuild.tools.config import build_option
-from typing import Callable, List
 
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError
@@ -23,6 +22,10 @@ if sys.version_info >= (3, 10):
     # Python >= 3.10 uses importlib.metadata.EntryPoints as a type for entry_points()
     HAVE_ENTRY_POINTS_CLS = True
 
+
+EASYBLOCK_ENTRYPOINT = "easybuild.easyblock"
+TOOLCHAIN_ENTRYPOINT = "easybuild.toolchain"
+HOOKS_ENTRYPOINT = "easybuild.hooks"
 
 _log = fancylogger.getLogger('entrypoints', fname=False)
 
@@ -54,220 +57,144 @@ def get_group_entrypoints(group: str):
     return res
 
 
-# EASYCONFIG_ENTRYPOINT = "easybuild.easyconfig"
-EASYBLOCK_ENTRYPOINT = "easybuild.easyblock"
-EASYBLOCK_ENTRYPOINT_MARK = "_is_easybuild_easyblock"
+class EasybuildEntrypoint:
+    _group = None
+    expected_type = None
+    registered = {}
 
-TOOLCHAIN_ENTRYPOINT = "easybuild.toolchain"
-TOOLCHAIN_ENTRYPOINT_MARK = "_is_easybuild_toolchain"
-TOOLCHAIN_ENTRYPOINT_PREPEND = "_prepend"
+    def __init__(self):
+        self.wrapped = None
 
-HOOKS_ENTRYPOINT = "easybuild.hooks"
-HOOKS_ENTRYPOINT_STEP = "_step"
-HOOKS_ENTRYPOINT_PRE_STEP = "_pre_step"
-HOOKS_ENTRYPOINT_POST_STEP = "_post_step"
-HOOKS_ENTRYPOINT_MARK = "_is_easybuild_hook"
-HOOKS_ENTRYPOINT_PRIORITY = "_priority"
+        self.module = None
+        self.name = None
+        self.file = None
 
+    def __repr__(self):
+        return f"{self.__class__.__name__} <{self.module}:{self.name}>"
 
-#########################################################################################
-# Easyblock entrypoints
-def register_easyblock_entrypoint():
-    """Decorator to register an easyblock entrypoint."""
-    def decorator(cls: type) -> type:
-        if not isinstance(cls, type):
-            raise EasyBuildError("Easyblock entrypoint `%s` is not a class", cls.__name__)
-        setattr(cls, EASYBLOCK_ENTRYPOINT_MARK, True)
-        _log.debug("Registering easyblock entrypoint: %s", cls.__name__)
-        return cls
+    def __call__(self, wrap):
+        """Use an instance of this class as a decorator to register an entrypoint."""
+        if self.expected_type is not None:
+            check = False
+            try:
+                check = isinstance(wrap, self.expected_type) or issubclass(wrap, self.expected_type)
+            except:
+                pass
+            if not check:
+                raise EasyBuildError(
+                    "Entrypoint '%s' expected type '%s', got '%s'",
+                    self.name, self.expected_type, type(wrap)
+                )
+        self.wrapped = wrap
+        self.module = getattr(wrap, '__module__', None)
+        self.name = getattr(wrap, '__name__', None)
+        if self.module:
+            mod = importlib.import_module(self.module)
+            self.file = getattr(mod, '__file__', None)
 
-    return decorator
+        grp = self.registered.setdefault(self.group, set())
 
+        for ep in grp:
+            if ep.name == self.name and ep.module != self.module:
+                raise ValueError(
+                    "Entrypoint '%s' already registered in group '%s' by module '%s' vs '%s'",
+                    self.name, self.group, ep.module, self.module
+                )
+        grp.add(self)
 
-def validate_easyblock_entrypoints() -> List[str]:
-    """Validate all easyblock entrypoints.
+        self.validate()
 
-    Returns:
-        List of invalid easyblocks.
-    """
-    invalid_easyblocks = []
-    for ep in get_group_entrypoints(EASYBLOCK_ENTRYPOINT):
-        full_name = f'{ep.name} <{ep.value}>'
+        _log.debug("Registered entrypoint: %s", self)
 
-        eb = ep.load()
-        if not hasattr(eb, EASYBLOCK_ENTRYPOINT_MARK):
-            invalid_easyblocks.append(full_name)
-            _log.warning(f"Easyblock {ep.name} <{ep.value}> is not a valid EasyBuild easyblock")
-            continue
+        return wrap
 
-        if not isinstance(eb, type):
-            _log.warning(f"Easyblock {ep.name} <{ep.value}> is not a class")
-            invalid_easyblocks.append(full_name)
-            continue
+    @property
+    def group(self):
+        if self._group is None:
+            raise EasyBuildError("Entrypoint group not set for %s", self.__class__.__name__)
+        return self._group
 
-    return invalid_easyblocks
+    @classmethod
+    def get_entrypoints(cls, name=None, **filter_params):
+        """Get all entrypoints in this group."""
+        for ep in get_group_entrypoints(cls._group):
+            try:
+                ep.load()
+            except Exception as e:
+                msg = f"Error loading entrypoint {ep}: {e}"
+                _log.error(msg)
+                raise EasyBuildError(msg) from e
 
+        entrypoints = []
+        for ep in cls.registered.get(cls._group, []):
+            cond = name is None or ep.name == name
+            for key, value in filter_params.items():
+                cond = cond and getattr(ep, key, None) == value
+            if cond:
+                entrypoints.append(ep)
 
-def get_easyblock_entrypoints(name=None) -> dict:
-    """Get all easyblock entrypoints.
+        return entrypoints
 
-    Returns:
-        List of easyblocks.
-    """
-    easyblocks = {}
-    for ep in get_group_entrypoints(EASYBLOCK_ENTRYPOINT):
-        try:
-            eb = ep.load()
-        except Exception as e:
-            _log.warning(f"Error loading easyblock entry point {ep.name}: {e}")
-            raise EasyBuildError(f"Error loading easyblock entry point {ep.name}: {e}")
-        mod = importlib.import_module(eb.__module__)
+    @staticmethod
+    def clear():
+        """Clear the registered entrypoints. Used for testing when the same entrypoint is loaded multiple times
+        from different temporary directories."""
+        EasybuildEntrypoint.registered.clear()
 
-        ptr = {
-            'class': eb.__name__,
-            'loc': mod.__file__,
-        }
-        easyblocks[f'{ep.module}'] = ptr
-    if name is not None:
-        for key, value in easyblocks.items():
-            if value['class'] == name:
-                return {key: value}
-            if key == name:
-                return {key: value}
-        return {}
-
-    return easyblocks
-
-
-#########################################################################################
-# Hooks entrypoints
-def register_entrypoint_hooks(step, pre_step=False, post_step=False, priority=0):
-    """Decorator to add metadata on functions to be used as hooks.
-
-    priority: integer, the priority of the hook, higher value means higher priority
-    """
-    def decorator(func):
-        setattr(func, HOOKS_ENTRYPOINT_MARK, True)
-        setattr(func, HOOKS_ENTRYPOINT_STEP, step)
-        setattr(func, HOOKS_ENTRYPOINT_PRE_STEP, pre_step)
-        setattr(func, HOOKS_ENTRYPOINT_POST_STEP, post_step)
-        setattr(func, HOOKS_ENTRYPOINT_PRIORITY, priority)
-
-        _log.info(
-            "Registering entry point hook '%s' 'pre=%s' 'post=%s' with priority %d",
-            func.__name__, pre_step, post_step, priority
-        )
-        return func
-    return decorator
+    def validate(self):
+        """Validate the entrypoint."""
+        if self.module is None or self.name is None:
+            raise EasyBuildError("Entrypoint `%s` has no module or name associated", self.wrapped)
 
 
-def validate_entrypoint_hooks(known_hooks: List[str], pre_prefix: str, post_prefix: str, suffix: str) -> List[str]:
-    """Validate all entrypoints hooks.
+class EntrypointHook(EasybuildEntrypoint):
+    """Class to represent a hook entrypoint."""
+    _group = HOOKS_ENTRYPOINT
 
-    Args:
-        known_hooks: List of known hooks.
-        pre_prefix: Prefix for pre hooks.
-        post_prefix: Prefix for post hooks.
-        suffix: Suffix for hooks.
+    def __init__(self, step, pre_step=False, post_step=False, priority=0):
+        """Initialize the EntrypointHook."""
+        super().__init__()
+        self.step = step
+        self.pre_step = pre_step
+        self.post_step = post_step
+        self.priority = priority
 
-    Returns:
-        List of invalid hooks.
-    """
-    invalid_hooks = []
-    for ep in get_group_entrypoints(HOOKS_ENTRYPOINT):
-        full_name = f'{ep.name} <{ep.value}>'
-
-        hook = ep.load()
-        if not hasattr(hook, HOOKS_ENTRYPOINT_MARK):
-            invalid_hooks.append(f"{ep.name} <{ep.value}>")
-            _log.warning(f"Hook {ep.name} <{ep.value}> is not a valid EasyBuild hook")
-            continue
-
-        if not callable(hook):
-            _log.warning(f"Hook {ep.name} <{ep.value}> is not callable")
-            invalid_hooks.append(full_name)
-            continue
-
-        label = getattr(hook, HOOKS_ENTRYPOINT_STEP)
-        pre_cond = getattr(hook, HOOKS_ENTRYPOINT_PRE_STEP)
-        post_cond = getattr(hook, HOOKS_ENTRYPOINT_POST_STEP)
+    def validate(self):
+        """Validate the hook entrypoint."""
+        from easybuild.tools.hooks import KNOWN_HOOKS, HOOK_SUFF, PRE_PREF, POST_PREF
+        super().validate()
 
         prefix = ''
-        if pre_cond:
-            prefix = pre_prefix
-        elif post_cond:
-            prefix = post_prefix
+        if self.pre_step:
+            prefix = PRE_PREF
+        elif self.post_step:
+            prefix = POST_PREF
 
-        hook_name = prefix + label + suffix
+        hook_name = f'{prefix}{self.step}{HOOK_SUFF}'
 
-        if hook_name not in known_hooks:
-            _log.warning(f"Hook {full_name} does not match known hooks patterns")
-            invalid_hooks.append(full_name)
-            continue
+        if hook_name not in KNOWN_HOOKS:
+            msg = f"Attempting to register unknown hook '{hook_name}'"
+            _log.warning(msg)
+            raise EasyBuildError(msg)
 
-    return invalid_hooks
+class EntrypointEasyblock(EasybuildEntrypoint):
+    """Class to represent an easyblock entrypoint."""
+    _group = EASYBLOCK_ENTRYPOINT
 
-
-def find_entrypoint_hooks(label, pre_step_hook=False, post_step_hook=False) -> List[Callable]:
-    """Get all hooks defined in entry points."""
-    hooks = []
-    for ep in get_group_entrypoints(HOOKS_ENTRYPOINT):
-        try:
-            hook = ep.load()
-        except Exception as e:
-            _log.warning(f"Error loading entry point {ep.name}: {e}")
-            raise EasyBuildError(f"Error loading entry point {ep.name}: {e}")
-
-        cond = all([
-            getattr(hook, HOOKS_ENTRYPOINT_STEP) == label,
-            getattr(hook, HOOKS_ENTRYPOINT_PRE_STEP) == pre_step_hook,
-            getattr(hook, HOOKS_ENTRYPOINT_POST_STEP) == post_step_hook,
-        ])
-        if cond:
-            hooks.append(hook)
-
-    return hooks
+    def __init__(self):
+        super().__init__()
+        # Avoid circular imports by importing EasyBlock here
+        from easybuild.framework.easyblock import EasyBlock
+        self.expected_type = EasyBlock
 
 
-#########################################################################################
-# Toolchain entrypoints
-def register_toolchain_entrypoint(prepend=False):
-    def decorator(cls):
+class EntrypointToolchain(EasybuildEntrypoint):
+    """Class to represent a toolchain entrypoint."""
+    _group = TOOLCHAIN_ENTRYPOINT
+
+    def __init__(self, prepend=False):
+        super().__init__()
+        # Avoid circular imports by importing Toolchain here
         from easybuild.tools.toolchain.toolchain import Toolchain
-        if not isinstance(cls, type) or not issubclass(cls, Toolchain):
-            raise EasyBuildError("Toolchain entrypoint `%s` is not a subclass of `Toolchain`", cls.__name__)
-        setattr(cls, TOOLCHAIN_ENTRYPOINT_MARK, True)
-        setattr(cls, TOOLCHAIN_ENTRYPOINT_PREPEND, prepend)
-
-        _log.debug("Registering toolchain entrypoint: %s", cls.__name__)
-        return cls
-
-    return decorator
-
-
-def get_toolchain_entrypoints():
-    """Get all toolchain entrypoints."""
-    toolchains = []
-    for ep in get_group_entrypoints(TOOLCHAIN_ENTRYPOINT):
-        try:
-            tc = ep.load()
-        except Exception as e:
-            _log.warning(f"Error loading toolchain entry point {ep.name}: {e}")
-            raise EasyBuildError(f"Error loading toolchain entry point {ep.name}: {e}")
-        toolchains.append(tc)
-    return toolchains
-
-
-def validate_toolchain_entrypoints() -> List[str]:
-    """Validate all toolchain entrypoints."""
-    invalid_toolchains = []
-    for ep in get_group_entrypoints(TOOLCHAIN_ENTRYPOINT):
-        full_name = f'{ep.name} <{ep.value}>'
-
-        tc = ep.load()
-        if not hasattr(tc, TOOLCHAIN_ENTRYPOINT_MARK):
-            invalid_toolchains.append(full_name)
-            _log.warning(f"Toolchain {ep.name} <{ep.value}> is not a valid EasyBuild toolchain")
-            continue
-
-    return invalid_toolchains
+        self.expected_type = Toolchain
+        self.prepend = prepend

--- a/easybuild/tools/entrypoints.py
+++ b/easybuild/tools/entrypoints.py
@@ -13,7 +13,9 @@ from typing import Callable
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError
 
+
 _log = fancylogger.getLogger('entrypoints', fname=False)
+
 
 def get_group_entrypoints(group: str) -> set[EntryPoint]:
     """Get all entrypoints for a group"""
@@ -23,8 +25,8 @@ def get_group_entrypoints(group: str) -> set[EntryPoint]:
         return set()
     return set(ep for ep in entry_points(group=group))
 
-# EASYCONFIG_ENTRYPOINT = "easybuild.easyconfig"
 
+# EASYCONFIG_ENTRYPOINT = "easybuild.easyconfig"
 EASYBLOCK_ENTRYPOINT = "easybuild.easyblock"
 EASYBLOCK_ENTRYPOINT_MARK = "_is_easybuild_easyblock"
 
@@ -39,7 +41,8 @@ HOOKS_ENTRYPOINT_POST_STEP = "_post_step"
 HOOKS_ENTRYPOINT_MARK = "_is_easybuild_hook"
 HOOKS_ENTRYPOINT_PRIORITY = "_priority"
 
-#########################################################################################3
+
+#########################################################################################
 # Easyblock entrypoints
 def register_easyblock_entrypoint():
     """Decorator to register an easyblock entrypoint."""
@@ -77,7 +80,7 @@ def validate_easyblock_entrypoints() -> list[str]:
     return invalid_easyblocks
 
 
-def get_easyblock_entrypoints(name = None) -> dict:
+def get_easyblock_entrypoints(name=None) -> dict:
     """Get all easyblock entrypoints.
 
     Returns:
@@ -97,9 +100,6 @@ def get_easyblock_entrypoints(name = None) -> dict:
             'loc': mod.__file__,
         }
         easyblocks[f'{ep.module}'] = ptr
-    # print('--' * 80)
-    # print(easyblocks)
-    # print('--' * 80)
     if name is not None:
         for key, value in easyblocks.items():
             if value['class'] == name:
@@ -109,6 +109,7 @@ def get_easyblock_entrypoints(name = None) -> dict:
         return {}
 
     return easyblocks
+
 
 #########################################################################################
 # Hooks entrypoints
@@ -183,9 +184,7 @@ def validate_entrypoint_hooks(known_hooks: list[str], pre_prefix: str, post_pref
 def find_entrypoint_hooks(label, pre_step_hook=False, post_step_hook=False) -> list[Callable]:
     """Get all hooks defined in entry points."""
     hooks = []
-    # print(f"--- Searching for entry point hooks with label: {label}, pre_step_hook: {pre_step_hook}, post_step_hook: {post_step_hook}")
     for ep in get_group_entrypoints(HOOKS_ENTRYPOINT):
-        # print(f"--- Processing entry point: {ep.name}")
         try:
             hook = ep.load()
         except Exception as e:
@@ -201,6 +200,7 @@ def find_entrypoint_hooks(label, pre_step_hook=False, post_step_hook=False) -> l
             hooks.append(hook)
 
     return hooks
+
 
 #########################################################################################
 # Toolchain entrypoints
@@ -228,8 +228,6 @@ def get_toolchain_entrypoints() -> set[EntryPoint]:
             _log.error(f"Error loading toolchain entry point {ep.name}: {e}")
             raise EasyBuildError(f"Error loading toolchain entry point {ep.name}: {e}")
         toolchains.append(tc)
-    # print(f"Found {len(toolchains)} toolchain entry points")
-    # print(f"Toolchain entry points: {toolchains}")
     return toolchains
 
 

--- a/easybuild/tools/entrypoints.py
+++ b/easybuild/tools/entrypoints.py
@@ -91,7 +91,7 @@ def get_easyblock_entrypoints(name=None) -> dict:
         try:
             eb = ep.load()
         except Exception as e:
-            _log.error(f"Error loading easyblock entry point {ep.name}: {e}")
+            _log.warning(f"Error loading easyblock entry point {ep.name}: {e}")
             raise EasyBuildError(f"Error loading easyblock entry point {ep.name}: {e}")
         mod = importlib.import_module(eb.__module__)
 
@@ -188,7 +188,7 @@ def find_entrypoint_hooks(label, pre_step_hook=False, post_step_hook=False) -> l
         try:
             hook = ep.load()
         except Exception as e:
-            _log.error(f"Error loading entry point {ep.name}: {e}")
+            _log.warning(f"Error loading entry point {ep.name}: {e}")
             raise EasyBuildError(f"Error loading entry point {ep.name}: {e}")
 
         cond = all([
@@ -225,7 +225,7 @@ def get_toolchain_entrypoints() -> set[EntryPoint]:
         try:
             tc = ep.load()
         except Exception as e:
-            _log.error(f"Error loading toolchain entry point {ep.name}: {e}")
+            _log.warning(f"Error loading toolchain entry point {ep.name}: {e}")
             raise EasyBuildError(f"Error loading toolchain entry point {ep.name}: {e}")
         toolchains.append(tc)
     return toolchains

--- a/easybuild/tools/entrypoints.py
+++ b/easybuild/tools/entrypoints.py
@@ -122,7 +122,7 @@ class EasybuildEntrypoint:
                 ep.load()
             except Exception as e:
                 msg = f"Error loading entrypoint {ep}: {e}"
-                _log.error(msg)
+                _log.warning(msg)
                 raise EasyBuildError(msg) from e
 
         entrypoints = []

--- a/easybuild/tools/entrypoints.py
+++ b/easybuild/tools/entrypoints.py
@@ -1,0 +1,248 @@
+"""Python module to manage entry points for EasyBuild.
+
+Authors:
+
+* Davide Grassano (CECAM)
+"""
+
+import importlib
+from importlib.metadata import EntryPoint, entry_points
+from easybuild.tools.config import build_option
+from typing import Callable
+
+from easybuild.base import fancylogger
+from easybuild.tools.build_log import EasyBuildError
+
+_log = fancylogger.getLogger('entrypoints', fname=False)
+
+def get_group_entrypoints(group: str) -> set[EntryPoint]:
+    """Get all entrypoints for a group"""
+    # print(f"--- Getting entry points for group: {group}")
+    # Default True needed to work with commands like --list-toolchains that do not initialize the BuildOptions
+    if not build_option('use_entrypoints', default=True):
+        return set()
+    return set(ep for ep in entry_points(group=group))
+
+# EASYCONFIG_ENTRYPOINT = "easybuild.easyconfig"
+
+EASYBLOCK_ENTRYPOINT = "easybuild.easyblock"
+EASYBLOCK_ENTRYPOINT_MARK = "_is_easybuild_easyblock"
+
+TOOLCHAIN_ENTRYPOINT = "easybuild.toolchain"
+TOOLCHAIN_ENTRYPOINT_MARK = "_is_easybuild_toolchain"
+TOOLCHAIN_ENTRYPOINT_PREPEND = "_prepend"
+
+HOOKS_ENTRYPOINT = "easybuild.hooks"
+HOOKS_ENTRYPOINT_STEP = "_step"
+HOOKS_ENTRYPOINT_PRE_STEP = "_pre_step"
+HOOKS_ENTRYPOINT_POST_STEP = "_post_step"
+HOOKS_ENTRYPOINT_MARK = "_is_easybuild_hook"
+HOOKS_ENTRYPOINT_PRIORITY = "_priority"
+
+#########################################################################################3
+# Easyblock entrypoints
+def register_easyblock_entrypoint():
+    """Decorator to register an easyblock entrypoint."""
+    def decorator(cls: type) -> type:
+        if not isinstance(cls, type):
+            raise EasyBuildError("Easyblock entrypoint `%s` is not a class", cls.__name__)
+        setattr(cls, EASYBLOCK_ENTRYPOINT_MARK, True)
+        _log.debug("Registering easyblock entrypoint: %s", cls.__name__)
+        return cls
+
+    return decorator
+
+
+def validate_easyblock_entrypoints() -> list[str]:
+    """Validate all easyblock entrypoints.
+
+    Returns:
+        List of invalid easyblocks.
+    """
+    invalid_easyblocks = []
+    for ep in get_group_entrypoints(EASYBLOCK_ENTRYPOINT):
+        full_name = f'{ep.name} <{ep.value}>'
+
+        eb = ep.load()
+        if not hasattr(eb, EASYBLOCK_ENTRYPOINT_MARK):
+            invalid_easyblocks.append(full_name)
+            _log.warning(f"Easyblock {ep.name} <{ep.value}> is not a valid EasyBuild easyblock")
+            continue
+
+        if not isinstance(eb, type):
+            _log.warning(f"Easyblock {ep.name} <{ep.value}> is not a class")
+            invalid_easyblocks.append(full_name)
+            continue
+
+    return invalid_easyblocks
+
+
+def get_easyblock_entrypoints(name = None) -> dict:
+    """Get all easyblock entrypoints.
+
+    Returns:
+        List of easyblocks.
+    """
+    easyblocks = {}
+    for ep in get_group_entrypoints(EASYBLOCK_ENTRYPOINT):
+        try:
+            eb = ep.load()
+        except Exception as e:
+            _log.error(f"Error loading easyblock entry point {ep.name}: {e}")
+            raise EasyBuildError(f"Error loading easyblock entry point {ep.name}: {e}")
+        mod = importlib.import_module(eb.__module__)
+
+        ptr = {
+            'class': eb.__name__,
+            'loc': mod.__file__,
+        }
+        easyblocks[f'{ep.module}'] = ptr
+    # print('--' * 80)
+    # print(easyblocks)
+    # print('--' * 80)
+    if name is not None:
+        for key, value in easyblocks.items():
+            if value['class'] == name:
+                return {key: value}
+            if key == name:
+                return {key: value}
+        return {}
+
+    return easyblocks
+
+#########################################################################################
+# Hooks entrypoints
+def register_entrypoint_hooks(step, pre_step=False, post_step=False, priority=0):
+    """Decorator to add metadata on functions to be used as hooks.
+
+    priority: integer, the priority of the hook, higher value means higher priority
+    """
+    def decorator(func):
+        setattr(func, HOOKS_ENTRYPOINT_MARK, True)
+        setattr(func, HOOKS_ENTRYPOINT_STEP, step)
+        setattr(func, HOOKS_ENTRYPOINT_PRE_STEP, pre_step)
+        setattr(func, HOOKS_ENTRYPOINT_POST_STEP, post_step)
+        setattr(func, HOOKS_ENTRYPOINT_PRIORITY, priority)
+
+        # Register the function as an entry point
+        _log.info(
+            "Registering entry point hook '%s' 'pre=%s' 'post=%s' with priority %d",
+            func.__name__, pre_step, post_step, priority
+        )
+        return func
+    return decorator
+
+
+def validate_entrypoint_hooks(known_hooks: list[str], pre_prefix: str, post_prefix: str, suffix: str) -> list[str]:
+    """Validate all entrypoints hooks.
+
+    Args:
+        known_hooks: List of known hooks.
+        pre_prefix: Prefix for pre hooks.
+        post_prefix: Prefix for post hooks.
+        suffix: Suffix for hooks.
+
+    Returns:
+        List of invalid hooks.
+    """
+    invalid_hooks = []
+    for ep in get_group_entrypoints(HOOKS_ENTRYPOINT):
+        full_name = f'{ep.name} <{ep.value}>'
+
+        hook = ep.load()
+        if not hasattr(hook, HOOKS_ENTRYPOINT_MARK):
+            invalid_hooks.append(f"{ep.name} <{ep.value}>")
+            _log.warning(f"Hook {ep.name} <{ep.value}> is not a valid EasyBuild hook")
+            continue
+
+        if not callable(hook):
+            _log.warning(f"Hook {ep.name} <{ep.value}> is not callable")
+            invalid_hooks.append(full_name)
+            continue
+
+        label = getattr(hook, HOOKS_ENTRYPOINT_STEP)
+        pre_cond = getattr(hook, HOOKS_ENTRYPOINT_PRE_STEP)
+        post_cond = getattr(hook, HOOKS_ENTRYPOINT_POST_STEP)
+
+        prefix = ''
+        if pre_cond:
+            prefix = pre_prefix
+        elif post_cond:
+            prefix = post_prefix
+
+        hook_name = prefix + label + suffix
+
+        if hook_name not in known_hooks:
+            _log.warning(f"Hook {full_name} does not match known hooks patterns")
+            invalid_hooks.append(full_name)
+            continue
+
+    return invalid_hooks
+
+
+def find_entrypoint_hooks(label, pre_step_hook=False, post_step_hook=False) -> list[Callable]:
+    """Get all hooks defined in entry points."""
+    hooks = []
+    # print(f"--- Searching for entry point hooks with label: {label}, pre_step_hook: {pre_step_hook}, post_step_hook: {post_step_hook}")
+    for ep in get_group_entrypoints(HOOKS_ENTRYPOINT):
+        # print(f"--- Processing entry point: {ep.name}")
+        try:
+            hook = ep.load()
+        except Exception as e:
+            _log.error(f"Error loading entry point {ep.name}: {e}")
+            raise EasyBuildError(f"Error loading entry point {ep.name}: {e}")
+
+        cond = all([
+            getattr(hook, HOOKS_ENTRYPOINT_STEP) == label,
+            getattr(hook, HOOKS_ENTRYPOINT_PRE_STEP) == pre_step_hook,
+            getattr(hook, HOOKS_ENTRYPOINT_POST_STEP) == post_step_hook,
+        ])
+        if cond:
+            hooks.append(hook)
+
+    return hooks
+
+#########################################################################################
+# Toolchain entrypoints
+def register_toolchain_entrypoint(prepend=False):
+    def decorator(cls):
+        from easybuild.tools.toolchain.toolchain import Toolchain
+        if not isinstance(cls, type) or not issubclass(cls, Toolchain):
+            raise EasyBuildError("Toolchain entrypoint `%s` is not a subclass of `Toolchain`", cls.__name__)
+        setattr(cls, TOOLCHAIN_ENTRYPOINT_MARK, True)
+        setattr(cls, TOOLCHAIN_ENTRYPOINT_PREPEND, prepend)
+
+        _log.debug("Registering toolchain entrypoint: %s", cls.__name__)
+        return cls
+
+    return decorator
+
+
+def get_toolchain_entrypoints() -> set[EntryPoint]:
+    """Get all toolchain entrypoints."""
+    toolchains = []
+    for ep in get_group_entrypoints(TOOLCHAIN_ENTRYPOINT):
+        try:
+            tc = ep.load()
+        except Exception as e:
+            _log.error(f"Error loading toolchain entry point {ep.name}: {e}")
+            raise EasyBuildError(f"Error loading toolchain entry point {ep.name}: {e}")
+        toolchains.append(tc)
+    # print(f"Found {len(toolchains)} toolchain entry points")
+    # print(f"Toolchain entry points: {toolchains}")
+    return toolchains
+
+
+def validate_toolchain_entrypoints() -> list[str]:
+    """Validate all toolchain entrypoints."""
+    invalid_toolchains = []
+    for ep in get_group_entrypoints(TOOLCHAIN_ENTRYPOINT):
+        full_name = f'{ep.name} <{ep.value}>'
+
+        tc = ep.load()
+        if not hasattr(tc, TOOLCHAIN_ENTRYPOINT_MARK):
+            invalid_toolchains.append(full_name)
+            _log.warning(f"Toolchain {ep.name} <{ep.value}> is not a valid EasyBuild toolchain")
+            continue
+
+    return invalid_toolchains

--- a/easybuild/tools/entrypoints.py
+++ b/easybuild/tools/entrypoints.py
@@ -10,7 +10,7 @@ from easybuild.tools.config import build_option
 
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError
-from typing import TypeVar, List, Callable, Set, Any
+from typing import TypeVar, List, Set, Any
 
 _T = TypeVar('_T')
 
@@ -169,6 +169,9 @@ class EntrypointHook(EasybuildEntrypoint):
         """Validate the hook entrypoint."""
         from easybuild.tools.hooks import KNOWN_HOOKS, HOOK_SUFF, PRE_PREF, POST_PREF
         super().validate()
+
+        if not callable(self.wrapped):
+            raise EasyBuildError("Hook entrypoint `%s` is not callable", self.wrapped)
 
         prefix = ''
         if self.pre_step:

--- a/easybuild/tools/entrypoints.py
+++ b/easybuild/tools/entrypoints.py
@@ -32,7 +32,8 @@ def get_group_entrypoints(group: str) -> Set[EntryPoint]:
         msg = "Python importlib.metadata requires Python >= 3.8"
         _log.warning(msg)
         raise EasyBuildError(msg)
-    return set(ep for ep in entry_points(group=group))
+    # Can't use the group keyword argument in entry_points() for Python < 3.10
+    return set(ep for ep in entry_points() if ep.group == group)
 
 
 # EASYCONFIG_ENTRYPOINT = "easybuild.easyconfig"

--- a/easybuild/tools/entrypoints.py
+++ b/easybuild/tools/entrypoints.py
@@ -7,13 +7,13 @@ Authors:
 
 import importlib
 from easybuild.tools.config import build_option
-from typing import Callable, List, Set
+from typing import Callable, List
 
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError
 
 try:
-    from importlib.metadata import entry_points, EntryPoint
+    from importlib.metadata import entry_points
 except ModuleNotFoundError:
     HAVE_ENTRY_POINTS = False
 else:
@@ -23,7 +23,7 @@ else:
 _log = fancylogger.getLogger('entrypoints', fname=False)
 
 
-def get_group_entrypoints(group: str) -> Set[EntryPoint]:
+def get_group_entrypoints(group: str):
     """Get all entrypoints for a group"""
     # Default True needed to work with commands like --list-toolchains that do not initialize the BuildOptions
     if not build_option('use_entrypoints', default=True):
@@ -227,7 +227,7 @@ def register_toolchain_entrypoint(prepend=False):
     return decorator
 
 
-def get_toolchain_entrypoints() -> Set[EntryPoint]:
+def get_toolchain_entrypoints():
     """Get all toolchain entrypoints."""
     toolchains = []
     for ep in get_group_entrypoints(TOOLCHAIN_ENTRYPOINT):

--- a/easybuild/tools/entrypoints.py
+++ b/easybuild/tools/entrypoints.py
@@ -1,3 +1,27 @@
+# #
+# Copyright 2009-2026 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+# #
 """Python module to manage entry points for EasyBuild.
 
 Authors:

--- a/easybuild/tools/hooks.py
+++ b/easybuild/tools/hooks.py
@@ -251,7 +251,9 @@ def run_hook(label, hooks, pre_step_hook=False, post_step_hook=False, args=None,
         _log.info("Running '%s' hook function (args: %s, keyword args: %s)...", hook.__name__, args, kwargs)
         res = hook(*args, **kwargs)
 
-    entrypoint_hooks = EntrypointHook.get_loaded_entrypoints(step=label, pre_step=pre_step_hook, post_step=post_step_hook)
+    entrypoint_hooks = EntrypointHook.get_loaded_entrypoints(
+        step=label, pre_step=pre_step_hook, post_step=post_step_hook
+    )
     if entrypoint_hooks:
         msg = "Running entry point %s hook..." % label
         if build_option('debug') and not build_option('silence_hook_trigger'):

--- a/easybuild/tools/hooks.py
+++ b/easybuild/tools/hooks.py
@@ -251,7 +251,7 @@ def run_hook(label, hooks, pre_step_hook=False, post_step_hook=False, args=None,
         _log.info("Running '%s' hook function (args: %s, keyword args: %s)...", hook.__name__, args, kwargs)
         res = hook(*args, **kwargs)
 
-    entrypoint_hooks = EntrypointHook.get_entrypoints(step=label, pre_step=pre_step_hook, post_step=post_step_hook)
+    entrypoint_hooks = EntrypointHook.get_loaded_entrypoints(step=label, pre_step=pre_step_hook, post_step=post_step_hook)
     if entrypoint_hooks:
         msg = "Running entry point %s hook..." % label
         if build_option('debug') and not build_option('silence_hook_trigger'):

--- a/easybuild/tools/hooks.py
+++ b/easybuild/tools/hooks.py
@@ -274,7 +274,7 @@ def run_hook(label, hooks, pre_step_hook=False, post_step_hook=False, args=None,
             try:
                 res = hook(*args, **kwargs)
             except Exception as e:
-                _log.error("Error running entry point '%s' hook: %s", hook.__name__, e)
+                _log.warning("Error running entry point '%s' hook: %s", hook.__name__, e)
                 raise EasyBuildError("Error running entry point '%s' hook: %s", hook.__name__, e) from e
 
     return res

--- a/easybuild/tools/hooks.py
+++ b/easybuild/tools/hooks.py
@@ -31,11 +31,9 @@ Authors:
 """
 import difflib
 import os
-from functools import wraps
 
 from easybuild.tools.entrypoints import (
     find_entrypoint_hooks, validate_entrypoint_hooks,
-    HOOKS_ENTRYPOINT_MARK, HOOKS_ENTRYPOINT_STEP, HOOKS_ENTRYPOINT_PRE_STEP, HOOKS_ENTRYPOINT_POST_STEP,
     HOOKS_ENTRYPOINT_PRIORITY
 )
 
@@ -269,7 +267,10 @@ def run_hook(label, hooks, pre_step_hook=False, post_step_hook=False, args=None,
             key=lambda x: (-getattr(x, HOOKS_ENTRYPOINT_PRIORITY, 0), x.__name__),
             )
         for hook in entrypoint_hooks:
-            _log.info("Running entry point '%s' hook function (args: %s, keyword args: %s)...", hook.__name__, args, kwargs)
+            _log.info(
+                "Running entry point '%s' hook function (args: %s, keyword args: %s)...",
+                hook.__name__, args, kwargs
+            )
             try:
                 res = hook(*args, **kwargs)
             except Exception as e:

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -110,6 +110,7 @@ from easybuild.tools.systemtools import DARWIN, UNKNOWN, check_python_version, g
 from easybuild.tools.systemtools import get_cpu_features, get_gpu_info, get_os_type, get_system_info
 from easybuild.tools.utilities import flatten
 from easybuild.tools.version import this_is_easybuild
+from easybuild.tools.entrypoints import EntrypointHook, EntrypointEasyblock, EntrypointToolchain
 
 
 try:
@@ -1663,6 +1664,30 @@ class EasyBuildOptions(GeneralOption):
                     opts_dict[opt] = (cur_opt_val, loc)
 
         pretty_print_opts(opts_dict)
+
+        if build_option('use_entrypoints', default=True):
+            hook_epts = EntrypointHook.get_entrypoints()
+            eb_epts = EntrypointEasyblock.get_entrypoints()
+            tc_epts = EntrypointToolchain.get_entrypoints()
+
+            if hook_epts:
+                print()
+                print("Hooks from entrypoints (%d):" % len(hook_epts))
+                for hook in hook_epts:
+                    print('-', hook)
+
+            if eb_epts:
+                print()
+                print("Easyblocks from entrypoints (%d):" % len(eb_epts))
+                for eb in eb_epts:
+                    print('-', eb)
+
+            if tc_epts:
+                print()
+                print("Toolchains from entrypoints (%d):" % len(tc_epts))
+                for tc in tc_epts:
+                    print('-', tc)
+
 
 
 def parse_options(args=None, with_include=True):

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -303,6 +303,9 @@ class EasyBuildOptions(GeneralOption):
             'stop': ("Stop the installation after certain step",
                      'choice', 'store_or_None', EXTRACT_STEP, 's', all_stops),
             'strict': ("Set strictness level", 'choice', 'store', WARN, strictness_options),
+            'use-entrypoints': (
+                "Use entry points for easyblocks, toolchains, and hooks", None, 'store_true', False,
+            ),
         })
 
         self.log.debug("basic_options: descr %s opts %s" % (descr, opts))

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1671,7 +1671,7 @@ class EasyBuildOptions(GeneralOption):
                 ('Easyblock', EntrypointEasyblock),
                 ('Toolchain', EntrypointToolchain),
             ]:
-                ept_list = cls.get_entrypoints()
+                ept_list = cls.retrieve_entrypoints()
                 if ept_list:
                     print()
                     print("%ss from entrypoints (%d):" % (prefix, len(ept_list)))

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1666,28 +1666,17 @@ class EasyBuildOptions(GeneralOption):
         pretty_print_opts(opts_dict)
 
         if build_option('use_entrypoints', default=True):
-            hook_epts = EntrypointHook.get_entrypoints()
-            eb_epts = EntrypointEasyblock.get_entrypoints()
-            tc_epts = EntrypointToolchain.get_entrypoints()
-
-            if hook_epts:
-                print()
-                print("Hooks from entrypoints (%d):" % len(hook_epts))
-                for hook in hook_epts:
-                    print('-', hook)
-
-            if eb_epts:
-                print()
-                print("Easyblocks from entrypoints (%d):" % len(eb_epts))
-                for eb in eb_epts:
-                    print('-', eb)
-
-            if tc_epts:
-                print()
-                print("Toolchains from entrypoints (%d):" % len(tc_epts))
-                for tc in tc_epts:
-                    print('-', tc)
-
+            for prefix, cls in [
+                ('Hook', EntrypointHook),
+                ('Easyblock', EntrypointEasyblock),
+                ('Toolchain', EntrypointToolchain),
+            ]:
+                ept_list = cls.get_entrypoints()
+                if ept_list:
+                    print()
+                    print("%ss from entrypoints (%d):" % (prefix, len(ept_list)))
+                    for ept in ept_list:
+                        print('-', ept)
 
 
 def parse_options(args=None, with_include=True):

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -168,7 +168,7 @@ class Toolchain:
     CLASS_CONSTANTS_TO_RESTORE = None
     CLASS_CONSTANT_COPIES = {}
 
-    # class method
+    @classmethod
     def _is_toolchain_for(cls, name):
         """see if this class can provide support for toolchain named name"""
         # TODO report later in the initialization the found version
@@ -180,8 +180,6 @@ class Toolchain:
         else:
             # is no name is supplied, check whether class can be used as a toolchain
             return bool(getattr(cls, 'NAME', None))
-
-    _is_toolchain_for = classmethod(_is_toolchain_for)
 
     def __init__(self, name=None, version=None, mns=None, class_constants=None, tcdeps=None, modtool=None,
                  hidden=False):

--- a/easybuild/tools/toolchain/utilities.py
+++ b/easybuild/tools/toolchain/utilities.py
@@ -42,7 +42,7 @@ import sys
 import easybuild.tools.toolchain
 from easybuild.tools.entrypoints import (
     get_toolchain_entrypoints, validate_toolchain_entrypoints,
-    TOOLCHAIN_ENTRYPOINT_PREPEND
+    TOOLCHAIN_ENTRYPOINT_PREPEND, TOOLCHAIN_ENTRYPOINT_MARK
 )
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError
@@ -112,6 +112,10 @@ def search_toolchain(name):
 
     # obtain all subclasses of toolchain
     found_tcs = nub(get_subclasses(Toolchain))
+
+    # Getting all subclasses will also include toolchains that are registered as entrypoints even if we are not
+    # using the `--use-entrypoints` option, so we filter them out here and re-add them later if needed.
+    found_tcs = [x for x in found_tcs if not hasattr(x, TOOLCHAIN_ENTRYPOINT_MARK)]
 
     invalid_eps = validate_toolchain_entrypoints()
     if invalid_eps:

--- a/easybuild/tools/toolchain/utilities.py
+++ b/easybuild/tools/toolchain/utilities.py
@@ -110,11 +110,11 @@ def search_toolchain(name):
 
     # Getting all subclasses will also include toolchains that are registered as entrypoints even if we are not
     # using the `--use-entrypoints` option, so we filter them out here and re-add them later if needed.
-    all_eps_names = [ep.wrapped.NAME for ep in EntrypointToolchain.get_entrypoints()]
+    all_eps_names = [ep.wrapped.NAME for ep in EntrypointToolchain.get_loaded_entrypoints()]
     found_tcs = [x for x in found_tcs if x.NAME not in all_eps_names]
 
-    prepend_eps = [_.wrapped for _ in EntrypointToolchain.get_entrypoints(prepend=True)]
-    append_eps = [_.wrapped for _ in EntrypointToolchain.get_entrypoints(prepend=False)]
+    prepend_eps = [_.wrapped for _ in EntrypointToolchain.get_loaded_entrypoints(prepend=True)]
+    append_eps = [_.wrapped for _ in EntrypointToolchain.get_loaded_entrypoints(prepend=False)]
     found_tcs = prepend_eps + found_tcs + append_eps
 
     # filter found toolchain subclasses based on whether they can be used a toolchains

--- a/easybuild/tools/toolchain/utilities.py
+++ b/easybuild/tools/toolchain/utilities.py
@@ -40,6 +40,10 @@ import re
 import sys
 
 import easybuild.tools.toolchain
+from easybuild.tools.entrypoints import (
+    get_toolchain_entrypoints, validate_toolchain_entrypoints,
+    TOOLCHAIN_ENTRYPOINT_MARK, TOOLCHAIN_ENTRYPOINT_PREPEND
+)
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.toolchain.toolchain import Toolchain
@@ -69,14 +73,17 @@ def search_toolchain(name):
 
         # make sure all defined toolchain constants are available in toolchain module
         tc_const_re = re.compile('^%s(.*)$' % TC_CONST_PREFIX)
+        # print(f'!! TC_MODULES: {tc_modules}')
         for tc_mod in tc_modules:
             # determine classes imported in this module
             mod_classes = []
             for elem in [getattr(tc_mod, x) for x in dir(tc_mod)]:
+                # print('-----', elem)
                 if hasattr(elem, '__module__'):
                     # exclude the toolchain class defined in that module
                     if not tc_mod.__file__ == sys.modules[elem.__module__].__file__:
                         elem_name = getattr(elem, '__name__', elem)
+                        # print(f"   Adding {elem_name} to list of imported classes used for looking for constants")
                         _log.debug("Adding %s to list of imported classes used for looking for constants", elem_name)
                         mod_classes.append(elem)
 
@@ -105,6 +112,19 @@ def search_toolchain(name):
 
     # obtain all subclasses of toolchain
     found_tcs = nub(get_subclasses(Toolchain))
+
+    invalid_eps = validate_toolchain_entrypoints()
+    if invalid_eps:
+        _log.warning("Invalid toolchain entrypoints found: %s", ', '.join(invalid_eps))
+        raise EasyBuildError("Invalid toolchain entrypoints found: %s", ', '.join(invalid_eps))
+    prepend_eps = []
+    append_eps = []
+    for tc in get_toolchain_entrypoints():
+        if getattr(tc, TOOLCHAIN_ENTRYPOINT_PREPEND):
+            prepend_eps.append(tc)
+        else:
+            append_eps.append(tc)
+    found_tcs = prepend_eps + found_tcs + append_eps
 
     # filter found toolchain subclasses based on whether they can be used a toolchains
     found_tcs = [tc for tc in found_tcs if tc._is_toolchain_for(None)]

--- a/easybuild/tools/toolchain/utilities.py
+++ b/easybuild/tools/toolchain/utilities.py
@@ -42,7 +42,7 @@ import sys
 import easybuild.tools.toolchain
 from easybuild.tools.entrypoints import (
     get_toolchain_entrypoints, validate_toolchain_entrypoints,
-    TOOLCHAIN_ENTRYPOINT_MARK, TOOLCHAIN_ENTRYPOINT_PREPEND
+    TOOLCHAIN_ENTRYPOINT_PREPEND
 )
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError

--- a/easybuild/tools/toolchain/utilities.py
+++ b/easybuild/tools/toolchain/utilities.py
@@ -78,7 +78,6 @@ def search_toolchain(name):
                     # exclude the toolchain class defined in that module
                     if not tc_mod.__file__ == sys.modules[elem.__module__].__file__:
                         elem_name = getattr(elem, '__name__', elem)
-                        # print(f"   Adding {elem_name} to list of imported classes used for looking for constants")
                         _log.debug("Adding %s to list of imported classes used for looking for constants", elem_name)
                         mod_classes.append(elem)
 

--- a/test/framework/entrypoints.py
+++ b/test/framework/entrypoints.py
@@ -1,5 +1,5 @@
 # #
-# Copyright 2013-2025 Ghent University
+# Copyright 2013-2026 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/test/framework/entrypoints.py
+++ b/test/framework/entrypoints.py
@@ -183,19 +183,19 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
 
     def setUp(self):
         """Set up the test environment."""
-        global FORMAT_DCT
-
-        FORMAT_DCT = {
-            'invalid_hook': '',
-            'invalid_easyblock': '',
-            'invalid_toolchain': '',
-        }
-
-        reload(eboptions)
-        super().setUp()
-        self.tmpdir = tempfile.mkdtemp(prefix='easybuild_test_')
-
         if HAVE_ENTRY_POINTS:
+            global FORMAT_DCT
+
+            FORMAT_DCT = {
+                'invalid_hook': '',
+                'invalid_easyblock': '',
+                'invalid_toolchain': '',
+            }
+
+            reload(eboptions)
+            super().setUp()
+            self.tmpdir = tempfile.mkdtemp(prefix='easybuild_test_')
+
             filename_root = "mock"
             dirname, dirpath = os.path.split(self.tmpdir)
 
@@ -211,15 +211,14 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
 
     def tearDown(self):
         """Clean up the test environment."""
-        super().tearDown()
-
-        try:
-            shutil.rmtree(self.tmpdir)
-        except OSError:
-            pass
-        tempfile.tempdir = None
-
         if HAVE_ENTRY_POINTS:
+            super().tearDown()
+
+            try:
+                shutil.rmtree(self.tmpdir)
+            except (OSError, IOError):
+                pass
+
             # Remove the entry point from the working set
             dirname, _ = os.path.split(self.tmpdir)
             if dirname in sys.path:

--- a/test/framework/entrypoints.py
+++ b/test/framework/entrypoints.py
@@ -1,0 +1,275 @@
+# #
+# Copyright 2013-2025 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+# #
+"""
+Unit tests for EasyBuild configuration.
+
+@author: Davide Grassano (CECAM - EPFL)
+"""
+
+import os
+import re
+import shutil
+import sys
+import tempfile
+from importlib import reload
+from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
+from unittest import TextTestRunner
+
+import easybuild.tools.options as eboptions
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.config import ERROR, IGNORE, WARN, BuildOptions, ConfigurationVariables
+from easybuild.tools.config import build_option, build_path, get_build_log_path, get_log_filename, get_repositorypath
+from easybuild.tools.config import install_path, log_file_format, log_path, source_paths
+from easybuild.tools.config import update_build_option, update_build_options
+from easybuild.tools.config import DEFAULT_PATH_SUBDIRS, init_build_options
+from easybuild.tools.filetools import copy_dir, mkdir, write_file
+from easybuild.tools.options import CONFIG_ENV_VAR_PREFIX
+from easybuild.tools.docs import list_easyblocks, list_software, list_toolchains
+from easybuild.tools.entrypoints import (
+    get_group_entrypoints, HOOKS_ENTRYPOINT, EASYBLOCK_ENTRYPOINT, TOOLCHAIN_ENTRYPOINT,
+    HAVE_ENTRY_POINTS
+)
+from easybuild.framework.easyconfig.easyconfig import get_module_path
+from easybuild.framework.easyblock import EasyBlock
+
+
+if HAVE_ENTRY_POINTS:
+    from importlib.metadata import DistributionFinder, Distribution
+
+
+MOCK_HOOK_EP_NAME = "mock_hook"
+MOCK_EASYBLOCK_EP_NAME = "mock_easyblock"
+MOCK_TOOLCHAIN_EP_NAME = "mock_toolchain"
+
+MOCK_HOOK = "hello_world"
+MOCK_EASYBLOCK = "TestEasyBlock"
+MOCK_TOOLCHAIN = "MockTc"
+
+
+MOCK_EP_FILE=f"""
+from easybuild.tools.entrypoints import register_entrypoint_hooks
+from easybuild.tools.hooks import CONFIGURE_STEP, START
+
+
+@register_entrypoint_hooks(START)
+def {MOCK_HOOK}():
+    print("Hello, World! ----------------------------------------")
+
+##########################################################################
+from easybuild.framework.easyblock import EasyBlock
+from easybuild.tools.entrypoints import register_easyblock_entrypoint
+
+@register_easyblock_entrypoint()
+class {MOCK_EASYBLOCK}(EasyBlock):
+    def configure_step(self):
+        print("{MOCK_EASYBLOCK}: configure_step called.")
+
+    def build_step(self):
+        print("{MOCK_EASYBLOCK}: build_step called.")
+
+    def install_step(self):
+        print("{MOCK_EASYBLOCK}: install_step called.")
+
+    def sanity_check_step(self):
+        print("{MOCK_EASYBLOCK}: sanity_check_step called.")
+
+##########################################################################
+from easybuild.tools.entrypoints import register_toolchain_entrypoint
+from easybuild.tools.toolchain.compiler import DEFAULT_OPT_LEVEL, Compiler
+from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
+
+TC_CONSTANT_MOCK = "Mock"
+
+class MockCompiler(Compiler):
+    COMPILER_FAMILY = TC_CONSTANT_MOCK
+    SUBTOOLCHAIN = SYSTEM_TOOLCHAIN_NAME
+
+@register_toolchain_entrypoint()
+class {MOCK_TOOLCHAIN}(MockCompiler):
+    NAME = '{MOCK_TOOLCHAIN}'  # Using `...tc` to distinguish toolchain from package
+    COMPILER_MODULE_NAME = [NAME]
+    SUBTOOLCHAIN = [SYSTEM_TOOLCHAIN_NAME]
+"""
+
+
+
+MOCK_EP_META_FILE = f"""
+[{HOOKS_ENTRYPOINT}]
+{MOCK_HOOK_EP_NAME} = {{module}}:hello_world
+
+[{EASYBLOCK_ENTRYPOINT}]
+{MOCK_EASYBLOCK_EP_NAME} = {{module}}:TestEasyBlock
+
+[{TOOLCHAIN_ENTRYPOINT}]
+{MOCK_TOOLCHAIN_EP_NAME} = {{module}}:MockTc
+"""
+
+
+class MockDistribution(Distribution):
+    """Mock distribution for testing entry points."""
+    def __init__(self, module):
+        self.module = module
+
+    def read_text(self, filename):
+        if filename == "entry_points.txt":
+            return MOCK_EP_META_FILE.format(module=self.module)
+
+        if filename == "METADATA":
+            return "Name: mock_hook\nVersion: 0.1.0\n"
+
+class MockDistributionFinder(DistributionFinder):
+    """Mock distribution finder for testing entry points."""
+    def __init__(self, *args, module, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.module = module
+
+    def find_distributions(self, context=None):
+        yield MockDistribution(self.module)
+
+
+class EasyBuildEntrypointsTest(EnhancedTestCase):
+    """Test cases for EasyBuild configuration."""
+
+    tmpdir = None
+
+    def setUp(self):
+        """Set up the test environment."""
+        reload(eboptions)
+        super().setUp()
+        self.tmpdir = tempfile.mkdtemp(prefix='easybuild_test_')
+
+        if HAVE_ENTRY_POINTS:
+            filename_root = "mock"
+            dirname, dirpath = os.path.split(self.tmpdir)
+
+            self.module = '.'.join([dirpath, filename_root])
+            sys.path.insert(0, dirname)
+            sys.meta_path.insert(0, MockDistributionFinder(module=self.module))
+
+            # Create a mock entry point for testing
+            mock_hook_file = os.path.join(self.tmpdir, f'{filename_root}.py')
+            write_file(mock_hook_file, MOCK_EP_FILE)
+
+    def tearDown(self):
+        """Clean up the test environment."""
+        if self.tmpdir and os.path.isdir(self.tmpdir):
+            shutil.rmtree(self.tmpdir)
+
+        if HAVE_ENTRY_POINTS:
+            # Remove the entry point from the working set
+            torm = []
+            for idx,cls in enumerate(sys.meta_path):
+                if isinstance(cls, MockDistributionFinder):
+                    torm.append(idx)
+            for idx in reversed(torm):
+                del sys.meta_path[idx]
+
+    def test_entrypoints_get_group_too_old_python(self):
+        """Test retrieving entrypoints for a specific group with too old Python version."""
+        if HAVE_ENTRY_POINTS:
+            self.skipTest("Entry points available in this Python version")
+        self.assertRaises(EasyBuildError, get_group_entrypoints, HOOKS_ENTRYPOINT)
+
+    def test_entrypoints_get_group(self):
+        """Test retrieving entrypoints for a specific group."""
+        if not HAVE_ENTRY_POINTS:
+            self.skipTest("Entry points not available in this Python version")
+
+        expected = {
+            HOOKS_ENTRYPOINT: MOCK_HOOK_EP_NAME,
+            EASYBLOCK_ENTRYPOINT: MOCK_EASYBLOCK_EP_NAME,
+            TOOLCHAIN_ENTRYPOINT: MOCK_TOOLCHAIN_EP_NAME,
+        }
+
+        # init_config()
+        for group in [HOOKS_ENTRYPOINT, EASYBLOCK_ENTRYPOINT, TOOLCHAIN_ENTRYPOINT]:
+            epts = get_group_entrypoints(group)
+            self.assertIsInstance(epts, set, f"Expected set for group {group}")
+            self.assertEqual(len(epts), 0, f"Expected non-empty set for group {group}")
+
+        init_config(build_options={'use_entrypoints': True})
+        for group in [HOOKS_ENTRYPOINT, EASYBLOCK_ENTRYPOINT, TOOLCHAIN_ENTRYPOINT]:
+            epts = get_group_entrypoints(group)
+            self.assertIsInstance(epts, set, f"Expected set for group {group}")
+            self.assertGreater(len(epts), 0, f"Expected non-empty set for group {group}")
+
+            loaded_names = [ep.name for ep in epts]
+            self.assertIn(expected[group], loaded_names, f"Expected entry point {expected[group]} in group {group}")
+
+    def test_entrypoints_list_easyblocks(self):
+        """
+        Tests for list_easyblocks function with entry points enabled.
+        """
+        if not HAVE_ENTRY_POINTS:
+            self.skipTest("Entry points not available in this Python version")
+
+        # init_config()
+        # print('-------', build_option('use_entrypoints', default='1234'))
+        txt = list_easyblocks()
+        self.assertNotIn("TestEasyBlock", txt, "TestEasyBlock should not be listed without entry points enabled")
+
+        init_config(build_options={'use_entrypoints': True})
+        txt = list_easyblocks()
+        self.assertIn("TestEasyBlock", txt, "TestEasyBlock should be listed with entry points enabled")
+
+    def test_entrypoints_list_toolchains(self):
+        """
+        Tests for list_toolchains function with entry points enabled.
+        """
+        if not HAVE_ENTRY_POINTS:
+            self.skipTest("Entry points not available in this Python version")
+
+        # init_config()
+        txt = list_toolchains()
+        self.assertNotIn(MOCK_TOOLCHAIN, txt, f"{MOCK_TOOLCHAIN} should not be listed without entry points enabled")
+
+        init_config(build_options={'use_entrypoints': True})
+
+        txt = list_toolchains()
+        self.assertIn(MOCK_TOOLCHAIN, txt, f"{MOCK_TOOLCHAIN} should be listed with entry points enabled")
+
+    def test_entrypoints_get_module_path(self):
+        """
+        Tests for get_module_path function with entry points enabled.
+        """
+        if not HAVE_ENTRY_POINTS:
+            self.skipTest("Entry points not available in this Python version")
+
+        module_path = get_module_path(MOCK_EASYBLOCK)
+        self.assertIn('.generic.', module_path, "Module path should contain '.generic.'")
+
+        init_config(build_options={'use_entrypoints': True})
+        # Reload the EasyBlock module to ensure it is recognized
+        module_path = get_module_path(MOCK_EASYBLOCK)
+        self.assertEqual(module_path, self.module, "Module path should match the mock module path")
+
+
+def suite():
+    return TestLoaderFiltered().loadTestsFromTestCase(EasyBuildEntrypointsTest, sys.argv[1:])
+
+
+if __name__ == '__main__':
+    res = TextTestRunner(verbosity=1).run(suite())
+    sys.exit(len(res.failures))

--- a/test/framework/entrypoints.py
+++ b/test/framework/entrypoints.py
@@ -37,13 +37,15 @@ from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_
 from unittest import TextTestRunner
 
 import easybuild.tools.options as eboptions
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import write_file
 from easybuild.tools.docs import list_easyblocks, list_toolchains
 from easybuild.tools.entrypoints import (
     get_group_entrypoints, HOOKS_ENTRYPOINT, EASYBLOCK_ENTRYPOINT, TOOLCHAIN_ENTRYPOINT,
-    HAVE_ENTRY_POINTS
+    HAVE_ENTRY_POINTS, EntrypointHook, EntrypointEasyblock, EntrypointToolchain,
 )
-from easybuild.framework.easyconfig.easyconfig import get_module_path
+from easybuild.framework.easyconfig.easyconfig import get_easyblock_class
+from easybuild.tools.hooks import START
 
 
 if HAVE_ENTRY_POINTS:
@@ -57,25 +59,28 @@ MOCK_HOOK_EP_NAME = "mock_hook"
 MOCK_EASYBLOCK_EP_NAME = "mock_easyblock"
 MOCK_TOOLCHAIN_EP_NAME = "mock_toolchain"
 
-MOCK_HOOK = "hello_world"
-MOCK_EASYBLOCK = "TestEasyBlock"
-MOCK_TOOLCHAIN = "MockTc"
+MOCK_HOOK = "hello_world_12412412"
+MOCK_EASYBLOCK = "TestEasyBlock_1212461"
+MOCK_TOOLCHAIN = "MockTc_352124671346"
 
 
 MOCK_EP_FILE = f"""
-from easybuild.tools.entrypoints import register_entrypoint_hooks
+from easybuild.tools.entrypoints import EntrypointHook
 from easybuild.tools.hooks import CONFIGURE_STEP, START
 
 
-@register_entrypoint_hooks(START)
+@EntrypointHook(START)
 def {MOCK_HOOK}():
     print("Hello, World! ----------------------------------------")
 
+def {MOCK_HOOK}_invalid():
+    print("This hook should not be registered, as it is invalid.")
+
 ##########################################################################
 from easybuild.framework.easyblock import EasyBlock
-from easybuild.tools.entrypoints import register_easyblock_entrypoint
+from easybuild.tools.entrypoints import EntrypointEasyblock
 
-@register_easyblock_entrypoint()
+@EntrypointEasyblock()
 class {MOCK_EASYBLOCK}(EasyBlock):
     def configure_step(self):
         print("{MOCK_EASYBLOCK}: configure_step called.")
@@ -89,8 +94,11 @@ class {MOCK_EASYBLOCK}(EasyBlock):
     def sanity_check_step(self):
         print("{MOCK_EASYBLOCK}: sanity_check_step called.")
 
+class {MOCK_EASYBLOCK}_invalid(EasyBlock):
+    pass
+
 ##########################################################################
-from easybuild.tools.entrypoints import register_toolchain_entrypoint
+from easybuild.tools.entrypoints import EntrypointToolchain
 from easybuild.tools.toolchain.compiler import DEFAULT_OPT_LEVEL, Compiler
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
 
@@ -100,24 +108,36 @@ class MockCompiler(Compiler):
     COMPILER_FAMILY = TC_CONSTANT_MOCK
     SUBTOOLCHAIN = SYSTEM_TOOLCHAIN_NAME
 
-@register_toolchain_entrypoint()
+@EntrypointToolchain()
 class {MOCK_TOOLCHAIN}(MockCompiler):
     NAME = '{MOCK_TOOLCHAIN}'  # Using `...tc` to distinguish toolchain from package
     COMPILER_MODULE_NAME = [NAME]
     SUBTOOLCHAIN = [SYSTEM_TOOLCHAIN_NAME]
+
+class {MOCK_TOOLCHAIN}_invalid(MockCompiler):
+    pass
 """
 
 
 MOCK_EP_META_FILE = f"""
 [{HOOKS_ENTRYPOINT}]
-{MOCK_HOOK_EP_NAME} = {{module}}:hello_world
+{MOCK_HOOK_EP_NAME} = {{module}}:{MOCK_HOOK}
+{{invalid_hook}}
 
 [{EASYBLOCK_ENTRYPOINT}]
-{MOCK_EASYBLOCK_EP_NAME} = {{module}}:TestEasyBlock
+{MOCK_EASYBLOCK_EP_NAME} = {{module}}:{MOCK_EASYBLOCK}
+{{invalid_easyblock}}
 
 [{TOOLCHAIN_ENTRYPOINT}]
-{MOCK_TOOLCHAIN_EP_NAME} = {{module}}:MockTc
+{MOCK_TOOLCHAIN_EP_NAME} = {{module}}:{MOCK_TOOLCHAIN}
+{{invalid_toolchain}}
 """
+
+FORMAT_DCT = {
+    'invalid_hook': '',
+    'invalid_easyblock': '',
+    'invalid_toolchain': '',
+}
 
 
 class MockDistribution(Distribution):
@@ -127,7 +147,7 @@ class MockDistribution(Distribution):
 
     def read_text(self, filename):
         if filename == "entry_points.txt":
-            return MOCK_EP_META_FILE.format(module=self.module)
+            return MOCK_EP_META_FILE.format(module=self.module, **FORMAT_DCT)
 
         if filename == "METADATA":
             return "Name: mock_hook\nVersion: 0.1.0\n"
@@ -148,11 +168,34 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
 
     tmpdir = None
 
+    def _run_mock_eb(self, args, strip=False, **kwargs):
+        """Helper function to mock easybuild runs
+
+        Return (stdout, stderr) optionally stripped of whitespace at start/end
+        """
+        with self.mocked_stdout_stderr() as (stdout, stderr):
+            self.eb_main(args, **kwargs)
+        stdout_txt = stdout.getvalue()
+        stderr_txt = stderr.getvalue()
+        if strip:
+            stdout_txt = stdout_txt.strip()
+            stderr_txt = stderr_txt.strip()
+        return stdout_txt, stderr_txt
+
     def setUp(self):
         """Set up the test environment."""
+        global FORMAT_DCT
+
+        FORMAT_DCT = {
+            'invalid_hook': '',
+            'invalid_easyblock': '',
+            'invalid_toolchain': '',
+        }
+
         reload(eboptions)
         super().setUp()
         self.tmpdir = tempfile.mkdtemp(prefix='easybuild_test_')
+
 
         if HAVE_ENTRY_POINTS:
             filename_root = "mock"
@@ -163,8 +206,8 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
             sys.meta_path.insert(0, MockDistributionFinder(module=self.module))
 
             # Create a mock entry point for testing
-            mock_hook_file = os.path.join(self.tmpdir, f'{filename_root}.py')
-            write_file(mock_hook_file, MOCK_EP_FILE)
+            self.mock_hook_file = os.path.join(self.tmpdir, f'{filename_root}.py')
+            write_file(self.mock_hook_file, MOCK_EP_FILE)
         else:
             self.skipTest("Entry points not available in this Python version")
 
@@ -172,20 +215,70 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
         """Clean up the test environment."""
         super().tearDown()
 
-        if self.tmpdir and os.path.isdir(self.tmpdir):
+        try:
             shutil.rmtree(self.tmpdir)
+        except OSError as err:
+            pass
+        tempfile.tempdir = None
 
         if HAVE_ENTRY_POINTS:
             # Remove the entry point from the working set
-            torm = []
             dirname, _ = os.path.split(self.tmpdir)
             if dirname in sys.path:
                 sys.path.remove(dirname)
+            torm = []
             for idx, cls in enumerate(sys.meta_path):
                 if isinstance(cls, MockDistributionFinder):
                     torm.append(idx)
             for idx in reversed(torm):
                 del sys.meta_path[idx]
+
+            EntrypointHook.clear()
+
+    def test_entrypoints_register_hook(self):
+        """Test registering entry point hooks with both valid and invalid hook names."""
+        func = lambda: None  # Dummy function
+
+        decorator = EntrypointHook('123')
+        with self.assertRaises(EasyBuildError):
+            decorator(func)
+
+        decorator = EntrypointHook(START, pre_step=True)
+        with self.assertRaises(EasyBuildError):
+            decorator(func)
+
+        decorator = EntrypointHook(START)
+        decorator(func)
+
+    def test_entrypoints_register_easyblock(self):
+        """Test registering entry point easyblocks with both valid and invalid easyblock names."""
+        from easybuild.framework.easyblock import EasyBlock
+        decorator = EntrypointEasyblock()
+
+        with self.assertRaises(EasyBuildError):
+            decorator(123)
+
+        class MOCK(): pass
+        with self.assertRaises(EasyBuildError):
+            decorator(MOCK)
+
+        class MOCK(EasyBlock): pass
+        decorator(MOCK)
+
+    def test_entrypoints_register_toolchain(self):
+        """Test registering entry point toolchains with both valid and invalid toolchain names."""
+        from easybuild.tools.toolchain.toolchain import Toolchain
+        decorator = EntrypointToolchain()
+
+        with self.assertRaises(EasyBuildError):
+            decorator(123)
+
+        class MOCK(): pass
+        with self.assertRaises(EasyBuildError):
+            decorator(MOCK)
+
+        class MOCK(Toolchain): pass
+        decorator(MOCK)
 
     def test_entrypoints_get_group(self):
         """Test retrieving entrypoints for a specific group."""
@@ -209,12 +302,40 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
             loaded_names = [ep.name for ep in epts]
             self.assertIn(expected[group], loaded_names, f"Expected entry point {expected[group]} in group {group}")
 
+    def test_entrypoints_exclude_invalid(self):
+        """Check that invalid entry points are excluded from the get_entrypoints function."""
+        init_config(build_options={'use_entrypoints': True})
+
+        # Check that the invalid hook is not registered
+
+        FORMAT_DCT['invalid_hook'] = f"{MOCK_HOOK_EP_NAME}_invalid = {self.module}:{MOCK_HOOK}_invalid"
+        FORMAT_DCT['invalid_easyblock'] = f"{MOCK_EASYBLOCK_EP_NAME}_invalid = {self.module}:{MOCK_EASYBLOCK}_invalid"
+        FORMAT_DCT['invalid_toolchain'] = f"{MOCK_TOOLCHAIN_EP_NAME}_invalid = {self.module}:{MOCK_TOOLCHAIN}_invalid"
+
+        hooks = EntrypointHook.get_entrypoints()
+        self.assertNotIn(
+            MOCK_HOOK + '_invalid', [ep.name for ep in hooks], "Invalid hook should not be registered"
+        )
+
+        # Check that the invalid easyblock is not registered
+        easyblocks = EntrypointEasyblock.get_entrypoints()
+        self.assertNotIn(
+            MOCK_EASYBLOCK + '_invalid', [ep.name for ep in easyblocks], "Invalid easyblock should not be registered"
+        )
+
+        # Check that the invalid toolchain is not registered
+        toolchains = EntrypointToolchain.get_entrypoints()
+        self.assertNotIn(
+            MOCK_TOOLCHAIN + '_invalid', [ep.name for ep in toolchains], "Invalid toolchain should not be registered"
+        )
+
     def test_entrypoints_list_easyblocks(self):
         """
         Tests for list_easyblocks function with entry points enabled.
         """
-        txt = list_easyblocks()
-        self.assertNotIn("TestEasyBlock", txt, "TestEasyBlock should not be listed without entry points enabled")
+        # Invalid EBs are still picked up as subclasses of EasyBlock, difficult to exclude them from this behavior
+        # txt = list_easyblocks()
+        # self.assertNotIn("TestEasyBlock", txt, "TestEasyBlock should not be listed without entry points enabled")
 
         init_config(build_options={'use_entrypoints': True})
         txt = list_easyblocks()
@@ -224,25 +345,43 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
         """
         Tests for list_toolchains function with entry points enabled.
         """
-        txt = list_toolchains()
-        self.assertNotIn(MOCK_TOOLCHAIN, txt, f"{MOCK_TOOLCHAIN} should not be listed without entry points enabled")
+        # Invalid TCs are still picked up as subclasses of Toolchain, difficult to exclude them from this behavior
+        # txt = list_toolchains()
+        # self.assertNotIn(MOCK_TOOLCHAIN, txt, f"{MOCK_TOOLCHAIN} should not be listed without entry points enabled")
 
         init_config(build_options={'use_entrypoints': True})
 
         txt = list_toolchains()
         self.assertIn(MOCK_TOOLCHAIN, txt, f"{MOCK_TOOLCHAIN} should be listed with entry points enabled")
 
-    def test_entrypoints_get_module_path(self):
+    def test_entrypoints_get_easyblock_class(self):
         """
-        Tests for get_module_path function with entry points enabled.
+        Tests for get_easyblock_class function with entry points enabled.
         """
-        module_path = get_module_path(MOCK_EASYBLOCK)
-        self.assertIn('.generic.', module_path, "Module path should contain '.generic.'")
+        with self.assertRaises(EasyBuildError):
+            get_easyblock_class(MOCK_EASYBLOCK)
+        # self.assertIn('.generic.', module_path, "Module path should contain '.generic.'")
 
         init_config(build_options={'use_entrypoints': True})
         # Reload the EasyBlock module to ensure it is recognized
-        module_path = get_module_path(MOCK_EASYBLOCK)
-        self.assertEqual(module_path, self.module, "Module path should match the mock module path")
+        cls = get_easyblock_class(MOCK_EASYBLOCK)
+        self.assertEqual(cls.__module__, self.module, "Module path should match the mock module path")
+
+    def test_entrypoints_show_config(self):
+        """Test that showing configuration includes entry points."""
+        args = ['--show-config']
+        stdout, stderr = self._run_mock_eb(args, strip=True)
+
+        for name in ['Hooks', 'Easyblocks', 'Toolchains']:
+            pattern = f"{name} from entrypoints ("
+            self.assertIn(pattern, stdout, f"Expected {name} in configuration output")
+
+        args = ['--show-full-config']
+        stdout, stderr = self._run_mock_eb(args, strip=True)
+
+        for name in ['Hooks', 'Easyblocks', 'Toolchains']:
+            pattern = f"{name} from entrypoints ("
+            self.assertIn(pattern, stdout, f"Expected {name} in configuration output")
 
 
 def suite():

--- a/test/framework/entrypoints.py
+++ b/test/framework/entrypoints.py
@@ -479,8 +479,12 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
             self.assertEqual(val, key == 'post_cfg', "Should only run post-configure hooks")
 
 
-def suite():
-    return TestLoaderFiltered().loadTestsFromTestCase(EasyBuildEntrypointsTest, sys.argv[1:])
+def suite(loader=None):
+    """ returns all the testcases in this module """
+    if loader:
+        return loader.loadTestsFromTestCase(EasyBuildEntrypointsTest)
+    else:
+        return TestLoaderFiltered().loadTestsFromTestCase(EasyBuildEntrypointsTest, sys.argv[1:])
 
 
 if __name__ == '__main__':

--- a/test/framework/entrypoints.py
+++ b/test/framework/entrypoints.py
@@ -170,12 +170,17 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
 
     def tearDown(self):
         """Clean up the test environment."""
+        super().tearDown()
+
         if self.tmpdir and os.path.isdir(self.tmpdir):
             shutil.rmtree(self.tmpdir)
 
         if HAVE_ENTRY_POINTS:
             # Remove the entry point from the working set
             torm = []
+            dirname, _ = os.path.split(self.tmpdir)
+            if dirname in sys.path:
+                sys.path.remove(dirname)
             for idx, cls in enumerate(sys.meta_path):
                 if isinstance(cls, MockDistributionFinder):
                     torm.append(idx)

--- a/test/framework/entrypoints.py
+++ b/test/framework/entrypoints.py
@@ -29,7 +29,6 @@ Unit tests for EasyBuild configuration.
 """
 
 import os
-import re
 import shutil
 import sys
 import tempfile
@@ -39,20 +38,13 @@ from unittest import TextTestRunner
 
 import easybuild.tools.options as eboptions
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.config import ERROR, IGNORE, WARN, BuildOptions, ConfigurationVariables
-from easybuild.tools.config import build_option, build_path, get_build_log_path, get_log_filename, get_repositorypath
-from easybuild.tools.config import install_path, log_file_format, log_path, source_paths
-from easybuild.tools.config import update_build_option, update_build_options
-from easybuild.tools.config import DEFAULT_PATH_SUBDIRS, init_build_options
-from easybuild.tools.filetools import copy_dir, mkdir, write_file
-from easybuild.tools.options import CONFIG_ENV_VAR_PREFIX
-from easybuild.tools.docs import list_easyblocks, list_software, list_toolchains
+from easybuild.tools.filetools import write_file
+from easybuild.tools.docs import list_easyblocks, list_toolchains
 from easybuild.tools.entrypoints import (
     get_group_entrypoints, HOOKS_ENTRYPOINT, EASYBLOCK_ENTRYPOINT, TOOLCHAIN_ENTRYPOINT,
     HAVE_ENTRY_POINTS
 )
 from easybuild.framework.easyconfig.easyconfig import get_module_path
-from easybuild.framework.easyblock import EasyBlock
 
 
 if HAVE_ENTRY_POINTS:
@@ -68,7 +60,7 @@ MOCK_EASYBLOCK = "TestEasyBlock"
 MOCK_TOOLCHAIN = "MockTc"
 
 
-MOCK_EP_FILE=f"""
+MOCK_EP_FILE = f"""
 from easybuild.tools.entrypoints import register_entrypoint_hooks
 from easybuild.tools.hooks import CONFIGURE_STEP, START
 
@@ -114,7 +106,6 @@ class {MOCK_TOOLCHAIN}(MockCompiler):
 """
 
 
-
 MOCK_EP_META_FILE = f"""
 [{HOOKS_ENTRYPOINT}]
 {MOCK_HOOK_EP_NAME} = {{module}}:hello_world
@@ -138,6 +129,7 @@ class MockDistribution(Distribution):
 
         if filename == "METADATA":
             return "Name: mock_hook\nVersion: 0.1.0\n"
+
 
 class MockDistributionFinder(DistributionFinder):
     """Mock distribution finder for testing entry points."""
@@ -180,7 +172,7 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
         if HAVE_ENTRY_POINTS:
             # Remove the entry point from the working set
             torm = []
-            for idx,cls in enumerate(sys.meta_path):
+            for idx, cls in enumerate(sys.meta_path):
                 if isinstance(cls, MockDistributionFinder):
                     torm.append(idx)
             for idx in reversed(torm):

--- a/test/framework/entrypoints.py
+++ b/test/framework/entrypoints.py
@@ -196,7 +196,6 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
         super().setUp()
         self.tmpdir = tempfile.mkdtemp(prefix='easybuild_test_')
 
-
         if HAVE_ENTRY_POINTS:
             filename_root = "mock"
             dirname, dirpath = os.path.split(self.tmpdir)
@@ -217,7 +216,7 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
 
         try:
             shutil.rmtree(self.tmpdir)
-        except OSError as err:
+        except OSError:
             pass
         tempfile.tempdir = None
 
@@ -237,7 +236,9 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
 
     def test_entrypoints_register_hook(self):
         """Test registering entry point hooks with both valid and invalid hook names."""
-        func = lambda: None  # Dummy function
+        # Dummy function
+        def func():
+            return
 
         decorator = EntrypointHook('123')
         with self.assertRaises(EasyBuildError):
@@ -258,11 +259,13 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
         with self.assertRaises(EasyBuildError):
             decorator(123)
 
-        class MOCK(): pass
+        class MOCK():
+            pass
         with self.assertRaises(EasyBuildError):
             decorator(MOCK)
 
-        class MOCK(EasyBlock): pass
+        class MOCK(EasyBlock):
+            pass
         decorator(MOCK)
 
     def test_entrypoints_register_toolchain(self):
@@ -273,11 +276,13 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
         with self.assertRaises(EasyBuildError):
             decorator(123)
 
-        class MOCK(): pass
+        class MOCK():
+            pass
         with self.assertRaises(EasyBuildError):
             decorator(MOCK)
 
-        class MOCK(Toolchain): pass
+        class MOCK(Toolchain):
+            pass
         decorator(MOCK)
 
     def test_entrypoints_get_group(self):

--- a/test/framework/entrypoints.py
+++ b/test/framework/entrypoints.py
@@ -405,6 +405,7 @@ class EasyBuildEntrypointsTest(EnhancedTestCase):
     def test_entrypoints_run_hook(self):
         """Ensure that entry point hooks are run in the correct order."""
         cnt = 0
+
         @EntrypointHook(START, priority=50)
         def func2_2():
             nonlocal cnt

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -52,6 +52,7 @@ import test.framework.easyconfigformat as ef
 import test.framework.easyconfigversion as ev
 import test.framework.easystack as es
 import test.framework.ebconfigobj as ebco
+import test.framework.entrypoints as epts
 import test.framework.environment as env
 import test.framework.docs as d
 import test.framework.filetools as f
@@ -112,7 +113,7 @@ except EasyBuildError as err:
 
 # call suite() for each module and then run them all
 # note: make sure the options unit tests run first, to avoid running some of them with a readily initialized config
-tests = [gen, d, bl, o, r, ef, ev, ebco, ep, e, mg, m, mt, f, run, a, robot, b, v, g, tcv, tc, t, c, s, lic, f_c,
+tests = [gen, d, bl, o, r, ef, ev, ebco, ep, epts, e, mg, m, mt, f, run, a, robot, b, v, g, tcv, tc, t, c, s, lic, f_c,
          tw, p, i, pkg, env, et, st, h, ct, lib, u, es, ou]
 
 


### PR DESCRIPTION
The proposed changes leverage [python EntryPoints](https://docs.python.org/3/library/importlib.metadata.html#importlib.metadata.EntryPoints) to allow injecting new functionalities in easybuild without touching the main repo

For now this is a demo of what could be possible implementing the following:

- `easybuild.toolchain` entrypoint to inject a toolchain into EasyBuild from a separate python package
- `easybuild.easyblock` entrypoint to inject a new easyblock into EasyBuild from a separate python package
- `easybuild.hooks` entrypoint to inject new hooks into EasyBuild from a separate python package

For easier error detection in the plugin package, the new `easybuild.tools.entrypoints` defines several `registed_XXX` decorators that needs to be used in order to pass the entrypoint validation.

An example of a python package that makes use of the proposed functionalities can be found in https://github.com/Crivella/test_eb_ep

Using entrypoints is not enabled by default and requires the `--use-entrypoints` flag to be passed to `eb` command.

## Possible upsides

- Simplifies extending EasyBuild functionalities without touching the main repo
- Could simplify working with/maintaining a customized local stack
  - In particular allowing running multiple hooks on the same step with ordering enforced by the priority can be useful
- Could allow to have a minimal version of easybuild that is extensible via modules

## Possible downsides

- Could promote fragmentation, with different packages providing different functionalities and less upstream contributions

## TODO

- [x] Add documentation on how to create a package that uses the entrypoints
  - https://github.com/easybuilders/easybuild-docs/pull/331 
- [x] Add tests

## MAYBE

- [ ] Add new entrypoints for other functionalities
- [x] Possibly rework current (demo) functionalities for better integration (for now i took what i felt was the path of least resistance to implement the demo)

## Notes

- `importlib.metadata` has been part of python only from `3.8` before the 3rd party `importlib-metadata` package would be required
- Currently for `docs.py` CLI options like `--list-easyblocks`  `--list-toolchains` and `--show-config` that are run before the build options are initialized, the default is to assume that `use_entrypoints` is `True`. At runtime when the hooks/easyblocks/toolchains need to be injected, this will only be performed if the options is actually set to `True`