### PR TITLE
Disable module extensions for EnvModules for the moment

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1790,7 +1790,9 @@ class EnvironmentModules(ModulesTool):
         self.supports_tcl_getenv = True
         self.supports_tcl_check_group = version >= LooseVersion(self.REQ_VERSION_TCL_CHECK_GROUP)
         self.supports_safe_auto_load = True
-        self.supports_extensions = True
+        # Environment Modules should support "informational extension" to safely handle the
+        # extensions built here (see https://github.com/envmodules/modules/issues/585)
+        self.supports_extensions = False
 
     def check_module_function(self, allow_mismatch=False, regex=None):
         """Check whether selected module tool matches 'module' function definition."""

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -794,6 +794,10 @@ class ModuleGeneratorTest(EnhancedTestCase):
 
     def test_module_extensions(self):
         """test the extensions() for extensions"""
+        # not supported by Environment Modules for the moment
+        if isinstance(self.modtool, EnvironmentModules):
+            return
+
         # check if extensions option is enabled and some module extensions are defined
         init_config(build_options={'module_extensions': True})
 


### PR DESCRIPTION
Environment Modules needs to support *informational extension* to safely handle the module extensions generated by EasyBuild. See envmodules/modules#585.

Until then, it is safer to disable support the module extensions for Environment Modules, otherwise several builds may fail.