### PR TITLE
unset `$PROMPT_COMMAND` in `cmd.sh` shell

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -255,6 +255,9 @@ def create_cmd_scripts(cmd_str, work_dir, env, tmpdir, out_file, err_file):
 
         fid.write('\n\nPS1="eb-shell> "')
 
+        # If set it would rely on functions that are not defined in this shell, messing up the prompt
+        fid.write('\nunset PROMPT_COMMAND\n')
+
         # define $EB_CMD_OUT_FILE to contain path to file with command output
         fid.write(f'\nEB_CMD_OUT_FILE="{out_file}"')
         # define $EB_CMD_ERR_FILE to contain path to file with command stderr output (if available)


### PR DESCRIPTION
`PROMPT_COMMAND` is in general used with functions like `_direnv_hook` or `posh-git`  (EG `PROMPT_COMMAND="_direnv_hook;posh-git"`) that are unset in the environment of `cmd.sh` causing warning like

```
bash: _direnv_hook: command not found
bash: posh-git: command not found
```

at every command ran in a `cmd.sh` environment.

`PROMPT_COMMAND` is in general used for cosmetic / helper functions.
If there are usecases that do not rely on functions and do more than cosmetic we should also consider of it interfering with the `cmd.sh` environment.

Example of `cmd.sh` before and after unsetting `PROMPT_COMMAND`

```
crivella@crivella-desktop:~$ /tmp/eb-1bk1n87b/run-shell-cmd-output/export-fflfr7wr/cmd.sh
# Shell for the command: 'export OMPI_MCA_rmaps_base_oversubscribe=true &&  make test'
# Use command history, exit to stop
bash: _direnv_hook: command not found
bash: posh-git: command not found
eb-shell> 
bash: _direnv_hook: command not found
bash: posh-git: command not found
eb-shell> 
bash: _direnv_hook: command not found
bash: posh-git: command not found
eb-shell> unset PROMPT_COMMAND
eb-shell> 
eb-shell> 
```