### PR TITLE
Add script to gather git submodules

### DIFF
--- a/easybuild/scripts/get-submodule-info.sh
+++ b/easybuild/scripts/get-submodule-info.sh
@@ -1,4 +1,37 @@
 #!/bin/bash
+##
+# Copyright 2025-2025 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+Utility to gather submodules of an existing, recursively cloned repository
+in the current working directory.
+
+The output is a dictionary mapping submodule names to their repository slug, commit hash and relative path.
+
+author: Alexander Grund (TU Dresden)
+"""
+
 
 echo "Print information on all submodules for the git repository in $PWD"
 echo

--- a/easybuild/scripts/get-submodule-info.sh
+++ b/easybuild/scripts/get-submodule-info.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ##
-# Copyright 2025-2025 Ghent University
+# Copyright 2025-2026 Ghent University
 #
 # This file is part of EasyBuild,
 # originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),

--- a/easybuild/scripts/get-submodule-info.sh
+++ b/easybuild/scripts/get-submodule-info.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+echo "Print information on all submodules for the git repository in $PWD"
+echo
+echo "Format: '<name>': ('<owner>/<name>', '<commit>', '<path>'),"
+echo
+
+function print_submodules {
+    local base_path=$1
+    git -C "$base_path" submodule status | while read -r line; do
+        # Example line: " 3a6b7dc libs/foo (heads/main)"
+        commit=$(echo "$line" | awk '{print $1}')
+        path=$(echo "$line" | awk '{print $2}')
+
+        if [[ -z $base_path ]]; then
+            sub_folder=$path
+        else
+            sub_folder=$base_path/$path
+        fi
+
+        # Extract owner/repo from URL
+        url=$(git config --file "${base_path:-$PWD}/.gitmodules" --get "submodule.$path.url")
+        repo_slug=$(echo "$url" | sed -E 's#.*[:/]([^/:]+/[^/.]+)(\.git)?$#\1#')
+
+        name=$(basename "$path")
+        short_commit=$(git -C "$sub_folder" rev-parse --short "$commit" 2>/dev/null || echo "$commit")
+
+        printf "'%s': ('%s', '%s', '%s'),\n" "$name" "$repo_slug" "$short_commit" "$sub_folder"
+        print_submodules "$sub_folder"
+    done
+}
+
+print_submodules "" | sort


### PR DESCRIPTION
Running this on a recursively cloned git repository will show all submodules, its path and commit hash formatted as a Python dict which can be used in easyconfigs.

I needed this recently for an easyconfig.
Result was:
```
 {
    'amqpcpp': ('CopernicaMarketingSoftware/AMQP-CPP', '6ddabe4', 'lib/metricq/lib/amqpcpp'),
    'asio': ('chriskohlhoff/asio', 'fa27820c0', 'lib/metricq/lib/asio'),
    'Catch': ('catchorg/Catch2', '7c9f92bc', 'lib/metricq/lib/nitro/tests/Catch'),
    'Catch': ('catchorg/Catch2', '7c9f92bc', 'lib/plugin_cxx_wrapper/lib/nitro/tests/Catch'),
    'common': ('mem/plugin_common', '1aa933b', 'lib/plugin_cxx_wrapper/common'),
    'date': ('HowardHinnant/date', '6e921e1', 'lib/metricq/lib/date'),
    'fmt': ('fmtlib/fmt', '7bdf0628', 'lib/metricq/lib/fmt'),
    'metricq': ('metricq/metricq-cpp', '40018cb', 'lib/metricq'),
    'metricq-protobuf': ('metricq/metricq-protobuf', '733b836', 'lib/metricq/lib/metricq-protobuf'),
    'nitro': ('energy/nitro', 'ac613d6', 'lib/plugin_cxx_wrapper/lib/nitro'),
    'nitro': ('energy/nitro', 'e117e60', 'lib/metricq/lib/nitro'),
    'plugin_cxx_wrapper': ('mem/plugin_cxx_wrapper', '7adb5a9', 'lib/plugin_cxx_wrapper'),
}
```