### PR TITLE
Don't show command string again when showing in which folder it runs

### DIFF
--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -447,8 +447,8 @@ class RunTest(EnhancedTestCase):
         fd, logfile = tempfile.mkstemp(suffix='.log', prefix='eb-test-')
         os.close(fd)
 
-        regex_start_cmd = re.compile(r"Running 'echo \.\.\.' shell command in /")
-        regex_cmd_exit = re.compile(r"Shell command completed successfully: echo hello")
+        regex_start_cmd = re.compile(r"Running 'echo ...' shell command in .*:\n\techo hello", re.M)
+        regex_cmd_exit = re.compile(r"'echo ...' shell command completed successfully")
         regex_cmd_output = re.compile(r"Output of 'echo \.\.\.' shell command \(stdout \+ stderr\):\nhello", re.M)
 
         # command output is logged
@@ -2250,7 +2250,8 @@ class RunTest(EnhancedTestCase):
             f"rm -rf {workdir} && echo 'Working directory removed.'"
         )
 
-        error_pattern = rf"Failed to return to .*/{os.path.basename(self.test_prefix)}/workdir after executing command"
+        error_pattern = rf"Failed to return to .*/{os.path.basename(self.test_prefix)}/workdir "
+        error_pattern += r"after executing 'echo ...' shell command"
 
         mkdir(workdir, parents=True)
         with self.mocked_stdout_stderr():


### PR DESCRIPTION
Follow up to:
- https://github.com/easybuilders/easybuild-framework/pull/4999

This should change

> == 2025-09-15 09:27:24,887 run.py:457 INFO run_shell_cmd: command environment of
>     "export PYTHONPATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/lib/python3.12/site-packages:$PYTHONPATH && export PATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/bin:$PATH &&   PYTORCH_BUILD_VERSION=2.7.1 PYTORCH_BUILD_NUMBER=1 VERBOSE=0 MAX_JOBS=16 BLAS=FlexiBLAS WITH_BLAS=flexi USE_GFLAGS=0 USE_GLOG=0 USE_CUDSS=0 USE_CUSPARSELT=1 USE_UCC=0 USE_SYSTEM_UCC=0 BUILD_CUSTOM_PROTOBUF=0 USE_SYSTEM_EIGEN_INSTALL=0 USE_SYSTEM_PYBIND11=1 USE_IBVERBS=1 USE_CUDA=1 CUDNN_LIB_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/lib64 CUDNN_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/include USE_SYSTEM_NCCL=1 NCCL_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/NCCL/2.26.2-GCCcore-13.3.0-CUDA-12.6.0/include USE_ROCM=0 CMAKE_BUILD_TYPE=Release   /software/genoa/r24.04/Python/3.12.3-GCCcore-13.3.0/bin/python -m pip install --prefix=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on  --verbose --no-deps --ignore-installed --no-index --no-build-isolation ."
> will be saved to /tmp/easybuild-tmp/eb-ujvxdd0l/run-shell-cmd-output/export-g0peat6s/cmd.sh
> Output will be logged to /tmp/easybuild-tmp/eb-ujvxdd0l/run-shell-cmd-output/export-g0peat6s/out.txt
> == 2025-09-15 09:27:24,926 run.py:494 INFO Path to bash that will be used to run shell commands: /usr/bin/bash
> == 2025-09-15 09:27:24,926 run.py:508 INFO Running shell command 'export PYTHONPATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/lib/python3.12/site-packages:$PYTHONPATH && export PATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/bin:$PATH &&   PYTORCH_BUILD_VERSION=2.7.1 PYTORCH_BUILD_NUMBER=1 VERBOSE=0 MAX_JOBS=16 BLAS=FlexiBLAS WITH_BLAS=flexi USE_GFLAGS=0 USE_GLOG=0 USE_CUDSS=0 USE_CUSPARSELT=1 USE_UCC=0 USE_SYSTEM_UCC=0 BUILD_CUSTOM_PROTOBUF=0 USE_SYSTEM_EIGEN_INSTALL=0 USE_SYSTEM_PYBIND11=1 USE_IBVERBS=1 USE_CUDA=1 CUDNN_LIB_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/lib64 CUDNN_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/include USE_SYSTEM_NCCL=1 NCCL_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/NCCL/2.26.2-GCCcore-13.3.0-CUDA-12.6.0/include USE_ROCM=0 CMAKE_BUILD_TYPE=Release   /software/genoa/r24.04/Python/3.12.3-GCCcore-13.3.0/bin/python -m pip install --prefix=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on  --verbose --no-deps --ignore-installed --no-index --no-build-isolation .' in /dev/shm/s3248973-EasyBuild/PyTorch/2.7.1/foss-2024a-CUDA-12.6.0/pytorch-v2.7.1
> == 2025-09-26 13:56:48,683 run.py:628 INFO Shell command completed successfully: export PYTHONPATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/lib/python3.12/site-packages:$PYTHONPATH && export PATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/bin:$PATH &&   PYTORCH_BUILD_VERSION=2.7.1 PYTORCH_BUILD_NUMBER=1 VERBOSE=0 MAX_JOBS=16 BLAS=FlexiBLAS WITH_BLAS=flexi USE_GFLAGS=0 USE_GLOG=0 USE_CUDSS=0 USE_CUSPARSELT=1 USE_UCC=0 USE_SYSTEM_UCC=0 BUILD_CUSTOM_PROTOBUF=0 USE_SYSTEM_EIGEN_INSTALL=0 USE_SYSTEM_PYBIND11=1 USE_IBVERBS=1 USE_CUDA=1 CUDNN_LIB_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/lib64 CUDNN_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/include USE_SYSTEM_NCCL=1 NCCL_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/NCCL/2.26.2-GCCcore-13.3.0-CUDA-12.6.0/include USE_ROCM=0 CMAKE_BUILD_TYPE=Release   /software/genoa/r24.04/Python/3.12.3-GCCcore-13.3.0/bin/python -m pip install --prefix=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on  --verbose --no-deps --ignore-installed --no-index --no-build-isolation .
> == 2025-09-26 13:56:48,684 run.py:630 INFO Output of 'export ...' shell command (stdout + stderr):


