### PR TITLE
fix passing command as list of strings to `run_shell_cmd`

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -364,6 +364,8 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
     """
     Run specified (interactive) shell command, and capture output + exit code.
 
+    :param cmd: command to run; can be specified as string value (which implies interpretation by shell),
+                or as a list of strings (no interpretation by the shell)
     :param fail_on_error: fail on non-zero exit code (enabled by default)
     :param split_stderr: split of stderr from stdout output
     :param stdin: input to be sent to stdin (nothing if set to None)
@@ -490,6 +492,9 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
         bash = shutil.which('bash')
         _log.info(f"Path to bash that will be used to run shell commands: {bash}")
         executable, shell = bash, True
+        if isinstance(cmd, (list, tuple)):
+            _log.info(f"Setting 'shell' option to False, since command is specified as a list of strings: {cmd}")
+            shell = False
     else:
         executable, shell = None, False
 

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -1615,6 +1615,13 @@ class RunTest(EnhancedTestCase):
         self.assertEqual(res.exit_code, 0)
         self.assertEqual(res.output, "hello\n")
 
+        os.environ['TEST'] = '123'
+        cmd = ['/bin/sh', '-c', "echo $TEST"]
+        with self.mocked_stdout_stderr():
+            res = run_shell_cmd(cmd)
+        self.assertEqual(res.exit_code, 0)
+        self.assertEqual(res.output, "123\n")
+
     def test_run_cmd_script(self):
         """Testing use of run_cmd with shell=False to call external scripts"""
 

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -1605,6 +1605,16 @@ class RunTest(EnhancedTestCase):
         # no reason echo hello could fail
         self.assertEqual(ec, 0)
 
+    def test_run_shell_cmd_list(self):
+        """Test run_shell_cmd with command specified as a list rather than a string"""
+
+        cmd = ['/bin/sh', '-c', "echo hello"]
+        with self.mocked_stdout_stderr():
+            res = run_shell_cmd(cmd)
+        # no reason echo hello could fail
+        self.assertEqual(res.exit_code, 0)
+        self.assertEqual(res.output, "hello\n")
+
     def test_run_cmd_script(self):
         """Testing use of run_cmd with shell=False to call external scripts"""
 


### PR DESCRIPTION
~Draft PR, because the test fails, signaling a problem with `run_shell_cmd`...~