### PR TITLE
add support for ROCm-based toolchains (`rocm-compilers`, `rompi`, `rfbf`, `rfoss`)

### DIFF
--- a/easybuild/toolchains/compiler/rocm_compilers.py
+++ b/easybuild/toolchains/compiler/rocm_compilers.py
@@ -1,0 +1,52 @@
+##
+# Copyright 2013-2025 Ghent University
+#
+# This file is triple-licensed under GPLv2 (see below), MIT, and
+# BSD three-clause licenses.
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for Clang + Flang compiler toolchain.
+
+Authors:
+
+* Jan Reuter (jan@zyten.de)
+"""
+
+from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
+from easybuild.tools.toolchain.compiler import LLVMCompilers
+
+TC_CONSTANT_LLVM = "ROCm"
+
+
+class ROCmCompilers(LLVMCompilers):
+    """Compiler toolchain with ROCm compilers (amdclang/amdflang)."""
+    COMPILER_FAMILY = TC_CONSTANT_LLVM
+    SUBTOOLCHAIN = SYSTEM_TOOLCHAIN_NAME
+
+    COMPILER_CC = 'amdclang'
+    COMPILER_CXX = 'amdclang++'
+
+    COMPILER_F77 = 'amdflang'
+    COMPILER_F90 = 'amdflang'
+    COMPILER_FC = 'amdflang'

--- a/easybuild/toolchains/compiler/rocm_compilers.py
+++ b/easybuild/toolchains/compiler/rocm_compilers.py
@@ -34,7 +34,7 @@ Authors:
 """
 
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
-from easybuild.tools.toolchain.compiler.llvm_compilers import LLVMCompilers
+from easybuild.toolchains.compiler.llvm_compilers import LLVMCompilers
 
 TC_CONSTANT_ROCM = "ROCm"
 

--- a/easybuild/toolchains/compiler/rocm_compilers.py
+++ b/easybuild/toolchains/compiler/rocm_compilers.py
@@ -34,7 +34,7 @@ Authors:
 """
 
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
-from easybuild.tools.toolchain.compiler import LLVMCompilers
+from easybuild.tools.toolchain.compiler.llvm_compilers import LLVMCompilers
 
 TC_CONSTANT_ROCM = "ROCm"
 

--- a/easybuild/toolchains/compiler/rocm_compilers.py
+++ b/easybuild/toolchains/compiler/rocm_compilers.py
@@ -36,12 +36,12 @@ Authors:
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
 from easybuild.tools.toolchain.compiler import LLVMCompilers
 
-TC_CONSTANT_LLVM = "ROCm"
+TC_CONSTANT_ROCM = "ROCm"
 
 
 class ROCmCompilers(LLVMCompilers):
     """Compiler toolchain with ROCm compilers (amdclang/amdflang)."""
-    COMPILER_FAMILY = TC_CONSTANT_LLVM
+    COMPILER_FAMILY = TC_CONSTANT_ROCM
     SUBTOOLCHAIN = SYSTEM_TOOLCHAIN_NAME
 
     COMPILER_CC = 'amdclang'

--- a/easybuild/toolchains/compiler/rocm_compilers.py
+++ b/easybuild/toolchains/compiler/rocm_compilers.py
@@ -40,13 +40,10 @@ TC_CONSTANT_ROCM = "ROCm"
 
 
 class ROCmCompilers(LLVMCompilers):
-    """Compiler toolchain with ROCm compilers (amdclang/amdflang)."""
+    """Compiler toolchain with ROCm compilers (clang/flang)."""
     COMPILER_FAMILY = TC_CONSTANT_ROCM
     SUBTOOLCHAIN = SYSTEM_TOOLCHAIN_NAME
 
-    COMPILER_CC = 'amdclang'
-    COMPILER_CXX = 'amdclang++'
-
-    COMPILER_F77 = 'amdflang'
-    COMPILER_F90 = 'amdflang'
-    COMPILER_FC = 'amdflang'
+    # We use clang, clang++ and flang for now (instead of amdclang/amdclang++/amdflang).
+    # These are simply inherited from LLVMCompilers, so we don't need to respecify them
+    # See https://github.com/easybuilders/easybuild-framework/pull/5099#issuecomment-4054952860

--- a/easybuild/toolchains/compiler/rocm_compilers.py
+++ b/easybuild/toolchains/compiler/rocm_compilers.py
@@ -26,7 +26,7 @@
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 ##
 """
-EasyBuild support for Clang + Flang compiler toolchain.
+EasyBuild support for ROCm Clang + Flang compiler toolchain.
 
 Authors:
 

