### PR TITLE
Honor `sanity_check_commands` & `sanity_check_paths` from extensions

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4660,6 +4660,7 @@ class EasyBlock:
                     else:
                         print_warning(mod_files_found_msg)
 
+            # Do not do those checks for extensions, only in the main easyconfig
             if self.toolchain.use_rpath:
                 rpath_fails = self.sanity_check_rpath()
                 if rpath_fails:
@@ -4688,13 +4689,13 @@ class EasyBlock:
             self.fake_mod_data = None
 
         # pass or fail
-        if self.sanity_check_fail_msgs:
+        if not self.sanity_check_fail_msgs:
+            self.log.debug("Sanity check passed!")
+        elif not self.is_extension:
             raise EasyBuildError(
                 "Sanity check failed: " + '\n'.join(self.sanity_check_fail_msgs),
                 exit_code=EasyBuildExit.FAIL_SANITY_CHECK,
             )
-
-        self.log.debug("Sanity check passed!")
 
     def _set_module_as_default(self, fake=False):
         """

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -72,8 +72,6 @@ class ExtensionEasyBlock(EasyBlock, Extension):
     def __init__(self, *args, **kwargs):
         """Initialize either as EasyBlock or as Extension."""
 
-        self.is_extension = False
-
         if isinstance(args[0], EasyBlock):
             # make sure that extra custom easyconfig parameters are known
             extra_params = self.__class__.extra_options()
@@ -187,19 +185,20 @@ class ExtensionEasyBlock(EasyBlock, Extension):
                         self.log.info(info_msg)
                         trace_msg(info_msg)
                     # perform sanity check for stand-alone extension
-                    (sanity_check_ok, fail_msg) = Extension.sanity_check_step(self)
+                    Extension.sanity_check_step(self)
         else:
             # perform single sanity check for extension
-            (sanity_check_ok, fail_msg) = Extension.sanity_check_step(self)
+            Extension.sanity_check_step(self)
 
-        if custom_paths or custom_commands or not self.is_extension:
-            super().sanity_check_step(custom_paths=custom_paths,
-                                      custom_commands=custom_commands)
+        super().sanity_check_step(custom_paths=custom_paths,
+                                  custom_commands=custom_commands)
 
         # pass or fail sanity check
-        if sanity_check_ok:
+        if not self.sanity_check_fail_msgs:
+            sanity_check_ok = True
             self.log.info("Sanity check for %s successful!", self.name)
         else:
+            sanity_check_ok = False
             if not self.is_extension:
                 msg = "Sanity check for %s failed: %s" % (self.name, '; '.join(self.sanity_check_fail_msgs))
                 raise EasyBuildError(msg)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2754,6 +2754,52 @@ class EasyBlockTest(EnhancedTestCase):
         with self.mocked_stdout_stderr(), self.saved_env():
             eb.run_all_steps(True)
 
+        # Verify custom paths and commands of extensions are checked
+        toy_ec_fn = os.path.join(test_ecs_dir, 't', 'toy', 'toy-0.0.eb')
+        toy_ec_txt = read_file(toy_ec_fn)
+
+        self.contents = toy_ec_txt + textwrap.dedent("""
+            exts_defaultclass = 'DummyExtension'
+            exts_filter = ('true', '')
+            exts_list = [
+                ('bar', '0.0', {
+                    'sanity_check_commands': ['echo "%(name)s extension output"'],
+                    'sanity_check_paths': {'dirs': ['.'], 'files': ['any_file']},
+                }),
+                ('barbar', '0.0', {'sanity_check_commands': ['echo "%(name)s extension output"']}),
+            ]
+            sanity_check_commands = ['echo "%(name)s output"']
+            sanity_check_paths = {
+                'dirs': ['.'],
+                'files': [],
+            }
+        """)
+
+        self.writeEC()
+        eb = EB_toy(EasyConfig(self.eb_file))
+        eb.silent = True
+        write_file(os.path.join(eb.installdir, 'any_file'), '')
+        with self.mocked_stdout_stderr(), self.saved_env():
+            eb.sanity_check_step()
+        logtxt = read_file(eb.logfile)
+        self.assertRegex(logtxt, 'sanity check command.*echo "toy output" ran successfully')
+        self.assertRegex(logtxt, 'sanity check command.*echo "bar extension output" ran successfully')
+        self.assertRegex(logtxt, 'Using .*sanity check paths .*any_file')
+        self.assertRegex(logtxt, 'sanity check command.*echo "barbar extension output" ran successfully')
+        # Only do this once, not for every extension which would be redundant
+        self.assertEqual(logtxt.count('Checking for banned/required linked shared libraries'), 1)
+
+        # Verify that sanity_check_paths are actually verified
+        self.contents += "\nexts_list[-1][2]['sanity_check_paths'] = {'dirs': [], 'files': ['nosuchfile']}"
+        self.writeEC()
+        eb = EB_toy(EasyConfig(self.eb_file))
+        eb.silent = True
+        write_file(os.path.join(eb.installdir, 'any_file'), '')
+        with self.mocked_stdout_stderr():
+            self.assertRaisesRegex(EasyBuildError,
+                                   "extensions sanity check failed for 1 extensions: barbar\n.*nosuchfile",
+                                   eb.sanity_check_step)
+
     def test_parallel(self):
         """Test defining of parallelism."""
         topdir = os.path.abspath(os.path.dirname(__file__))

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2735,7 +2735,6 @@ class EasyBlockTest(EnhancedTestCase):
             exts_list = toy_ec['exts_list']
             exts_list[-1][2]['exts_filter'] = ("thisshouldfail", '')
             toy_ec['exts_list'] = exts_list
-            toy_ec['exts_defaultclass'] = 'DummyExtension'
 
         eb = EB_toy(toy_ec)
         eb.silent = True
@@ -2750,7 +2749,6 @@ class EasyBlockTest(EnhancedTestCase):
         # sanity check commands are checked after checking sanity check paths, so this should work
         toy_ec = EasyConfig(toy_ec_fn)
         toy_ec.update('sanity_check_commands', [("%(installdir)s/bin/toy && rm %(installdir)s/bin/toy", '')])
-        toy_ec['exts_defaultclass'] = 'DummyExtension'
         eb = EB_toy(toy_ec)
         eb.silent = True
         with self.mocked_stdout_stderr(), self.saved_env():

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -1526,7 +1526,6 @@ class EasyConfigTest(EnhancedTestCase):
             preconfigopts = 'echo start_dir in configure is %(start_dir)s && '
             prebuildopts = 'echo start_dir in build is %(start_dir)s && '
 
-            exts_defaultclass = 'EB_Toy'
             exts_list = [
                ('bar', '0.0', {
                    'sources': ['bar-0.0-local.tar.gz'],

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -6760,7 +6760,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
         test_ec_txt += '\n' + '\n'.join([
             "sanity_check_commands = ['barbar', 'toy']",
             "sanity_check_paths = {'files': ['bin/barbar', 'bin/toy'], 'dirs': ['bin']}",
-            "exts_defaultclass = 'DummyExtension'",
             "exts_list = [",
             "    ('barbar', '0.0', {",
             "        'start_dir': 'src',",

--- a/test/framework/sandbox/easybuild/easyblocks/t/toy.py
+++ b/test/framework/sandbox/easybuild/easyblocks/t/toy.py
@@ -81,9 +81,10 @@ class EB_toy(ExtensionEasyBlock):
         """
         Prepare for installing toy extensions.
         """
-        # insert new packages by building them with RPackage
-        self.cfg['exts_defaultclass'] = "Toy_Extension"
-        self.cfg['exts_filter'] = ("%(ext_name)s", "")
+        if not self.cfg.get('exts_defaultclass', resolve=False):
+            self.cfg['exts_defaultclass'] = "Toy_Extension"
+        if not self.cfg.get('exts_filter', resolve=False):
+            self.cfg['exts_filter'] = ("%(ext_name)s", "")
 
     def run_all_steps(self, *args, **kwargs):
         """

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1938,7 +1938,7 @@ class ToyBuildTest(EnhancedTestCase):
         move_file(libbarbar, libbarbar + '.foobar')
 
         # check whether sanity check fails now when using --module-only
