### PR TITLE
Pass correct `-march` option on RISC-V systems when `optarch` toolchain option is enabled

### DIFF
--- a/easybuild/toolchains/compiler/gcc.py
+++ b/easybuild/toolchains/compiler/gcc.py
@@ -94,14 +94,17 @@ class Gcc(Compiler):
         # no support for -march on POWER; implies -mtune=native
         (systemtools.POWER, systemtools.POWER): '-mcpu=native',
         (systemtools.POWER, systemtools.POWER_LE): '-mcpu=native',
+        (systemtools.X86_64, systemtools.AMD): '-march=native',  # implies -mtune=native
+        (systemtools.X86_64, systemtools.INTEL): '-march=native',  # implies -mtune=native
+    }
+    if systemtools.get_cpu_family() == systemtools.RISCV:
         # documentation about the RISC-V ISA field and GCC's -march option:
         # https://github.com/riscv-non-isa/riscv-toolchain-conventions/blob/main/src/toolchain-conventions.adoc
         # https://docs.riscv.org/reference/isa/unpriv/naming.html
         # https://gcc.gnu.org/gcc-14/changes.html
-        (systemtools.RISCV64, systemtools.RISCV): '-march=' + systemtools.get_isa_riscv(),  # use all extensions
-        (systemtools.X86_64, systemtools.AMD): '-march=native',  # implies -mtune=native
-        (systemtools.X86_64, systemtools.INTEL): '-march=native',  # implies -mtune=native
-    }
+        march_opt = '-march=' + systemtools.get_isa_riscv()
+        COMPILER_OPTIMAL_ARCHITECTURE_OPTION[(systemtools.RISCV64, systemtools.RISCV)] = march_opt
+
     # used with --optarch=GENERIC
     COMPILER_GENERIC_OPTION = {
         (systemtools.AARCH32, systemtools.ARM): '-mcpu=generic-armv7',  # implies -march=armv7 and -mtune=generic-armv7

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -629,8 +629,11 @@ def get_cpu_features():
 
 def get_isa_riscv():
     """
-    Get supported ISA string
+    Get supported ISA string on RISC-V Linux systems
     """
+    if get_cpu_family() != RISCV:
+        return None
+
     # 'rv64imafdc identifies the baseline RISC-V CPU architecture we are targetting.
     # - rv64: 64-bit RISC-V
     # - i: Integer instruction set (mandatory base ISA)
@@ -644,6 +647,7 @@ def get_isa_riscv():
     # provides all the capabilities expected by modern toolchains and runtimes,
     # and ensures broad compatibility and good performance.
     isa_string = 'rv64imafdc'
+    _log.debug(f"Default ISA string: {isa_string}")
     os_type = get_os_type()
     if os_type == LINUX:
         if is_readable(PROC_CPUINFO_FP):
@@ -653,13 +657,16 @@ def get_isa_riscv():
             res = isa_regex.search(proc_cpuinfo)
             if res:
                 isa_string = res.group(1)
-                _log.debug("Found ISA string using regex '%s': %s", isa_regex.pattern, isa_string)
+                _log.debug(f"Found ISA string using regex '{isa_regex.pattern}': {isa_string}")
+                # sort parts separated by underscore alphabetically, as required by older GCC versions (< 14)
+                isa_string = '_'.join(sorted(isa_string.split('_')))
+                _log.debug(f"Sorted ISA string {isa_string}")
             else:
-                _log.debug("Failed to determine ISA string from %s", PROC_CPUINFO_FP)
+                _log.debug(f"Failed to determine ISA string from {PROC_CPUINFO_FP}")
         else:
-            _log.debug("%s not found to determine ISA string", PROC_CPUINFO_FP)
+            _log.debug(f"{PROC_CPUINFO_FP} not found to determine ISA string")
     else:
-        _log.debug("Could not determine ISA string (OS: %s), defaulting to: %s", os_type, isa_string)
+        _log.debug(f"Could not determine ISA string (OS: {os_type}), defaulting to {isa_string}")
     return isa_string
 
 

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -43,7 +43,7 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.environment import setvar
 from easybuild.tools.filetools import adjust_permissions, mkdir, read_file, symlink, which, write_file
 from easybuild.tools.run import RunShellCmdResult, run_shell_cmd
-from easybuild.tools.systemtools import CPU_ARCHITECTURES, AARCH32, AARCH64, POWER, X86_64
+from easybuild.tools.systemtools import CPU_ARCHITECTURES, AARCH32, AARCH64, POWER, RISCV, X86_64
 from easybuild.tools.systemtools import CPU_FAMILIES, POWER_LE, DARWIN, LINUX, UNKNOWN
 from easybuild.tools.systemtools import CPU_VENDORS, AMD, APM, ARM, CAVIUM, IBM, INTEL
 from easybuild.tools.systemtools import MAX_FREQ_FP, PROC_CPUINFO_FP, PROC_MEMINFO_FP
@@ -51,9 +51,8 @@ from easybuild.tools.systemtools import check_linked_shared_libs, check_os_depen
 from easybuild.tools.systemtools import det_parallelism, det_pypkg_version, get_avail_core_count
 from easybuild.tools.systemtools import get_cuda_object_dump_raw, get_cuda_architectures, get_cpu_arch_name
 from easybuild.tools.systemtools import get_cpu_architecture, get_cpu_family, get_cpu_features, get_cpu_model
-from easybuild.tools.systemtools import get_isa_riscv
-from easybuild.tools.systemtools import get_cpu_speed, get_cpu_vendor, get_gcc_version, get_glibc_version, get_os_type
-from easybuild.tools.systemtools import get_os_name, get_os_version, get_platform_name, get_shared_lib_ext
+from easybuild.tools.systemtools import get_cpu_speed, get_cpu_vendor, get_gcc_version, get_glibc_version, get_isa_riscv
+from easybuild.tools.systemtools import get_os_name, get_os_type, get_os_version, get_platform_name, get_shared_lib_ext
 from easybuild.tools.systemtools import get_system_info, get_total_memory, get_linked_libs_raw
 from easybuild.tools.systemtools import find_library_path, locate_solib, pick_dep_version, pick_system_specific_value
 
@@ -573,6 +572,7 @@ class SystemToolsTest(EnhancedTestCase):
         """Set up systemtools test."""
         super().setUp()
         self.orig_get_cpu_architecture = st.get_cpu_architecture
+        self.orig_get_cpu_family = st.get_cpu_family
         self.orig_get_os_name = st.get_os_name
         self.orig_get_os_type = st.get_os_type
         self.orig_is_readable = st.is_readable
@@ -592,6 +592,7 @@ class SystemToolsTest(EnhancedTestCase):
         st.is_readable = self.orig_is_readable
         st.read_file = self.orig_read_file
         st.get_cpu_architecture = self.orig_get_cpu_architecture
+        st.get_cpu_family = self.orig_get_cpu_family
         st.get_os_name = self.orig_get_os_name
         st.get_os_type = self.orig_get_os_type
         st.run_shell_cmd = self.orig_run_shell_cmd
@@ -763,13 +764,18 @@ class SystemToolsTest(EnhancedTestCase):
                     'vme', 'vmx', 'x2apic', 'xd', 'xsave']
         self.assertEqual(get_cpu_features(), expected)
 