To

> == 2025-09-15 09:27:24,887 run.py:457 INFO run_shell_cmd: command environment of
>     "export PYTHONPATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/lib/python3.12/site-packages:$PYTHONPATH && export PATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/bin:$PATH &&   PYTORCH_BUILD_VERSION=2.7.1 PYTORCH_BUILD_NUMBER=1 VERBOSE=0 MAX_JOBS=16 BLAS=FlexiBLAS WITH_BLAS=flexi USE_GFLAGS=0 USE_GLOG=0 USE_CUDSS=0 USE_CUSPARSELT=1 USE_UCC=0 USE_SYSTEM_UCC=0 BUILD_CUSTOM_PROTOBUF=0 USE_SYSTEM_EIGEN_INSTALL=0 USE_SYSTEM_PYBIND11=1 USE_IBVERBS=1 USE_CUDA=1 CUDNN_LIB_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/lib64 CUDNN_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/include USE_SYSTEM_NCCL=1 NCCL_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/NCCL/2.26.2-GCCcore-13.3.0-CUDA-12.6.0/include USE_ROCM=0 CMAKE_BUILD_TYPE=Release   /software/genoa/r24.04/Python/3.12.3-GCCcore-13.3.0/bin/python -m pip install --prefix=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on  --verbose --no-deps --ignore-installed --no-index --no-build-isolation ."
> will be saved to /tmp/easybuild-tmp/eb-ujvxdd0l/run-shell-cmd-output/export-g0peat6s/cmd.sh
> Output will be logged to /tmp/easybuild-tmp/eb-ujvxdd0l/run-shell-cmd-output/export-g0peat6s/out.txt
> == 2025-09-15 09:27:24,926 run.py:494 INFO Path to bash that will be used to run shell commands: /usr/bin/bash
> == 2025-09-15 09:27:24,926 run.py:508 INFO Running 'export ...' shell command in /dev/shm/s3248973-EasyBuild/PyTorch/2.7.1/foss-2024a-CUDA-12.6.0/pytorch-v2.7.1
> == 2025-09-26 13:56:48,683 run.py:628 INFO Shell command completed successfully: export PYTHONPATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/lib/python3.12/site-packages:$PYTHONPATH && export PATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/bin:$PATH &&   PYTORCH_BUILD_VERSION=2.7.1 PYTORCH_BUILD_NUMBER=1 VERBOSE=0 MAX_JOBS=16 BLAS=FlexiBLAS WITH_BLAS=flexi USE_GFLAGS=0 USE_GLOG=0 USE_CUDSS=0 USE_CUSPARSELT=1 USE_UCC=0 USE_SYSTEM_UCC=0 BUILD_CUSTOM_PROTOBUF=0 USE_SYSTEM_EIGEN_INSTALL=0 USE_SYSTEM_PYBIND11=1 USE_IBVERBS=1 USE_CUDA=1 CUDNN_LIB_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/lib64 CUDNN_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/include USE_SYSTEM_NCCL=1 NCCL_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/NCCL/2.26.2-GCCcore-13.3.0-CUDA-12.6.0/include USE_ROCM=0 CMAKE_BUILD_TYPE=Release   /software/genoa/r24.04/Python/3.12.3-GCCcore-13.3.0/bin/python -m pip install --prefix=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on  --verbose --no-deps --ignore-installed --no-index --no-build-isolation .
> == 2025-09-26 13:56:48,684 run.py:630 INFO Output of 'export ...' shell command (stdout + stderr):

