### PR TITLE
add `clean_dir` function, use it to try to empty install dir if removing it fails

### DIFF
--- a/easybuild/base/testing.py
+++ b/easybuild/base/testing.py
@@ -114,13 +114,13 @@ class TestCase(OrigTestCase):
             raise AssertionError("%s:\nDIFF%s:\n%s" % (msg, limit, ''.join(diff[:self.ASSERT_MAX_DIFF]))) from None
 
     def assertExists(self, path, msg=None):
-        """Assert the given path exists"""
+        """Assert that the given path exists"""
         if msg is None:
             msg = "'%s' should exist" % path
         self.assertTrue(os.path.exists(path), msg)
 
     def assertNotExists(self, path, msg=None):
-        """Assert the given path exists"""
+        """Assert that the given path does not exist"""
         if msg is None:
             msg = "'%s' should not exist" % path
         self.assertFalse(os.path.exists(path), msg)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1251,6 +1251,7 @@ class EasyBlock:
                     # empty the installation directory, but never remove it
                     empty_dir(dir_name)
                     self.log.info("Emptied old directory %s", dir_name)
+                    set_gid_sticky_bits(dir_name, set_gid, sticky, recursive=True)
                 else:
                     remove_dir(dir_name)
                     self.log.info("Removed old directory %s", dir_name)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -90,10 +90,10 @@ from easybuild.tools.config import install_path, log_path, package_path, source_
 from easybuild.tools.config import DATA, SOFTWARE
 from easybuild.tools.environment import restore_env, sanitize_env
 from easybuild.tools.filetools import CHECKSUM_TYPE_SHA256
-from easybuild.tools.filetools import adjust_permissions, apply_patch, back_up_file, change_dir, check_lock
+from easybuild.tools.filetools import adjust_permissions, apply_patch, back_up_file, change_dir, check_lock, clean_dir
 from easybuild.tools.filetools import compute_checksum, convert_name, copy_dir, copy_file, create_lock
 from easybuild.tools.filetools import create_non_existing_paths, create_patch_info, derive_alt_pypi_url, diff_files
-from easybuild.tools.filetools import download_file, clean_dir, encode_class_name, extract_file
+from easybuild.tools.filetools import download_file, encode_class_name, extract_file
 from easybuild.tools.filetools import find_backup_name_candidate, get_cwd, get_source_tarball_from_git, is_alt_pypi_url
 from easybuild.tools.filetools import is_binary, is_parent_path, is_sha256_checksum, mkdir, move_file, move_logs
 from easybuild.tools.filetools import read_file, remove_dir, remove_file, remove_lock, symlink, verify_checksum
@@ -1176,7 +1176,7 @@ class EasyBlock:
             pass
         elif self.build_in_installdir:
             # building in installation directory, so clean it
-            self.make_dir(self.builddir, self.cfg['cleanupoldbuild'], isinstalldir=True)
+            self.make_dir(self.builddir, self.cfg['cleanupoldbuild'], clean_instead_of_remove=True)
         else:
             # make sure we no longer sit in the build directory before removing it.
             change_dir(self.orig_workdir)
@@ -1229,7 +1229,7 @@ class EasyBlock:
         self.make_dir(self.installdir, self.cfg['cleanupoldinstall'], dontcreateinstalldir=dontcreate,
                       isinstalldir=True)
 
-    def make_dir(self, dir_name, clean, dontcreateinstalldir=False, isinstalldir=False):
+    def make_dir(self, dir_name, clean, dontcreateinstalldir=False, clean_instead_of_remove=False):
         """
         Create the directory.
         """
@@ -1247,7 +1247,7 @@ class EasyBlock:
                     backupdir = "%s.%s" % (dir_name, timestamp)
                     copy_dir(dir_name, backupdir)
                     self.log.info("Copied old directory %s to %s", dir_name, backupdir)
-                if isinstalldir:
+                if clean_instead_of_remove:
                     # clean the installation directory: first try to remove it; if that fails, empty it
                     clean_dir(dir_name)
                     self.log.info("Emptied old directory %s", dir_name)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1175,7 +1175,7 @@ class EasyBlock:
         if self.build_in_installdir and self.iter_idx > 0:
             pass
         elif self.build_in_installdir:
-            # building in installation directory, so empty it but don't remove it
+            # building in installation directory, so clean it
             self.make_dir(self.builddir, self.cfg['cleanupoldbuild'], isinstalldir=True)
         else:
             # make sure we no longer sit in the build directory before removing it.