-        error_pattern = 'Sanity check failed: command "ls -l lib/libbarbar.a" failed'
+        error_pattern = 'Sanity check failed: .*barbar\n.*command "ls -l lib/libbarbar.a" failed'
         for extra_args in (['--module-only'], ['--module-only', '--rebuild']):
             with self.mocked_stdout_stderr():
                 self.assertErrorRegex(EasyBuildError, error_pattern, self.eb_main, [test_ec] + extra_args,

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1340,7 +1340,6 @@ class ToyBuildTest(EnhancedTestCase):
 
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         test_ec_txt = f"{TOY_EC_TXT}\n" + textwrap.dedent("""
-            exts_defaultclass = "DummyExtension"
             exts_list = [
                ("bar", "0.0", {
                    "buildopts": " && ls -l test.txt",
@@ -1401,7 +1400,6 @@ class ToyBuildTest(EnhancedTestCase):
             # test use of single-element list in 'sources' with just the filename
             test_ec_txt = '\n'.join([
                 TOY_EC_TXT,
-                'exts_defaultclass = "DummyExtension"',
                 'exts_list = [',
                 '   ("bar", "0.0", {',
                 '       "sources": %s,' % bar_sources_spec,
@@ -1429,7 +1427,6 @@ class ToyBuildTest(EnhancedTestCase):
 
             test_ec_txt = '\n'.join([
                 TOY_EC_TXT,
-                'exts_defaultclass = "DummyExtension"',
                 'exts_list = [',
                 '   ("bar", "0.0", {',
                 '       "source_urls": ["file://%s"],' % test_source_path,
@@ -1445,7 +1442,6 @@ class ToyBuildTest(EnhancedTestCase):
             # check that checksums are picked up and verified
             test_ec_txt = '\n'.join([
                 TOY_EC_TXT,
-                'exts_defaultclass = "DummyExtension"',
                 'exts_list = [',
                 '   ("bar", "0.0", {',
                 '       "source_urls": ["file://%s"],' % test_source_path,
@@ -1469,7 +1465,6 @@ class ToyBuildTest(EnhancedTestCase):
             # test again with correct checksum for bar-0.0.tar.gz, but faulty checksum for patch file
             test_ec_txt = '\n'.join([
                 TOY_EC_TXT,
-                'exts_defaultclass = "DummyExtension"',
                 'exts_list = [',
                 '   ("bar", "0.0", {',
                 '       "source_urls": ["file://%s"],' % test_source_path,
@@ -1493,7 +1488,6 @@ class ToyBuildTest(EnhancedTestCase):
             # test again with correct checksums
             test_ec_txt = '\n'.join([
                 TOY_EC_TXT,
-                'exts_defaultclass = "DummyExtension"',
                 'exts_list = [',
                 '   ("bar", "0.0", {',
                 '       "source_urls": ["file://%s"],' % test_source_path,
@@ -1515,7 +1509,6 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         test_ec_txt = '\n'.join([
             TOY_EC_TXT,
-            'exts_defaultclass = "DummyExtension"',
             'exts_list = [',
             '   ("bar", "0.0", {',
             # deliberately incorrect custom extract command, just to verify that it's picked up
@@ -1552,7 +1545,6 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec_txt = '\n'.join([
             TOY_EC_TXT,
             'prebuildopts = "echo \\\"%s\\\" > %s && ",' % (ext_code, ext_cfile),
-            'exts_defaultclass = "DummyExtension"',
             'exts_list = [',
             '   ("exts-git", "0.0", {',
             '       "buildopts": "&& ls -l %s %s",' % (ext_tarball, ext_tarfile),
@@ -1910,7 +1902,6 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec_txt += '\n' + '\n'.join([
             "sanity_check_commands = ['barbar', 'toy']",
             "sanity_check_paths = {'files': ['bin/barbar', 'bin/toy'], 'dirs': ['bin']}",
-            "exts_defaultclass = 'DummyExtension'",
             "exts_list = [",
             "    ('barbar', '0.0', {",
             "        'start_dir': 'src',",
@@ -1983,7 +1974,6 @@ class ToyBuildTest(EnhancedTestCase):
             ''
             "dependencies = [('OpenMPI', '4.1.5')]",
             '',
-            "exts_defaultclass = 'DummyExtension'",
             "exts_list = [",
             "    ('ls'),",
             "    ('bar', '0.0'),",
@@ -2457,7 +2447,6 @@ class ToyBuildTest(EnhancedTestCase):
         ec1 = os.path.join(self.test_prefix, 'toy1.eb')
         ec1_txt = '\n'.join([
             TOY_EC_TXT,
-            "exts_defaultclass = 'DummyExtension'",
             "exts_list = [('barbar', '1.2', {'start_dir': 'src'})]",
             "",
         ])
@@ -3228,7 +3217,6 @@ class ToyBuildTest(EnhancedTestCase):
             "    'cp %s %s/plugins/libpytoy_cuda.%s'," % (toy_bin, py_site_pkgs, shlib_ext),
             "]",
             "exts_list = [('bar', '0.0')]",
-            "exts_defaultclass = 'DummyExtension'",
         ])
         write_file(toy_ec_cuda, toy_ec_txt)
 
@@ -3660,7 +3648,6 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         test_ec_txt = TOY_EC_TXT + '\n'.join([
             "exts_list = [('bar', '0.0'), ('toy', '0.0')]",
-            "exts_defaultclass = 'DummyExtension'",
         ])
         write_file(test_ec, test_ec_txt)
 
@@ -3824,7 +3811,6 @@ class ToyBuildTest(EnhancedTestCase):
         test_ec = os.path.join(self.test_prefix, 'test.eb')
 
         # also inject (minimal) list of extensions to test iterative installation of extensions
-        test_ec_txt += "\nexts_defaultclass = 'DummyExtension'"
         test_ec_txt += "\nexts_list = [('barbar', '1.2', {'start_dir': 'src'})]"
 
         test_ec_txt += "\nmulti_deps = {'GCC': ['4.6.3', '7.3.0-2.30']}"


### PR DESCRIPTION
Currently those are silently ignored leading to success where it should fail.

The only official easyconfig affected by this so far is `MDAnalysis-2.4.2-foss-2021a.eb` but I ran into this while creating an easyconfig

Includes
- [x] https://github.com/easybuilders/easybuild-framework/pull/5015