Shall we remove the duplication in the completed/failed message too?

Then I'd go for:

> == 2025-09-15 09:27:24,887 run.py:457 INFO run_shell_cmd: command environment of
>     'export ...' shell command
> will be saved to /tmp/easybuild-tmp/eb-ujvxdd0l/run-shell-cmd-output/export-g0peat6s/cmd.sh
> Output will be logged to /tmp/easybuild-tmp/eb-ujvxdd0l/run-shell-cmd-output/export-g0peat6s/out.txt
> == 2025-09-15 09:27:24,926 run.py:494 INFO Path to bash that will be used to run shell commands: /usr/bin/bash
> == 2025-09-15 09:27:24,926 run.py:508 INFO Running 'export PYTHONPATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/lib/python3.12/site-packages:$PYTHONPATH && export PATH=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on/bin:$PATH &&   PYTORCH_BUILD_VERSION=2.7.1 PYTORCH_BUILD_NUMBER=1 VERBOSE=0 MAX_JOBS=16 BLAS=FlexiBLAS WITH_BLAS=flexi USE_GFLAGS=0 USE_GLOG=0 USE_CUDSS=0 USE_CUSPARSELT=1 USE_UCC=0 USE_SYSTEM_UCC=0 BUILD_CUSTOM_PROTOBUF=0 USE_SYSTEM_EIGEN_INSTALL=0 USE_SYSTEM_PYBIND11=1 USE_IBVERBS=1 USE_CUDA=1 CUDNN_LIB_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/lib64 CUDNN_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/cuDNN/9.5.1.17-CUDA-12.6.0/include USE_SYSTEM_NCCL=1 NCCL_INCLUDE_DIR=/data/horse/ws/s3248973-EasyBuild/easybuild-genoa/software/NCCL/2.26.2-GCCcore-13.3.0-CUDA-12.6.0/include USE_ROCM=0 CMAKE_BUILD_TYPE=Release   /software/genoa/r24.04/Python/3.12.3-GCCcore-13.3.0/bin/python -m pip install --prefix=/tmp/easybuild-tmp/eb-ujvxdd0l/tmp_8ohi9on  --verbose --no-deps --ignore-installed --no-index --no-build-isolation .' shell command in /dev/shm/s3248973-EasyBuild/PyTorch/2.7.1/foss-2024a-CUDA-12.6.0/pytorch-v2.7.1
> == 2025-09-26 13:56:48,683 run.py:628 INFO Shell command completed successfully
> == 2025-09-26 13:56:48,684 run.py:630 INFO Output of 'export ...' shell command (stdout + stderr):


I.e. show the full command only when the actual run starts and abbreviate otherwise. The part with "command environment of .. will be saved to" will not always be present as it depends on an argument