### PR TITLE
fix `TypeError: '<' not supported between instances of 'int' and 'tuple'`

### DIFF
--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1970,7 +1970,7 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(eb.src[0]['cmd'], None)
 
         reference_checksum = "00000000"
-        if sys.version_info[0] < (3, 9):
+        if sys.version_info < (3, 9):
             # checksums of tarballs made by EB cannot be reliably checked prior to Python 3.9
             # due to changes introduced in python/cpython#90021
             reference_checksum = None


### PR DESCRIPTION
#4917 missed changing this correctly. See https://github.com/easybuilders/easybuild-framework/actions/runs/15781864867/job/44489234590

```
======================================================================
ERROR: test_fetch_sources_git (test.framework.easyblock.EasyBlockTest)
Test fetch_sources method from git repo.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/runner/68f96500815b8f9cffee903b731e08a62efea3f2/lib/python3.10/site-packages/test/framework/easyblock.py", line 1973, in test_fetch_sources_git
    if sys.version_info[0] < (3, 9):
TypeError: '<' not supported between instances of 'int' and 'tuple'

----------------------------------------------------------------------
```