### PR TITLE
Extend list of easyconfig parameters that extensions should not inherit: `sources`, `patches`, `checksums`, `skipsteps`

### DIFF
--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -116,6 +116,7 @@ class Extension:
             'postinstallcmds',
             'sanity_check_commands',
             'sanity_check_paths',
+            'skipsteps',
             'sources',
         )
         for opt_name in restore_options:


### PR DESCRIPTION
It does not make sense for extensions to inherit source(-likes), patches or checksums from the parent easyconfig.

Especially the `sources` won't be used anyway, so reset those to the defaults to avoid confusion.   
`self.src` is set by using `ext['src']` set by `collect_exts_file_info` possibly based on `options['sources']`

I found this while handling the case where `crates` for a Cargo extension were found which is an error: They would be unused.   
However they were not set for the extension but in the parent easyconfig.

More general: Most easyconfig parameters should not be inherited for extensions.   
Do we actually want to inherit any parameters at all? If so which? Should we just annotate those and reset or remove the rest?