### PR TITLE
Fix logic for `pr_repo` used in `--sync-pr-with-develop`

### DIFF
--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -2190,11 +2190,12 @@ def det_account_branch_for_pr(pr_id, github_user=None, pr_target_repo=None):
 
     # branch that corresponds with PR is supplied in form <account>:<branch_label>
     account = pr_data['head']['label'].split(':')[0]
+    repo = pr_data['head']['repo']['name']
     branch = ':'.join(pr_data['head']['label'].split(':')[1:])
     github_target = '%s/%s' % (pr_target_account, pr_target_repo)
     print_msg("Determined branch name corresponding to %s PR #%s: %s" % (github_target, pr_id, branch), log=_log)
 
-    return account, branch
+    return account, repo, branch
 
 
 def det_pr_target_repo(paths):
@@ -2291,7 +2292,7 @@ def update_pr(pr_id, paths, ecs, commit_msg=None):
             exit_code=EasyBuildExit.OPTION_ERROR
         )
 
-    github_account, branch_name = det_account_branch_for_pr(pr_id, pr_target_repo=pr_target_repo)
+    github_account, _, branch_name = det_account_branch_for_pr(pr_id, pr_target_repo=pr_target_repo)
 
     update_branch(branch_name, paths, ecs, github_account=github_account, commit_msg=commit_msg)
 
@@ -2883,18 +2884,18 @@ def sync_pr_with_develop(pr_id):
     target_account = build_option('pr_target_account')
     target_repo = build_option('pr_target_repo') or GITHUB_EASYCONFIGS_REPO
 
-    pr_account, pr_branch = det_account_branch_for_pr(pr_id)
+    pr_account, pr_repo, pr_branch = det_account_branch_for_pr(pr_id)
 
     # initialize repository
     git_working_dir = tempfile.mkdtemp(prefix='git-working-dir')
     git_repo = init_repo(git_working_dir, target_repo)
 
-    setup_repo(git_repo, pr_account, target_repo, pr_branch)
+    setup_repo(git_repo, pr_account, pr_repo, pr_branch)
 
     sync_with_develop(git_repo, pr_branch, target_account, target_repo)
 
     # push updated branch back to GitHub (unless we're doing a dry run)
-    return push_branch_to_github(git_repo, pr_account, target_repo, pr_branch)
+    return push_branch_to_github(git_repo, pr_account, pr_repo, pr_branch)
 
 
 def sync_branch_with_develop(branch_name):

--- a/easybuild/tools/github.py
+++ b/easybuild/tools/github.py
@@ -2173,7 +2173,7 @@ def new_pr(paths, ecs, title=None, descr=None, commit_msg=None):
                        pr_metadata=(file_info, deleted_paths, diff_stat), commit_msg=commit_msg)
 
 
-def det_account_branch_for_pr(pr_id, github_user=None, pr_target_repo=None):
+def det_account_repo_branch_for_pr(pr_id, github_user=None, pr_target_repo=None):
     """Determine account & branch corresponding to pull request with specified id."""
 
     if github_user is None:
@@ -2196,6 +2196,14 @@ def det_account_branch_for_pr(pr_id, github_user=None, pr_target_repo=None):
     print_msg("Determined branch name corresponding to %s PR #%s: %s" % (github_target, pr_id, branch), log=_log)
 
     return account, repo, branch
+
+
+def det_account_branch_for_pr(pr_id, github_user=None, pr_target_repo=None):
+    """Deprecated version of `det_account_repo_branch_for_pr`"""
+    _log.deprecated("`det_account_branch_for_pr` is deprecated, use `det_account_repo_branch_for_pr` instead", "6.0")
+    account, _, branch = det_account_repo_branch_for_pr(pr_id, github_user=github_user, pr_target_repo=pr_target_repo)
+
+    return account, branch
 
 
 def det_pr_target_repo(paths):
@@ -2292,7 +2300,7 @@ def update_pr(pr_id, paths, ecs, commit_msg=None):
             exit_code=EasyBuildExit.OPTION_ERROR
         )
 
