### PR TITLE
Fix reporting of method name in `EasyBlock.run_step`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4662,8 +4662,11 @@ class EasyBlock:
         run_hook(step, self.hooks, pre_step_hook=True, args=[self])
 
         for step_method in step_methods:
+            # step_method is a lambda function that takes an EasyBlock instance as an argument,
+            # and returns the actual method
+            current_method = step_method(self)
             # Remove leading underscore from e.g. "_test_step"
-            method_name = '_'.join(step_method.__code__.co_names).lstrip('_')
+            method_name = current_method.__name__.lstrip('_')
             self.log.info("Running method %s part of step %s", method_name, step)
 
             if self.dry_run:
@@ -4671,9 +4674,7 @@ class EasyBlock:
 
                 # if an known possible error occurs, just report it and continue
                 try:
-                    # step_method is a lambda function that takes an EasyBlock instance as an argument,
-                    # and returns the actual method, so use () to execute it
-                    step_method(self)()
+                    current_method()
                 except Exception as err:
                     if build_option('extended_dry_run_ignore_errors'):
                         dry_run_warning("ignoring error %s" % err, silent=self.silent)
@@ -4682,9 +4683,7 @@ class EasyBlock:
                         raise
                 self.dry_run_msg('')
             else:
-                # step_method is a lambda function that takes an EasyBlock instance as an argument,
-                # and returns the actual method, so use () to execute it
-                step_method(self)()
+                current_method()
 
         run_hook(step, self.hooks, post_step_hook=True, args=[self])
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -42,7 +42,7 @@ from unittest import TextTestRunner
 
 import easybuild.tools.systemtools as st
 from easybuild.base import fancylogger
-from easybuild.framework.easyblock import EasyBlock, get_easyblock_instance
+from easybuild.framework.easyblock import EasyBlock, get_easyblock_instance, BUILD_STEP
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, ITERATE_OPTIONS
 from easybuild.framework.easyconfig.tools import avail_easyblocks, process_easyconfig
@@ -3554,6 +3554,43 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(getattr(file_log, 'logtofile_%s' % eb.logfile), False)
 
         os.remove(eb.logfile)
+
+    def test_report_current_step_method(self):
+        testdir = os.path.abspath(os.path.dirname(__file__))
+        toy_ec = os.path.join(testdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
+
+        class MockEasyBlock(EasyBlock):
+            # Mock methods
+            def build_step(self):
+                self.log.info('Ran build')
+
+            def test_step(self):
+                self.log.info('Ran test')
+
+            # New method for easy detection
+            def custom_step(self):
+                self.log.info('Ran custom')
+
+        eb = MockEasyBlock(EasyConfig(toy_ec))
+        # Part of run_all_steps
+        steps = [step for step in eb.get_steps() if step[0] == BUILD_STEP]
+        for step_name, _, step_methods, _ in steps:
+            with self.log_to_testlogfile():
+                eb.run_step(step_name, step_methods)
+        logtxt = read_file(self.logfile)
+        self.assertIn('Running method build_step', logtxt)
+        self.assertIn('Ran build', logtxt)
+
+        method_name = 'custom_step'
+        step_name = 'new name'
+        # Run multiple methods in one step, the custom step uses getattr similar to the Bundle easyblock
+        with self.log_to_testlogfile():
+            eb.run_step(step_name, [lambda x: x.test_step, lambda x: getattr(x, method_name)])
+        logtxt = read_file(self.logfile)
+        self.assertRegex(logtxt, f'Running method test_step .* {step_name}')
+        self.assertIn('Ran test', logtxt)
+        self.assertRegex(logtxt, f'Running method {method_name} .* {step_name}')
+        self.assertIn('Ran custom', logtxt)
 
 
 def suite():


### PR DESCRIPTION
The step method is a method returning the actual method. The `Bundle` easyblock uses a `getattr` call there instead of the method name.

As the reflection looks at local name(s) it will find the `getattr` instead of the actual method.

Access the `__name__` property of the returned function instead so we will always get the right name no matter how the lambda/method is defined.