### PR TITLE
Ban `ligomp.so` at GCCcore level

### DIFF
--- a/easybuild/toolchains/gcc.py
+++ b/easybuild/toolchains/gcc.py
@@ -31,7 +31,7 @@ Authors:
 """
 import re
 
-from easybuild.toolchains.gcccore import GCCcore
+from easybuild.toolchains.gcccore import GCCcore, GCCCORE_BANNED_LIBRARIES
 from easybuild.tools import LooseVersion
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
 
@@ -42,6 +42,16 @@ class GccToolchain(GCCcore):
     COMPILER_MODULE_NAME = [NAME]
     SUBTOOLCHAIN = [GCCcore.NAME, SYSTEM_TOOLCHAIN_NAME]
     OPTIONAL = False
+
+    def banned_linked_shared_libs(self):
+        """
+        List of shared libraries (names, file names, paths) which are
+        not allowed to be linked in any installed binary/library.
+        """
+        banned_libs = super().banned_linked_shared_libs()
+
+        # Restore libraries that were banned at GCCcore level but ok for GCC
+        return list(set(banned_libs) - set(GCCCORE_BANNED_LIBRARIES))
 
     def is_deprecated(self):
         """Return whether or not this toolchain is deprecated."""

--- a/easybuild/toolchains/gcccore.py
+++ b/easybuild/toolchains/gcccore.py
@@ -35,6 +35,8 @@ from easybuild.toolchains.compiler.gcc import Gcc
 from easybuild.tools import LooseVersion
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
 
+# At GCCcore level we do not allow OpenMP
+GCCCORE_BANNED_LIBRARIES = ['libgomp.so']
 
 class GCCcore(Gcc):
     """Compiler-only toolchain, including only GCC and binutils."""
@@ -45,6 +47,15 @@ class GCCcore(Gcc):
     # GCCcore is only guaranteed to be present in recent toolchains
     # for old versions of some toolchains (GCC, intel) it is not part of the hierarchy and hence optional
     OPTIONAL = True
+
+    def banned_linked_shared_libs(self):
+        """
+        List of shared libraries (names, file names, paths) which are
+        not allowed to be linked in any installed binary/library.
+        """
+        banned_libs = super().banned_linked_shared_libs()
+
+        return banned_libs + GCCCORE_BANNED_LIBRARIES
 
     def is_deprecated(self):
         """Return whether or not this toolchain is deprecated."""


### PR DESCRIPTION
Fixes #4535 

Will need work for easyconfigs that exist with GCCcore and use OpenMP (see https://github.com/easybuilders/easybuild-framework/issues/4535#issuecomment-3035326270)