### PR TITLE
make sure that test commands used in `test_cases` step are executable

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4682,14 +4682,12 @@ class EasyBlock:
             else:
                 original_perms = None
             try:
-                self.log.debug(f"Running test {test_cmd}")
-                try:
-                    run_shell_cmd(test_cmd)
-                finally:
-                    if original_perms is not None:
-                        adjust_permissions(test_cmd, original_perms, relative=False)
-            except BaseException as err:
+                run_shell_cmd(test_cmd)
+            except Exception as err:
                 raise EasyBuildError(f"Running test {test_cmd} failed: {err}")
+            finally:
+                if original_perms is not None:
+                    adjust_permissions(test_cmd, original_perms, relative=False)
 
     def update_config_template_run_step(self):
         """Update the the easyconfig template dictionary with easyconfig.TEMPLATE_NAMES_EASYBLOCK_RUN_STEP names"""

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4683,6 +4683,8 @@ class EasyBlock:
                 original_perms = None
             try:
                 run_shell_cmd(test_cmd)
+            except RunShellCmdError:
+                raise  # Let that propagate which will report more information
             except Exception as err:
                 raise EasyBuildError(f"Running test {test_cmd} failed: {err}")
             finally:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4671,7 +4671,7 @@ class EasyBlock:
                 else:
                     test_cmd = test
             if not os.path.exists(test_cmd):
-                raise EasyBuildError(f"Test specifies invalid path: {test_cmd}")
+                raise EasyBuildError(f"Test specifies non-existing path: {test_cmd}")
 
             if os.path.isfile(test_cmd):
                 original_perms = os.lstat(test_cmd).st_mode

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -101,7 +101,7 @@ with the following fields:
 """
 
 
-class RunShellCmdError(BaseException):
+class RunShellCmdError(Exception):
 
     def __init__(self, cmd_result, caller_info, *args, **kwargs):
         """Constructor for RunShellCmdError."""

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -57,6 +57,7 @@ from easybuild.tools.filetools import adjust_permissions, change_dir, copy_dir, 
 from easybuild.tools.filetools import remove_dir, remove_file, symlink, verify_checksum, write_file
 from easybuild.tools.module_generator import module_generator
 from easybuild.tools.modules import EnvironmentModules, Lmod, reset_module_caches
+from easybuild.tools.run import RunShellCmdError
 from easybuild.tools.version import get_git_revision, this_is_easybuild
 
 
@@ -1323,13 +1324,13 @@ class EasyBlockTest(EnhancedTestCase):
         write_file(mock_test_bin_fail, "#!/bin/bash\necho 'Test case failure' && exit 1")
         eb.cfg['tests'] = [mock_test_bin_fail]
         write_file(eb.logfile, '')
-        self.assertRaisesRegex(EasyBuildError, f'Running test {mock_test_bin_fail} failed', eb.test_cases_step)
+        self.assertRaisesRegex(RunShellCmdError, f"'{os.path.basename(mock_test_bin_fail)}' failed", eb.test_cases_step)
         self.assertIn('Test case failure', read_file(eb.logfile))
 
         # Multiple tests
         eb.cfg['tests'] = [mock_test_bin, mock_test_bin_fail]
         write_file(eb.logfile, '')
-        self.assertRaisesRegex(EasyBuildError, f'Running test {mock_test_bin_fail} failed', eb.test_cases_step)
+        self.assertRaisesRegex(RunShellCmdError, f"'{os.path.basename(mock_test_bin_fail)}' failed", eb.test_cases_step)
         log_txt = read_file(eb.logfile)
         self.assertIn('Test case success', log_txt)
         self.assertIn('Test case failure', log_txt)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1285,9 +1285,9 @@ class EasyBlockTest(EnhancedTestCase):
         self.writeEC()
         eb = EasyBlock(EasyConfig(self.eb_file))
         eb.cfg['tests'] = ['does-not-exist']
-        self.assertRaisesRegex(EasyBuildError, 'invalid path: does-not-exist', eb.test_cases_step)
+        self.assertRaisesRegex(EasyBuildError, 'non-existing path: does-not-exist', eb.test_cases_step)
         eb.cfg['tests'] = ['/abs/path/does-not-exist']
-        self.assertRaisesRegex(EasyBuildError, 'invalid path: /abs/path/does-not-exist', eb.test_cases_step)
+        self.assertRaisesRegex(EasyBuildError, 'non-existing path: /abs/path/does-not-exist', eb.test_cases_step)
 
         mock_test_bin = os.path.join(self.test_prefix, 'pi', 'test_me')
         os.environ['PATH'] += f':{os.path.dirname(mock_test_bin)}'
@@ -1295,7 +1295,8 @@ class EasyBlockTest(EnhancedTestCase):
 
         adjust_permissions(mock_test_bin, stat.S_IXUSR)
         eb.cfg['tests'] = [os.path.basename(mock_test_bin)]
-        self.assertRaisesRegex(EasyBuildError, f'invalid path: {os.path.basename(mock_test_bin)}', eb.test_cases_step)
+        fn = os.path.basename(mock_test_bin)
+        self.assertRaisesRegex(EasyBuildError, f'non-existing path: {fn}', eb.test_cases_step)
 
         init_config(args=[f"--sourcepath={self.test_prefix}"])
         write_file(eb.logfile, '')
@@ -1318,7 +1319,6 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertIn('Test case success', read_file(eb.logfile))
 
         # Detect failure
-        adjust_permissions(mock_test_bin, stat.S_IWRITE)
         mock_test_bin_fail = mock_test_bin + "_fail"
         write_file(mock_test_bin_fail, "#!/bin/bash\necho 'Test case failure' && exit 1")
         eb.cfg['tests'] = [mock_test_bin_fail]


### PR DESCRIPTION
Scripts specified in the `tests` easyconfig parameter, especially from PRs, might not be executable.

Temporarily make them executable to avoid failing with permission issues.

Add test for this step (currently missing)