@@ -1248,7 +1248,7 @@ class EasyBlock:
                     copy_dir(dir_name, backupdir)
                     self.log.info("Copied old directory %s to %s", dir_name, backupdir)
                 if isinstalldir:
-                    # empty the installation directory, but never remove it
+                    # clean the installation directory: first try to remove it; if that fails, empty it
                     clean_dir(dir_name)
                     self.log.info("Emptied old directory %s", dir_name)
                 else:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1174,13 +1174,11 @@ class EasyBlock:
         # see https://github.com/easybuilders/easybuild-framework/issues/2556
         if self.build_in_installdir and self.iter_idx > 0:
             pass
-        elif self.build_in_installdir:
-            # building in installation directory, so clean it
-            self.make_dir(self.builddir, self.cfg['cleanupoldbuild'], clean_instead_of_remove=True)
         else:
             # make sure we no longer sit in the build directory before removing it.
             change_dir(self.orig_workdir)
-            self.make_dir(self.builddir, self.cfg['cleanupoldbuild'])
+            # if we’re building in installation directory, clean it
+            self.make_dir(self.builddir, self.cfg['cleanupoldbuild'], clean_instead_of_remove=self.build_in_installdir)
 
         trace_msg("build dir: %s" % self.builddir)
 
@@ -1245,15 +1243,19 @@ class EasyBlock:
                     self.log.info("Creating backup of directory %s...", dir_name)
                     timestamp = time.strftime("%Y%m%d-%H%M%S")
                     backupdir = "%s.%s" % (dir_name, timestamp)
-                    copy_dir(dir_name, backupdir)
-                    self.log.info("Copied old directory %s to %s", dir_name, backupdir)
+                    if clean_instead_of_remove:
+                        copy_dir(dir_name, backupdir)
+                        self.log.info(f"Copied old directory {dir_name} to {backupdir}")
+                    else:
+                        move_file(dir_name, backupdir)
+                        self.log.info(f"Moved old directory {dir_name} to {backupdir}")
                 if clean_instead_of_remove:
                     # clean the installation directory: first try to remove it; if that fails, empty it
                     clean_dir(dir_name)
-                    self.log.info("Emptied old directory %s", dir_name)
+                    self.log.info(f"Cleaned old directory {dir_name}")
                 else:
                     remove_dir(dir_name)
-                    self.log.info("Removed old directory %s", dir_name)
+                    self.log.info(f"Removed old directory {dir_name}")
 
         if dontcreateinstalldir:
             olddir = dir_name

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1227,7 +1227,7 @@ class EasyBlock:
             self.cfg['keeppreviousinstall'] = True
         dontcreate = (dontcreate is None and self.cfg['dontcreateinstalldir']) or dontcreate
         self.make_dir(self.installdir, self.cfg['cleanupoldinstall'], dontcreateinstalldir=dontcreate,
-                      isinstalldir=True)
+                      clean_instead_of_remove=True)
 
     def make_dir(self, dir_name, clean, dontcreateinstalldir=False, clean_instead_of_remove=False):
         """

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1253,7 +1253,7 @@ class EasyBlock:
                     # clean the installation directory: first try to remove it; if that fails, empty it
                     clean_dir(dir_name)
                     self.log.info(f"Cleaned old directory {dir_name}")
-                else:
+                elif clean:
                     remove_dir(dir_name)
                     self.log.info(f"Removed old directory {dir_name}")
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -93,7 +93,7 @@ from easybuild.tools.filetools import CHECKSUM_TYPE_SHA256
 from easybuild.tools.filetools import adjust_permissions, apply_patch, back_up_file, change_dir, check_lock
 from easybuild.tools.filetools import compute_checksum, convert_name, copy_dir, copy_file, create_lock
 from easybuild.tools.filetools import create_non_existing_paths, create_patch_info, derive_alt_pypi_url, diff_files
-from easybuild.tools.filetools import download_file, empty_dir, encode_class_name, extract_file
+from easybuild.tools.filetools import download_file, clean_dir, encode_class_name, extract_file
 from easybuild.tools.filetools import find_backup_name_candidate, get_cwd, get_source_tarball_from_git, is_alt_pypi_url
 from easybuild.tools.filetools import is_binary, is_parent_path, is_sha256_checksum, mkdir, move_file, move_logs
 from easybuild.tools.filetools import read_file, remove_dir, remove_file, remove_lock, symlink, verify_checksum
@@ -1249,7 +1249,7 @@ class EasyBlock:
                     self.log.info("Copied old directory %s to %s", dir_name, backupdir)
                 if isinstalldir:
                     # empty the installation directory, but never remove it
-                    empty_dir(dir_name)
+                    clean_dir(dir_name)
                     self.log.info("Emptied old directory %s", dir_name)
                 else:
                     remove_dir(dir_name)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1251,7 +1251,6 @@ class EasyBlock:
                     # empty the installation directory, but never remove it
                     empty_dir(dir_name)
                     self.log.info("Emptied old directory %s", dir_name)
-                    set_gid_sticky_bits(dir_name, set_gid, sticky, recursive=True)
                 else:
                     remove_dir(dir_name)
                     self.log.info("Removed old directory %s", dir_name)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -380,7 +380,7 @@ def empty_dir(path):
     """Empty directory at specified path, keeping directory itself intact."""
     # early exit in 'dry run' mode
     if build_option('extended_dry_run'):
-        dry_run_msg("directory %s removed" % path, silent=build_option('silent'))
+        dry_run_msg("directory %s emptied" % path, silent=build_option('silent'))
         return
 
     if os.path.exists(path):

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -447,8 +447,8 @@ def clean_dir(path):
     """
     try:
         remove_dir(path)