--- a/easybuild/toolchains/compiler/rocm_compilers.py
+++ b/easybuild/toolchains/compiler/rocm_compilers.py
@@ -31,8 +31,12 @@ EasyBuild support for ROCm Clang + Flang compiler toolchain.
 Authors:
 
 * Jan Reuter (jan@zyten.de)
+* Kenneth Hoste (HPC-UGent)
 """
+import os
+import re
 
+from easybuild.tools.filetools import copy_file, read_file, write_file, which
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
 from easybuild.toolchains.compiler.llvm_compilers import LLVMCompilers
 
@@ -40,10 +44,42 @@ TC_CONSTANT_ROCM = "ROCm"
 
 
 class ROCmCompilers(LLVMCompilers):
-    """Compiler toolchain with ROCm compilers (clang/flang)."""
+    """Compiler toolchain with ROCm compilers (amdclang/amdclang++/amdflang)."""
     COMPILER_FAMILY = TC_CONSTANT_ROCM
     SUBTOOLCHAIN = SYSTEM_TOOLCHAIN_NAME
 
-    # We use clang, clang++ and flang for now (instead of amdclang/amdclang++/amdflang).
-    # These are simply inherited from LLVMCompilers, so we don't need to respecify them
-    # See https://github.com/easybuilders/easybuild-framework/pull/5099#issuecomment-4054952860
+    COMPILER_CC = 'amdclang'
+    COMPILER_CXX = 'amdclang++'
+
+    COMPILER_F77 = 'amdflang'
+    COMPILER_F90 = 'amdflang'
+    COMPILER_FC = 'amdflang'
+
+    def prepare_rpath_wrappers(self, *args, **kwargs):
+        """
+        Put RPATH wrapper scripts in place for compiler and linker commands
+
+        Also do this for clang/clang++/flang commands, next to ROCm compiler commands (amdclang/amdclang++/amdflang)
+        """
+        super().prepare_rpath_wrappers(*args, **kwargs)
+
+        amd_prefix = 'amd'
+        compiler_cmds = [self.COMPILER_CC, self.COMPILER_CXX, self.COMPILER_F77, self.COMPILER_F90, self.COMPILER_FC]
+        for compiler_cmd in [c for c in compiler_cmds if c.startswith(amd_prefix)]:
+            wrapper = which(compiler_cmd)
+
+            if not wrapper:
+                raise EasyBuildError(f"{compiler_cmd} command not found!")
+            elif not self.is_rpath_wrapper(wrapper):
+                raise EasyBuildError(f"{wrapper} is not an RPATH compiler wrapper for {compiler_cmd}")
+            else:
+                parent_dir = os.path.dirname(wrapper)
+                new_compiler_cmd = compiler_cmd[len(amd_prefix):]
+                new_wrapper = os.path.join(parent_dir, new_compiler_cmd)
+                copy_file(wrapper, new_wrapper)
+
+                new_wrapper_txt = read_file(new_wrapper)
+                regex = re.compile(re.escape(compiler_cmd), re.M)
+                new_wrapper_txt = regex.sub(new_compiler_cmd, new_wrapper_txt)
+                write_file(new_wrapper, new_wrapper_txt)
+                self.log.info(f"Extra RPATH compiler wrapper created for {new_compiler_cmd}")

--- a/easybuild/toolchains/compiler/rocm_compilers.py
+++ b/easybuild/toolchains/compiler/rocm_compilers.py
@@ -36,6 +36,7 @@ Authors:
 import os
 import re
 
+from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.filetools import copy_file, read_file, write_file, which
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
 from easybuild.toolchains.compiler.llvm_compilers import LLVMCompilers

--- a/easybuild/toolchains/rfbf.py
+++ b/easybuild/toolchains/rfbf.py
@@ -23,7 +23,7 @@
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 ##
 """
-EasyBuild support for gfbf compiler toolchain (includes GCC, FlexiBLAS and FFTW)
+EasyBuild support for rfbf compiler toolchain (includes ROCm-LLVM, FlexiBLAS and FFTW)
 
 Authors:
 

