### PR TITLE
add `all_patches` variable to store all patches (incl the ones for extensions) that need to be copied to a repo/reprod dir

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -188,6 +188,7 @@ class EasyBlock:
 
         # list of patch/source files, along with checksums
         self.patches = []
+        self.all_patches = [] # also includes patches of extensions
         self.src = []
         self.data_src = []
         self.checksums = []
@@ -601,6 +602,7 @@ class EasyBlock:
                 patch_info['path'] = path
                 patch_info['checksum'] = self.get_checksum_for(checksums, filename=patch_info['name'], index=index)
 
+                self.all_patches.append(patch_info)
                 if extension:
                     patches.append(patch_info)
                 else:
@@ -5126,10 +5128,7 @@ def build_and_install_one(ecdict, init_env):
                     block = det_full_ec_version(app.cfg) + ".block"
                     repo.add_easyconfig(ecdict['original_spec'], app.name, block, buildstats, currentbuildstats)
                 repo.add_easyconfig(spec, app.name, det_full_ec_version(app.cfg), buildstats, currentbuildstats)
-                patches = app.patches
-                for ext in app.exts:
-                    patches += ext.get('patches', [])
-                for patch in patches:
+                for patch in app.all_patches:
                     if 'path' in patch:
                         repo.add_patch(patch['path'], app.name)
                 repo.commit("Built %s" % app.full_mod_name)
@@ -5153,10 +5152,7 @@ def build_and_install_one(ecdict, init_env):
                 _log.debug("Copied easyconfig file %s to %s", spec, newspec)
 
                 # copy patches
-                patches = app.patches
-                for ext in app.exts:
-                    patches += ext.get('patches', [])
-                for patch in patches:
+                for patch in app.all_patches:
                     if 'path' in patch:
                         target = os.path.join(new_log_dir, os.path.basename(patch['path']))
                         copy_file(patch['path'], target)


### PR DESCRIPTION
This also solves the duplication issue that https://github.com/easybuilders/easybuild-framework/pull/4959 tried to solve. 

Note that patches of components are added to `self.patches` by the Bundle easyblock: https://github.com/easybuilders/easybuild-easyblocks/blob/develop/easybuild/easyblocks/generic/bundle.py#L222. Hence, they will also be included in `self.all_patches`. 
Do note that, regardless of the change in this PR, the approach used by the Bundle may actually cause issues, because sources/patches may then be expected by the main easyblock itself, and they may also end up in the easyconfig stored in the  `reprod` folder (see https://github.com/easybuilders/easybuild-framework/issues/4862). However, I felt that solving that was out of scope for this PR, and could be handled in a follow-up PR.