### PR TITLE
Fix `check_checksums` when using templates, patch-dicts or `checksums.json`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2765,10 +2765,11 @@ class EasyBlock:
             checksums = ent.get('checksums', [])
         except EasyBuildError:
             if isinstance(ent, EasyConfig):
-                sources = ent.get_ref('sources')
-                data_sources = ent.get_ref('data_sources')
-                patches = ent.get_ref('patches') + ent.get_ref('postinstallpatches')
-                checksums = ent.get_ref('checksums')
+                with ent.disable_templating():
+                    sources = ent['sources']
+                    data_sources = ent['data_sources']
+                    patches = ent['patches'] + ent['postinstallpatches']
+                    checksums = ent['checksums']
 
         # Single source should be re-wrapped as a list, and checksums with it
         if isinstance(sources, dict):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -594,7 +594,7 @@ class EasyBlock:
             if not isinstance(patch_specs, tuple) or len(patch_specs) != 2:
                 raise EasyBuildError('Patch specs must be a tuple of (patches, post-install patches) or a list')
             post_install_patches = patch_specs[1]
-            patch_specs = itertools.chain(*patch_specs)
+            patch_specs = itertools.chain.from_iterable(patch_specs)
 
         patches = []
         for index, patch_spec in enumerate(patch_specs):
@@ -796,7 +796,7 @@ class EasyBlock:
                     if fetch_files:
                         ext_patches = self.fetch_patches(patch_specs=ext_patch_specs, extension=True)
                     else:
-                        ext_patches = [create_patch_info(p) for p in itertools.chain(*ext_patch_specs)]
+                        ext_patches = [create_patch_info(p) for p in itertools.chain.from_iterable(ext_patch_specs)]
 
                     if ext_patches:
                         self.log.debug('Found patches for extension %s: %s', ext_name, ext_patches)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2860,7 +2860,7 @@ class EasyBlock:
         checksum_issues.extend(self.check_checksums_for(self.cfg))
 
         # also check checksums for extensions
-        for ext in self.cfg.get_ref('exts_list'):
+        for ext in self.cfg['exts_list']:
             # just skip extensions for which only a name is specified
             # those are just there to check for things that are in the "standard library"
             if not isinstance(ext, str):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -686,6 +686,7 @@ class EasyBlock:
 
                     source_urls = resolve_template(ext_options.get('source_urls', []), template_values)
                     checksums = resolve_template(ext_options.get('checksums', []), template_values)
+                    ext_src['checksums'] = checksums
 
                     download_instructions = resolve_template(ext_options.get('download_instructions'), template_values)
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2860,19 +2860,9 @@ class EasyBlock:
         checksum_issues.extend(self.check_checksums_for(self.cfg))
 
         # also check checksums for extensions
-        with self.cfg.allow_unresolved_templates():
-            exts_list = self.cfg['exts_list']
-        for ext in exts_list:
-            # just skip extensions for which only a name is specified
-            # those are just there to check for things that are in the "standard library"
-            if not isinstance(ext, str):
-                ext_name = ext[0]
-                # take into account that extension may be a 2-tuple with just name/version
-                ext_opts = ext[2] if len(ext) == 3 else {}
-                # only a single source per extension is supported (see source_tmpl)
-                source_cnt = 1 if not ext_opts.get('nosource') else 0
-                res = self.check_checksums_for(ext_opts, sub="of extension %s" % ext_name, source_cnt=source_cnt)
-                checksum_issues.extend(res)
+        for ext in self.collect_exts_file_info(fetch_files=False, verify_checksums=False):
+            res = self.check_checksums_for(ext, sub=f"of extension {ext['name']}")
+            checksum_issues.extend(res)
 
         return checksum_issues
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2860,7 +2860,9 @@ class EasyBlock:
         checksum_issues.extend(self.check_checksums_for(self.cfg))
 
         # also check checksums for extensions
-        for ext in self.cfg['exts_list']:
+        with self.cfg.allow_unresolved_templates():
+            exts_list = self.cfg['exts_list']
+        for ext in exts_list:
             # just skip extensions for which only a name is specified
             # those are just there to check for things that are in the "standard library"
             if not isinstance(ext, str):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -729,6 +729,11 @@ class EasyBlock:
                                 # copy 'path' entry to 'src' for use with extensions
                                 'src': src['path'],
                             })
+                            filename = src['name']
+                        else:
+                            filename = source.get('filename')
+                        if filename is not None:
+                            ext_src['sources'] = [filename]
 
                     else:
 