--- a/easybuild/toolchains/rfbf.py
+++ b/easybuild/toolchains/rfbf.py
@@ -1,0 +1,46 @@
+##
+# Copyright 2021-2026 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for gfbf compiler toolchain (includes GCC, FlexiBLAS and FFTW)
+
+Authors:
+
+* Kenneth Hoste (Ghent University)
+* Bart Oldeman (McGill University, Calcul Quebec, Compute Canada)
+* Davide Grassano (CECAM EPFL)
+* Jan Reuter (jan@zyten.de)
+
+"""
+
+from easybuild.toolchains.rocm_compilers import ROCmCompilersToolchain
+from easybuild.toolchains.fft.fftw import Fftw
+from easybuild.toolchains.linalg.flexiblas import FlexiBLAS
+
+
+class Rfbf(ROCmCompilersToolchain, FlexiBLAS, Fftw):
+    """Compiler toolchain with ROCm-LLVM, FlexiBLAS and FFTW."""
+    NAME = 'rfbf'
+    SUBTOOLCHAIN = ROCmCompilersToolchain.NAME
+    OPTIONAL = True

--- a/easybuild/toolchains/rfoss.py
+++ b/easybuild/toolchains/rfoss.py
@@ -1,0 +1,90 @@
+##
+# Copyright 2013-2026 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for foss compiler toolchain (includes ROCm-LLVM, OpenMPI, OpenBLAS, LAPACK, ScaLAPACK and FFTW).
+
+Authors:
+
+* Kenneth Hoste (Ghent University)
+* Davide Grassano (CECAM EPFL)
+* Jan Reuter (jan@zyten.de)
+
+"""
+from easybuild.toolchains.rompi import Rompi
+from easybuild.toolchains.rfbf import Rfbf
+from easybuild.toolchains.fft.fftw import Fftw
+from easybuild.toolchains.linalg.flexiblas import FlexiBLAS
+from easybuild.toolchains.linalg.scalapack import ScaLAPACK
+from easybuild.tools import LooseVersion
+
+
+class RFoss(Rompi, FlexiBLAS, ScaLAPACK, Fftw):
+    """Compiler toolchain with ROCm-LLVM, OpenMPI, FlexiBLAS, ScaLAPACK and FFTW."""
+    NAME = 'lfoss'
+    SUBTOOLCHAIN = [
+        Rompi.NAME,
+        Rfbf.NAME
+    ]
+
+    def __init__(self, *args, **kwargs):
+        """Toolchain constructor."""
+        super(RFoss, self).__init__(*args, **kwargs)
+
+        # need to transform a version like '2018b' with something that is safe to compare with '2019'
+        # comparing subversions that include letters causes TypeErrors in Python 3
+        # 'a' is assumed to be equivalent with '.01' (January), and 'b' with '.07' (June) (good enough for this purpose)
+        version = self.version.replace('a', '.01').replace('b', '.07')
+
+        self.looseversion = LooseVersion(version)
+
+        constants = ('BLAS_MODULE_NAME', 'BLAS_LIB', 'BLAS_LIB_MT', 'BLAS_FAMILY',
+                     'LAPACK_MODULE_NAME', 'LAPACK_IS_BLAS', 'LAPACK_FAMILY')
+
+        for constant in constants:
+            setattr(self, constant, getattr(FlexiBLAS, constant))
+
+    def banned_linked_shared_libs(self):
+        """
+        List of shared libraries (names, file names, paths) which are
+        not allowed to be linked in any installed binary/library.
+        """
+        res = []
+        res.extend(Rompi.banned_linked_shared_libs(self))
+        res.extend(FlexiBLAS.banned_linked_shared_libs(self))
+        res.extend(ScaLAPACK.banned_linked_shared_libs(self))
+        res.extend(Fftw.banned_linked_shared_libs(self))
+
+        return res
+
+    def is_deprecated(self):
+        """Return whether or not this toolchain is deprecated."""
+
+        # lfoss toolchains older than 2023b should not exist (need GCC >= 13)
+        if self.looseversion < LooseVersion('2023'):
+            deprecated = True
+        else:
+            deprecated = False
+
+        return deprecated

--- a/easybuild/toolchains/rfoss.py
+++ b/easybuild/toolchains/rfoss.py
@@ -42,7 +42,7 @@ from easybuild.tools import LooseVersion
 
 class RFoss(Rompi, FlexiBLAS, ScaLAPACK, Fftw):
     """Compiler toolchain with ROCm-LLVM, OpenMPI, FlexiBLAS, ScaLAPACK and FFTW."""
