### PR TITLE
Handle `post_install_patches` and `post_install_msgs` for extensions

### DIFF
--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -232,6 +232,8 @@ class Extension:
         Stuff to do after installing a extension.
         """
         self.master.run_post_install_commands(commands=self.cfg.get('postinstallcmds', []))
+        self.master.apply_post_install_patches(patches=[p for p in self.patches if p['postinstall']])
+        self.master.print_post_install_messages(msgs=self.cfg.get('postinstallmsgs', []))
 
     def install_extension_substep(self, substep, *args, **kwargs):
         """


### PR DESCRIPTION
Those EasyConfig parameters were silently ignored. Run the appropriate steps in the default implementation of `post_install_extension` similar to postinstall_cmds and add a test. Using the new name for `post_install_patches` in the test reveals the need to handle that explicitely as a raw dict is used.