### PR TITLE
Catch `HTTPException` when doing GitHub API request

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -44,6 +44,7 @@ import sys
 import tempfile
 import time
 from datetime import datetime, timedelta
+from http.client import HTTPException
 from string import ascii_letters
 from urllib.request import HTTPError, URLError, urlopen
 
@@ -281,7 +282,7 @@ def github_api_get_request(request_f, github_user=None, token=None, **kwargs):
 
     try:
         status, data = url.get(**kwargs)
-    except socket.gaierror as err:
+    except (socket.gaierror, HTTPException) as err:
         _log.warning("Error occurred while performing get request: %s", err)
         status, data = 0, None
 


### PR DESCRIPTION
The REST API (can?) use `http.client` via `request` which may fail at that level with a `HTTPException`.
E.g.:
> http.client.RemoteDisconnected: Remote end closed connection without response

Catch that to report better errors.

Example backtrace:

```
  File "/easybuild-framework/easybuild/tools/github.py", line 677, in fetch_easyblocks_from_pr
    return fetch_files_from_pr(pr, path, github_user, github_repo=GITHUB_EASYBLOCKS_REPO)
  File "/easybuild-framework/easybuild/tools/github.py", line 475, in cache_aware_func
    res = func(pr, path=path, github_user=github_user, github_account=github_account, github_repo=github_repo)
  File "/easybuild-framework/easybuild/tools/github.py", line 567, in fetch_files_from_pr
    status, data = github_api_get_request(pr_request_fn, github_user=github_user, headers=accept_diff)
  File "/easybuild-framework/easybuild/tools/github.py", line 283, in github_api_get_request
    status, data = url.get(**kwargs)
  File "/easybuild-framework/easybuild/base/rest.py", line 116, in get
    return self.request(self.GET, url, None, headers)
  File "/easybuild-framework/easybuild/base/rest.py", line 177, in request
    conn = self.get_connection(method, url, body, headers)
  File "/easybuild-framework/easybuild/base/rest.py", line 216, in get_connection
    connection = self.opener.open(request)
  File "/usr/lib64/python3.9/urllib/request.py", line 517, in open
    response = self._open(req, data)
  File "/usr/lib64/python3.9/urllib/request.py", line 534, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
  File "/usr/lib64/python3.9/urllib/request.py", line 494, in _call_chain
    result = func(*args)
  File "/usr/lib64/python3.9/urllib/request.py", line 1389, in https_open
    return self.do_open(http.client.HTTPSConnection, req,
  File "/usr/lib64/python3.9/urllib/request.py", line 1350, in do_open
    r = h.getresponse()
  File "/usr/lib64/python3.9/http/client.py", line 1377, in getresponse
    response.begin()
  File "/usr/lib64/python3.9/http/client.py", line 320, in begin
    version, status, reason = self._read_status()
  File "/usr/lib64/python3.9/http/client.py", line 289, in _read_status
    raise RemoteDisconnected("Remote end closed connection without"
http.client.RemoteDisconnected: Remote end closed connection without response
```