### PR TITLE
Fix setting `$OMPI_MCA_rmaps_base_oversubscribe` in sanity check

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4367,7 +4367,7 @@ class EasyBlock:
 
         # allow oversubscription of P processes on C cores (P>C) for software installed on top of Open MPI;
         # this is useful to avoid failing of sanity check commands that involve MPI
-        if self.toolchain.mpi_family() and self.toolchain.mpi_family() in toolchain.OPENMPI:
+        if self.toolchain.mpi_family() and self.toolchain.mpi_family() == toolchain.OPENMPI:
             env.setvar('OMPI_MCA_rmaps_base_oversubscribe', '1')
 
         # run sanity checks from an empty temp directory


### PR DESCRIPTION
`toolchain.OPENMPI` is a string so must be checked with equals

The code is likely a C&P mistake from where it was a list of families.

On that occasion: Having the constants in `toolchain` be automatically generated is nice but breaks any linter that could detect misspellings