### PR TITLE
Add templates for patch versions

### DIFF
--- a/easybuild/framework/easyconfig/templates.py
+++ b/easybuild/framework/easyconfig/templates.py
@@ -50,6 +50,7 @@ TEMPLATE_NAMES_EASYCONFIG = {
     'nameletter': 'First letter of software name',
     'toolchain_name': 'Toolchain name',
     'toolchain_version': 'Toolchain version',
+    'version_major_minor_patch': "Major.Minor.Patch version",
     'version_major_minor': "Major.Minor version",
     'version_major': 'Major version',
     'version_minor_patch': 'Minor.Patch version',
@@ -206,6 +207,7 @@ ALTERNATIVE_EASYCONFIG_TEMPLATES = {
     'r_short_ver': 'rshortver',
     'r_ver': 'rver',
     'toolchain_ver': 'toolchain_version',
+    'ver_maj_min_patch': 'version_major_minor_patch',
     'ver_maj_min': 'version_major_minor',
     'ver_maj': 'version_major',
     'ver_min_patch': 'version_minor_patch',
@@ -351,6 +353,7 @@ def template_constant_dict(config, ignore=None, toolchain=None):
                         patch = version[2]
                         template_values['version_patch'] = patch
                         template_values['version_minor_patch'] = '.'.join([minor, patch])
+                        template_values['version_major_minor_patch'] = '.'.join([major, minor, patch])
                 except IndexError:
                     # if there is no minor version, skip it
                     pass

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3723,7 +3723,7 @@ class EasyConfigTest(EnhancedTestCase):
         # also check result of template_constant_dict when dict representing extension is passed
         ext_dict = {
             'name': 'foo',
-            'version': '1.2.3',
+            'version': '1.2.3.42',
             'options': {
                 'source_urls': ['https://example.com'],
                 'source_tmpl': '%(name)s-%(version)s.tar.gz',
@@ -3744,9 +3744,10 @@ class EasyConfigTest(EnhancedTestCase):
             'rpath_enabled': rpath,
             'software_commit': '',
             'sysroot': '',
-            'version': '1.2.3',
+            'version': '1.2.3.42',
             'version_major': '1',
             'version_major_minor': '1.2',
+            'version_major_minor_patch': '1.2.3',
             'version_minor': '2',
             'version_minor_patch': '2.3',
             'version_patch': '3',
@@ -3756,7 +3757,9 @@ class EasyConfigTest(EnhancedTestCase):
         # No patch version makes the templates undefined
         ext_dict['version'] = '1.2'
         res = template_constant_dict(ext_dict)
+        res.pop('arch')
 
+        del expected['version_major_minor_patch']
         del expected['version_minor_patch']
         del expected['version_patch']
         expected['version'] = '1.2'


### PR DESCRIPTION
As it is used by some easyconfigs add
`version_patch` and `version_minor_patch` templates similar to existing version templates.

As some easyconfigs don't have patch versions don't define those templates in this case so access to/use of them fails.

This avoids error-prone repetitions like `local_patch = version.split('.')[2]` or `'files/lcms/%s/' % '.'.join(version.split('.')[:2])`

The `major.minor.patch` variant is useful e.g. for CUDA related ECs, e.g. cuDNN 8.8.0.121 where the download path contains only 8.8.0