### PR TITLE
Make command environment of shell commands more discoverable in the log

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -466,8 +466,8 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
             'Script to start debug shell for command',
             f'\t{cmd_str}',
             f'will be saved to {cmd_sh}',
+            f'Output will be logged to {cmd_out_fp}',
         ])
-        log_str += f'\nOutput will be logged to {cmd_out_fp}'
         if cmd_err_fp:
             log_str += f'\nErrors and warnings will be logged to {cmd_err_fp}'
         _log.info(f'run_shell_cmd: {log_str}')


### PR DESCRIPTION
Put the command on an own, indented line so it is easier to find in the log.

Currently it is a (potentially) very long line hidden in other output. E.g.:
```
== 2025-09-15 09:27:24,887 run.py:457 INFO run_shell_cmd: command environment of "export PYTHONPATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/lib/python3.12/site-packages:$PYTHONPATH && export PATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/bin:$PATH &&   PYTORCH_BUILD_VERSION=2.7.1 PYTORCH_BUILD_NUMBER=1 VERBOSE=0 MAX_JOBS=16 BLAS=FlexiBLAS WITH_BLAS=flexi USE_GFLAGS=0 USE_GLOG=0 USE_CUDSS=0 USE_CUSPARSELT=1 USE_UCC=0 USE_SYSTEM_UCC=0 BUILD_CUSTOM_PROTOBUF=0 USE_SYSTEM_EIGEN_INSTALL=0 USE_SYSTEM_PYBIND11=1 USE_IBVERBS=1 USE_CUDA=1 CUDNN_LIB_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/lib64 CUDNN_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/include USE_SYSTEM_NCCL=1 NCCL_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/NCCL/2.26.2-GCCcore-13.3.0-CUDA-12.6.0/include USE_ROCM=0 CMAKE_BUILD_TYPE=Release   /software/genoa/r24.04/Python/3.12.3-GCCcore-13.3.0/bin/python -m pip install --prefix=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on  --verbose --no-deps --ignore-installed --no-index --no-build-isolation ." will be saved to /tmp/easybuild-tmp/eb-ujvxdd0l/run-shell-cmd-output/export-g0peat6s
== 2025-09-15 09:27:24,887 run.py:460 INFO run_shell_cmd: Output of "export PYTHONPATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/lib/python3.12/site-packages:$PYTHONPATH && export PATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/bin:$PATH &&   PYTORCH_BUILD_VERSION=2.7.1 PYTORCH_BUILD_NUMBER=1 VERBOSE=0 MAX_JOBS=16 BLAS=FlexiBLAS WITH_BLAS=flexi USE_GFLAGS=0 USE_GLOG=0 USE_CUDSS=0 USE_CUSPARSELT=1 USE_UCC=0 USE_SYSTEM_UCC=0 BUILD_CUSTOM_PROTOBUF=0 USE_SYSTEM_EIGEN_INSTALL=0 USE_SYSTEM_PYBIND11=1 USE_IBVERBS=1 USE_CUDA=1 CUDNN_LIB_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/lib64 CUDNN_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/include USE_SYSTEM_NCCL=1 NCCL_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/NCCL/2.26.2-GCCcore-13.3.0-CUDA-12.6.0/include USE_ROCM=0 CMAKE_BUILD_TYPE=Release   /software/genoa/r24.04/Python/3.12.3-GCCcore-13.3.0/bin/python -m pip install --prefix=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on  --verbose --no-deps --ignore-installed --no-index --no-build-isolation ." will be logged to /tmp/easybuild-tmp/eb-ujvxdd0l/run-shell-cmd-output/export-g0peat6s/out.txt
== 2025-09-15 09:27:24,926 run.py:494 INFO Path to bash that will be used to run shell commands: /usr/bin/bash
== 2025-09-15 09:27:24,926 run.py:508 INFO Running shell command 'export PYTHONPATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/lib/python3.12/site-packages:$PYTHONPATH && export PATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/bin:$PATH &&   PYTORCH_BUILD_VERSION=2.7.1 PYTORCH_BUILD_NUMBER=1 VERBOSE=0 MAX_JOBS=16 BLAS=FlexiBLAS WITH_BLAS=flexi USE_GFLAGS=0 USE_GLOG=0 USE_CUDSS=0 USE_CUSPARSELT=1 USE_UCC=0 USE_SYSTEM_UCC=0 BUILD_CUSTOM_PROTOBUF=0 USE_SYSTEM_EIGEN_INSTALL=0 USE_SYSTEM_PYBIND11=1 USE_IBVERBS=1 USE_CUDA=1 CUDNN_LIB_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/lib64 CUDNN_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/include USE_SYSTEM_NCCL=1 NCCL_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/NCCL/2.26.2-GCCcore-13.3.0-CUDA-12.6.0/include USE_ROCM=0 CMAKE_BUILD_TYPE=Release   /software/genoa/r24.04/Python/3.12.3-GCCcore-13.3.0/bin/python -m pip install --prefix=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on  --verbose --no-deps --ignore-installed --no-index --no-build-isolation .' in /dev/shm/s3248973-EasyBuild/PyTorch/2.7.1/foss-2024a-CUDA-12.6.0/pytorch-v2.7.1
```

