### PR TITLE
update `build_and_install_one` function to take into account that application log file may not exists

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -5269,6 +5269,11 @@ def build_and_install_one(ecdict, init_env):
 
     del app
 
+    # take into account that log file may not exist,
+    # for example when we're operating in extended dry run mode (-x)
+    if not os.path.exists(application_log):
+        application_log = None
+
     return (success, application_log, error_msg, exit_code)
 
 


### PR DESCRIPTION
This fixes a regression that was introduced in:
* #4958

The `application_log = app.logfile` change that was made there implicitly assumes that `app.logfile` is always a path to an *existing* file, but that's not necessarily the case, for example when `eb --extended-dry-run` or `eb -x` is used.

This bug was caught by `test_github_from_pr_x`, which fails as follows currently in `develop`:
```
ERROR: test_github_from_pr_x (test.framework.options.CommandLineOptionsTest)
Test combination of --from-pr with --extended-dry-run.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/easybuild-framework/test/framework/options.py", line 2211, in test_github_from_pr_x
    self.eb_main(args, do_build=True, raise_error=True, testing=False)
  File "/tmp/easybuild-framework/test/framework/utilities.py", line 352, in eb_main
    raise myerr
  File "/tmp/easybuild-framework/test/framework/utilities.py", line 325, in eb_main
    main(args=main_args, logfile=logfile, do_build=do_build, testing=testing, modtool=modtool)
  File "/tmp/easybuild-framework/easybuild/main.py", line 774, in main
    do_cleanup = process_eb_args(orig_paths, eb_go, cfg_settings, modtool, testing, init_session_state,
  File "/tmp/easybuild-framework/easybuild/main.py", line 593, in process_eb_args
    ecs_with_res = build_and_install_software(
  File "/tmp/easybuild-framework/easybuild/main.py", line 191, in build_and_install_software
    if os.stat(parent_dir).st_mode & 0o200:
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/eb-be7trg__/eb-tlnxxs7u/eb-prc3a4a3/eb-vmvw1t3n'
```

This didn't surface in PRs because this test requires a GitHub token, so it's only actually run *after* a PR is merged, or when a branch is pushed to a fork where a GitHub token is available as a "secret".