### PR TITLE
Remove escaping when converting EasyBuildError to a string

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3037,7 +3037,7 @@ class EasyBlock:
         try:
             self.test_step()
         except EasyBuildError as err:
-            self.report_test_failure(f"An error was raised during test step: {err.msg}")
+            self.report_test_failure(f"An error was raised during test step: {err}")
         except RunShellCmdError as err:
             err.print()
             ec_path = os.path.basename(self.cfg.path)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3037,7 +3037,7 @@ class EasyBlock:
         try:
             self.test_step()
         except EasyBuildError as err:
-            self.report_test_failure(f"An error was raised during test step: {err}")
+            self.report_test_failure(f"An error was raised during test step: {err.msg}")
         except RunShellCmdError as err:
             err.print()
             ec_path = os.path.basename(self.cfg.path)

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -139,7 +139,7 @@ class EasyBuildError(LoggedException):
 
     def __str__(self):
         """Return string representation of this EasyBuildError instance."""
-        return repr(self.msg)
+        return self.msg
 
 
 def raise_easybuilderror(msg, *args):

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -135,7 +135,7 @@ class EB_toy(ExtensionEasyBlock):
     def test_step(self, *args, **kwargs):
         """Test toy."""
         if self.cfg['runtest'] == 'RAISE_ERROR':
-            raise EasyBuildError("TOY_TEST_FAIL")
+            raise EasyBuildError("TOY_TEST_FAIL\nDescription on new line")
         else:
             super().test_step(*args, **kwargs)
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -4842,7 +4842,7 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec_txt += '\nruntest = "RAISE_ERROR"'
         write_file(test_ec, test_ec_txt)
 
-        error_pattern = r"An error was raised during test step: 'TOY_TEST_FAIL'"
+        error_pattern = "An error was raised during test step: TOY_TEST_FAIL\nDescription"
         self.assertErrorRegex(EasyBuildError, error_pattern, self.run_test_toy_build_with_output,
                               ec_file=test_ec, raise_error=True)
 


### PR DESCRIPTION
This is especially useful for Pytorch tests where the error message contains formatted output which becomes hard to read:

> == FAILED: Installation ended unsuccessfully: An error was raised during test step: 'Failing because not all failed tests could be determined. Tests failed to start, crashed or the test accounting in the PyTorch EasyBlock needs updating!\nMissing: distributed/test_c10d_nccl\nYou can check the test failures (in the log) manually and if they are harmless, use --ignore-test-failure to make the test step pass.\n109 test failures, 0 test errors (out of 262294):\nFailed tests (suites/files):\n\tdistributed/test_symmetric_memory (23 failed, 20 passed, 1 skipped, 0 errors)\n\tdynamo/test_misc (1 failed, 539 passed, 12 skipped, 0 errors)\n\tdynamo/test_utils (1 failed, 7 passed, 0 skipped, 0 errors)\n\tinductor/test_codecache (1 failed, 110 passed, 3 skipped, 0 errors)\n\tinductor/test_cudacodecache (3 failed, 0 passed, 0 skipped, 0 errors)\n\tinductor/test_cutlass_backend (39 failed, 1 passed, 2 skipped, 0 errors)\n\tinductor/test_fp8 (40 failed, 149 passed, 72 skipped, 0 errors)\n\tinductor/test_torchinductor_dynamic_shapes (1 failed, 1527 passed, 71 skipped, 0 errors)\nCould not count failed tests for the following test suites/files:\n\tdistributed/test_c10d_nccl (Undetected or did not run properly)' (took 64 hours 17 mins 9 secs)
