### PR TITLE
Check module extensions support within Tcl modulefiles

### DIFF
--- a/easybuild/tools/module_generator.py
+++ b/easybuild/tools/module_generator.py
@@ -895,10 +895,12 @@ class ModuleGeneratorTcl(ModuleGenerator):
             # - 'conflict Compiler/GCC/4.8.2/OpenMPI' for 'Compiler/GCC/4.8.2/OpenMPI/1.6.4'
             lines.extend(['', "conflict %s" % os.path.dirname(self.app.short_mod_name)])
 
-        if build_option('module_extensions'):
+        if build_option('module_extensions') and self.modules_tool.supports_extensions:
             extensions_list = self.app.make_extension_string(name_version_sep='/', ext_sep=' ')
-            if self.modules_tool.supports_extensions and extensions_list:
-                lines.extend(['', 'extensions %s' % extensions_list])
+            if extensions_list:
+                extensions_stmt = 'extensions %s' % extensions_list
+                extensions_guard = self.check_version(*self.modules_tool.REQ_VERSION_EXTENSIONS.split("."))
+                lines.extend(['', self.conditional_statement(extensions_guard, extensions_stmt)])
 
         return '\n'.join(lines + [''])
 

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1790,7 +1790,7 @@ class EnvironmentModules(ModulesTool):
         self.supports_tcl_getenv = True
         self.supports_tcl_check_group = version >= LooseVersion(self.REQ_VERSION_TCL_CHECK_GROUP)
         self.supports_safe_auto_load = True
-        self.supports_extensions = version >= LooseVersion(self.REQ_VERSION_EXTENSIONS)
+        self.supports_extensions = True
 
     def check_module_function(self, allow_mismatch=False, regex=None):
         """Check whether selected module tool matches 'module' function definition."""
@@ -1923,7 +1923,7 @@ class Lmod(ModulesTool):
         version = LooseVersion(self.version)
 
         self.supports_depends_on = True
-        self.supports_extensions = version >= LooseVersion(self.REQ_VERSION_EXTENSIONS)
+        self.supports_extensions = True
         # See https://lmod.readthedocs.io/en/latest/125_personal_spider_cache.html
         if version >= LooseVersion('8.7.12'):
             self.USER_CACHE_DIR = os.path.join(os.path.expanduser('~'), '.cache', 'lmod')

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -43,7 +43,7 @@ from easybuild.tools.module_naming_scheme.utilities import is_valid_module_name
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, ActiveMNS
 from easybuild.tools.build_log import EasyBuildError
-from easybuild.tools.modules import EnvironmentModulesC, EnvironmentModulesTcl, Lmod
+from easybuild.tools.modules import EnvironmentModules, EnvironmentModulesC, EnvironmentModulesTcl, Lmod
 from easybuild.tools.utilities import quote_str
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, find_full_path, init_config
 
@@ -806,23 +806,27 @@ class ModuleGeneratorTest(EnhancedTestCase):
         modgen = self.MODULE_GENERATOR_CLASS(eb)
         desc = modgen.get_description()
 
+        req_version_pattern = re.escape(self.modtool.REQ_VERSION_EXTENSIONS)
         if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
-            pattern = r'^extensions bar/0.0 barbar/1.2 toy/0.0 ulimit$'
-            regex = re.compile(pattern, re.M)
-            if self.modtool.supports_extensions:
-                self.assertTrue(regex.search(desc), "Pattern '%s' found in: %s" % (regex.pattern, desc))
+            if isinstance(self.modtool, EnvironmentModules):
+                version_var = "::ModuleToolVersion"
             else:
-                self.assertFalse(regex.search(desc), "No extensions found in: %s" % desc)
+                version_var = r"::env\(LMOD_VERSION\)"
+            patterns = [
+                (r'^if \{ \[ info exists %s \] && \[ string equal \[lindex \[lsort -dictionary '
+                 r'\[list %s \$%s\]\] 0\] %s \] \} \{\n') % (version_var, req_version_pattern,
+                                                             version_var, req_version_pattern),
+                r'\s*extensions bar/0.0 barbar/1.2 toy/0.0 ulimit$',
+            ]
         else:
-            req_version_pattern = re.escape(self.modtool.REQ_VERSION_EXTENSIONS)
             patterns = [
                 r'^if convertToCanonical\(LmodVersion\(\)\) >= convertToCanonical\("%s"\) then\n' % req_version_pattern,
                 r'\s*extensions\("bar/0.0,barbar/1.2,toy/0.0,ulimit"\)\nend$',
             ]
 
-            for pattern in patterns:
-                regex = re.compile(pattern, re.M)
-                self.assertTrue(regex.search(desc), "Pattern '%s' found in: %s" % (regex.pattern, desc))
+        for pattern in patterns:
+            regex = re.compile(pattern, re.M)
+            self.assertTrue(regex.search(desc), "Pattern '%s' found in: %s" % (regex.pattern, desc))
 
         # check if the extensions is missing if there are no extensions
         test_ec = os.path.join(test_dir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0-test.eb')
@@ -833,7 +837,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
         desc = modgen.get_description()
 
         if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
-            pattern = r"^extensions "
+            pattern = r"\s*extensions "
         else:
             pattern = r"\s*extensions\("
 
@@ -848,13 +852,9 @@ class ModuleGeneratorTest(EnhancedTestCase):
         modgen = self.MODULE_GENERATOR_CLASS(eb)
         desc = modgen.get_description()
 
-        if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
-            pattern = r'^extensions '
-            self.assertFalse(re.search(pattern, desc), "No extensions found in: %s" % desc)
-        else:
-            for pattern in patterns:
-                regex = re.compile(pattern, re.M)
-                self.assertFalse(regex.search(desc), "Pattern '%s' not found in: %s" % (regex.pattern, desc))
+        for pattern in patterns:
+            regex = re.compile(pattern, re.M)
+            self.assertFalse(regex.search(desc), "Pattern '%s' not found in: %s" % (regex.pattern, desc))
 
     def test_prepend_paths(self):
         """Test generating prepend-paths statements."""


### PR DESCRIPTION
Instead of making EasyBuild check if module extensions are supported by module tool to generate the proper Tcl modulefiles, move this check directly within modulefile code, like done with Lua modulefiles.

It means module extensions code is always written in modulefile, but a condition guards it, to execute this code only if the version of the module tool evaluating the modulefile supports it.

So instead of checking the version of the module tool used by EasyBuild, the check is made on the module tool that evaluates the generated modulefiles.

With this new approach, the "supports_extensions" ModuleTool state is now useless thus it is removed.