### PR TITLE
Add decorator to ignore PR test failures due to rate limit

### DIFF
--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -78,16 +78,26 @@ def requires_github_access():
 
     Useful when the test uses e.g. `git` commands to download from Github and would run into rate limits
     """
-    if 'FORCE_EB_GITHUB_TESTS' in os.environ or os.getenv('GITHUB_EVENT_NAME') != 'pull_request':
-        return unittest.skipIf(False, None)
-    else:
-        # For pull requests silently skip to avoid rate limits
-        def decorator(test_item):
-            @functools.wraps(test_item)
-            def skip_wrapper(*args, **kwargs):
-                return
-            return skip_wrapper
-        return decorator
+    return unittest.skipUnless(
+        os.environ.get('FORCE_EB_GITHUB_TESTS', '0') != '0' or os.getenv('GITHUB_EVENT_NAME') != 'pull_request',
+        "Skipping test requiring GitHub access"
+    )
+
+
+def ignore_rate_limit_in_pr(test_item):
+    """Decorator: If tests are run in a pull request and fail with a rate limit error, ignore that"""
+    if os.environ.get('FORCE_EB_GITHUB_TESTS', '0') != '0' or os.getenv('GITHUB_EVENT_NAME') != 'pull_request':
+        return test_item
+
+    @functools.wraps(test_item)
+    def skip_wrapper(self, *args, **kwargs):
+        try:
+            test_item(self, *args, **kwargs)
+        except EasyBuildError as e:
+            if 'HTTP Error 403' in e.msg:
+                self.skipTest('Ignoring rate limit error')
+            raise
+    return skip_wrapper
 
 
 class GithubTest(EnhancedTestCase):
@@ -518,6 +528,7 @@ class GithubTest(EnhancedTestCase):
         res = gh.fetch_easyblocks_from_pr(12345, tmpdir)
         self.assertEqual(sorted(pr12345_files), sorted(res))
 
+    @ignore_rate_limit_in_pr
     def test_fetch_files_from_commit(self):
         """Test fetch_files_from_commit function."""
 
@@ -551,6 +562,7 @@ class GithubTest(EnhancedTestCase):
         error_pattern = r"Failed to download diff for easybuilders/easybuild-easyconfigs commit c0ff33c0ff33"
         self.assertErrorRegex(EasyBuildError, error_pattern, fetch_files_from_commit, 'c0ff33c0ff33')
 
+    @ignore_rate_limit_in_pr
     def test_fetch_easyconfigs_from_commit(self):
         """Test fetch_easyconfigs_from_commit function."""
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -68,6 +68,7 @@ from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.systemtools import DARWIN, HAVE_ARCHSPEC, get_os_type
 from easybuild.tools.version import VERSION
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, cleanup, init_config
+from test.framework.github import ignore_rate_limit_in_pr
 
 try:
     import pycodestyle  # noqa
@@ -1521,6 +1522,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertIn("name = 'EasyBuild'", read_file(test_ec))
         remove_file(test_ec)
 
+    @ignore_rate_limit_in_pr
     def test_copy_ec_from_commit(self):
         """Test combination of --copy-ec with --from-commit."""
         # note: --from-commit does not involve using GitHub API, so no GitHub token required


### PR DESCRIPTION
The decorator checks if the test is run in a GitHub PR and ignores any error caused by a "HTTP 403" rate-limit exception.