### PR TITLE
change NVHPCToolchain deprecation warning to simple warning in unit tests

### DIFF
--- a/easybuild/toolchains/nvhpc.py
+++ b/easybuild/toolchains/nvhpc.py
@@ -38,6 +38,7 @@ from easybuild.toolchains.linalg.nvblas import NVBLAS
 from easybuild.toolchains.linalg.nvscalapack import NVScaLAPACK
 from easybuild.toolchains.mpi.nvhpcx import NVHPCX
 from easybuild.toolchains.nvidia_compilers import NvidiaCompilersToolchain
+from easybuild.tools.build_log import print_warning
 from easybuild.tools.toolchain.toolchain import SYSTEM_TOOLCHAIN_NAME
 
 
@@ -71,6 +72,6 @@ class NVHPCToolchain(NvidiaCompilersToolchain):
         warn_msg = "NVHPCToolchain was replaced by NvidiaCompilersToolchain in EasyBuild 5.2.0"
         in_test_env = any('unittest' in frame.filename for frame in inspect.stack())
         if in_test_env:
-            self.log.warning(warn_msg)
+            print_warning(warn_msg)
         else:
             self.log.deprecated(warn_msg, '6.0')


### PR DESCRIPTION
CI test suite in `easybuild-easyconfigs` is currently broken due to this deprecation warning adn the recent changes in https://github.com/easybuilders/easybuild-framework/pull/5103.

Instead of mending the tens of test failing to blindly ignore all deprecation errors, we can avoid the error altogether by switching to a regular warning in the test suite.