### PR TITLE
Add line breaks in log for run-shell-cmd environment

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -468,13 +468,13 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
 
         cmd_sh = create_cmd_scripts(cmd_str, work_dir, env, tmpdir, cmd_out_fp, cmd_err_fp)
 
-        log_str = ' '.join([
+        log_str = '\n'.join([
             f'Script to start debug shell for {short_cmd_msg}',
-            f'will be saved to {cmd_sh},',
-            f'output will be logged to {cmd_out_fp}',
+            f'\twill be saved to {cmd_sh}',
+            f'\toutput will be logged to {cmd_out_fp}',
         ])
         if cmd_err_fp:
-            log_str += f'\nErrors and warnings will be logged to {cmd_err_fp}'
+            log_str += f'\n\tErrors and warnings will be logged to {cmd_err_fp}'
         _log.info(f'run_shell_cmd: {log_str}')
 
     else:


### PR DESCRIPTION
The command is put on an indented new line already. The error/warnings file is also on a new line.

Put also the debug shell and (standard) output file on new lines and indent them by a tab so they can be easier seen and copied.

Follow-up to:
- https://github.com/easybuilders/easybuild-framework/pull/5003