### PR TITLE
fix ignoring of URLError in `test_copy_ec_from_commit`

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -2063,7 +2063,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
             self.assertRegex(outtxt, r"Extended list of robot search paths with \['%s'\]:" % pr_tmpdir)
         except URLError as err:
             print("Ignoring URLError '%s' in test_from_pr" % err)
-            shutil.rmtree(tmpdir)
 
         # test with multiple prs
         tmpdir = tempfile.mkdtemp()
@@ -2096,7 +2095,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         except URLError as err:
             print("Ignoring URLError '%s' in test_from_pr" % err)
-            shutil.rmtree(tmpdir)
 
     def test_github_from_pr_token_log(self):
         """Check that --from-pr doesn't leak GitHub token in log."""
@@ -2180,7 +2178,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         except URLError as err:
             print("Ignoring URLError '%s' in test_from_pr" % err)
-            shutil.rmtree(tmpdir)
 
     def test_github_from_pr_x(self):
         """Test combination of --from-pr with --extended-dry-run."""
@@ -2304,7 +2301,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
             self.assertRegex(outtxt, r"Extended list of robot search paths with \['%s'\]:" % pr_tmpdir)
         except URLError as err:
             print("Ignoring URLError '%s' in test_from_commit" % err)
-            shutil.rmtree(tmpdir)
 
     # must be run after test for --list-easyblocks, hence the '_xxx_'
     # cleaning up the imported easyblocks is quite difficult...
@@ -2356,7 +2352,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         except URLError as err:
             print("Ignoring URLError '%s' in test_include_easyblocks_from_commit" % err)
-            shutil.rmtree(tmpdir)
 
     def test_no_such_software(self):
         """Test using no arguments."""


### PR DESCRIPTION
When the exception is thrown and ignored `stdout` is unassigned so the following tests cannot be done.

Fix regression from #4468.

See https://github.com/easybuilders/easybuild-framework/actions/runs/20333704730/job/58414942098?pr=5045

> UnboundLocalError: local variable 'stdout' referenced before assignment

Note that CI will still fail with
> ERROR: Found printed messages in output of test suite

And similar:
> ................................................................................................................................................................................................................Skipping online test for det_file_size (working offline)

cc @boegel 