### PR TITLE
import specific submodule `pygraph.classes.digraph` in `test_dep_graph*` so we can skip the test if import fails with setuptools >= 82.0.0

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -245,6 +245,7 @@ jobs:
             # try and make sure output of running tests is clean (no printed messages/warnings)
             IGNORE_PATTERNS="no GitHub token available"
             IGNORE_PATTERNS+="|skipping SvnRepository test"
+            IGNORE_PATTERNS+="|Skipping test_dep_graph"
             IGNORE_PATTERNS+="|requires Lmod as modules tool"
             IGNORE_PATTERNS+="|stty: 'standard input': Inappropriate ioctl for device"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 3.7"

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3281,7 +3281,10 @@ class EasyConfigTest(EnhancedTestCase):
     def test_dep_graph(self):
         """Test for dep_graph."""
         try:
-            import pygraph  # noqa # pylint:disable=unused-import
+            # do specific import, since python-graph-dot is not compatible with setuptools >= 82.0.0
+            # in which pkg_resources was removed;
+            # see also https://github.com/easybuilders/easybuild-framework/issues/5110
+            import pygraph.classes.digraph  # noqa # pylint:disable=unused-import
         except ImportError:
             print("Skipping test_dep_graph, since pygraph is not available")
             return
@@ -3320,47 +3323,51 @@ class EasyConfigTest(EnhancedTestCase):
         Test for dep_graph using easyconfig that uses multi_deps.
         """
         try:
-            import pygraph  # noqa # pylint:disable=unused-import
-
-            test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
-            build_options = {
-                'external_modules_metadata': ConfigObj(),
-                'valid_module_classes': module_classes(),
-                'robot_path': [test_easyconfigs],
-                'silent': True,
-            }
-            init_config(build_options=build_options)
-
-            toy_ec = os.path.join(test_easyconfigs, 't', 'toy', 'toy-0.0.eb')
-            toy_ec_txt = read_file(toy_ec)
-
-            test_ec = os.path.join(self.test_prefix, 'test.eb')
-            test_ec_txt = toy_ec_txt + "\nmulti_deps = {'GCC': ['4.6.3', '4.8.3', '7.3.0-2.30']}"
-            write_file(test_ec, test_ec_txt)
-
-            ec_files = [(test_ec, False)]
-            ecs, _ = parse_easyconfigs(ec_files)
-
-            dot_file = os.path.join(self.test_prefix, 'test.dot')
-            ordered_ecs = resolve_dependencies(ecs, self.modtool, retain_all_deps=True)
-            dep_graph(dot_file, ordered_ecs)
-
-            # hard check for expect .dot file contents
-            # 3 nodes should be there: 'GCC/6.4.0-2.28 (EXT)', 'toy', and 'intel/2018a'
-            # and 2 edges: 'toy -> intel' and 'toy -> "GCC/6.4.0-2.28 (EXT)"'
-            dottxt = read_file(dot_file)
-
-            self.assertTrue(dottxt.startswith('digraph graphname {'))
-
-            # just check for toy -> GCC deps
-            # don't bother doing full output check
-            # (different order for fields depending on Python version makes that tricky)
-            for gccver in ['4.6.3', '4.8.3', '7.3.0-2.30']:
-                self.assertTrue('"GCC/%s";' % gccver in dottxt)
-                self.assertTrue('"toy/0.0" -> "GCC/%s"' % gccver in dottxt)
+            # do specific import, since python-graph-dot is not compatible with setuptools >= 82.0.0
+            # in which pkg_resources was removed;
+            # see also https://github.com/easybuilders/easybuild-framework/issues/5110
+            import pygraph.classes.digraph  # noqa # pylint:disable=unused-import
 
         except ImportError:
-            print("Skipping test_dep_graph, since pygraph is not available")
+            print("Skipping test_dep_graph_multi_deps, since pygraph is not available")
+            return
+
+        test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
+        build_options = {
+            'external_modules_metadata': ConfigObj(),
+            'valid_module_classes': module_classes(),
+            'robot_path': [test_easyconfigs],
+            'silent': True,
+        }
+        init_config(build_options=build_options)
+
+        toy_ec = os.path.join(test_easyconfigs, 't', 'toy', 'toy-0.0.eb')
+        toy_ec_txt = read_file(toy_ec)
+
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        test_ec_txt = toy_ec_txt + "\nmulti_deps = {'GCC': ['4.6.3', '4.8.3', '7.3.0-2.30']}"
+        write_file(test_ec, test_ec_txt)
+
+        ec_files = [(test_ec, False)]
+        ecs, _ = parse_easyconfigs(ec_files)
+
+        dot_file = os.path.join(self.test_prefix, 'test.dot')
+        ordered_ecs = resolve_dependencies(ecs, self.modtool, retain_all_deps=True)
+        dep_graph(dot_file, ordered_ecs)
+
+        # hard check for expect .dot file contents
+        # 3 nodes should be there: 'GCC/6.4.0-2.28 (EXT)', 'toy', and 'intel/2018a'
+        # and 2 edges: 'toy -> intel' and 'toy -> "GCC/6.4.0-2.28 (EXT)"'
+        dottxt = read_file(dot_file)
+
+        self.assertTrue(dottxt.startswith('digraph graphname {'))
+
+        # just check for toy -> GCC deps
+        # don't bother doing full output check
+        # (different order for fields depending on Python version makes that tricky)
+        for gccver in ['4.6.3', '4.8.3', '7.3.0-2.30']:
+            self.assertTrue('"GCC/%s";' % gccver in dottxt)
+            self.assertTrue('"toy/0.0" -> "GCC/%s"' % gccver in dottxt)
 
     def test_ActiveMNS_singleton(self):
         """Make sure ActiveMNS is a singleton class."""


### PR DESCRIPTION
follow-up for #5111, fixes #5110