### PR TITLE
Skip RPATH sanity check for symlinks explicitely

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3791,12 +3791,10 @@ class EasyBlock:
                 self.log.debug(f"Sanity checking RPATH for files in {dirpath}")
 
                 for path in [os.path.join(dirpath, x) for x in os.listdir(dirpath)]:
-                    # skip the check for any symlinks that resolve to outside the installation directory
-                    if not is_parent_path(self.installdir, path):
+                    # skip the check for symlinks
+                    if os.path.islink(path):
                         realpath = os.path.realpath(path)
-                        msg = (f"Skipping RPATH sanity check for {path}, since its absolute path {realpath} resolves to"
-                               f" outside the installation directory {self.installdir}")
-                        self.log.info(msg)
+                        self.log.debug(f"Skipping RPATH sanity check for {path}, since it is a symlink to {realpath}")
                         continue
 
                     self.log.debug(f"Sanity checking RPATH for {path}")

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3791,7 +3791,7 @@ class EasyBlock:
                 self.log.debug(f"Sanity checking RPATH for files in {dirpath}")
 
                 for path in [os.path.join(dirpath, x) for x in os.listdir(dirpath)]:
-                    # skip the check for symlinks
+                    # skip the check for symlinks (since get_linked_libs_raw will return None anyway)
                     if os.path.islink(path):
                         realpath = os.path.realpath(path)
                         self.log.debug(f"Skipping RPATH sanity check for {path}, since it is a symlink to {realpath}")

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -1457,15 +1457,16 @@ class SystemToolsTest(EnhancedTestCase):
         """
         Test get_linked_libs_raw function.
         """
-        bin_ls = which('ls')
-        linked_libs_out = get_linked_libs_raw(bin_ls)
         os_type = get_os_type()
         if os_type == LINUX:
             libname = 'libc.so.6'
         elif os_type == DARWIN:
             libname = 'libSystem.B.dylib'
         else:
-            self.fail(f"Unknown OS: {os_type}")
+            self.skipTest(f"Unknown OS: {os_type}")
+
+        bin_ls = which('ls')
+        linked_libs_out = get_linked_libs_raw(bin_ls)
 
         # check whether expected pattern is found
         self.assertIn(libname, linked_libs_out)
@@ -1474,12 +1475,12 @@ class SystemToolsTest(EnhancedTestCase):
         symlinked_ls = os.path.join(self.test_prefix, 'ls')
         symlink(bin_ls, symlinked_ls)
         res = get_linked_libs_raw(symlinked_ls)
-        self.assertEqual(res, None)
+        self.assertIs(res, None)
 
         txt_file = os.path.join(self.test_prefix, 'test.txt')
         write_file(txt_file, 'not-a-binary')
         res = get_linked_libs_raw(txt_file)
-        self.assertEqual(res, None)
+        self.assertIs(res, None)
 
 
 def suite(loader=None):


### PR DESCRIPTION
`get_libs_raw` will return `None` anyway leading to a suboptimal warning.

Follow-up to https://github.com/easybuilders/easybuild-framework/pull/4975