### PR TITLE
Ignore stderr for `rocm-smi` during test report creation

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -706,7 +706,7 @@ def get_gpu_info():
             cmd = "amd-smi static --driver --board --asic --csv"
             _log.debug("Trying to determine AMD GPU info on Linux via cmd '%s'", cmd)
             res = run_shell_cmd(cmd, fail_on_error=False, in_dry_run=True, hidden=True, with_hooks=False,
-                                output_file=False, stream_output=False)
+                                output_file=False, stream_output=False, split_stderr=True)
             if res.exit_code == EasyBuildExit.SUCCESS:
                 csv_reader = csv.DictReader(io.StringIO(res.output.strip()))
 
@@ -737,14 +737,14 @@ def get_gpu_info():
             cmd = "rocm-smi --showdriverversion --csv"
             _log.debug("Trying to determine AMD GPU driver on Linux via cmd '%s'", cmd)
             res = run_shell_cmd(cmd, fail_on_error=False, in_dry_run=True, hidden=True, with_hooks=False,
-                                output_file=False, stream_output=False)
+                                output_file=False, stream_output=False, split_stderr=True)
             if res.exit_code == EasyBuildExit.SUCCESS:
                 amd_driver = res.output.strip().split('\n')[1].split(',')[1]
 
             cmd = "rocm-smi --showproductname --csv"
             _log.debug("Trying to determine AMD GPU info on Linux via cmd '%s'", cmd)
             res = run_shell_cmd(cmd, fail_on_error=False, in_dry_run=True, hidden=True, with_hooks=False,
-                                output_file=False, stream_output=False)
+                                output_file=False, stream_output=False, split_stderr=True)
             if res.exit_code == EasyBuildExit.SUCCESS:
                 for line in res.output.strip().split('\n')[1:]:
                     amd_card_series = line.split(',')[1]


### PR DESCRIPTION
rocm-smi might return a warning when calling the tool:

```
WARNING: AMD GPU device(s) is/are in a low-power state. Check power control/runtime_status
```

That warning is entirely useless, since we want to determine the GPU and driver version. In fact, this warning breaks our parsing of the result, causing EasyBuild to crash with an error:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/data/EasyBuild/lib/python3.13/site-packages/easybuild/main.py", line 859, in <module>
    main_with_hooks()
    ~~~~~~~~~~~~~~~^^
  File "/data/EasyBuild/lib/python3.13/site-packages/easybuild/main.py", line 844, in main_with_hooks
    exit_code: EasyBuildExit = main(args=args, prepared_cfg_data=(init_session_state, eb_go, cfg_settings))
                               ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/EasyBuild/lib/python3.13/site-packages/easybuild/main.py", line 795, in main
    is_successful = process_eb_args(orig_paths, eb_go, cfg_settings, modtool, testing, init_session_state,
                                    hooks, do_build)
  File "/data/EasyBuild/lib/python3.13/site-packages/easybuild/main.py", line 629, in process_eb_args
    test_report_msg = overall_test_report(ecs_with_res, len(paths), overall_success, success_msg, init_session_state)
  File "/data/EasyBuild/lib/python3.13/site-packages/easybuild/tools/testing.py", line 459, in overall_test_report
    txt = post_pr_test_report(pr_nrs, GITHUB_EASYCONFIGS_REPO, test_report, msg, init_session_state,
                              success)
  File "/data/EasyBuild/lib/python3.13/site-packages/easybuild/tools/testing.py", line 372, in post_pr_test_report
    gpu_info = get_gpu_info()
  File "/data/EasyBuild/lib/python3.13/site-packages/easybuild/tools/systemtools.py", line 746, in get_gpu_info
    amd_driver = res.output.strip().split('\n')[1].split(',')[1]
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
IndexError: list index out of range
```

Therefore, ignore the warning entirely, and just use the output provided by stdout.

---

Related to the issue https://github.com/easybuilders/easybuild-framework/issues/5086, but fixes a different issue.