### PR TITLE
Include full shell command that failed in raised error

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3071,8 +3071,9 @@ class EasyBlock:
         except RunShellCmdError as err:
             err.print()
             ec_path = os.path.basename(self.cfg.path)
-            error_msg = f"shell command '{err.cmd_name} ...' failed in test step for {ec_path}"
-            self.report_test_failure(error_msg)
+            error_msg = "shell command '{cmd}' failed in test step for " + ec_path
+            self.log.warning(error_msg.format(cmd=err.cmd))
+            self.report_test_failure(error_msg.format(cmd=f"{err.cmd_name} ..."))
 
     def stage_install_step(self):
         """Install in a stage directory before actual installation."""
@@ -4922,15 +4923,16 @@ class EasyBlock:
                         self.run_step(step_name, step_methods)
                     except RunShellCmdError as err:
                         err.print()
-                        error_msg = (
-                            f"shell command '{err.cmd}' failed with exit code {err.exit_code} "
-                            f"in {step_name} step for {os.path.basename(self.cfg.path)}"
+                        msg = (
+                            "shell command '{cmd}' failed with exit code "
+                            f"{err.exit_code} in {step_name} step for {os.path.basename(self.cfg.path)}"
                         )
+                        self.log.warning(msg.format(cmd=err.cmd))  # pylint: disable=logging-format-interpolation
                         try:
                             step_exit_code = EasyBuildExit[f"FAIL_{step_name.upper()}_STEP"]
                         except KeyError:
                             step_exit_code = EasyBuildExit.ERROR
-                        raise EasyBuildError(error_msg, exit_code=step_exit_code) from err
+                        raise EasyBuildError(msg.format(cmd=f"{err.cmd_name} ..."), exit_code=step_exit_code) from err
                     finally:
                         if not self.dry_run:
                             step_duration = datetime.now() - start_time

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -1554,12 +1554,14 @@ class ToyBuildTest(EnhancedTestCase):
         ])
         write_file(test_ec, test_ec_txt)
 
-        error_pattern = r"shell command 'unzip .*bar-0.0.tar.gz' failed with exit code 9 in extensions step for test.eb"
+        pat_in_err = r"shell command 'unzip \.\.\.' failed with exit code 9 in extensions step for test.eb"
+        pat_in_log = r"shell command 'unzip .*bar-0.0.tar.gz' failed with exit code 9 in extensions step for test.eb"
         with self.mocked_stdout_stderr():
             # for now, we expect subprocess.CalledProcessError, but eventually 'run' function will
             # do proper error reporting
-            self.assertErrorRegex(EasyBuildError, error_pattern,
+            self.assertErrorRegex(EasyBuildError, pat_in_err,
                                   self._test_toy_build, ec_file=test_ec, raise_error=True, verbose=False)
+            self.assertRegex(read_file(self.logfile), pat_in_log)
 
     def test_toy_extension_sources_git_config(self):
         """Test install toy that includes extensions with 'sources' spec including 'git_config'."""


### PR DESCRIPTION
Allow to quickly inspect the command in the log, especially in test reports.