### PR TITLE
Do not fail for read-only installation directory on `--module-only` (re)builds

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4494,11 +4494,11 @@ class EasyBlock:
                 with self.fake_module_environment():
                     try:
                         self.make_devel_module()
-                    except EasyBuildError as error:
+                    except EasyBuildError:
                         if build_option('module_only') or self.cfg['module_only']:
-                            self.log.info("Using --module-only so can recover from error: %s", error)
+                            self.log.info("Using --module-only so can recover from error")
                         else:
-                            raise error
+                            raise
             else:
                 self.log.info("Skipping devel module...")
 
@@ -5016,16 +5016,16 @@ def build_and_install_one(ecdict, init_env):
     try:
         run_test_cases = not build_option('skip_test_cases') and app.cfg['tests']
 
-        if not dry_run and not module_only:
+        if not dry_run:
             # create our reproducibility files before carrying out the easyblock steps
             reprod_dir_root = os.path.dirname(app.logfile)
             reprod_dir = reproduce_build(app, reprod_dir_root)
 
-            if os.path.exists(app.installdir) and build_option('read_only_installdir') and (
-                    build_option('rebuild') or build_option('force')):
-                enabled_write_permissions = True
-                # re-enable write permissions so we can install additional modules
+            # re-enable write permissions so we can install additional modules if not module-only
+            if not module_only and os.path.exists(app.installdir) and build_option('read_only_installdir') and \
+                    (build_option('rebuild') or build_option('force')):
                 adjust_permissions(app.installdir, stat.S_IWUSR, add=True, recursive=True)
+                enabled_write_permissions = True
             else:
                 enabled_write_permissions = False
 
@@ -5033,7 +5033,7 @@ def build_and_install_one(ecdict, init_env):
 
         result = app.run_all_steps(run_test_cases=run_test_cases)
 
-        if not dry_run and not module_only:
+        if not dry_run:
             # Copy over the build environment used during the configuraton
             reprod_spec = os.path.join(reprod_dir, app.cfg.filename())
             try:
@@ -5064,7 +5064,7 @@ def build_and_install_one(ecdict, init_env):
     # make sure we're back in original directory before we finish up
     change_dir(cwd)
 
-    application_log = None
+    application_log = app.logfile
 
     # successful (non-dry-run) build
     if result and not dry_run:
@@ -5093,30 +5093,47 @@ def build_and_install_one(ecdict, init_env):
             else:
                 new_log_dir = os.path.dirname(app.logfile)
             ensure_writable_log_dir(new_log_dir)
-
         # if we're only running the sanity check, we should not copy anything new to the installation directory
         elif build_option('sanity_check_only'):
             _log.info("Only running sanity check, so skipping build stats, easyconfigs archive, reprod files...")
-        elif module_only:  # Same fore module-only
-            _log.info("Only creating module, so skipping build stats, easyconfigs archive, reprod files...")
         else:
-            new_log_dir = os.path.join(app.installdir, config.log_path(ec=app.cfg))
-            ensure_writable_log_dir(new_log_dir)
-
             # collect build stats
             _log.info("Collecting build stats...")
 
             buildstats = get_build_stats(app, start_time, build_option('command_line'))
             _log.info("Build stats: %s" % buildstats)
 
-            # move the reproducibility files to the final log directory
-            archive_reprod_dir = os.path.join(new_log_dir, REPROD)
-            if os.path.exists(archive_reprod_dir):
-                backup_dir = find_backup_name_candidate(archive_reprod_dir)
-                move_file(archive_reprod_dir, backup_dir)
-                _log.info("Existing reproducibility directory %s backed up to %s", archive_reprod_dir, backup_dir)
-            move_file(reprod_dir, archive_reprod_dir)
-            _log.info("Wrote files for reproducibility to %s", archive_reprod_dir)
+            new_log_dir = os.path.join(app.installdir, config.log_path(ec=app.cfg))
+            try:
+                ensure_writable_log_dir(new_log_dir)
+            except EasyBuildError:
+                if module_only:
+                    what = ("make directory %s writeable" if os.path.exists(new_log_dir)
+                            else "create directory %s") % new_log_dir
+                    print_warning("Cannot %s.\n"
+                                  "So logs, easyconfigs, patches and files for reproducibility will not be saved.",
+                                  what, log=_log)
+                    # Don't even try to use this again
+                    new_log_dir = None
+                else:
+                    raise
+            else:
+                try:
+                    # move the reproducibility files to the final log directory
+                    archive_reprod_dir = os.path.join(new_log_dir, REPROD)
+                    if os.path.exists(archive_reprod_dir):
+                        backup_dir = find_backup_name_candidate(archive_reprod_dir)
+                        move_file(archive_reprod_dir, backup_dir)
+                        _log.info("Existing reproducibility directory %s backed up to %s",
+                                  archive_reprod_dir, backup_dir)
+                    move_file(reprod_dir, archive_reprod_dir)
+                    _log.info("Wrote files for reproducibility to %s", archive_reprod_dir)
+                except EasyBuildError:
+                    if module_only:
+                        print_warning("Could not create files for reproducibility but continuing module-only build",
+                                      log=_log)
+                    else:
+                        raise
 
             try:
                 # upload easyconfig (and patch files) to central repository
@@ -5136,15 +5153,13 @@ def build_and_install_one(ecdict, init_env):
         # cleanup logs
         app.close_log()
 
-        if build_option('sanity_check_only'):
-            _log.info("Only running sanity check, so not copying anything to software install directory...")
-        elif module_only:  # Same fore module-only
-            _log.info("Only creating module, so not copying anything to software install directory...")
-        else:
+        if not build_option('sanity_check_only') and new_log_dir is not None:
             log_fn = os.path.basename(get_log_filename(app.name, app.version))
             try:
-                application_log = os.path.join(new_log_dir, log_fn)
-                move_logs(app.logfile, application_log)
+                # Ensure application_log always points to an existing file
+                new_application_log = os.path.join(new_log_dir, log_fn)
+                move_logs(application_log, new_application_log)
+                application_log = new_application_log
 
                 newspec = os.path.join(new_log_dir, app.cfg.filename())
                 copy_file(spec, newspec)
@@ -5160,12 +5175,11 @@ def build_and_install_one(ecdict, init_env):
                     # take away user write permissions (again)
                     perms = stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH
                     adjust_permissions(new_log_dir, perms, add=False, recursive=True)
-            except EasyBuildError as error:
-                if build_option('module_only'):
-                    application_log = None
-                    _log.debug("Using --module-only so can recover from error: %s", error)
+            except EasyBuildError:
+                if module_only:
+                    print_warning("Could not copy log files, easyconfig and/or patches to %s", new_log_dir, log=_log)
                 else:
-                    raise error
+                    raise
 
     end_timestamp = datetime.now()
 
@@ -5183,7 +5197,6 @@ def build_and_install_one(ecdict, init_env):
 
         # cleanup logs
         app.close_log()
-        application_log = app.logfile
 
     req_time = time2str(end_timestamp - start_timestamp)
     print_msg("%s: Installation %s %s (took %s)" % (summary, ended, succ, req_time), log=_log, silent=silent)


### PR DESCRIPTION
When only creating a module the installation directory must not be touched as it might be on a read-only file system.

Skip the code that copies reprod-files (easyconfig, easyblock, hooks) and log files.


This came up when trying to create a module-tree for EESSI reusing the installed software.