### PR TITLE
Don't install `test.framework` package

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -195,6 +195,9 @@ jobs:
           # run tests *outside* of checked out easybuild-framework directory,
           # to ensure we're testing installed version (see previous step)
           cd $HOME
+          # Copy test folder first as that module is NOT installed. Could be run from source tree but we want to test the installed package
+          cp -r $GITHUB_WORKSPACE/test .
+
           # initialize environment for modules tool
           if [ -f $HOME/moduleshome ]; then export MODULESHOME=$(cat $HOME/moduleshome); fi
           source $(cat $HOME/mod_init)

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -207,6 +207,9 @@ jobs:
           # run tests *outside* of checked out easybuild-framework directory,
           # to ensure we're testing installed version (see previous step)
           cd $HOME
+          # Copy test folder first as that module is NOT installed. Could be run from source tree but we want to test the installed package
+          cp -r $GITHUB_WORKSPACE/test .
+
           # initialize environment for modules tool
           if [ -f $HOME/moduleshome ]; then export MODULESHOME=$(cat $HOME/moduleshome); fi
           source $(cat $HOME/mod_init)

--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,6 @@ easybuild_packages = [
     "easybuild.tools.module_naming_scheme", "easybuild.tools.package", "easybuild.tools.package.package_naming_scheme",
     "easybuild.tools.py2vs3", "easybuild.tools.repository",
     "easybuild.tools.tomllib", "easybuild.tools.tomllib.tomli", "easybuild.tools._toml_writer",
-    "test.framework", "test",
 ]
 
 # Verify the above list is complete, if setuptools is installed
@@ -86,7 +85,7 @@ try:
 except ImportError:
     pass
 else:
-    packages = set(setuptools.find_packages())
+    packages = set(setuptools.find_packages(exclude=["test", "test.*"]))
     easybuild_packages_set = set(easybuild_packages)
     if easybuild_packages_set != packages:
         # Warning only

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -3737,32 +3737,44 @@ class FileToolsTest(EnhancedTestCase):
 
         topdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         test_files = [
-            os.path.join('easybuild', 'tools', 'filetools.py'),
-            os.path.join('test', 'framework', 'modules.py'),
-            os.path.join('test', 'framework', 'sandbox', 'sources', 'toy', 'toy-0.0.tar.gz'),
+            (topdir, os.path.join('test', 'framework', 'modules.py')),
+            (topdir, os.path.join('test', 'framework', 'sandbox', 'sources', 'toy', 'toy-0.0.tar.gz')),
         ]
-        expected_entries = ['easybuild', 'test']
+        expected_entries = ['test']
         # test/framework/modules.py is not new
-        expected_new = [True, False, True]
+        expected_new = [False, True]
 
-        # we include setup.py conditionally because it may not be there,
+        # CI might copy the test folder, so find source dir
+        possible_dirs = [topdir,
+                         os.environ.get('GITHUB_WORKSPACE', ''),
+                         # Fallback: If we are run from the source dir without being installed
+                         os.getcwd(),
+                         ] + os.environ.get('PYTHONPATH', '').split(':')  # Or at least have it in PYTHONPATH
+
+        # we include those conditionally because it may not be there,
         # for example when running the tests on an actual easybuild-framework instalation,
         # as opposed to when running from a repository checkout...
         # setup.py is an important test case, since it has no parent directory
         # (it's straight in the easybuild-framework directory)
-        setup_py = 'setup.py'
-        if os.path.exists(os.path.join(topdir, setup_py)):
-            test_files.append(setup_py)
-            expected_entries.append(setup_py)
-            expected_new.append(True)
+        try:
+            srcdir = next(d for d in possible_dirs if os.path.basename(d) == 'easybuild-framework' and
+                          os.path.exists(os.path.join(d, 'easybuild', 'framework')))
+        except StopIteration:
+            print(f"Running on installation without source, skipping parts of the checks\nTried: {possible_dirs}")
+        else:
+            setup_py = 'setup.py'
+            filetools_py = os.path.join('easybuild', 'tools', 'filetools.py')
+            test_files.extend([(srcdir, setup_py), (srcdir, filetools_py)])
+            expected_entries.extend([setup_py, 'easybuild'])
+            expected_new.extend([True, True])
 
         # files being copied are expected to be in a directory named 'easybuild-framework',
         # so we need to make sure that's the case here as well (may not be in workspace dir on Travis from example)
         framework_dir = os.path.join(self.test_prefix, 'easybuild-framework')
-        for test_file in test_files:
-            ft.copy_file(os.path.join(topdir, test_file), os.path.join(framework_dir, test_file))
+        for root, test_file in test_files:
+            ft.copy_file(os.path.join(root, test_file), os.path.join(framework_dir, test_file))
 
-        test_paths = [os.path.join(framework_dir, f) for f in test_files]
+        test_paths = [os.path.join(framework_dir, f) for _root, f in test_files]
 
         res = ft.copy_framework_files(test_paths, target_dir)
 
@@ -3770,8 +3782,8 @@ class FileToolsTest(EnhancedTestCase):
 
         self.assertEqual(sorted(res.keys()), ['new', 'paths_in_repo'])
 
-        for idx, test_file in enumerate(test_files):
-            orig_path = os.path.join(topdir, test_file)
+        for idx, (root, test_file) in enumerate(test_files):
+            orig_path = os.path.join(root, test_file)
             copied_path = os.path.join(target_dir, test_file)
 
             self.assertExists(copied_path)

--- a/test/framework/parallelbuild.py
+++ b/test/framework/parallelbuild.py
@@ -261,9 +261,9 @@ class ParallelBuildTest(EnhancedTestCase):
         ec_file = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
         easyconfigs = process_easyconfig(ec_file)
         ordered_ecs = resolve_dependencies(easyconfigs, self.modtool)
-        topdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         test_easyblocks_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'sandbox')
-        cmd = "PYTHONPATH=%s:%s:$PYTHONPATH eb %%(spec)s -df" % (topdir, test_easyblocks_path)
+        pythonpath = ':'.join((os.environ.get('PYTHONPATH', ''), test_easyblocks_path))
+        cmd = f"PYTHONPATH={pythonpath} eb %(spec)s -df"
 
         with self.mocked_stdout_stderr():
             build_easyconfigs_in_parallel(cmd, ordered_ecs, prepare_first=False)

--- a/test/framework/parallelbuild.py
+++ b/test/framework/parallelbuild.py
@@ -260,9 +260,9 @@ class ParallelBuildTest(EnhancedTestCase):
         ec_file = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
         easyconfigs = process_easyconfig(ec_file)
         ordered_ecs = resolve_dependencies(easyconfigs, self.modtool)
-        topdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         test_easyblocks_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'sandbox')
-        cmd = "PYTHONPATH=%s:%s:$PYTHONPATH eb %%(spec)s -df" % (topdir, test_easyblocks_path)
+        pythonpath = ':'.join((os.environ.get('PYTHONPATH', ''), test_easyblocks_path))
+        cmd = f"PYTHONPATH={pythonpath} eb %(spec)s -df"
 
         with self.mocked_stdout_stderr():
             build_easyconfigs_in_parallel(cmd, ordered_ecs, prepare_first=False)


### PR DESCRIPTION
This results in a top-level Python package called "test". As this isn't namespaced to easybuild it can cause issues with other Python packages and shouldn't be installed.


Additionally IMO it isn't useful to install the tests in the first place.