### PR TITLE
Add support for "extensions" on Tcl modulefiles

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -866,6 +866,11 @@ class ModuleGeneratorTcl(ModuleGenerator):
             # - 'conflict Compiler/GCC/4.8.2/OpenMPI' for 'Compiler/GCC/4.8.2/OpenMPI/1.6.4'
             lines.extend(['', "conflict %s" % os.path.dirname(self.app.short_mod_name)])
 
+        if build_option('module_extensions'):
+            extensions_list = self.app.make_extension_string(name_version_sep='/', ext_sep=' ')
+            if self.modules_tool.supports_extensions and extensions_list:
+                lines.extend(['', 'extensions %s' % extensions_list])
+
         return '\n'.join(lines + [''])
 
     def getenv_cmd(self, envvar, default=None):

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -648,6 +648,7 @@ class ModulesTool:
         self.supports_tcl_getenv = False
         self.supports_tcl_check_group = False
         self.supports_safe_auto_load = False
+        self.supports_extensions = False
 
     def __str__(self):
         """String representation of this ModulesTool instance."""
@@ -1758,6 +1759,7 @@ class EnvironmentModules(ModulesTool):
     DEPR_VERSION = '4.3.0'
     MAX_VERSION = None
     REQ_VERSION_TCL_CHECK_GROUP = '4.6.0'
+    REQ_VERSION_EXTENSIONS = '5.1.0'
     VERSION_REGEXP = r'^Modules\s+Release\s+(?P<version>\d[^+\s]*)(\+\S*)?\s'
 
     SHOW_HIDDEN_OPTION = '--all'
@@ -1788,6 +1790,7 @@ class EnvironmentModules(ModulesTool):
         self.supports_tcl_getenv = True
         self.supports_tcl_check_group = version >= LooseVersion(self.REQ_VERSION_TCL_CHECK_GROUP)
         self.supports_safe_auto_load = True
+        self.supports_extensions = version >= LooseVersion(self.REQ_VERSION_EXTENSIONS)
 
     def check_module_function(self, allow_mismatch=False, regex=None):
         """Check whether selected module tool matches 'module' function definition."""
@@ -1897,6 +1900,7 @@ class Lmod(ModulesTool):
     COMMAND_ENVIRONMENT = 'LMOD_CMD'
     REQ_VERSION = '8.0.0'
     DEPR_VERSION = '8.0.0'
+    REQ_VERSION_EXTENSIONS = '8.2.8'
     VERSION_REGEXP = r"^Modules\s+based\s+on\s+Lua:\s+Version\s+(?P<version>\d\S*)\s"
 
     SHOW_HIDDEN_OPTION = '--show-hidden'
@@ -1919,6 +1923,7 @@ class Lmod(ModulesTool):
         version = LooseVersion(self.version)
 
         self.supports_depends_on = True
+        self.supports_extensions = version >= LooseVersion(self.REQ_VERSION_EXTENSIONS)
         # See https://lmod.readthedocs.io/en/latest/125_personal_spider_cache.html
         if version >= LooseVersion('8.7.12'):
             self.USER_CACHE_DIR = os.path.join(os.path.expanduser('~'), '.cache', 'lmod')

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -665,7 +665,7 @@ class EasyBuildOptions(GeneralOption):
             'module-depends-on': ("Use depends_on (Lmod 7.6.1+) for dependencies in all generated modules "
                                   "(implies recursive unloading of modules).",
                                   None, 'store_true', True),
-            'module-extensions': ("Include 'extensions' statement in generated module file (Lua syntax only)",
+            'module-extensions': ("Include 'extensions' statement in generated module file",
                                   None, 'store_true', True),
             'module-naming-scheme': ("Module naming scheme to use", None, 'store', DEFAULT_MNS),
             'module-search-path-headers': ("Environment variable set by modules on load with search paths "

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -794,11 +794,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
 
     def test_module_extensions(self):
         """test the extensions() for extensions"""
-        # not supported for Tcl modules
-        if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
-            return
-
-        # currently requires opt-in via --module-extensions
+        # check if extensions option is enabled and some module extensions are defined
         init_config(build_options={'module_extensions': True})
 
         test_dir = os.path.abspath(os.path.dirname(__file__))
@@ -810,14 +806,22 @@ class ModuleGeneratorTest(EnhancedTestCase):
         modgen = self.MODULE_GENERATOR_CLASS(eb)
         desc = modgen.get_description()
 
-        patterns = [
-            r'^if convertToCanonical\(LmodVersion\(\)\) >= convertToCanonical\("8\.2\.8"\) then\n' +
-            r'\s*extensions\("bar/0.0,barbar/1.2,toy/0.0,ulimit"\)\nend$',
-        ]
-
-        for pattern in patterns:
+        if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
+            pattern = r'^extensions bar/0.0 barbar/1.2 toy/0.0 ulimit$'
             regex = re.compile(pattern, re.M)
-            self.assertTrue(regex.search(desc), "Pattern '%s' found in: %s" % (regex.pattern, desc))
+            if self.modtool.supports_extensions:
+                self.assertTrue(regex.search(desc), "Pattern '%s' found in: %s" % (regex.pattern, desc))
+            else:
+                self.assertFalse(regex.search(desc), "No extensions found in: %s" % desc)
+        else:
+            patterns = [
+                r'^if convertToCanonical\(LmodVersion\(\)\) >= convertToCanonical\("8\.2\.8"\) then\n' +
+                r'\s*extensions\("bar/0.0,barbar/1.2,toy/0.0,ulimit"\)\nend$',
+            ]
+
+            for pattern in patterns:
+                regex = re.compile(pattern, re.M)
+                self.assertTrue(regex.search(desc), "Pattern '%s' found in: %s" % (regex.pattern, desc))
 
         # check if the extensions is missing if there are no extensions
         test_ec = os.path.join(test_dir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0-test.eb')
@@ -827,7 +831,12 @@ class ModuleGeneratorTest(EnhancedTestCase):
         modgen = self.MODULE_GENERATOR_CLASS(eb)
         desc = modgen.get_description()
 
-        self.assertFalse(re.search(r"\s*extensions\(", desc), "No extensions found in: %s" % desc)
+        if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
+            pattern = r"^extensions "
+        else:
+            pattern = r"\s*extensions\("
+
+        self.assertFalse(re.search(pattern, desc), "No extensions found in: %s" % desc)
 
     def test_prepend_paths(self):
         """Test generating prepend-paths statements."""


### PR DESCRIPTION
Module extensions are supported by Lmod in Tcl modulefiles since version 8.2.8. "extensions" command can be safely used in Tcl modulefiles with Environment Modules since version 5.1.0, even if it is ignored until version 5.6.0.

Check for support of module extensions is made within EasyBuild, thus "extensions" command is not included in generated Tcl modulefiles if the module tool detected by EasyBuild does not support it (Lmod<8.2.8 or EnvironmentModules<5.1.0).