-    except EasyBuildError:
-        _log.debug("Failed to remove directory %s, emptying it instead", path)
+    except EasyBuildError as err:
+        _log.debug(f"Removing directory {path} failed, will try to empty it instead: {err}")
         empty_dir(path)
 
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -440,6 +440,18 @@ def remove_dir(path):
                                  path, max_attempts, errors)
 
 
+def clean_dir(path):
+    """
+    Try to remove directory at specified path.
+    If that fails, empty directory instead.
+    """
+    try:
+        remove_dir(path)
+    except EasyBuildError:
+        _log.debug("Failed to remove directory %s, emptying it instead", path)
+        empty_dir(path)
+
+
 def remove(paths):
     """
     Remove single file/directory or list of files and directories

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -402,7 +402,7 @@ def empty_dir(path):
                 errors.append(err)
                 time.sleep(2)
                 # make sure write permissions are enabled on entire directory
-                adjust_permissions(path, stat.S_IWUSR, add=True, recursive=True, ignore_root=True)
+                adjust_permissions(path, stat.S_IWUSR, add=True, recursive=True)
         if ok:
             _log.info("Path %s successfully emptied." % path)
         else:
@@ -1892,7 +1892,7 @@ def convert_name(name, upper=False):
 
 
 def adjust_permissions(provided_path, permission_bits, add=True, onlyfiles=False, onlydirs=False, recursive=True,
-                       group_id=None, relative=True, ignore_errors=False, ignore_root=False):
+                       group_id=None, relative=True, ignore_errors=False):
     """
     Change permissions for specified path, using specified permission bits
 
