### PR TITLE
Added command line parameter `--fetch-all`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -831,8 +831,9 @@ class EasyBlock:
                     git_config=None, no_download=False, download_instructions=None, alt_location=None,
                     warning_only=False):
         try:
-            return self.obtain_file_and_fail(filename, extension, urls, download_filename, force_download, git_config, no_download, download_instructions, alt_location, warning_only)
-        except Exception as e:
+            return self.obtain_file_and_fail(filename, extension, urls, download_filename, force_download, git_config,
+                                             no_download, download_instructions, alt_location, warning_only)
+        except Exception:
             if build_option('fetch_continue'):
                 if not urls:
                     urls = ['NO_URL']
@@ -843,8 +844,8 @@ class EasyBlock:
 
     @_obtain_file_update_progress_bar_on_return
     def obtain_file_and_fail(self, filename, extension=False, urls=None, download_filename=None, force_download=False,
-                    git_config=None, no_download=False, download_instructions=None, alt_location=None,
-                    warning_only=False):
+                             git_config=None, no_download=False, download_instructions=None, alt_location=None,
+                             warning_only=False):
         """
         Locate the file with the given name
         - searches in different subdirectories of source path

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -830,6 +830,21 @@ class EasyBlock:
     def obtain_file(self, filename, extension=False, urls=None, download_filename=None, force_download=False,
                     git_config=None, no_download=False, download_instructions=None, alt_location=None,
                     warning_only=False):
+        try:
+            return self.obtain_file_and_fail(filename, extension, urls, download_filename, force_download, git_config, no_download, download_instructions, alt_location, warning_only)
+        except Exception as e:
+            if build_option('fetch_continue'):
+                if not urls:
+                    urls = ['NO_URL']
+                print_warning(f"FAILED: File {filename} not found from {urls[0]}. Continuing ...")
+                return 'NO_FILE_FOUND'
+            else:
+                raise
+
+    @_obtain_file_update_progress_bar_on_return
+    def obtain_file_and_fail(self, filename, extension=False, urls=None, download_filename=None, force_download=False,
+                    git_config=None, no_download=False, download_instructions=None, alt_location=None,
+                    warning_only=False):
         """
         Locate the file with the given name
         - searches in different subdirectories of source path

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -857,7 +857,7 @@ class EasyBlock:
             return self.obtain_file_raise_on_failure(filename, extension, urls, download_filename, force_download,
                                                      git_config, no_download, download_instructions, alt_location,
                                                      warning_only)
-        except Exception as e:
+        except Exception:
             if build_option('fetch_all'):
                 if not urls:
                     urls = ['NO_URL']

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -831,10 +831,11 @@ class EasyBlock:
                     git_config=None, no_download=False, download_instructions=None, alt_location=None,
                     warning_only=False):
         try:
-            return self.obtain_file_and_fail(filename, extension, urls, download_filename, force_download, git_config,
-                                             no_download, download_instructions, alt_location, warning_only)
+            return self.obtain_file_raise_on_failure(filename, extension, urls, download_filename, force_download,
+                                                     git_config, no_download, download_instructions, alt_location,
+                                                     warning_only)
         except Exception:
-            if build_option('fetch_continue'):
+            if build_option('fetch_all'):
                 if not urls:
                     urls = ['NO_URL']
                 print_warning(f"FAILED: File {filename} not found from {urls[0]}. Continuing ...")
@@ -843,9 +844,9 @@ class EasyBlock:
                 raise
 
     @_obtain_file_update_progress_bar_on_return
