### PR TITLE
No modulepath prepend if already enabled in load method

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1111,9 +1111,10 @@ class ModulesTool:
             self.check_module_path()
 
         # extend $MODULEPATH if needed
+        curr_mod_paths = curr_module_paths()
         for mod_path in mod_paths:
             full_mod_path = os.path.join(install_path('mod'), build_option('suffix_modules_path'), mod_path)
-            if os.path.exists(full_mod_path):
+            if os.path.exists(full_mod_path) and full_mod_path not in curr_mod_paths:
                 self.prepend_module_path(full_mod_path)
 
         loaded_modules = self.loaded_modules()


### PR DESCRIPTION
Update `load` method of ModuleTool class to avoid prepending a modulepath passed as argument if it is already enabled.

This change avoid setting a modulepath at top priority that could lead to wrong module dependency resolution.

Fixes #4986
Fixes easybuilders/easybuild-easyconfigs#23675
Fixes easybuilders/easybuild-easyconfigs#17407
Fixes easybuilders/easybuild-easyconfigs#17368
Fixes easybuilders/easybuild-easyconfigs#23579