### PR TITLE
Honor 'module_extensions' build option

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -1312,6 +1312,8 @@ class ModuleGeneratorLua(ModuleGenerator):
         elif conflict:
             # conflict on 'name' part of module name (excluding version part at the end)
             lines.extend(['', 'conflict("%s")' % os.path.dirname(self.app.short_mod_name)])
+
+        if build_option('module_extensions'):
             extensions_list = self.app.make_extension_string(name_version_sep='/', ext_sep=',')
             if extensions_list:
                 extensions_stmt = 'extensions("%s")' % extensions_list

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -829,6 +829,19 @@ class ModuleGeneratorTest(EnhancedTestCase):
 
         self.assertFalse(re.search(r"\s*extensions\(", desc), "No extensions found in: %s" % desc)
 
+        # check if the extensions is missing if 'module_extensions' is disabled
+        init_config(build_options={'module_extensions': False})
+        test_ec = os.path.join(test_dir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0-gompi-2018a-test.eb')
+
+        ec = EasyConfig(test_ec)
+        eb = EasyBlock(ec)
+        modgen = self.MODULE_GENERATOR_CLASS(eb)
+        desc = modgen.get_description()
+
+        for pattern in patterns:
+            regex = re.compile(pattern, re.M)
+            self.assertFalse(regex.search(desc), "Pattern '%s' not found in: %s" % (regex.pattern, desc))
+
     def test_prepend_paths(self):
         """Test generating prepend-paths statements."""
         # test prepend_paths


### PR DESCRIPTION
Commit a48c6bb dismissed the check of 'module_extensions' build option before generating module extensions. As a result it was not possible to disable module extensions with --disable-module-extensions. Commit a48c6bb also moved extension generation code behind the `elif conflict:` condition branch.

This commit restores a correct check for 'module_extensions' build option and provides a test to check behavior when 'module_extensions' is disabled.

Fixes #4887

Supersedes #4898