### PR TITLE
introduce `PYTHON_EXE` variable in template for RPATH wrapper script (to easily replace name of `python` command to use in `buildenv` easyblock)

### DIFF
--- a/easybuild/scripts/rpath_wrapper_template.sh.in
+++ b/easybuild/scripts/rpath_wrapper_template.sh.in
@@ -46,6 +46,8 @@ TOPDIR=`dirname $0`
 
 log "found CMD: $CMD | original command: %(orig_cmd)s | orig args: '$(echo \"$@\")'"
 
+PYTHON_EXE=%(python)s
+
 # rpath_args.py script spits out statement that defines $CMD_ARGS
 # options for 'python' command (see https://docs.python.org/3/using/cmdline.html#miscellaneous-options)
 # * -E: ignore all $PYTHON* environment variables that might be set (like $PYTHONPATH);
@@ -53,8 +55,8 @@ log "found CMD: $CMD | original command: %(orig_cmd)s | orig args: '$(echo \"$@\
 # * -s: don’t add the user site-packages directory to sys.path;
 # * -S: disable the import of the module site and the site-dependent manipulations of sys.path that it entails;
 # (once we only support Python 3, we can (also) use -I (isolated mode)
-log "%(python)s -E -O -s -S %(rpath_args_py)s $CMD '%(rpath_filter)s' '%(rpath_include)s' $(echo \"$@\")'"
-rpath_args_out=$(%(python)s -E -O -s -S %(rpath_args_py)s $CMD '%(rpath_filter)s' '%(rpath_include)s' "$@")
+log "$PYTHON_EXE -E -O -s -S %(rpath_args_py)s $CMD '%(rpath_filter)s' '%(rpath_include)s' $(echo \"$@\")'"
+rpath_args_out=$($PYTHON_EXE -E -O -s -S %(rpath_args_py)s $CMD '%(rpath_filter)s' '%(rpath_include)s' "$@")
 
 log "rpath_args_out:
 $rpath_args_out"

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -55,6 +55,7 @@ Authors:
 import copy
 import os
 import stat
+import sys
 import tempfile
 
 from easybuild.base import fancylogger
@@ -1086,7 +1087,7 @@ class Toolchain:
                 # complete template script and put it in place
                 cmd_wrapper_txt = read_file(rpath_wrapper_template) % {
                     'orig_cmd': orig_cmd,
-                    'python': 'python3',
+                    'python': sys.executable,
                     'rpath_args_py': rpath_args_py,
                     'rpath_filter': rpath_filter,
                     'rpath_include': rpath_include,

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -1087,7 +1087,7 @@ class Toolchain:
                 # complete template script and put it in place
                 cmd_wrapper_txt = read_file(rpath_wrapper_template) % {
                     'orig_cmd': orig_cmd,
-                    'python': sys.executable,
+                    'python': 'python3',
                     'rpath_args_py': rpath_args_py,
                     'rpath_filter': rpath_filter,
                     'rpath_include': rpath_include,

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -55,7 +55,6 @@ Authors:
 import copy
 import os
 import stat
-import sys
 import tempfile
 
 from easybuild.base import fancylogger


### PR DESCRIPTION
we run easybuild in a venv, causing the wrappers contain the absolute path to the python executable in the venv, and thus is unusable for our users.

EDIT:
changed this PR to use a shell variable for the python executable, which makes it easier to substitute it with `python3` in the `buildenv` easyblock, see https://github.com/easybuilders/easybuild-easyblocks/pull/3910