### PR TITLE
Load dependencies of SYSTEM toolchain by full name 

### DIFF
--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -654,12 +654,13 @@ class Toolchain:
             self.log.debug("Loading toolchain module and dependencies...")
 
         tc_mod = None if system_toolchain else self.det_short_module_name()
-        # For SYSTEM software we allow using dependencies from any toolchain so we need to use the full
-        # module name to allow loading them in the hierarchical MNS
-        is_system_toolchain = self.is_system_toolchain()
 
         def get_module_name(dep):
-            key = 'full_mod_name' if is_system_toolchain and not dep[SYSTEM_TOOLCHAIN_NAME] else 'short_mod_name'
+            key = 'short_mod_name'
+            if system_toolchain and not dep[SYSTEM_TOOLCHAIN_NAME]:
+                # When using the SYSTEM toolchain, we should use the full module name to load dependencies NOT from the
+                # SYSTEM toolchain to allow using dependencies from any toolchain when using a hierarchical MNS
+                key = 'full_mod_name'
             return dep[key]
 
         dep_mods = [get_module_name(dep) for dep in self.dependencies]

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -656,8 +656,13 @@ class Toolchain:
         tc_mod = None if system_toolchain else self.det_short_module_name()
         # For SYSTEM software we allow using dependencies from any toolchain so we need to use the full
         # module name to allow loading them in the hierarchical MNS
-        mod_name_key = 'full_mod_name' if self.is_system_toolchain() else 'short_mod_name'
-        dep_mods = [dep[mod_name_key] for dep in self.dependencies]
+        is_system_toolchain = self.is_system_toolchain()
+
+        def get_module_name(dep):
+            key = 'full_mod_name' if is_system_toolchain and not dep[SYSTEM_TOOLCHAIN_NAME] else 'short_mod_name'
+            return dep[key]
+
+        dep_mods = [get_module_name(dep) for dep in self.dependencies]
 
         mods_to_load = []
 
@@ -691,7 +696,7 @@ class Toolchain:
 
             # load available modules for dependencies, simulate load for others
             for dep, dep_mod_exists in zip(self.dependencies, mods_exist):
-                mod_name = dep[mod_name_key]
+                mod_name = get_module_name(dep)
                 self.modules.append(mod_name)
                 if dep_mod_exists:
                     mods_to_load.append(mod_name)
@@ -722,7 +727,7 @@ class Toolchain:
             self.log.debug(f"Loading modules for dependencies: {' '.join(dep_mods)}")
             mods_to_load.extend(dep_mods)
             if dep_mods:
-                build_dep_mods = [dep[mod_name_key] for dep in self.dependencies if dep['build_only']]
+                build_dep_mods = [get_module_name(dep) for dep in self.dependencies if dep['build_only']]
                 if build_dep_mods:
                     trace_msg("loading modules for build dependencies:")
                     for dep_mod in build_dep_mods:
@@ -730,7 +735,7 @@ class Toolchain:
                 else:
                     trace_msg("(no build dependencies specified)")
 
-                run_dep_mods = [dep[mod_name_key] for dep in self.dependencies if not dep['build_only']]
+                run_dep_mods = [get_module_name(dep) for dep in self.dependencies if not dep['build_only']]
                 if run_dep_mods:
                     trace_msg("loading modules for (runtime) dependencies:")
                     for dep_mod in run_dep_mods:
@@ -788,7 +793,7 @@ class Toolchain:
         self.log.debug("List of toolchain dependencies from toolchain module: %s", self.toolchain_dep_mods)
 
         # only retain names of toolchain elements, excluding toolchain name
-        toolchain_definition = {e for es in self.definition().values() for e in es if not e == self.name}
+        toolchain_definition = {e for es in self.definition().values() for e in es if e != self.name}
 
         # filter out optional toolchain elements if they're not used in the module
         for elem_name in toolchain_definition.copy():

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -654,7 +654,10 @@ class Toolchain:
             self.log.debug("Loading toolchain module and dependencies...")
 
         tc_mod = None if system_toolchain else self.det_short_module_name()
-        dep_mods = [dep['short_mod_name'] for dep in self.dependencies]
+        # For SYSTEM software we allow using dependencies from any toolchain so we need to use the full
+        # module name to allow loading them in the hierarchical MNS
+        mod_name_key = 'full_mod_name' if self.is_system_toolchain() else 'short_mod_name'
+        dep_mods = [dep[mod_name_key] for dep in self.dependencies]
 
         mods_to_load = []
 
@@ -688,7 +691,7 @@ class Toolchain:
 
             # load available modules for dependencies, simulate load for others
             for dep, dep_mod_exists in zip(self.dependencies, mods_exist):
-                mod_name = dep['short_mod_name']
+                mod_name = dep[mod_name_key]
                 self.modules.append(mod_name)
                 if dep_mod_exists:
                     mods_to_load.append(mod_name)
@@ -719,7 +722,7 @@ class Toolchain:
             self.log.debug(f"Loading modules for dependencies: {' '.join(dep_mods)}")
             mods_to_load.extend(dep_mods)
             if dep_mods:
-                build_dep_mods = [dep['short_mod_name'] for dep in self.dependencies if dep['build_only']]
+                build_dep_mods = [dep[mod_name_key] for dep in self.dependencies if dep['build_only']]
                 if build_dep_mods:
                     trace_msg("loading modules for build dependencies:")
                     for dep_mod in build_dep_mods:
@@ -727,7 +730,7 @@ class Toolchain:
                 else:
                     trace_msg("(no build dependencies specified)")
 
