### PR TITLE
Enhance `get_source_tarball_from_git` to ensure that Git repo URL does not contain double slashes due to trailing slash in source URL

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2821,6 +2821,8 @@ def get_source_tarball_from_git(filename, target_dir, git_config):
     # checkout is done separately below for specific commits
     clone_cmd.append('--no-checkout')
 
+    # Ensure URL is also processed correctly by tools that don't collapse double slashes
+    url = url.rstrip('/')
     clone_cmd.append(f'{url}/{repo_name}.git')
 
     if clone_into:


### PR DESCRIPTION
I've encountered this when trying to install a package that requires a `git lfs pull` before installing in order to  bring in some optional files.

If the `url` in `git_config` is written with a trailing slash, the final url will contain a double slash, eg
```
            'git_config': {
                'url': 'https://github.com/SOME_USER/',
                'repo_name': 'SOME_REPO',
                ...
            }
```
where the URL will result in `https://github.com/SOME_USER//SOME_REPO`

GIT deals with this fine, by collapsing the double-slash into one when interpreting the URL, but the version with the double-slash is what is written by `git clone` in the `.git/config`
This causes a generic connection error when calling `git lfs pull` due to it not being able to handle the double-slash in the URL.

This minor fix ensures that trailing slashes in the `url` of `git_config`s is properly removed as it is re-added when joining the url with the repo_name

Even if there exists url's where the double-slash is required i would argue that we should not rely on the string joining logic for it and probably add it to the `repo_name`
An alternative would be to check whether the `url` ends with a slash and only add an extra one if it does not