### PR TITLE
load list of modules in one go as opposed to running separate `module load` commands for each of them

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -1127,8 +1127,8 @@ class ModulesTool:
 
         if not allow_reload:
             modules = set(modules) - set(self.loaded_modules())
-        for mod in modules:
-            self.run_module('load', mod)
+
+        self.run_module('load', *modules)
 
     def unload(self, modules, log_changes=True):
         """


### PR DESCRIPTION
This should help quite a bit with resolving the performance regression reported in #5052, since all dependencies are being loaded in one go rather than one by one, at least for the "parent" installation.

We're still doing a separate `module load` for the toolchain, but I won't look into that yet since changing that is lot more involved (there are separate private methods called from `Toolchain._load_modules`: `_load_toolchain_module` and `_load_dependencies_modules`).

As I write this (rubber ducking 🦆 ) , I realize that I'm not sure how much impact this will have for extensions, since we only load the "fake" (temporary) module file for each extension (so a single `module load`) via `EasyBlock.fake_module_environment`...