### PR TITLE
pick up on `config.cfg` EasyBuild configuration file in current working directory

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -131,7 +131,7 @@ XDG_CONFIG_DIRS = os.environ.get('XDG_CONFIG_DIRS', '/etc/xdg').split(os.pathsep
 DEFAULT_SYS_CFGFILES = [sorted(glob.glob(os.path.join(d, 'easybuild.d', '*.cfg')))
                         for d in XDG_CONFIG_DIRS]
 DEFAULT_USER_CFGFILE = os.path.join(XDG_CONFIG_HOME, 'easybuild', 'config.cfg')
-DEFAULT_LOCAL_CFGFILE= os.path.join(os.path.normpath(os.getcwd()), 'config.cfg')
+DEFAULT_LOCAL_CFGFILE = os.path.join(os.path.normpath(os.getcwd()), 'config.cfg')
 
 DEFAULT_LIST_PR_STATE = GITHUB_PR_STATE_OPEN
 DEFAULT_LIST_PR_ORDER = GITHUB_PR_ORDER_CREATED


### PR DESCRIPTION
Closes #3965 

I used git config as a reference: https://git-scm.com/docs/git-config#SCOPES

(there they call the easybuild user scope global scope, but we don't need to change that)

I ran some small tests locally with `eb --show-default-configfiles` and `eb --show-config` and everything seems to work as expected, but I don't know if there are some unit tests I should create.

tagging: @boegel 