-    def test_isa_native(self):
-        """Test getting ISA string."""
+    def test_isa_riscv_native(self):
+        """Test getting ISA string (for RISC-V)."""
         isa_string = get_isa_riscv()
-        self.assertIsInstance(isa_string, str)
 
-    def test_isa_linux(self):
+        if get_cpu_family() == RISCV:
+            self.assertIsInstance(isa_string, str)
+        else:
+            self.assertEqual(isa_string, None)
+
+    def test_isa_riscv_linux(self):
         """Test getting ISA string (mocked for Linux)."""
+        st.get_cpu_family = lambda: RISCV
         st.get_os_type = lambda: st.LINUX
         st.read_file = mocked_read_file
         st.is_readable = lambda fp: mocked_is_readable(PROC_CPUINFO_FP, fp)
@@ -778,7 +784,7 @@ class SystemToolsTest(EnhancedTestCase):
         global PROC_CPUINFO_TXT
 
         PROC_CPUINFO_TXT = PROC_CPUINFO_TXT_RISCV64
-        expected = 'rv64imafdch_zicsr_zifencei_zba_zbb_sscofpmf'
+        expected = 'rv64imafdch_sscofpmf_zba_zbb_zicsr_zifencei'
         self.assertEqual(get_isa_riscv(), expected)
 
     def test_cpu_architecture_native(self):


### PR DESCRIPTION
'-march=native" is not a valid value when building in RISC-V. 
Pass the ISA string with the supported extensions of the target platform instead.