### PR TITLE
Remove superflous `module list` call in `ModulesTool.load`

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1123,10 +1123,10 @@ class ModulesTool:
             if os.path.exists(full_mod_path):
                 self.prepend_module_path(full_mod_path, priority=priority)
 
-        loaded_modules = self.loaded_modules()
+        if not allow_reload:
+            modules = set(modules) - set(self.loaded_modules())
         for mod in modules:
-            if allow_reload or mod not in loaded_modules:
-                self.run_module('load', mod)
+            self.run_module('load', mod)
 
     def unload(self, modules, log_changes=True):
         """


### PR DESCRIPTION
If `allow_reload=True` (default) then we don't need the loaded modules and can remove that call which saves time as the `module` command can be very slow