-                run_dep_mods = [dep['short_mod_name'] for dep in self.dependencies if not dep['build_only']]
+                run_dep_mods = [dep[mod_name_key] for dep in self.dependencies if not dep['build_only']]
                 if run_dep_mods:
                     trace_msg("loading modules for (runtime) dependencies:")
                     for dep_mod in run_dep_mods:
@@ -742,7 +745,7 @@ class Toolchain:
             self.modules.extend(mods_to_load)
 
         # define $EBROOT* and $EBVERSION* for external modules, if metadata is available
-        for dep in [d for d in self.dependencies if d['external_module']]:
+        for dep in (d for d in self.dependencies if d['external_module']):
             mod_name = dep['full_mod_name']
             metadata = dep['external_module_metadata']
             self.log.debug("Metadata for external module %s: %s", mod_name, metadata)
@@ -905,7 +908,7 @@ class Toolchain:
         if deps is None:
             deps = []
         self.dependencies = self._check_dependencies(deps, check_modules=loadmod)
-        if not len(deps) == len(self.dependencies):
+        if len(deps) != len(self.dependencies):
             self.log.debug("dep %s (%s)" % (len(deps), deps))
             self.log.debug("tc.dep %s (%s)" % (len(self.dependencies), self.dependencies))
             raise EasyBuildError('Not all dependencies have a matching toolchain version')

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -54,7 +54,7 @@ from easybuild.tools.systemtools import get_shared_lib_ext
 
 
 # number of modules included for testing purposes
-TEST_MODULES_COUNT = 119
+TEST_MODULES_COUNT = 120
 
 
 class ModulesTest(EnhancedTestCase):

--- a/test/framework/modules/ncurses/6.4-GCCcore-12.3.0
+++ b/test/framework/modules/ncurses/6.4-GCCcore-12.3.0
@@ -1,0 +1,36 @@
+#%Module
+proc ModulesHelp { } {
+    puts stderr {
+
+Description
+===========
+The Ncurses (new curses) library is a free software emulation of curses in
+ System V Release 4.0, and more. It uses Terminfo format, supports pads and
+ color and multiple highlights and forms characters and function-key mapping,
+ and has all the other SYSV-curses enhancements over BSD Curses.
+
+
+More information
+================
+ - Homepage: https://www.gnu.org/software/ncurses/
+    }
+}
+
+module-whatis {Description:
+ The Ncurses (new curses) library is a free software emulation of curses in
+ System V Release 4.0, and more. It uses Terminfo format, supports pads and
+ color and multiple highlights and forms characters and function-key mapping,
+ and has all the other SYSV-curses enhancements over BSD Curses.
+}
+module-whatis {Homepage: https://www.gnu.org/software/ncurses/}
+module-whatis {URL: https://www.gnu.org/software/ncurses/}
+
+set root /tmp/software/ncurses/6.4-GCCcore-12.3.0
+
+conflict ncurses
+
+setenv	EBROOTNCURSES		"$root"
+setenv	EBVERSIONNCURSES		"6.4"
+setenv	EBDEVELNCURSES		"$root/easybuild/Compiler-GCCcore-12.3.0-ncurses-6.4-easybuild-devel"
+
+# Built with EasyBuild version 5.1.2.dev0-r5819168038d7bd74810f38f75acfced9fb41870e

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -4820,6 +4820,25 @@ class ToyBuildTest(EnhancedTestCase):
                                             raise_error=True, verbose=True)
         self.assertExists(toy_mod_path)
 
+    def test_system_ec_with_gcccore_build_dep(self):
+        """
+        Test building a SYSTEM level software that has a module from GCCcore as build dependency"""
+        test_ec_txt = TOY_EC_TXT
+        # Using a software with existing (test) module and no dependencies itself for simplicity
+        test_ec_txt += "\nbuilddependencies = [('ncurses', '6.4', '', ('GCCcore', '12.3.0'))]"
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        write_file(test_ec, test_ec_txt)
+        common_args = ["--rebuild", test_ec]
+        for mns in ['EasyBuildMNS', 'HierarchicalMNS']:
+            with self.subTest(mns=mns):
+                args = common_args + [f'--module-naming-scheme={mns}']
+                modulepath = os.path.join(TEST_DIR, 'modules')
+                if mns == 'HierarchicalMNS':
+                    modulepath = os.path.join(modulepath, 'HierarchicalMNS')
+                os.environ['MODULEPATH'] = modulepath
+                outtxt = self.run_eb_main_capture_output(args, do_build=True, verbose=True, raise_error=True)
+                self.assertRegex(outtxt, r'\[SUCCESS\] .*toy/0.0')
+
     def test_eb_crash(self):
         """
         Test behaviour when EasyBuild crashes, for example due to a buggy hook


### PR DESCRIPTION
This allows loading e.g. `GCCcore/12.3.0/ncurses/6.1` without loading the GCCcore/12.3.0 toolchain module.
So we can use that as a dependency.

Note that this already works in the EasyBuildMNS because there the short and full module name are the same

Only in the HierarchicalMNS it fails because there 'Compiler/GCCcore/12.3.0/ncurses/6.4' needs to be used to load it.

A use of this is https://github.com/easybuilders/easybuild-easyconfigs/blob/8bca6595b2b975eb32eda0035613cf6fa17610a3/easybuild/easyconfigs/r/ripunzip/ripunzip-0.4.0.eb (from https://github.com/easybuilders/easybuild-easyconfigs/pull/17959) which uses `Rust` as a build dependency

cc @Micket 
