### PR TITLE
also test with Python 3.15

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -57,6 +57,8 @@ jobs:
             modules_tool: ${{needs.setup.outputs.lmod8}}
           - python: '3.14'
             modules_tool: ${{needs.setup.outputs.lmod8}}
+          - python: '3.15.0-alpha.5'
+            modules_tool: ${{needs.setup.outputs.lmod8}}
           # also test with Lmod 9.x
           - python: '3.9'
             modules_tool: ${{needs.setup.outputs.lmod9}}


### PR DESCRIPTION
draft PR since final release of Python 3.15 isn't there yet (expected 1 Oct'26, see [PEP 790](https://peps.python.org/pep-0790/))

There's one failing test, which isn't really a problem, it just trips over the funky Python version being reported, so it seems like no changes will be required in EasyBuild framework to support running on top of Python 3.15... \o/