### PR TITLE
Print total runtime of all builds

### DIFF
--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -604,7 +604,8 @@ def process_eb_args(eb_args, eb_go, cfg_settings, modtool, testing, init_session
     success_msg = "Build succeeded "
     if build_option('ignore_test_failure'):
         success_msg += "(with --ignore-test-failure) "
-    success_msg += f"for {correct_builds_cnt} out of {len(ordered_ecs)} (total: {time2str(datetime.now() - start_time)})"
+    success_msg += f"for {correct_builds_cnt} out of {len(ordered_ecs)} "
+    success_msg += f"(total: {time2str(datetime.now() - start_time)})"
 
     repo = init_repository(get_repository(), get_repositorypath())
     repo.cleanup()


### PR DESCRIPTION
We have individual runtimes like
> == COMPLETED: Installation ended successfully (took 34 secs)

But often, especially when builds are submitted as jobs and/or with many builds, I'd like to see a total build time

This PR adds that:
> == Build succeeded for 5 out of 5 in 46 mins 13 secs

I excluded the time for parsing cmdline params etc and included only the build itself, i.e. `build_and_install_software`.   
That should enough as the rest of the time should be reasonably small compared to the actual build(s)