### PR TITLE
Add templates for source with just version numbers (like `VERSION_TAR_GZ` and `V_VERSION_TAR_GZ`)

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -271,7 +271,7 @@ for ext in EXTENSIONS:
         'SOURCE_%s' % suffix: ('%(name)s-%(version)s.' + ext, "Source .%s bundle" % ext),
         'SOURCELOWER_%s' % suffix: ('%(namelower)s-%(version)s.' + ext, "Source .%s bundle with lowercase name" % ext),
         'VERSION_%s' % suffix: ('%(version)s.' + ext, "Source filename <version>.%s common at GitHub" % ext),
-        'VVERSION_%s' % suffix: ('v%(version)s.' + ext, "Source filename v<version>.%s common at GitHub" % ext),
+        'V_VERSION_%s' % suffix: ('v%(version)s.' + ext, "Source filename v<version>.%s common at GitHub" % ext),
     })
 
 for pyver in ('py2.py3', 'py2', 'py3'):


### PR DESCRIPTION
Adding templates for the common `%(version)s.tar.gz` and  `v%(version)s.tar.gz`  sources.

E.g.
1. `VERSION_TAR_GZ`
2. `VVERSION_ZIP`

I didn't know a better option but to append an extra V for the second option.

I haven't tested anything yet, throwing it out there to gauge the response first.