@@ -1904,24 +1904,16 @@ def adjust_permissions(provided_path, permission_bits, add=True, onlyfiles=False
     :param relative: add/remove permissions relative to current permissions (if False, hard set specified permissions)
     :param ignore_errors: ignore errors that occur when changing permissions
                           (up to a maximum ratio specified by --max-fail-ratio-adjust-permissions configuration option)
-    :param ignore_root: don’t change the permissions of the root path (provided_path)
 
     Add or remove (if add is False) permission_bits from all files (if onlydirs is False)
     and directories (if onlyfiles is False) in path
     """
 
-    if not recursive and ignore_root:
-        _log.info("Not adjusting permissions for %s (no recursion and ignoring root)", provided_path)
-        return
-
     provided_path = os.path.abspath(provided_path)
 
     if recursive:
         _log.info("Adjusting permissions recursively for %s", provided_path)
-        if ignore_root:
-            allpaths = []
-        else:
-            allpaths = [provided_path]
+        allpaths = [provided_path]
         for root, dirs, files in os.walk(provided_path):
             paths = []
             if not onlydirs:

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2563,6 +2563,7 @@ class FileToolsTest(EnhancedTestCase):
         self.assertNotExists(testfile)
         self.assertNotExists(testfile_hidden)
         self.assertNotExists(test_link)
+        self.assertNotExists(test_subdir)
 
         # also test behaviour under --dry-run
         build_options = {
@@ -2655,6 +2656,25 @@ class FileToolsTest(EnhancedTestCase):
             self.assertTrue(regex.match(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
 
         ft.adjust_permissions(self.test_prefix, stat.S_IWUSR, add=True)
+
+    def test_clean_dir(self):
+        """Test clean_dir function"""
+        test_dir = os.path.join(self.test_prefix, 'test123')
+        testfile = os.path.join(test_dir, 'foo')
+        testfile_hidden = os.path.join(test_dir, '.foo')
+        test_link = os.path.join(test_dir, 'foolink')
+        test_subdir = os.path.join(test_dir, 'foodir')
+
+        ft.mkdir(test_subdir, parents=True)
+        ft.write_file(testfile, 'bar')
+        ft.write_file(testfile_hidden, 'bar')
+        ft.symlink(testfile, test_link)
+        ft.clean_dir(test_dir)
+        ft.mkdir(test_dir, parents=True)
+        self.assertNotExists(testfile)
+        self.assertNotExists(testfile_hidden)
+        self.assertNotExists(test_link)
+        self.assertNotExists(test_subdir)
 
     def test_index_functions(self):
         """Test *_index functions."""

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2554,7 +2554,7 @@ class FileToolsTest(EnhancedTestCase):
         test_link = os.path.join(test_dir, 'foolink')
         test_subdir = os.path.join(test_dir, 'foodir')
 
-        ft.mkdir(test_subdir)
+        ft.mkdir(test_subdir, parents=True)
         ft.write_file(testfile, 'bar')
         ft.write_file(testfile_hidden, 'bar')
         ft.symlink(testfile, test_link)

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2546,6 +2546,40 @@ class FileToolsTest(EnhancedTestCase):
         self.assertFalse(stderr)
         self.assertFalse(stdout)
 
+    def test_empty_dir(self):
+        """Test empty_dir function"""
+        test_dir = os.path.join(self.test_prefix, 'test123')
+        testfile = os.path.join(test_dir, 'foo')
+        testfile_hidden = os.path.join(test_dir, '.foo')
+        test_link = os.path.join(test_dir, 'foolink')
+        test_subdir = os.path.join(test_dir, 'foodir')
+
+        ft.mkdir(test_subdir)
+        ft.write_file(testfile, 'bar')
+        ft.write_file(testfile_hidden, 'bar')
+        ft.symlink(testfile, test_link)
+        ft.empty_dir(test_dir)
+        self.assertExists(test_dir)
+        self.assertNotExists(testfile)
+        self.assertNotExists(testfile_hidden)
+        self.assertNotExists(test_link)
+
+        # also test behaviour under --dry-run
+        build_options = {
+            'extended_dry_run': True,
+            'silent': False,
+        }
+        init_config(build_options=build_options)
+
+        self.mock_stdout(True)
+        ft.mkdir(test_dir)
+        ft.empty_dir(test_dir)
+        txt = self.get_stdout()
+        self.mock_stdout(False)
+
+        regex = re.compile("^directory [^ ]* emptied$")
+        self.assertTrue(regex.match(txt), f"Pattern '{regex.pattern}' found in: {txt}")
+
     def test_remove(self):
         """Test remove_file, remove_dir and join remove functions."""
         testfile = os.path.join(self.test_prefix, 'foo')

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -798,9 +798,6 @@ class ToyBuildTest(EnhancedTestCase):
             self.assertFalse(perms & stat.S_ISVTX, "no sticky bit on %s" % fullpath)
 
         # git/sticky bits are set, but only on (re)created directories
-        # first remove install dir because it is not recreated
-        toy_installdir = os.path.join(self.test_installpath, *subdirs[3][0])
-        remove_dir(toy_installdir)
         self.run_test_toy_build_with_output(extra_args=['--set-gid-bit', '--sticky-bit'])
         for subdir, bits_set in subdirs:
             fullpath = os.path.join(self.test_installpath, *subdir)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -798,6 +798,9 @@ class ToyBuildTest(EnhancedTestCase):
             self.assertFalse(perms & stat.S_ISVTX, "no sticky bit on %s" % fullpath)
 
         # git/sticky bits are set, but only on (re)created directories
+        # first remove install dir because it is not recreated
+        toy_installdir = os.path.join(self.test_installpath, *subdirs[3][0])
+        remove_dir(toy_installdir)
         self.run_test_toy_build_with_output(extra_args=['--set-gid-bit', '--sticky-bit'])
         for subdir, bits_set in subdirs:
             fullpath = os.path.join(self.test_installpath, *subdir)


### PR DESCRIPTION
required for installing in bwrap namespace, see also https://github.com/easybuilders/easybuild-framework/issues/4110
if install dir is bind mounted, it cannot be removed