### PR TITLE
also copy patches of extensions to `easybuild` subdirectory of installation directory

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -5144,7 +5144,10 @@ def build_and_install_one(ecdict, init_env):
                 _log.debug("Copied easyconfig file %s to %s", spec, newspec)
 
                 # copy patches
-                for patch in app.patches:
+                patches = app.patches
+                for ext in app.exts:
+                    patches += ext.get('patches', [])
+                for patch in patches:
                     target = os.path.join(new_log_dir, os.path.basename(patch['path']))
                     copy_file(patch['path'], target)
                     _log.debug("Copied patch %s to %s", patch['path'], target)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -5119,7 +5119,10 @@ def build_and_install_one(ecdict, init_env):
                     block = det_full_ec_version(app.cfg) + ".block"
                     repo.add_easyconfig(ecdict['original_spec'], app.name, block, buildstats, currentbuildstats)
                 repo.add_easyconfig(spec, app.name, det_full_ec_version(app.cfg), buildstats, currentbuildstats)
-                for patch in app.patches:
+                patches = app.patches
+                for ext in app.exts:
+                    patches += ext.get('patches', [])
+                for patch in patches:
                     repo.add_patch(patch['path'], app.name)
                 repo.commit("Built %s" % app.full_mod_name)
                 del repo

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1387,6 +1387,16 @@ class ToyBuildTest(EnhancedTestCase):
         fn = 'created-via-postinstallcmds.txt'
         self.assertExists(os.path.join(installdir, fn))
 
+        # make sure that patch file for extension was copied to 'easybuild' subdir in installation directory
+        easybuild_subdir = os.path.join(installdir, 'easybuild')
+        patches = sorted(os.path.basename(x) for x in glob.glob(os.path.join(easybuild_subdir, '*.patch')))
+        expected_patches = [
+            'bar-0.0_fix-silly-typo-in-printf-statement.patch',
+            'bar-0.0_fix-very-silly-typo-in-printf-statement.patch',
+            'toy-0.0_fix-silly-typo-in-printf-statement.patch',
+        ]
+        self.assertEqual(patches, expected_patches)
+
     def test_toy_extension_sources(self):
         """Test install toy that includes extensions with 'sources' spec (as single-item list)."""
         topdir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Solves https://github.com/easybuilders/easybuild-framework/issues/4864 by adding the patches of extensions to the list of patches that are copied to `$installdir/easybuild`.

Note that there's also https://github.com/easybuilders/easybuild-framework/issues/4863: I'm not sure if the patches should go into either `easybuild` or `easybuild/reprod` or both, for now I've taken the same approach that is used for regular patches: only copy them to `easybuild`. But this can be easily changed.