-    github_account, _, branch_name = det_account_branch_for_pr(pr_id, pr_target_repo=pr_target_repo)
+    github_account, _, branch_name = det_account_repo_branch_for_pr(pr_id, pr_target_repo=pr_target_repo)
 
     update_branch(branch_name, paths, ecs, github_account=github_account, commit_msg=commit_msg)
 
@@ -2884,7 +2892,7 @@ def sync_pr_with_develop(pr_id):
     target_account = build_option('pr_target_account')
     target_repo = build_option('pr_target_repo') or GITHUB_EASYCONFIGS_REPO
 
-    pr_account, pr_repo, pr_branch = det_account_branch_for_pr(pr_id)
+    pr_account, pr_repo, pr_branch = det_account_repo_branch_for_pr(pr_id)
 
     # initialize repository
     git_working_dir = tempfile.mkdtemp(prefix='git-working-dir')

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -1142,9 +1142,10 @@ class GithubTest(EnhancedTestCase):
 
         # see https://github.com/easybuilders/easybuild-framework/pull/3069
         self.mock_stdout(True)
-        account, branch = gh.det_account_branch_for_pr(3069, github_user=GITHUB_TEST_ACCOUNT)
+        account, repo, branch = gh.det_account_branch_for_pr(3069, github_user=GITHUB_TEST_ACCOUNT)
         self.mock_stdout(False)
         self.assertEqual(account, 'migueldiascosta')
+        self.assertEqual(repo, 'easybuild-framework')
         self.assertEqual(branch, 'fix_inject_checksums')
 
     def test_github_det_pr_target_repo(self):

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -1129,9 +1129,10 @@ class GithubTest(EnhancedTestCase):
 
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/9149
         self.mock_stdout(True)
-        account, branch = gh.det_account_branch_for_pr(9149, github_user=GITHUB_TEST_ACCOUNT)
+        account, repo, branch = gh.det_account_branch_for_pr(9149, github_user=GITHUB_TEST_ACCOUNT)
         self.mock_stdout(False)
         self.assertEqual(account, 'boegel')
+        self.assertEqual(repo, 'easybuild-easyconfigs')
         self.assertEqual(branch, '20191017070734_new_pr_EasyBuild401')
 
         init_config(build_options={

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -1116,7 +1116,7 @@ class GithubTest(EnhancedTestCase):
         gist_id = gist_url.split('/')[-1]
         gh.delete_gist(gist_id, github_user=GITHUB_TEST_ACCOUNT, github_token=self.github_token)
 
-    def test_github_det_account_branch_for_pr(self):
+    def test_github_det_account_repo_branch_for_pr(self):
         """Test det_account_branch_for_pr."""
         if self.skip_github_tests:
             print("Skipping test_det_account_branch_for_pr, no GitHub token available?")
@@ -1129,7 +1129,7 @@ class GithubTest(EnhancedTestCase):
 
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/9149
         self.mock_stdout(True)
-        account, repo, branch = gh.det_account_branch_for_pr(9149, github_user=GITHUB_TEST_ACCOUNT)
+        account, repo, branch = gh.det_account_repo_branch_for_pr(9149, github_user=GITHUB_TEST_ACCOUNT)
         self.mock_stdout(False)
         self.assertEqual(account, 'boegel')
         self.assertEqual(repo, 'easybuild-easyconfigs')
@@ -1142,7 +1142,7 @@ class GithubTest(EnhancedTestCase):
 
         # see https://github.com/easybuilders/easybuild-framework/pull/3069
         self.mock_stdout(True)
-        account, repo, branch = gh.det_account_branch_for_pr(3069, github_user=GITHUB_TEST_ACCOUNT)
+        account, repo, branch = gh.det_account_repo_branch_for_pr(3069, github_user=GITHUB_TEST_ACCOUNT)
         self.mock_stdout(False)
         self.assertEqual(account, 'migueldiascosta')
         self.assertEqual(repo, 'easybuild-framework')


### PR DESCRIPTION
Fixes
- #4928

Properly detect and use the name of the repo that is submitting the PR instead of using the same one that is receiving it