### PR TITLE
Fix `test_gitrepo` in case global Git configuration is not in place

### DIFF
--- a/easybuild/tools/repository/gitrepo.py
+++ b/easybuild/tools/repository/gitrepo.py
@@ -103,7 +103,7 @@ class GitRepository(FileRepository):
             client = git.Git(self.wc)
             client.clone(self.repo)
             reponame = os.listdir(self.wc)[0]
-            self.log.debug("rep name is %s" % reponame)
+            self.log.debug("Repo name is %s", reponame)
         except (git.GitCommandError, OSError) as err:
             # it might already have existed
             self.log.warning("Git local repo initialization failed, it might already exist: %s", err)
@@ -111,7 +111,7 @@ class GitRepository(FileRepository):
         # local repo should now exist, let's connect to it again
         try:
             self.wc = os.path.join(self.wc, reponame)
-            self.log.debug("connectiong to git repo in %s" % self.wc)
+            self.log.debug("Connecting to git repo in %s", self.wc)
             self.client = git.Git(self.wc)
         except (git.GitCommandError, OSError) as err:
             raise EasyBuildError("Could not create a local git repo in wc %s: %s", self.wc, err)
@@ -119,7 +119,7 @@ class GitRepository(FileRepository):
         # try to get the remote data in the local repo
         try:
             res = self.client.pull()
-            self.log.debug("pulled succesfully to %s in %s" % (res, self.wc))
+            self.log.debug("Pulled succesfully to %s in %s", res, self.wc)
         except (git.GitCommandError, OSError) as err:
             raise EasyBuildError("pull in working copy %s went wrong: %s", self.wc, err)
 

--- a/test/framework/repository.py
+++ b/test/framework/repository.py
@@ -33,7 +33,7 @@ import shutil
 import sys
 import tempfile
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
-from unittest import TextTestRunner
+from unittest import TextTestRunner, mock
 
 from easybuild.framework.easyconfig.parser import EasyConfigParser
 from easybuild.tools.build_log import EasyBuildError
@@ -102,7 +102,9 @@ class RepositoryTest(EnhancedTestCase):
             repo.init()
             toy_ec_file = os.path.join(os.path.dirname(__file__), 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
             repo.add_easyconfig(toy_ec_file, 'test', '1.0', {}, None)
-            repo.commit("toy/0.0")
+            with mock.patch.dict(os.environ, {'GIT_AUTHOR_NAME': 'test', 'GIT_AUTHOR_EMAIL': 'test@test.org',
+                                              'GIT_COMMITTER_NAME': 'test', 'GIT_COMMITTER_EMAIL': 'test@test.org'}):
+                repo.commit("toy/0.0")
 
             log_regex = re.compile(r"toy/0.0 with EasyBuild v%s @ .* \(time: .*, user: .*\)" % VERSION, re.M)
             logmsg = repo.client.log('HEAD^!')


### PR DESCRIPTION
The test fails when no global git username is set. Set environment variables in the test to avoid that. Also fix some minor spelling issues.

Fixes #2312
Fixes #2754

At least I think so. That was the main offender and I guess the other failures should be fixed by now. At least I can't reproduce them and the issues are very old.