### PR TITLE
Add `return_conflicts` option to `check_conflicts` function and enhance tests

### DIFF
--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -1415,11 +1415,11 @@ class RobotTest(EnhancedTestCase):
 
         gzip_ec = os.path.join(test_easyconfigs, 'g', 'gzip', 'gzip-1.5-foss-2018a.eb')
         gompi_ec = os.path.join(test_easyconfigs, 'g', 'gompi', 'gompi-2018a.eb')
-        ecs, _ = parse_easyconfigs([(gzip_ec, False), (gompi_ec, False)])
+        non_conflict_ecs, _ = parse_easyconfigs([(gzip_ec, False), (gompi_ec, False)])
 
         # no conflicts found, no output to stderr
         self.mock_stderr(True)
-        conflicts = check_conflicts(ecs, self.modtool)
+        conflicts = check_conflicts(non_conflict_ecs, self.modtool)
         stderr = self.get_stderr()
         self.mock_stderr(False)
         self.assertFalse(conflicts)
@@ -1440,6 +1440,13 @@ class RobotTest(EnhancedTestCase):
 
         self.assertTrue(conflicts)
         self.assertIn("Conflict found for dependencies of foss-2018a: GCC-4.6.4 vs GCC-6.4.0-2.28", stderr)
+
+        # Can also return the text
+        with self.mocked_stdout_stderr(mock_stdout=False) as mocked_stderr:
+            conflict_lst = check_conflicts(ecs, self.modtool, return_conflicts=True)
+            self.assertEqual('\n'.join(conflict_lst), stderr.strip())
+            self.assertEqual(mocked_stderr.getvalue(), '')
+            self.assertEqual(check_conflicts(non_conflict_ecs, self.modtool, return_conflicts=True), [])
 
         # conflicts between specified easyconfigs are also detected
 

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -40,7 +40,7 @@ from unittest import TextTestRunner
 import easybuild.framework.easyconfig.easyconfig as ecec
 import easybuild.tools.build_log
 import easybuild.tools.robot as robot
-from easybuild.framework.easyconfig.easyconfig import process_easyconfig, EasyConfig
+from easybuild.framework.easyconfig.easyconfig import process_easyconfig, EasyConfig, make_easyconfig_dict
 from easybuild.framework.easyconfig.tools import alt_easyconfig_paths, find_resolved_modules, parse_easyconfigs
 from easybuild.framework.easyconfig.tweak import tweak
 from easybuild.framework.easyconfig.easyconfig import get_toolchain_hierarchy
@@ -1478,6 +1478,28 @@ class RobotTest(EnhancedTestCase):
 
         # test use of check_inter_ec_conflicts
         self.assertFalse(check_conflicts(ecs, self.modtool, check_inter_ec_conflicts=False), "No conflicts found")
+
+        # Conflict in build dependencies is fine
+        hwloc_txt = read_file(os.path.join(test_easyconfigs, 'h', 'hwloc', 'hwloc-1.11.8-GCC-6.4.0-2.28.eb'))
+        gzip_txt = read_file(os.path.join(test_easyconfigs, 'g', 'gzip', 'gzip-1.5-foss-2018a.eb'))
+        bzip_txt = read_file(os.path.join(test_easyconfigs, 'b', 'bzip2', 'bzip2-1.0.6-GCC-4.9.2.eb'))
+        tc = re.search(r"toolchain *=.*", hwloc_txt)[0]
+        bzip_txt += f"\n{tc}"
+        gzip_txt += f"\n{tc}"
+        gzip_txt_2 = gzip_txt.replace('1.5', '2.0')
+        hwloc_txt += "\nbuilddependencies = [('gzip', '2.0')]"
+        bzip_txt += "\nbuilddependencies = [('gzip', '1.5')]"
+        ecs = [make_easyconfig_dict(EasyConfig(path=None, rawtxt=txt))
+               for txt in (hwloc_txt, gzip_txt, gzip_txt_2, bzip_txt)]
+        self.assertFalse(check_conflicts(ecs, self.modtool, check_inter_ec_conflicts=False),
+                         "No conflicts should be found")
+        # But fail if A depends on B which depends on C and A has C as a build dependency in another version
+        hwloc_txt += "\ndependencies = [('bzip2', '1.0.6')]"
+        bzip_txt = bzip_txt.replace("builddependencies", "dependencies")
+        ecs = [make_easyconfig_dict(EasyConfig(path=None, rawtxt=txt))
+               for txt in (hwloc_txt, gzip_txt, gzip_txt_2, bzip_txt)]
+        self.assertTrue(check_conflicts(ecs, self.modtool, check_inter_ec_conflicts=False, return_conflicts=True),
+                        "Conflict should be found")
 
     def test_check_conflicts_wrapper_deps(self):
         """Test check_conflicts when dependency 'wrappers' are involved."""


