### PR TITLE
Fix failure to resolve template in tests

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -5054,7 +5054,7 @@ def build_and_install_one(ecdict, init_env):
     # timing info
     start_time = time.time()
     try:
-        run_test_cases = not build_option('skip_test_cases') and app.cfg['tests']
+        run_test_cases = not build_option('skip_test_cases') and app.cfg.get_ref('tests')
 
         if not dry_run:
             # create our reproducibility files before carrying out the easyblock steps


### PR DESCRIPTION
The check whether to run the test(cases) step accesses an easyconfig parameter which might include template `%(installdir)s` which isn't available at this point.
Just check the raw value as we only care about whether it is set.

Fixes #4990


I'm wondering if we should include backtraces because with that it is easy to find the error (replaced EasyBuildError by RuntimeError):
```
  File "/home/s3248973/.local/EasyBuildDev/easybuild-framework/easybuild/main.py", line 161, in build_and_install_software
    (ec_res['success'], app_log, err_msg, err_code) = build_and_install_one(ec, init_env)
  File "/home/s3248973/.local/EasyBuildDev/easybuild-framework/easybuild/framework/easyblock.py", line 5057, in build_and_install_one
    run_test_cases = not build_option('skip_test_cases') and app.cfg['tests']
  File "/home/s3248973/.local/EasyBuildDev/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 142, in new_ec_method
    return ec_method(self, key, *args, **kwargs)
  File "/home/s3248973/.local/EasyBuildDev/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 1885, in __getitem__
    value = self.resolve_template(value)
  File "/home/s3248973/.local/EasyBuildDev/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 1869, in resolve_template
    return resolve_template(value, self.template_values, expect_resolved=self.expect_resolved_template_values)
  File "/home/s3248973/.local/EasyBuildDev/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 2228, in resolve_template
    value = [resolve_template(val, tmpl_dict, expect_resolved) for val in value]
  File "/home/s3248973/.local/EasyBuildDev/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 2228, in <listcomp>
    value = [resolve_template(val, tmpl_dict, expect_resolved) for val in value]
  File "/home/s3248973/.local/EasyBuildDev/easybuild-framework/easybuild/framework/easyconfig/easyconfig.py", line 2206, in resolve_template
    raise RuntimeError(msg)

```