### PR TITLE
add example hook for updating OpenSSL 1.x dependency to 3.x

### DIFF
--- a/contrib/hooks/bumpOpenSSL.py
+++ b/contrib/hooks/bumpOpenSSL.py
@@ -15,7 +15,7 @@ def parse_hook(ec, *args, **kwargs):
     if openssl_found:
         print(f"[openssl1->3 hook] OpenSSL found in dependencies of {ec['name']}, replacing with OpenSSL 3")
         for i, dep in enumerate(raw_deps):
-            if dep[0] == 'OpenSSL':
+            if dep[0] == 'OpenSSL' and dep[1] == '1.1':
                 raw_deps[i] = ('OpenSSL', '3', '', EASYCONFIG_CONSTANTS['SYSTEM'][0])
                 break
 


### PR DESCRIPTION
I needed to build a <= 2023a toolchain on EL9-like Linux systems where OpenSSLv1 is unavailable (and deprecated).

This PR proposes an example hook that addresses this scenario. I believe it could be useful to others facing the same issue.

Credits:
Thanks to @Micket for guidance on how to approach this problem.