### PR TITLE
trigger `post_easyblock_hook` later

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -5126,8 +5126,6 @@ def build_and_install_one(ecdict, init_env):
             except EasyBuildError as err:
                 _log.warning("Unable to commit easyconfig to repository: %s", err)
 
-        run_hook(EASYBLOCK, hooks, post_step_hook=True, args=[app])
-
         # cleanup logs
         app.close_log()
 
@@ -5200,6 +5198,8 @@ def build_and_install_one(ecdict, init_env):
 
     if not success:
         copy_build_dirs_logs_failed_install(application_log, silent, app, ecdict['ec'])
+
+    run_hook(EASYBLOCK, hooks, post_step_hook=True, args=[app])
 
     del app
 


### PR DESCRIPTION
The `pre/post_easyblock_hook` was added in #4923, but the `post_easyblock_hook` is triggered a bit too early: though the installation itself should be completed, some files (e.g. the log file and env file) still need to be copied to the `easybuild` subdir. This PR fixes that by triggering it a bit later, right before calling `del app`.