### PR TITLE
add back `OrderedDict` import in (deprecated) `easybuild.tools.py2vs3.py3` module

### DIFF
--- a/easybuild/tools/py2vs3/py3.py
+++ b/easybuild/tools/py2vs3/py3.py
@@ -34,6 +34,7 @@ Authors:
 # these are not used here, but imported from here in other places
 import configparser  # noqa
 import urllib.request as std_urllib  # noqa
+from collections import OrderedDict  # noqa
 from collections.abc import Mapping  # noqa
 from functools import cmp_to_key
 from importlib.util import spec_from_file_location, module_from_spec


### PR DESCRIPTION
We still support that deprecated module and some older easyblocks do use it. E.g. the easybuildmeta easyblock in EESSI which fails with
>  cannot import name 'OrderedDict' from 'easybuild.tools.py2vs3'