### PR DESCRIPTION
This is motivated by the easyconfig tests where the result is hard to interpret:

> FAIL: test_conflicts (test.easyconfigs.easyconfigs.EasyConfigTest)
> Check whether any conflicts occur in software dependency graphs.
> ...
> AssertionError: True is not false : No conflicts detected

First the wording: It sounds like the error is that no conflicts are detected (similar in other places)

Second the actual conflicts are printed to stderr somewhere hidden above with other test output


The new parameter allows returning the text instead of printing it.

The PR where I've seen this was PyTorch: It has a build dependency on something which happens to be a runtime dependency of a dependency. So I added a test that this is detected but not if it is a build dependency for both where there would be no issue.

With that I ran into our somewhat strange dictionary duplicating a couple values that are easyconfig parameters, properties or functions: `{ 'ec': ec,  'spec': ec.path, 'short_mod_name': ec.short_mod_name, ...}`

As the robot-resolver uses that dict instead of an `EasyConfig` instance and I needed that in the test I factored out the creation of this dict into a new function. It is still strange... We should consider removing it or at least transforming it to a dataclass once we support only Python 3.7 to make it easier to reason about.



Should we report only primary dependents in the error message? See this confusing message:

> 	pybind11-2.13.6-GCC-13.3.0 as dep of: HiGHS-1.11.0-gfbf-2024a, **PyTorch-2.7.1-foss-2024a-CUDA-12.6.0**, Triton-3.1.0-foss-2024a-CUDA-12.6.0
> 	pybind11-2.12.0-GCC-13.3.0 as dep of: KMC-3.2.4-GCC-13.3.0, MACS3-3.0.3-gfbf-2024a, PyTorch-2.6.0-foss-2024a, **PyTorch-2.7.1-foss-2024a-CUDA-12.6.0**, SciPy-bundle-2024.05-gfbf-2024.05, SciPy-bundle-2024.05-gfbf-2024a, SignalP-6.0h-foss-2024a-fast, SnapATAC2-2.9.0-dev0-20250630-foss-2024a, TensorFlow-2.18.1-foss-2024a, Triton-3.3.1-foss-2024a-CUDA-12.6.0, bokeh-3.6.0-gfbf-2024a, dm-tree-0.1.9-gfbf-2024a, gemmi-0.7.1-GCC-13.3.0, heat-1.6.0-foss-2024a, hmmlearn-0.3.3-gfbf-2024a, matplotlib-3.9.2-gfbf-2024a, pybind11_abseil-202402.0-GCC-13.3.0, pyspoa-0.2.1-GCC-13.3.0, tensorstore-0.1.72-gfbf-2024a, torchvision-0.21.0-foss-2024a

I.e. it collects transitive dependents while collecting transitive dependencies in https://github.com/Flamefire/easybuild-framework/blob/9cd02c9ea03c5bdf278f0760453306e795737a5f/easybuild/tools/robot.py#L178-L181