After this change:
```
== 2025-09-15 09:27:24,887 run.py:457 INFO run_shell_cmd: command environment of
    "export PYTHONPATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/lib/python3.12/site-packages:$PYTHONPATH && export PATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/bin:$PATH &&   PYTORCH_BUILD_VERSION=2.7.1 PYTORCH_BUILD_NUMBER=1 VERBOSE=0 MAX_JOBS=16 BLAS=FlexiBLAS WITH_BLAS=flexi USE_GFLAGS=0 USE_GLOG=0 USE_CUDSS=0 USE_CUSPARSELT=1 USE_UCC=0 USE_SYSTEM_UCC=0 BUILD_CUSTOM_PROTOBUF=0 USE_SYSTEM_EIGEN_INSTALL=0 USE_SYSTEM_PYBIND11=1 USE_IBVERBS=1 USE_CUDA=1 CUDNN_LIB_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/lib64 CUDNN_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/include USE_SYSTEM_NCCL=1 NCCL_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/NCCL/2.26.2-GCCcore-13.3.0-CUDA-12.6.0/include USE_ROCM=0 CMAKE_BUILD_TYPE=Release   /software/genoa/r24.04/Python/3.12.3-GCCcore-13.3.0/bin/python -m pip install --prefix=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on  --verbose --no-deps --ignore-installed --no-index --no-build-isolation ."
will be saved to /tmp/easybuild-tmp/eb-ujvxdd0l/run-shell-cmd-output/export-g0peat6s/cmd.sh
Output will be logged to /tmp/easybuild-tmp/eb-ujvxdd0l/run-shell-cmd-output/export-g0peat6s/out.txt
== 2025-09-15 09:27:24,926 run.py:494 INFO Path to bash that will be used to run shell commands: /usr/bin/bash
== 2025-09-15 09:27:24,926 run.py:508 INFO Running shell command 'export PYTHONPATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/lib/python3.12/site-packages:$PYTHONPATH && export PATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/bin:$PATH &&   PYTORCH_BUILD_VERSION=2.7.1 PYTORCH_BUILD_NUMBER=1 VERBOSE=0 MAX_JOBS=16 BLAS=FlexiBLAS WITH_BLAS=flexi USE_GFLAGS=0 USE_GLOG=0 USE_CUDSS=0 USE_CUSPARSELT=1 USE_UCC=0 USE_SYSTEM_UCC=0 BUILD_CUSTOM_PROTOBUF=0 USE_SYSTEM_EIGEN_INSTALL=0 USE_SYSTEM_PYBIND11=1 USE_IBVERBS=1 USE_CUDA=1 CUDNN_LIB_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/lib64 CUDNN_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/include USE_SYSTEM_NCCL=1 NCCL_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/NCCL/2.26.2-GCCcore-13.3.0-CUDA-12.6.0/include USE_ROCM=0 CMAKE_BUILD_TYPE=Release   /software/genoa/r24.04/Python/3.12.3-GCCcore-13.3.0/bin/python -m pip install --prefix=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on  --verbose --no-deps --ignore-installed --no-index --no-build-isolation .' in /dev/shm/s3248973-EasyBuild/PyTorch/2.7.1/foss-2024a-CUDA-12.6.0/pytorch-v2.7.1

```

This also removes the duplication of the command from 3 (or 4) times to only 2



Should we also shorten the last message to "Running [interactive ][shell ]command in /path/to/dir"? Note that "shell" should be removed here if no shell/bash is used.