@@ -746,6 +751,7 @@ class EasyBlock:
                             raise EasyBuildError(error_msg, type(src_fn).__name__, src_fn)
 
                         src_fn = resolve_template(src_fn, template_values)
+                        ext_src['sources'] = [src_fn]
 
                         if fetch_files:
                             src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2368,14 +2368,17 @@ class EasyBlockTest(EnhancedTestCase):
         bar_patch2 = 'bar-0.0_fix-very-silly-typo-in-printf-statement.patch'
         self.assertEqual(exts_file_info[1]['patches'][1]['name'], bar_patch2)
         self.assertEqual(exts_file_info[1]['patches'][1]['path'], os.path.join(toy_ext_sources, bar_patch2))
+        self.assertEqual(len(exts_file_info[1]['checksums']), 1)
 
         self.assertEqual(exts_file_info[2]['name'], 'barbar')
         self.assertEqual(exts_file_info[2]['src'], os.path.join(toy_ext_sources, 'barbar-1.2.tar.gz'))
         self.assertNotIn('patches', exts_file_info[2])
+        self.assertEqual(len(exts_file_info[2]['checksums']), 0)
 
         self.assertEqual(exts_file_info[3]['name'], 'toy')
         self.assertEqual(exts_file_info[3]['src'], os.path.join(toy_sources, 'toy-0.0.tar.gz'))
         self.assertNotIn('patches', exts_file_info[3])
