### PR TITLE
Don't log variables (un)set + raw output of `module` command when cleaning up fake module

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1870,7 +1870,7 @@ class EasyBlock:
         # self.short_mod_name might not be set (e.g. during unit tests)
         if fake_mod_path and self.short_mod_name is not None:
             try:
-                self.modules_tool.unload([self.short_mod_name])
+                self.modules_tool.unload([self.short_mod_name], silent=True)
                 self.modules_tool.remove_module_path(os.path.join(fake_mod_path, self.mod_subdir))
                 remove_dir(os.path.dirname(fake_mod_path))
             except OSError as err:
@@ -1879,7 +1879,8 @@ class EasyBlock:
             self.log.warning("Not unloading module, since self.short_mod_name is not set.")
 
         # restore original environment
-        restore_env(env)
+        self.log.info("Restoring environment after unloading fake module")
+        restore_env(env, log_changes=False)
 
     def load_dependency_modules(self):
         """Load dependency modules."""

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1875,7 +1875,7 @@ class EasyBlock:
         # self.short_mod_name might not be set (e.g. during unit tests)
         if fake_mod_path and self.short_mod_name is not None:
             try:
-                self.modules_tool.unload([self.short_mod_name], silent=True)
+                self.modules_tool.unload([self.short_mod_name], log_changes=False)
                 self.modules_tool.remove_module_path(os.path.join(fake_mod_path, self.mod_subdir))
                 remove_dir(os.path.dirname(fake_mod_path))
             except OSError as err:

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1253,7 +1253,8 @@ class ModulesTool:
         cmd = ' '.join(cmd_list)
         # note: module commands are always run in dry mode, and are kept hidden in trace and dry run output
         res = run_shell_cmd(cmd_list, env=environ, fail_on_error=False, use_bash=False, split_stderr=True,
-                            hidden=True, in_dry_run=True, output_file=False)
+                            hidden=True, in_dry_run=True, output_file=False,
+                            hide_output_on_success=silent)
 
         # stdout will contain python code (to change environment etc)
         # stderr will contain text (just like the normal module command)

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1120,12 +1120,12 @@ class ModulesTool:
             if allow_reload or mod not in loaded_modules:
                 self.run_module('load', mod)
 
-    def unload(self, modules=None):
+    def unload(self, modules, silent=False):
         """
         Unload all requested modules.
         """
         for mod in modules:
-            self.run_module('unload', mod)
+            self.run_module('unload', mod, silent=silent)
 
     def purge(self):
         """
@@ -1188,9 +1188,9 @@ class ModulesTool:
 
         return modpath
 
-    def set_path_env_var(self, key, paths):
+    def set_path_env_var(self, key, paths, silent=False):
         """Set path environment variable to the given list of paths."""
-        setvar(key, os.pathsep.join(paths), verbose=False)
+        setvar(key, os.pathsep.join(paths), verbose=False, log_changes=not silent)
 
     def check_module_output(self, cmd, stdout, stderr):
         """Check output of 'module' command, see if if is potentially invalid."""
@@ -1249,6 +1249,7 @@ class ModulesTool:
                 self.log.debug("Changing %s from '%s' to '%s' in environment for module command",
                                key, old_value, new_value)
 
+        silent = kwargs.get('silent', False)
         cmd_list = self.compose_cmd_list(args)
         cmd = ' '.join(cmd_list)
         # note: module commands are always run in dry mode, and are kept hidden in trace and dry run output

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1121,12 +1121,12 @@ class ModulesTool:
             if allow_reload or mod not in loaded_modules:
                 self.run_module('load', mod)
 
-    def unload(self, modules, silent=False):
+    def unload(self, modules, log_changes=True):
         """
         Unload all requested modules.
         """
         for mod in modules:
-            self.run_module('unload', mod, silent=silent)
+            self.run_module('unload', mod, log_changes=log_changes)
 
     def purge(self):
         """
@@ -1189,9 +1189,9 @@ class ModulesTool:
 
         return modpath
 
