### PR TITLE
Set `$___EASYBUILD___` environment variable to '`EasyBuild`' to indicate that you're in an EasyBuild session

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -301,7 +301,6 @@ class EasyBlock:
         self.orig_modulepath = os.getenv('MODULEPATH')
 
         # keep track of initial environment we start in, so we can restore it if needed
-        os.environ['___EASYBUILD___'] = "EasyBuild"  # set an environment variable to know we are in an EB session
         self.initial_environ = copy.deepcopy(os.environ)
         self.reset_environ = None
         self.tweaked_env_vars = {}

--- a/easybuild/main.py
+++ b/easybuild/main.py
@@ -792,6 +792,9 @@ def prepare_main(args=None, logfile=None, testing=None):
     :param testing: enable testing mode
     :return: 3-tuple with initial session state data, EasyBuildOptions instance, and tuple with configuration settings
     """
+    # set $___EASYBUILD___ environment variable to 'EasyBuild' to indicate that we're in an EasyBuild session
+    os.environ['___EASYBUILD___'] = 'EasyBuild'
+
     register_lock_cleanup_signal_handlers()
 
     # if $CDPATH is set, unset it, it'll only cause trouble...


### PR DESCRIPTION
The use case for this is `buildenv` in EESSI (https://gitlab.com/eessi/support/-/issues/213), where you might want to auto-load a `buildenv` with your compiler, but not if you are in an EasyBuild session.