### PR TITLE
Switch to setuptools and `find_packages`

### DIFF
--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -35,10 +35,7 @@ jobs:
         # update to latest pip, check version
         pip install --upgrade pip
         pip --version
-        if ! python -c "import distutils" 2> /dev/null; then
-            # we need setuptools for distutils in Python 3.12+, needed for python setup.py sdist
-            pip install --upgrade setuptools
-        fi
+        pip install setuptools
 
         # for modules tool
         APT_PKGS="lua5.3 liblua5.3-dev lua-filesystem lua-posix tcl tcl-dev"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -127,10 +127,8 @@ jobs:
         pip install --upgrade pip
         pip --version
         pip install -r requirements.txt
-        if ! python -c "import distutils" 2> /dev/null; then
-            # we need setuptools for distutils in Python 3.12+, needed for python setup.py sdist
-            pip install --upgrade setuptools
-        fi
+	# pkg_resources was removed in setuptools 82.0.0, but python-graph-dot requires it
+        pip install --upgrade 'setuptools<82'
         # git config is required to make actual git commits (cfr. tests for GitRepository)
         git config --global user.name "Github Actions"
         git config --global user.email "actions@github.com"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -129,10 +129,8 @@ jobs:
         pip install --upgrade pip
         pip --version
         pip install -r requirements.txt
-        if ! python -c "import distutils" 2> /dev/null; then
-            # we need setuptools for distutils in Python 3.12+, needed for python setup.py sdist
-            pip install --upgrade setuptools
-        fi
+	# pkg_resources was removed in setuptools 82.0.0, but python-graph-dot requires it
+        pip install --upgrade 'setuptools<82'
         # git config is required to make actual git commits (cfr. tests for GitRepository)
         git config --global user.name "Github Actions"
         git config --global user.email "actions@github.com"

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,7 @@ This script can be used to install easybuild-framework, e.g. using:
 import glob
 import os
 import logging
-try:
-    from distutils.core import setup
-except ImportError:
-    from setuptools import setup
+from setuptools import setup, find_packages
 
 from easybuild.tools.version import VERSION
 
@@ -68,34 +65,6 @@ def find_rel_test():
     return res
 
 
-easybuild_packages = [
-    "easybuild", "easybuild.base",
-    "easybuild.framework", "easybuild.framework.easyconfig", "easybuild.framework.easyconfig.format",
-    "easybuild.toolchains", "easybuild.toolchains.compiler", "easybuild.toolchains.mpi",
-    "easybuild.toolchains.fft", "easybuild.toolchains.linalg", "easybuild.tools", "easybuild.tools.containers",
-    "easybuild.tools.deprecated", "easybuild.tools.job", "easybuild.tools.toolchain",
-    "easybuild.tools.module_naming_scheme", "easybuild.tools.package", "easybuild.tools.package.package_naming_scheme",
-    "easybuild.tools.py2vs3", "easybuild.tools.repository",
-    "easybuild.tools.tomllib", "easybuild.tools.tomllib.tomli", "easybuild.tools._toml_writer",
-    "test.framework", "test",
-]
-
-# Verify the above list is complete, if setuptools is installed
-try:
-    import setuptools
-except ImportError:
-    pass
-else:
-    packages = set(setuptools.find_packages())
-    easybuild_packages_set = set(easybuild_packages)
-    if easybuild_packages_set != packages:
-        # Warning only
-        print("="*80 + "\n"
-              "=== WARNING: Wrong list of easybuild_packages.\n"
-              f"Missing: {packages - easybuild_packages_set}\n"
-              f"Unneccessary: {easybuild_packages_set - packages}"
-              "\n" + "="*80 + "\n")
-
 setup(
     name="easybuild-framework",
     version=str(VERSION),
@@ -106,7 +75,7 @@ implement support for installing particular (groups of) software packages.""",
     license="GPLv2",
     keywords="software build building installation installing compilation HPC scientific",
     url="https://easybuild.io",
-    packages=easybuild_packages,
+    packages=find_packages(),
     package_dir={'test.framework': 'test/framework'},
     package_data={'test.framework': find_rel_test()},
     scripts=[


### PR DESCRIPTION
Any reasonably modern Python distribution includes setuptools. So the workaround, that was useful for Python 2.x, is no longer necessary and can be removed.
This allows using `find_packages` instead of maintaining an explicit list of packages which is error-prone.

I ran into this when adding the vendored `tomli` package

see https://github.com/easybuilders/easybuild-easyblocks/pull/4006 & https://github.com/easybuilders/easybuild-easyconfigs/pull/24747