-    def set_path_env_var(self, key, paths, silent=False):
+    def set_path_env_var(self, key, paths, log_changes=True):
         """Set path environment variable to the given list of paths."""
-        setvar(key, os.pathsep.join(paths), verbose=False, log_changes=not silent)
+        setvar(key, os.pathsep.join(paths), verbose=False, log_changes=log_changes)
 
     def check_module_output(self, cmd, stdout, stderr):
         """Check output of 'module' command, see if if is potentially invalid."""
@@ -1250,13 +1250,13 @@ class ModulesTool:
                 self.log.debug("Changing %s from '%s' to '%s' in environment for module command",
                                key, old_value, new_value)
 
-        silent = kwargs.get('silent', False)
+        log_changes = kwargs.get('log_changes', True)
         cmd_list = self.compose_cmd_list(args)
         cmd = ' '.join(cmd_list)
         # note: module commands are always run in dry mode, and are kept hidden in trace and dry run output
         res = run_shell_cmd(cmd_list, env=environ, fail_on_error=False, use_bash=False, split_stderr=True,
                             hidden=True, in_dry_run=True, output_file=False,
-                            hide_output_on_success=silent)
+                            log_output_on_success=log_changes)
 
         # stdout will contain python code (to change environment etc)
         # stderr will contain text (just like the normal module command)

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -360,7 +360,7 @@ def _answer_question(stdout, proc, qa_patterns, qa_wait_patterns):
 def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=None,
                   hidden=False, in_dry_run=False, verbose_dry_run=False, work_dir=None, use_bash=True,
                   output_file=True, stream_output=None, asynchronous=False, task_id=None, with_hooks=True,
-                  qa_patterns=None, qa_wait_patterns=None, qa_timeout=100, hide_output_on_success=False):
+                  qa_patterns=None, qa_wait_patterns=None, qa_timeout=100, log_output_on_success=True):
     """
     Run specified (interactive) shell command, and capture output + exit code.
 
@@ -381,6 +381,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
     :param qa_patterns: list of 2-tuples with patterns for questions + corresponding answers
     :param qa_wait_patterns: list of strings with patterns for non-questions
     :param qa_timeout: amount of seconds to wait until more output is produced when there is no matching question
+    :param log_output_on_success: log output of command if it was successful
 
     :return: Named tuple with:
     - output: command output, stdout+stderr combined if split_stderr is disabled, only stdout otherwise
@@ -604,17 +605,17 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
         }
         run_hook(RUN_SHELL_CMD, hooks, post_step_hook=True, args=[cmd], kwargs=run_hook_kwargs)
 
-    # always log command output
+    # log command output (unless command was successful and log_output_on_success is disabled)
     cmd_name = cmd_str.split(' ')[0]
     if split_stderr:
-        log_msg = f"Output of '{cmd_name} ...' shell command (stdout only):\n{res.output}\n"
+        log_msg = f"Output of '{cmd_name} ...' shell command (stdout only):\n{res.output}\n\n"
         log_msg += f"Warnings and errors of '{cmd_name} ...' shell command (stderr only):\n{res.stderr}"
     else:
         log_msg = f"Output of '{cmd_name} ...' shell command (stdout + stderr):\n{res.output}"
 
     if res.exit_code == EasyBuildExit.SUCCESS:
         _log.info(f"Shell command completed successfully: {cmd_str}")
-        if not hide_output_on_success:
+        if log_output_on_success:
             _log.info(log_msg)
     else:
         _log.warning(f"Shell command FAILED (exit code {res.exit_code}): {cmd_str}")

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -360,7 +360,7 @@ def _answer_question(stdout, proc, qa_patterns, qa_wait_patterns):
 def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=None,
                   hidden=False, in_dry_run=False, verbose_dry_run=False, work_dir=None, use_bash=True,
                   output_file=True, stream_output=None, asynchronous=False, task_id=None, with_hooks=True,
-                  qa_patterns=None, qa_wait_patterns=None, qa_timeout=100):
+                  qa_patterns=None, qa_wait_patterns=None, qa_timeout=100, hide_output_on_success=False):
     """
     Run specified (interactive) shell command, and capture output + exit code.
 