-    def obtain_file_and_fail(self, filename, extension=False, urls=None, download_filename=None, force_download=False,
-                             git_config=None, no_download=False, download_instructions=None, alt_location=None,
-                             warning_only=False):
+    def obtain_file_raise_on_failure(self, filename, extension=False, urls=None, download_filename=None,
+                                     force_download=False, git_config=None, no_download=False,
+                                     download_instructions=None, alt_location=None, warning_only=False):
         """
         Locate the file with the given name
         - searches in different subdirectories of source path

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -850,19 +850,21 @@ class EasyBlock:
         return exts_sources
 
     @_obtain_file_update_progress_bar_on_return
-    def obtain_file(self, filename, extension=False, urls=None, download_filename=None, force_download=False,
-                    git_config=None, no_download=False, download_instructions=None, alt_location=None,
-                    warning_only=False):
+    def obtain_file(self, filename, **kwargs):
+        """
+        Locate file with given name.
+        Wrapper around obtain_file_raise_on_failure which will raise an exception if file could not be found,
+        which checks whether --fetch-all was used.
+        """
         try:
-            return self.obtain_file_raise_on_failure(filename, extension, urls, download_filename, force_download,
-                                                     git_config, no_download, download_instructions, alt_location,
-                                                     warning_only)
+            return self.obtain_file_raise_on_failure(filename, **kwargs)
         except Exception:
             if build_option('fetch_all'):
+                urls = kwargs.get('urls')
                 if not urls:
-                    urls = ['NO_URL']
+                    urls = ['NO_SOURCE_URLS_PROVIDED']
                 print_warning(f"FAILED: File {filename} not found from {urls[0]}. Continuing ...")
-                return 'NO_FILE_FOUND'
+                return None
             else:
                 raise
 

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -607,7 +607,8 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
     # build software, will exit when errors occurs (except when testing)
     start_time = datetime.now()
     if not testing or (testing and do_build):
-        exit_on_failure = not any((options.dump_test_report, options.upload_test_report, options.keep_going), build_option('fetch_all'))
+        exit_on_failure = not any((options.dump_test_report, options.upload_test_report, options.keep_going),
+                                   build_option('fetch_all'))
 
         with rich_live_cm():
             run_hook(PRE_PREF + BUILD_AND_INSTALL_LOOP, hooks, args=[ordered_ecs])

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -586,7 +586,7 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
 
     # build software, will exit when errors occurs (except when testing)
     if not testing or (testing and do_build):
-        exit_on_failure = not (options.dump_test_report or options.upload_test_report)
+        exit_on_failure = not (options.dump_test_report or options.upload_test_report or build_option('fetch_continue'))
 
         with rich_live_cm():
             run_hook(PRE_PREF + BUILD_AND_INSTALL_LOOP, hooks, args=[ordered_ecs])

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -608,7 +608,7 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
     start_time = datetime.now()
     if not testing or (testing and do_build):
         exit_on_failure = not any((options.dump_test_report, options.upload_test_report, options.keep_going,
-            build_option('fetch_all')))
+                                   build_option('fetch_all')))
 
         with rich_live_cm():
             run_hook(PRE_PREF + BUILD_AND_INSTALL_LOOP, hooks, args=[ordered_ecs])

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -607,8 +607,8 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
     # build software, will exit when errors occurs (except when testing)
     start_time = datetime.now()
     if not testing or (testing and do_build):
-        exit_on_failure = not any((options.dump_test_report, options.upload_test_report, options.keep_going),
-                                   build_option('fetch_all'))
+        exit_on_failure = not any((options.dump_test_report, options.upload_test_report, options.keep_going,
+            build_option('fetch_all')))
 
         with rich_live_cm():
             run_hook(PRE_PREF + BUILD_AND_INSTALL_LOOP, hooks, args=[ordered_ecs])

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -586,7 +586,7 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
 
     # build software, will exit when errors occurs (except when testing)
     if not testing or (testing and do_build):
-        exit_on_failure = not (options.dump_test_report or options.upload_test_report or build_option('fetch_continue'))
+        exit_on_failure = not (options.dump_test_report or options.upload_test_report or build_option('fetch_all'))
 
         with rich_live_cm():
             run_hook(PRE_PREF + BUILD_AND_INSTALL_LOOP, hooks, args=[ordered_ecs])

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -607,8 +607,8 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
     # build software, will exit when errors occurs (except when testing)
     start_time = datetime.now()
     if not testing or (testing and do_build):
-        exit_on_failure = not any((options.dump_test_report, options.upload_test_report, options.keep_going,
-                                   build_option('fetch_all')))
+        exit_on_failure = not any((options.dump_test_report, options.fetch_all,
+                                   options.keep_going, options.upload_test_report, options.keep_going))
 
         with rich_live_cm():
             run_hook(PRE_PREF + BUILD_AND_INSTALL_LOOP, hooks, args=[ordered_ecs])

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -318,7 +318,7 @@ BUILD_OPTIONS_CMDLINE = {
         'experimental',
         'extended_dry_run',
         'fail_on_mod_files_gcccore',
-        'fetch_continue',
+        'fetch_all',
         'force',
         'generate_devel_module',
         'group_writable_installdir',

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -318,6 +318,7 @@ BUILD_OPTIONS_CMDLINE = {
         'experimental',
         'extended_dry_run',
         'fail_on_mod_files_gcccore',
+        'fetch_continue',
         'force',
         'generate_devel_module',
         'group_writable_installdir',

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -464,6 +464,7 @@ class EasyBuildOptions(GeneralOption):
                                           False),
             'fetch': ("Allow downloading sources ignoring OS and modules tool dependencies, "
                       "implies --stop=fetch, --ignore-osdeps and ignore modules tool", None, 'store_true', False),
+            'fetch-continue': ("Continue after failed fetch", None, 'store_true', False),
             'filter-deps': ("List of dependencies that you do *not* want to install with EasyBuild, "
                             "because equivalent OS packages are installed. (e.g. --filter-deps=zlib,ncurses)",
                             'strlist', 'extend', None),
@@ -1359,6 +1360,8 @@ class EasyBuildOptions(GeneralOption):
             self.options.search_paths = [os.path.abspath(path) for path in self.options.search_paths]
 
         # Fetch option implies stop=fetch, no moduletool and ignore-osdeps
+        if self.options.fetch_continue:
+            self.options.fetch = True
         if self.options.fetch:
             self.options.stop = FETCH_STEP
             self.options.ignore_locks = True

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -464,7 +464,8 @@ class EasyBuildOptions(GeneralOption):
                                           False),
             'fetch': ("Allow downloading sources ignoring OS and modules tool dependencies, "
                       "implies --stop=fetch, --ignore-osdeps and ignore modules tool", None, 'store_true', False),
-            'fetch-continue': ("Continue after failed fetch", None, 'store_true', False),
+            'fetch-all': ("Download sources (like --fetch), don't stop when downloading failed for one easyconfig",
+                          None, 'store_true', False),
             'filter-deps': ("List of dependencies that you do *not* want to install with EasyBuild, "
                             "because equivalent OS packages are installed. (e.g. --filter-deps=zlib,ncurses)",
                             'strlist', 'extend', None),
@@ -1360,7 +1361,7 @@ class EasyBuildOptions(GeneralOption):
             self.options.search_paths = [os.path.abspath(path) for path in self.options.search_paths]
 
         # Fetch option implies stop=fetch, no moduletool and ignore-osdeps
-        if self.options.fetch_continue:
+        if self.options.fetch_all:
             self.options.fetch = True
         if self.options.fetch:
             self.options.stop = FETCH_STEP

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -464,7 +464,7 @@ class EasyBuildOptions(GeneralOption):
                                           False),
             'fetch': ("Allow downloading sources ignoring OS and modules tool dependencies, "
                       "implies --stop=fetch, --ignore-osdeps and ignore modules tool", None, 'store_true', False),
-            'fetch-all': ("Download sources (like --fetch), don't stop when downloading failed for one easyconfig",
+            'fetch-all': ("Download sources (like --fetch), don't stop when download failed for one of the easyconfig",
                           None, 'store_true', False),
             'filter-deps': ("List of dependencies that you do *not* want to install with EasyBuild, "
                             "because equivalent OS packages are installed. (e.g. --filter-deps=zlib,ncurses)",
@@ -1364,9 +1364,11 @@ class EasyBuildOptions(GeneralOption):
         if self.options.search_paths is not None:
             self.options.search_paths = [os.path.abspath(path) for path in self.options.search_paths]
 
-        # Fetch option implies stop=fetch, no moduletool and ignore-osdeps
+        # --fetch-all implies --fetch
         if self.options.fetch_all:
             self.options.fetch = True
+
+        # Fetch option implies stop=fetch, no moduletool and ignore-osdeps
         if self.options.fetch:
             self.options.stop = FETCH_STEP
             self.options.ignore_locks = True

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5589,7 +5589,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
             self.assert_multi_regex(patterns, stdout)
             self.assertNotRegex(stdout, r"^== creating build dir, resetting environment\.\.\.$")
 
-            self.assertRegex(stderr, r"WARNING: FAILED: File toy-1.2.3.4.5.6.tar.gz not found from NO_URL")
+            pattern = r"WARNING: FAILED: File toy-1.2.3.4.5.6.tar.gz not found from NO_SOURCE_URLS_PROVIDED."
+            self.assertRegex(stderr, pattern)
 
     def test_parse_external_modules_metadata(self):
         """Test parse_external_modules_metadata function."""

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5544,6 +5544,53 @@ class CommandLineOptionsTest(EnhancedTestCase):
             args.append('--ignore-checksums')
             self.eb_main(args, do_build=True, raise_error=True)
 
+    def test_fetch_all(self):
+        """Test use of --fetch-all"""
+        options = EasyBuildOptions(go_args=['--fetch-all'])
+
+        self.assertTrue(options.options.fetch)
+        self.assertTrue(options.options.fetch_all)
+        self.assertEqual(options.options.stop, 'fetch')
+        self.assertEqual(options.options.modules_tool, None)
+        self.assertTrue(options.options.ignore_locks)
+        self.assertTrue(options.options.ignore_osdeps)
+
+        # in this test we want to fake the case were no modules tool are in the system so tweak it
+        self.modtool = None
+
+        # create lock dir to see whether --fetch-all trips over it (it shouldn't)
+        lock_fn = os.path.join(self.test_installpath, 'software', 'toy', '0.0').replace('/', '_') + '.lock'
+        lock_path = os.path.join(self.test_installpath, 'software', '.locks', lock_fn)
+        mkdir(lock_path, parents=True)
+
+        # copy toy-0.0.eb test easyconfig, tweak version to something that no source can be obtained for
+        toy_ec = os.path.join(os.path.dirname(__file__), 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
+        toy_ec_txt = read_file(toy_ec)
+        test_ec_txt = toy_ec_txt.replace("version = '0.0'", "version = '1.2.3.4.5.6'")
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        write_file(test_ec, test_ec_txt)
+
+        # Run for a "regular" EC and one with an external module dependency
+        # which might trip up the dependency resolution (see #4298)
+        for ec in ('toy-0.0.eb', 'toy-0.0-deps.eb'):
+            ecs = [test_ec, ec]
+
+            # verify that --fetch fails, it should
+            error_pattern = "Couldn't find file toy-1.2.3.4.5.6.tar.gz anywhere"
+            self.assertErrorRegex(EasyBuildError, error_pattern, self._run_mock_eb, ecs + ['--fetch'],
+                                  raise_error=True, testing=False)
+
+            stdout, stderr = self._run_mock_eb(ecs + ['--fetch-all'], raise_error=True, strip=True, testing=False)
+
+            patterns = [
+                r"^== fetching files and verifying checksums\.\.\.$",
+                r"^== COMPLETED: Installation STOPPED successfully \(took .* secs?\)$",
+            ]
+            self.assert_multi_regex(patterns, stdout)
+            self.assertNotRegex(stdout, r"^== creating build dir, resetting environment\.\.\.$")
+
+            self.assertRegex(stderr, r"WARNING: FAILED: File toy-1.2.3.4.5.6.tar.gz not found from NO_URL")
+
     def test_parse_external_modules_metadata(self):
         """Test parse_external_modules_metadata function."""
         # by default, provided external module metadata cfg files are picked up


### PR DESCRIPTION
Added command line parameter --fetch-all. It implies --fetch. But when a fetch fails, EasyBuild will still try to fetch all dependencies. This is handy in situations where the success of fetching is non-deterministic and the engineer wants to get all failures at once without having to restart after each failure. Non-deterministic success of fetching can for example happen if some downloads are intercepted by the CyberDefence team to scan for vulnerabilities and later retries are handled by earlier scans that have been cached.