### PR TITLE
Fix f-string in rpath check and Skip check for linked libs on symlinks

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3804,7 +3804,7 @@ class EasyBlock:
                     out = get_linked_libs_raw(path)
 
                     if out is None:
-                        msg = "Failed to determine dynamically linked libraries for {path}, "
+                        msg = f"Failed to determine dynamically linked libraries for {path}, "
                         msg += "so skipping it in RPATH sanity check"
                         self.log.debug(msg)
                     else:

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -1118,6 +1118,9 @@ def get_linked_libs_raw(path):
     or None for other types of files.
     """
 
+    if os.path.islink(path):
+        _log.debug(f"{path} is a symbolic link, so skipping check for linked libs")
+        return None
     res = run_shell_cmd("file %s" % path, fail_on_error=False, hidden=True, output_file=False, stream_output=False)
     if res.exit_code != EasyBuildExit.SUCCESS:
         fail_msg = "Failed to run 'file %s': %s" % (path, res.output)


### PR DESCRIPTION
In https://gist.github.com/boegelbot/1e87f59c5b2d74984a925e56a7adcb3d there is

> Failed to determine dynamically linked libraries for {path}, so skipping it in RPATH sanity check

There was a missed f-string causing this.

Additionally the `file` call (external tool) is unnecessary for symbolic links where it returns

>   symbolic link to libxxx

This will then not do any checks, so it can be skipped in a much cheaper way by using `islink`, This change doesn't change existing behavior it just makes it obvious.

This also means that `sanity_check_rpath` can/should be enhanced as the `is_parent_path` check for outside symlinks doesn't make sense if no check is done for any symlinks yielding an additional "Failed to determine dynamically linked libraries for..." message.

Shall we do that too?