@@ -607,15 +607,18 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
     # always log command output
     cmd_name = cmd_str.split(' ')[0]
     if split_stderr:
-        _log.info(f"Output of '{cmd_name} ...' shell command (stdout only):\n{res.output}")
-        _log.info(f"Warnings and errors of '{cmd_name} ...' shell command (stderr only):\n{res.stderr}")
+        log_msg = f"Output of '{cmd_name} ...' shell command (stdout only):\n{res.output}\n"
+        log_msg += f"Warnings and errors of '{cmd_name} ...' shell command (stderr only):\n{res.stderr}"
     else:
-        _log.info(f"Output of '{cmd_name} ...' shell command (stdout + stderr):\n{res.output}")
+        log_msg = f"Output of '{cmd_name} ...' shell command (stdout + stderr):\n{res.output}"
 
     if res.exit_code == EasyBuildExit.SUCCESS:
-        _log.info(f"Shell command completed successfully (see output above): {cmd_str}")
+        _log.info(f"Shell command completed successfully: {cmd_str}")
+        if not hide_output_on_success:
+            _log.info(log_msg)
     else:
-        _log.warning(f"Shell command FAILED (exit code {res.exit_code}, see output above): {cmd_str}")
+        _log.warning(f"Shell command FAILED (exit code {res.exit_code}): {cmd_str}")
+        _log.info(log_msg)
         if fail_on_error:
             raise_run_shell_cmd_error(res)
 

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -467,7 +467,7 @@ class RunTest(EnhancedTestCase):
         # command output can be suppressed
         init_logging(logfile, silent=True)
         with self.mocked_stdout_stderr():
-            res = run_shell_cmd("echo hello", hide_output_on_success=True)
+            res = run_shell_cmd("echo hello", log_output_on_success=False)
         stop_logging(logfile)
         self.assertEqual(res.exit_code, 0)
         self.assertEqual(res.output, 'hello\n')
@@ -479,7 +479,7 @@ class RunTest(EnhancedTestCase):
         # But is shown on error
         init_logging(logfile, silent=True)
         with self.mocked_stdout_stderr():
-            res = run_shell_cmd("echo hello && false", hide_output_on_success=True, fail_on_error=False)
+            res = run_shell_cmd("echo hello && false", log_output_on_success=False, fail_on_error=False)
         stop_logging(logfile)
         self.assertEqual(res.exit_code, 1)
         self.assertEqual(res.output, 'hello\n')


### PR DESCRIPTION
Unloading a module (and its dependencies) changes a massive amount of variables.
As the changes done by *unloading* the fake module aren't really relevant for the remaining build (it is usually done at the end) do not log them.

This avoids filling up the part of the log uploaded with test reports with irrelevant information.

Example: https://gist.github.com/Flamefire/afae1a8e2b18a4bc2786f539d5f439d3


This change silences the output of the `module unload <fake module>` command by introducing an additional parameter to `run_shell_command` that suppresses output for successful commands.   
Another parameter for the `environment` module allows to suppress output for each set variable, e.g. 
> == 2025-06-26 19:43:42,596 environment.py:93 INFO Environment variable EBEXTSLISTMPI4PY set to mpi4py-4.0.1 (previously undefined)

Closes #4937 (mostly, we might want to suppress output of all module commands or print them only in debug logs)

I think that unloading the fake module and removing the module path is not useful. The succeeding `restore_env` already undoes all changes done by loading the module.

Note that e.g. loading the fake module unsets many environment variables. E.g. `CUDA_CACHE_DISABLE` which the `restore_env` then sets again. So directly calling `restore_env` would already reduce the amount of changes done and hence reduce the number of log lines.   
Why don't we do that?