### PR TITLE
Exit with appropriate error code for `--search` when no match is found

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1202,6 +1202,11 @@ class CommandLineOptionsTest(EnhancedTestCase):
                 with self.mocked_stdout_stderr():
                     self.assertErrorRegex(EasyBuildError, "Invalid search query", self.eb_main, args, raise_error=True)
 
+        # test searching for non-existing easyconfig file (should produce non-zero exit code)
+        # 4 corresponds with MISSING_EASYCONFIG in EasyBuildExit (see easybuild/tools/build_log.py)
+        self.assertErrorRegex(SystemExit, '4', self.eb_main, ['--search', 'nosuchsoftware-1.2.3.4.5'],
+                              testing=False, raise_error=True, raise_systemexit=True)
+
     def test_ignore_index(self):
         """
         Test use of --ignore-index.

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1204,7 +1204,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         # test searching for non-existing easyconfig file (should produce non-zero exit code)
         # 4 corresponds with MISSING_EASYCONFIG in EasyBuildExit (see easybuild/tools/build_log.py)
-        self.assertErrorRegex(SystemExit, '4', self.eb_main, ['--search', 'nosuchsoftware-1.2.3.4.5'],
+        args = ['--search', 'nosuchsoftware-1.2.3.4.5']
+        self.assertErrorRegex(SystemExit, 'MISSING_EASYCONFIG|4', self.eb_main, args,
                               testing=False, raise_error=True, raise_systemexit=True)
 
     def test_ignore_index(self):


### PR DESCRIPTION
When searching for easyconfigs exit with an error code if none are found. This is useful for scripting.

I moved it to the if-elif ladder to handle it like the other early-exit options as I don't see why it would be special over e.g. `--list-software`