### PR TITLE
Take into account alternative name `post_install_patches` when checking checksums

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2743,7 +2743,8 @@ class EasyBlock:
         try:
             sources = ent.get('sources', [])
             data_sources = ent.get('data_sources', [])
-            patches = ent.get('patches', []) + ent.get('postinstallpatches', [])
+            patches = ent.get('patches', []) + ent.get(ALTERNATIVE_EASYCONFIG_PARAMETERS['post_install_patches'],
+                                                       ent.get('post_install_patches', []))
             checksums = ent.get('checksums', [])
         except EasyBuildError:
             if isinstance(ent, EasyConfig):


### PR DESCRIPTION
Extensions/components use a dict for "options" that is passed to this function and won't automatically replace the new name to the old one.

Do this manually.