-    NAME = 'lfoss'
+    NAME = 'rfoss'
     SUBTOOLCHAIN = [
         Rompi.NAME,
         Rfbf.NAME

--- a/easybuild/toolchains/rfoss.py
+++ b/easybuild/toolchains/rfoss.py
@@ -81,7 +81,7 @@ class RFoss(Rompi, FlexiBLAS, ScaLAPACK, Fftw):
     def is_deprecated(self):
         """Return whether or not this toolchain is deprecated."""
 
-        # lfoss toolchains older than 2023b should not exist (need GCC >= 13)
+        # rfoss toolchains older than 2023b should not exist (need GCC >= 13)
         if self.looseversion < LooseVersion('2023'):
             deprecated = True
         else:

--- a/easybuild/toolchains/rocm_compilers.py
+++ b/easybuild/toolchains/rocm_compilers.py
@@ -1,0 +1,45 @@
+##
+# Copyright 2013-2025 Ghent University
+#
+# This file is triple-licensed under GPLv2 (see below), MIT, and
+# BSD three-clause licenses.
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for Clang + Flang compiler toolchain.
+
+Authors:
+
+* Jan Reuter (jan@zyten.de)
+"""
+
+from easybuild.toolchains.gcccore import GCCcore
+from easybuild.toolchains.compiler.rocm_compilers import ROCmCompilers
+from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
+
+
+class ROCmCompilersToolchain(LLVMCompilers):
+    """Compiler toolchain with AMDClang and AMDFlang compilers."""
+    NAME = 'rocm-compilers'  # Follows naming scheme used for intel-compilers & nvidia-compilers
+    COMPILER_MODULE_NAME = [NAME]
+    SUBTOOLCHAIN = [GCCcore.NAME, SYSTEM_TOOLCHAIN_NAME]

--- a/easybuild/toolchains/rocm_compilers.py
+++ b/easybuild/toolchains/rocm_compilers.py
@@ -38,7 +38,7 @@ from easybuild.toolchains.compiler.rocm_compilers import ROCmCompilers
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
 
 
-class ROCmCompilersToolchain(LLVMCompilers):
+class ROCmCompilersToolchain(ROCmCompilers):
     """Compiler toolchain with AMDClang and AMDFlang compilers."""
     NAME = 'rocm-compilers'  # Follows naming scheme used for intel-compilers & nvidia-compilers
     COMPILER_MODULE_NAME = [NAME]

--- a/easybuild/toolchains/rocm_compilers.py
+++ b/easybuild/toolchains/rocm_compilers.py
@@ -26,7 +26,7 @@
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 ##
 """
-EasyBuild support for Clang + Flang compiler toolchain.
+EasyBuild support for ROCm Clang + Flang compiler toolchain.
 
 Authors:
 

--- a/easybuild/toolchains/rompi.py
+++ b/easybuild/toolchains/rompi.py
@@ -1,0 +1,62 @@
+##
+# Copyright 2012-2026 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://www.vscentrum.be),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for lompi compiler toolchain (includes LLVM and OpenMPI).
+
+Authors:
+
+* Kenneth Hoste (Ghent University)
+* Davide Grassano (CECAM EPFL)
+* Jan Reuter (jan@zyten.de)
+
+"""
+from easybuild.tools import LooseVersion
+import re
+
+from easybuild.toolchains.rocm_compilers import ROCmCompilersToolchain
+from easybuild.toolchains.mpi.openmpi import OpenMPI
+
+
+class Rompi(ROCmCompilersToolchain, OpenMPI):
+    """Compiler toolchain with ROCm-LLVM and OpenMPI."""
+    NAME = 'rompi'
+    SUBTOOLCHAIN = ROCmCompilersToolchain.NAME
+
+    def is_deprecated(self):
+        """Return whether or not this toolchain is deprecated."""
+        # need to transform a version like '2018b' with something that is safe to compare with '2019'
+        # comparing subversions that include letters causes TypeErrors in Python 3
+        # 'a' is assumed to be equivalent with '.01' (January), and 'b' with '.07' (June) (good enough for this purpose)
+        version = self.version.replace('a', '.01').replace('b', '.07')
+
+        deprecated = False
+
+        # make sure a non-symbolic version (e.g., 'system') is used before making comparisons using LooseVersion
+        if re.match('^[0-9]', version):
+            # rompi toolchains older than 2023b should not exist (need GCC >= 13)
+            if LooseVersion(version) < LooseVersion('2023'):
+                deprecated = True
+
+        return deprecated

--- a/easybuild/toolchains/rompi.py
+++ b/easybuild/toolchains/rompi.py
@@ -23,7 +23,7 @@
 # along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
 ##
 """
-EasyBuild support for lompi compiler toolchain (includes LLVM and OpenMPI).
+EasyBuild support for rompi compiler toolchain (includes ROCm-LLVM and OpenMPI).
 
 Authors:
 


### PR DESCRIPTION
This PR adds a `rocm-compilers` toolchain based on the extremely heavy lifting done for the LLVM toolchain.

We're reusing most of the efforts done there to get this toolchain running.
Marked as draft for now, since we're missing crucial parts such as math and MPI toolchains.

Since we're exploring as we go, we first need to get there with ECs...