+        self.assertEqual(len(exts_file_info[3]['checksums']), 0)
 
         # location of files is missing when fetch_files is set to False
         exts_file_info = toy_eb.collect_exts_file_info(fetch_files=False, verify_checksums=False)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2350,17 +2350,25 @@ class EasyBlockTest(EnhancedTestCase):
         toy_sources = os.path.join(testdir, 'sandbox', 'sources', 'toy')
         toy_ext_sources = os.path.join(toy_sources, 'extensions')
         toy_ec_file = os.path.join(testdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0-gompi-2018a-test.eb')
-        toy_ec = process_easyconfig(toy_ec_file)[0]
+
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        new_ext_txt = "('baz', '0.0', {'nosource': True}),"  # With nosource option
+        new_ext_txt += "('barbar', '0.0', {'sources': [SOURCE_TAR_GZ]}),"  # With sources containing a list
+        test_ectxt = re.sub(r'\(name, version', new_ext_txt+r"\g<0>", read_file(toy_ec_file))
+        write_file(test_ec, test_ectxt)
+
+        toy_ec = process_easyconfig(test_ec)[0]
         toy_eb = EasyBlock(toy_ec['ec'])
 
         exts_file_info = toy_eb.collect_exts_file_info()
 
         self.assertIsInstance(exts_file_info, list)
-        self.assertEqual(len(exts_file_info), 4)
+        self.assertEqual(len(exts_file_info), 6)
 
         self.assertEqual(exts_file_info[0], {'name': 'ulimit'})
 
         self.assertEqual(exts_file_info[1]['name'], 'bar')
+        self.assertEqual(exts_file_info[1]['sources'], ['bar-0.0.tar.gz'])
         self.assertEqual(exts_file_info[1]['src'], os.path.join(toy_ext_sources, 'bar-0.0.tar.gz'))
         bar_patch1 = 'bar-0.0_fix-silly-typo-in-printf-statement.patch'
         self.assertEqual(exts_file_info[1]['patches'][0]['name'], bar_patch1)
@@ -2371,24 +2379,38 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(len(exts_file_info[1]['checksums']), 1)
 
         self.assertEqual(exts_file_info[2]['name'], 'barbar')
+        self.assertEqual(exts_file_info[2]['sources'], ['barbar-1.2.tar.gz'])
         self.assertEqual(exts_file_info[2]['src'], os.path.join(toy_ext_sources, 'barbar-1.2.tar.gz'))
         self.assertNotIn('patches', exts_file_info[2])
         self.assertEqual(len(exts_file_info[2]['checksums']), 0)
 
-        self.assertEqual(exts_file_info[3]['name'], 'toy')
-        self.assertEqual(exts_file_info[3]['src'], os.path.join(toy_sources, 'toy-0.0.tar.gz'))
+        self.assertEqual(exts_file_info[3]['name'], 'baz')
+        self.assertNotIn('sources', exts_file_info[3])
+        self.assertNotIn('sources', exts_file_info[3]['options'])
+        self.assertNotIn('src', exts_file_info[3])
         self.assertNotIn('patches', exts_file_info[3])
         self.assertEqual(len(exts_file_info[3]['checksums']), 0)
+
+        self.assertEqual(exts_file_info[4]['name'], 'barbar')
+        self.assertEqual(exts_file_info[4]['sources'], ['barbar-0.0.tar.gz'])
+        self.assertEqual(exts_file_info[4]['src'], os.path.join(toy_ext_sources, 'barbar-0.0.tar.gz'))
+        self.assertNotIn('patches', exts_file_info[4])
+
+        self.assertEqual(exts_file_info[5]['name'], 'toy')
+        self.assertEqual(exts_file_info[5]['sources'], ['toy-0.0.tar.gz'])
+        self.assertEqual(exts_file_info[5]['src'], os.path.join(toy_sources, 'toy-0.0.tar.gz'))
+        self.assertNotIn('patches', exts_file_info[5])
 
         # location of files is missing when fetch_files is set to False
         exts_file_info = toy_eb.collect_exts_file_info(fetch_files=False, verify_checksums=False)
 
         self.assertIsInstance(exts_file_info, list)
-        self.assertEqual(len(exts_file_info), 4)
+        self.assertEqual(len(exts_file_info), 6)
 
         self.assertEqual(exts_file_info[0], {'name': 'ulimit'})
 
         self.assertEqual(exts_file_info[1]['name'], 'bar')
+        self.assertEqual(exts_file_info[1]['sources'], ['bar-0.0.tar.gz'])
         self.assertNotIn('src', exts_file_info[1])
         self.assertEqual(exts_file_info[1]['patches'][0]['name'], bar_patch1)
         self.assertNotIn('path', exts_file_info[1]['patches'][0])
@@ -2396,12 +2418,25 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertNotIn('path', exts_file_info[1]['patches'][1])
 
         self.assertEqual(exts_file_info[2]['name'], 'barbar')
+        self.assertEqual(exts_file_info[2]['sources'], ['barbar-1.2.tar.gz'])
         self.assertNotIn('src', exts_file_info[2])
         self.assertNotIn('patches', exts_file_info[2])
 
-        self.assertEqual(exts_file_info[3]['name'], 'toy')
+        self.assertEqual(exts_file_info[3]['name'], 'baz')
+        self.assertNotIn('sources', exts_file_info[3])
+        self.assertNotIn('sources', exts_file_info[3]['options'])
         self.assertNotIn('src', exts_file_info[3])
         self.assertNotIn('patches', exts_file_info[3])
+
+        self.assertEqual(exts_file_info[4]['name'], 'barbar')
+        self.assertEqual(exts_file_info[4]['sources'], ['barbar-0.0.tar.gz'])
+        self.assertNotIn('src', exts_file_info[4])
+        self.assertNotIn('patches', exts_file_info[4])
+
+        self.assertEqual(exts_file_info[5]['name'], 'toy')
+        self.assertEqual(exts_file_info[5]['sources'], ['toy-0.0.tar.gz'])
+        self.assertNotIn('src', exts_file_info[5])
+        self.assertNotIn('patches', exts_file_info[5])
 
         error_msg = "Can't verify checksums for extension files if they are not being fetched"
         self.assertErrorRegex(EasyBuildError, error_msg, toy_eb.collect_exts_file_info, fetch_files=False)


### PR DESCRIPTION
This is a similar fix as https://github.com/easybuilders/easybuild-easyconfigs/pull/15973

`check_checksums` had various shortcomings, some touched by https://github.com/easybuilders/easybuild-framework/commit/7112e406dc8ee75fd3d5257648d23d801d77e813 (from @boegel ) which disabled templating entirely when getting the `exts_list` list.

This breaks when `checksums.json` is used: It will report missing checksums even when they are available in the checksums.json   
Additionally templates in the name/version of extension won't be resolved causing the error message harder to understand

A quick fix was to replace the above commit by `allow_unresolved_templates`-decorator to allow partially resolved extensions but don't fail as before when templates are used e.g. in `install_cmd` which fixes the issues with the name/version of the extension

However that resolves too deep as inside the extension options different template values must be used.

We have `collect_exts_file_info` which does handle all those peculiarities of the extension specs already so just use that.

This also handles the default file name of extension sources and `nosource` which we can rely on here if it fills `sources` correctly. This requires  #4054 (merged here so that tests pass)

It also fixes a failure when patches were specified as dicts as In `sources` the keyname is "filename" while in `patches` it is "name" which causes a `KeyError` in `check_checksums_for`