### PR TITLE
make RPATH wrapper script not add RPATH (linking) flags when `-c` flag specified

### DIFF
--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -42,6 +42,9 @@ def is_new_existing_path(new_path, paths):
     """
     Check whether specified path exists and is a new path compared to provided list of paths (that surely exist as they
     were checked before).
+
+    :param new_path: The new path to check
+    :param paths: The list of existing paths
     """
     if not os.path.exists(new_path):
         return False
@@ -51,6 +54,24 @@ def is_new_existing_path(new_path, paths):
             return False
 
     return True
+
+
+def add_rpath_flag(lib_path, rpath_filter, rpath_lib_paths, cmd_args_rpath, ldflag_prefix):
+    """
+    Add an -rpath flag for the given library path if it is valid and not a duplicate.
+    Don't RPATH in empty or relative paths, or paths that are filtered out; linking relative paths via RPATH doesn't
+    make much sense and it can also break the build because it may result in reordering lib paths.
+
+    :param lib_path: Library path to process
+    :param rpath_filter: Compiled regex filter for excluding paths
+    :param rpath_lib_paths: List of already processed library paths
+    :param cmd_args_rpath: List of -rpath flags to append to
+    :param ldflag_prefix: Prefix for linker flags (e.g., '-Wl,' or empty)
+    """
+    if lib_path and os.path.isabs(lib_path) and (rpath_filter is None or not rpath_filter.match(lib_path)):
+        if is_new_existing_path(lib_path, rpath_lib_paths):
+            rpath_lib_paths.append(lib_path)
+            cmd_args_rpath.append(ldflag_prefix + '-rpath=' + lib_path)
 
 
 cmd = sys.argv[1]
@@ -90,7 +111,7 @@ while idx < len(args):
         add_rpath_args = False
         cmd_args.append(arg)
 
-    # -c implies no linking is done, so we must not inject -Wl,-rpath
+    # with '-c' no linking is done, so we must not inject any rpath
     elif arg == '-c':
         add_rpath_args = False
         cmd_args.append(arg)
@@ -118,15 +139,7 @@ while idx < len(args):
         else:
             lib_path = arg[2:]
 
-        # don't RPATH in empty or relative paths, or paths that are filtered out;
-        # linking relative paths via RPATH doesn't make much sense,
-        # and it can also break the build because it may result in reordering lib paths
-        if lib_path and os.path.isabs(lib_path) and (rpath_filter is None or not rpath_filter.match(lib_path)):
-            # avoid using duplicate library paths
-            if is_new_existing_path(lib_path, rpath_lib_paths):
-                # inject -rpath flag in front for every -L with an absolute path,
-                rpath_lib_paths.append(lib_path)
-                cmd_args_rpath.append(ldflag_prefix + '-rpath=%s' % lib_path)
+        add_rpath_flag(lib_path, rpath_filter, rpath_lib_paths, cmd_args_rpath, ldflag_prefix)
 
         # always retain -L flag (without reordering!)
         cmd_args.append('-L%s' % lib_path)
@@ -143,25 +156,13 @@ while idx < len(args):
     elif arg == ldflag_prefix + '--enable-new-dtags':  # detect '--enable-new-dtags' or '-Wl,--enable-new-dtags'
         cmd_args_rpath.append(ldflag_prefix + '--disable-new-dtags')
 
-    # detect and retain any -rpath explicitly specified
+    # detect and retain any -rpath flag that was explicitly specified
     elif arg.startswith(ldflag_prefix + '-rpath='):
         lib_path = arg.replace(ldflag_prefix + '-rpath=', '')
-        # don't RPATH in empty or relative paths, or paths that are filtered out;
-        if lib_path and os.path.isabs(lib_path) and (rpath_filter is None or not rpath_filter.match(lib_path)):
-            # avoid using duplicate library paths
-            if is_new_existing_path(lib_path, rpath_lib_paths):
-                # inject -rpath flag in front for every -L with an absolute path,
-                rpath_lib_paths.append(lib_path)
-                cmd_args_rpath.append(arg)
+        add_rpath_flag(lib_path, rpath_filter, rpath_lib_paths, cmd_args_rpath, ldflag_prefix)
     elif arg.startswith('-Xlinker') and args[idx+1].startswith('-rpath='):
         lib_path = args[idx+1].replace('-rpath=', '')
-        # don't RPATH in empty or relative paths, or paths that are filtered out;
-        if lib_path and os.path.isabs(lib_path) and (rpath_filter is None or not rpath_filter.match(lib_path)):
-            # avoid using duplicate library paths
-            if is_new_existing_path(lib_path, rpath_lib_paths):
-                # inject -rpath flag in front for every -L with an absolute path,
-                rpath_lib_paths.append(lib_path)
-                cmd_args_rpath.append(ldflag_prefix + '-rpath=' + lib_path)
+        add_rpath_flag(lib_path, rpath_filter, rpath_lib_paths, cmd_args_rpath, ldflag_prefix)
         idx += 1
 
     else:
@@ -172,11 +173,7 @@ while idx < len(args):
 # also inject -rpath options for all entries in $LIBRARY_PATH,
 # unless they are there already
 for lib_path in os.getenv('LIBRARY_PATH', '').split(os.pathsep):
-    if lib_path and os.path.isabs(lib_path) and (rpath_filter is None or not rpath_filter.match(lib_path)):
-        # avoid using duplicate library paths
-        if is_new_existing_path(lib_path, rpath_lib_paths):
-            rpath_lib_paths.append(lib_path)
-            cmd_args_rpath.append(ldflag_prefix + '-rpath=%s' % lib_path)
+    add_rpath_flag(lib_path, rpath_filter, rpath_lib_paths, cmd_args_rpath, ldflag_prefix)
 
 if add_rpath_args:
     # try to make sure that RUNPATH is not used by always injecting --disable-new-dtags


### PR DESCRIPTION
When the compiler is invoked with the `-c` flag, the linker is not run.
In this case, the RPATH linker flags are useless. Although they are
normally ignored, adding them has shown to cause problems in some cases,
e.g. with Intel + Meson:
https://github.com/easybuilders/easybuild-easyconfigs/pull/20262

The behavior of the `rpath_args.py` script has been modified so that RPATH
flags are not added when the `-c` flag is detected.
Moreover, it is now able to detect and process any RPATH flag that may have
been added explicitly by the user/build system.
Tests have been updated to check all these possible scenarios.

Fixes https://github.com/easybuilders/easybuild-easyconfigs/issues/23031
Fixes #4979