### PR TITLE
fix subtoolchains for nvompi + old NVHPC toolchains, and mark nvidia-compilers as optional subtoolchain since it's only used for recent NVHPC versions

### DIFF
--- a/easybuild/toolchains/nvhpc.py
+++ b/easybuild/toolchains/nvhpc.py
@@ -31,13 +31,17 @@ Authors:
 * Andreas Herten (Forschungszentrum Juelich)
 * Alex Domingo (Vrije Universiteit Brussel)
 """
+from easybuild.toolchains.gcccore import GCCcore
 from easybuild.toolchains.linalg.nvblas import NVBLAS
 from easybuild.toolchains.linalg.nvscalapack import NVScaLAPACK
 from easybuild.toolchains.mpi.nvhpcx import NVHPCX
 from easybuild.toolchains.nvidia_compilers import NvidiaCompilersToolchain
+from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
 
 
 class NVHPC(NvidiaCompilersToolchain, NVHPCX, NVBLAS, NVScaLAPACK):
     """Toolchain with Nvidia compilers and NVHPCX."""
     NAME = 'NVHPC'
-    SUBTOOLCHAIN = NvidiaCompilersToolchain.NAME
+    # GCCcore and system need to be listed as subtoolchains here only for legacy reasons;
+    # recent NVHPC toolchains (versions >= 25.0) only have nvidia-compilers are subtoolchain
+    SUBTOOLCHAIN = [NvidiaCompilersToolchain.NAME, GCCcore.NAME, SYSTEM_TOOLCHAIN_NAME]

--- a/easybuild/toolchains/nvidia_compilers.py
+++ b/easybuild/toolchains/nvidia_compilers.py
@@ -45,4 +45,6 @@ class NvidiaCompilersToolchain(NvidiaCompilers):
     # use GCCcore as subtoolchain rather than GCC, since two 'real' compiler-only toolchains don't mix well,
     # in particular in a hierarchical module naming scheme
     SUBTOOLCHAIN = [GCCcore.NAME, SYSTEM_TOOLCHAIN_NAME]
-    OPTIONAL = False
+    # nvidia-compilers is only an optional subtoolchain because of legacy reasons;
+    # recent NVHPC toolchains (versions >= 25.0) always have nvidia-compilers are subtoolchain
+    OPTIONAL = True

--- a/easybuild/toolchains/nvompi.py
+++ b/easybuild/toolchains/nvompi.py
@@ -37,4 +37,6 @@ from easybuild.toolchains.nvidia_compilers import NvidiaCompilersToolchain
 class Nvompi(NvidiaCompilersToolchain, OpenMPI):
     """Compiler toolchain with NVHPC and Open MPI."""
     NAME = 'nvompi'
-    SUBTOOLCHAIN = NvidiaCompilersToolchain.NAME
+    # NVHPC is only listed here as subtoolchain for legacy reasons;
+    # old nvompi toolchain don't have nvidia-compilers as subtoolchain
+    SUBTOOLCHAIN = ['NVHPC', NvidiaCompilersToolchain.NAME]


### PR DESCRIPTION
follow-up for:
- #4927

Required because of old toolchains like `nvompi/2022.07` (and `nvofbf/2022.07`) and `NVHPC` versions < 25.0