### PR TITLE
update regex used in `Lmod.get_setenv_value_from_modulefile`

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
-        lmod8: Lmod-8.7.58
+        lmod8: Lmod-8.7.65
         modules4: modules-4.5.3
         modules5: modules-5.3.1
     steps:

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -2112,11 +2112,11 @@ class Lmod(ModulesTool):
         """
         # Lmod produces "module show" output with setenv statements like:
         # setenv("EBROOTBZIP2","/tmp/software/bzip2/1.0.6")
-        # - line starts with setenv(
+        # - line starts with setenv( or setenv{ (see also https://github.com/TACC/Lmod/issues/792)
         # - both variable name and value are enclosed in double quotes, separated by comma
         # - value can contain spaces!
         # - line ends with )
-        regex = re.compile(r'^setenv\("%s"\s*,\s*"(?P<value>.+)"\)' % var_name, re.M)
+        regex = re.compile(r'^setenv[\({]"%s"\s*,\s*"(?P<value>.+)"[\)}]' % var_name, re.M)
         value = self.get_value_from_modulefile(mod_name, regex, strict=False)
 
         if value:


### PR DESCRIPTION
Update regex used in `Lmod.get_setenv_value_from_modulefile` to take into account `setenv{...}` rather than `setenv(...)` produced by `module show` with Lmod 8.7.60+ (for module files in Tcl syntax)

See also https://github.com/TACC/Lmod/issues/792

I don't think it hurts to make the regex just a little bit more liberal, especially since there's a range of Lmod versions (incl. the most recent versions currently) that produce slightly different `show` output...

Hat tip to @xdelaruelle who reported that the `test_external_dependencies` test was failing when using latest Lmod version