### PR TITLE
also copy easyblocks of components to reprod dir

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -5032,7 +5032,9 @@ def build_and_install_one(ecdict, init_env):
             except EasyBuildError as err:
                 _log.warning("Failed to create build environment dump for easyconfig %s: %s", reprod_spec, err)
 
-            # also add any extension easyblocks used during the build for reproducibility
+            # also add any component/extension easyblocks used during the build for reproducibility
+            if app.comp_instances:
+                copy_easyblocks_for_reprod([comp for cfg, comp in app.comp_instances], reprod_dir)
             if app.ext_instances:
                 copy_easyblocks_for_reprod(app.ext_instances, reprod_dir)
             # If not already done remove the granted write permissions if we did so

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -5033,7 +5033,7 @@ def build_and_install_one(ecdict, init_env):
                 _log.warning("Failed to create build environment dump for easyconfig %s: %s", reprod_spec, err)
 
             # also add any component/extension easyblocks used during the build for reproducibility
-            if app.comp_instances:
+            if hasattr(app, 'comp_instances'):
                 copy_easyblocks_for_reprod([comp for cfg, comp in app.comp_instances], reprod_dir)
             if app.ext_instances:
                 copy_easyblocks_for_reprod(app.ext_instances, reprod_dir)


### PR DESCRIPTION
Solves the issue spotted/reported by @Thyre in https://github.com/easybuilders/easybuild-framework/issues/4862#issuecomment-3013015997: easyblocks of extensions were copied to the `reprod/easyblocks` directory, but easyblocks of components were not.