### PR TITLE
Add rich colors to `print_msg`

### DIFF
--- a/easybuild/base/testing.py
+++ b/easybuild/base/testing.py
@@ -177,19 +177,23 @@ class TestCase(OrigTestCase):
                 regex = re.compile(regex)
             self.assertTrue(regex.search(msg), "Pattern '%s' is found in '%s'" % (regex.pattern, msg))
 
-    def mock_stdout(self, enable):
+    def mock_stdout(self, enable, force_tty=False):
         """Enable/disable mocking stdout."""
         sys.stdout.flush()
         if enable:
             sys.stdout = StringIO()
+            if force_tty:
+                sys.stdout.isatty = lambda: True
         else:
             sys.stdout = self.orig_sys_stdout
 
-    def mock_stderr(self, enable):
+    def mock_stderr(self, enable, force_tty=False):
         """Enable/disable mocking stdout."""
         sys.stderr.flush()
         if enable:
             sys.stderr = StringIO()
+            if force_tty:
+                sys.stderr.isatty = lambda: True
         else:
             sys.stderr = self.orig_sys_stderr
 

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -314,6 +314,7 @@ def print_msg(msg, *args, **kwargs):
     :param newline: end message with newline
     :param stderr: print to stderr rather than stdout
     """
+    from easybuild.tools.output import use_rich  # avoid circular import
     if args:
         msg = msg % args
 
@@ -333,6 +334,16 @@ def print_msg(msg, *args, **kwargs):
 
         if newline:
             msg += '\n'
+
+        if use_rich():
+            from io import StringIO
+            from rich.markup import escape
+            from rich.console import Console
+
+            buff = StringIO()
+            console = Console(file=buff, force_terminal=True)
+            console.print(escape(msg), end='')
+            msg = buff.getvalue()
 
         if stderr:
             sys.stderr.write(msg)

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -341,7 +341,7 @@ def print_msg(msg, *args, **kwargs):
             from rich.console import Console
 
             buff = StringIO()
-            console = Console(file=buff, force_terminal=True)
+            console = Console(file=buff, force_terminal=sys.stdout.isatty())
             console.print(escape(msg), end='')
             msg = buff.getvalue()
 

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -336,14 +336,14 @@ def print_msg(msg, *args, **kwargs):
             msg += '\n'
 
         if use_rich():
-            from io import StringIO
             from rich.markup import escape
             from rich.console import Console
 
-            buff = StringIO()
-            console = Console(file=buff, force_terminal=sys.stdout.isatty())
-            console.print(escape(msg), end='')
-            msg = buff.getvalue()
+            console = Console(force_terminal=sys.stdout.isatty())
+            with console.capture() as capture:
+                console.print(escape(msg), end="")
+
+            msg = capture.get()
 
         if stderr:
             sys.stderr.write(msg)

--- a/easybuild/tools/build_log.py
+++ b/easybuild/tools/build_log.py
@@ -339,7 +339,7 @@ def print_msg(msg, *args, **kwargs):
             from rich.markup import escape
             from rich.console import Console
 
-            console = Console(force_terminal=sys.stdout.isatty())
+            console = Console()
             with console.capture() as capture:
                 console.print(escape(msg), end="")
 

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -845,7 +845,12 @@ def get_module_syntax():
 
 def get_output_style():
     """Return output style to use."""
-    output_style = build_option('output_style')
+    try:
+        output_style = build_option('output_style')
+    except EasyBuildError:
+        # If BuildOptions was not initialized yet, fall back to default and reset singleton to force re-initialization
+        BuildOptions.__class__._instances.clear()
+        output_style = OUTPUT_STYLE_BASIC
 
     if output_style == OUTPUT_STYLE_AUTO:
         if HAVE_RICH:

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -677,11 +677,17 @@ def init_build_options(build_options=None, cmdline_options=None):
 def build_option(key, **kwargs):
     """Obtain value specified build option."""
 
-    build_options = BuildOptions()
-    if key in build_options:
-        return build_options[key]
-    elif 'default' in kwargs:
+    # return build option value if BuildOptions has been initialised and it's a known build option
+    if BuildOptions.__class__._instances:
+        build_options = BuildOptions()
+        if key in build_options:
+            return build_options[key]
+
+    # if above didn't return a value, return the specified default (if specified)
+    if 'default' in kwargs:
         return kwargs['default']
+
+    # if above didn't return a value, we give up
     else:
         error_msg = "Undefined build option: '%s'. " % key
         error_msg += "Make sure you have set up the EasyBuild configuration using set_up_configuration() "
@@ -845,12 +851,8 @@ def get_module_syntax():
 
 def get_output_style():
     """Return output style to use."""
-    try:
-        output_style = build_option('output_style')
-    except EasyBuildError:
-        # If BuildOptions was not initialized yet, fall back to default and reset singleton to force re-initialization
-        BuildOptions.__class__._instances.clear()
-        output_style = OUTPUT_STYLE_BASIC
+
+    output_style = build_option('output_style', default=OUTPUT_STYLE_BASIC)
 
     if output_style == OUTPUT_STYLE_AUTO:
         if HAVE_RICH:

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -689,7 +689,7 @@ def build_option(key, **kwargs):
 
     # if above didn't return a value, we give up
     else:
-        error_msg = "Undefined build option: '%s'. " % key
+        error_msg = f"Build options are not initialized yet, or undefined build option used: '%s'. "
         error_msg += "Make sure you have set up the EasyBuild configuration using set_up_configuration() "
         error_msg += "(from easybuild.tools.options) in case you're not using EasyBuild via the 'eb' CLI."
         raise EasyBuildError(error_msg, exit_code=EasyBuildExit.OPTION_ERROR)

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -689,7 +689,7 @@ def build_option(key, **kwargs):
 
     # if above didn't return a value, we give up
     else:
-        error_msg = f"Build options are not initialized yet, or undefined build option used: '%s'. "
+        error_msg = "Build options are not initialized yet, or undefined build option used: '%s'. "
         error_msg += "Make sure you have set up the EasyBuild configuration using set_up_configuration() "
         error_msg += "(from easybuild.tools.options) in case you're not using EasyBuild via the 'eb' CLI."
         raise EasyBuildError(error_msg, exit_code=EasyBuildExit.OPTION_ERROR)

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -342,6 +342,7 @@ class BuildLogTest(EnhancedTestCase):
     def test_print_msg_rich(self):
         """Test print_msg"""
         update_build_option('output_style', 'rich')
+
         def run_check(msg, args, expected_stdout='', expected_stderr='', **kwargs):
             """Helper function to check stdout/stderr produced via print_msg."""
             self.mock_stdout(True)

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -340,7 +340,7 @@ class BuildLogTest(EnhancedTestCase):
     def test_print_msg_rich(self):
         """Test print_msg"""
         try:
-            import rich
+            import rich  # noqa # pylint:disable=unused-import
         except ImportError:
             self.skipTest("rich not available")
         update_build_option('output_style', 'rich')

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -40,7 +40,6 @@ from easybuild.framework.easyconfig.tweak import tweak_one
 from easybuild.tools.build_log import (
     LOGGING_FORMAT, EasyBuildError, EasyBuildLog, dry_run_msg, dry_run_warning, init_logging, print_error,
     print_error_and_exit, print_msg, print_warning, stop_logging, time_str_since, raise_nosupport)
-from easybuild.tools.utilities import only_if_module_is_available
 from easybuild.tools.config import update_build_option
 from easybuild.tools.filetools import read_file, write_file
 
@@ -338,9 +337,12 @@ class BuildLogTest(EnhancedTestCase):
 
         self.assertErrorRegex(EasyBuildError, "Unknown named arguments", print_msg, 'foo', unknown_arg='bar')
 
-    @only_if_module_is_available('rich')
     def test_print_msg_rich(self):
         """Test print_msg"""
+        try:
+            import rich
+        except ImportError:
+            self.skipTest("rich not available")
         update_build_option('output_style', 'rich')
 
         def run_check(msg, args, expected_stdout='', expected_stderr='', **kwargs):

--- a/test/framework/build_log.py
+++ b/test/framework/build_log.py
@@ -345,8 +345,8 @@ class BuildLogTest(EnhancedTestCase):
 
         def run_check(msg, args, expected_stdout='', expected_stderr='', **kwargs):
             """Helper function to check stdout/stderr produced via print_msg."""
-            self.mock_stdout(True)
-            self.mock_stderr(True)
+            self.mock_stdout(True, force_tty=True)
+            self.mock_stderr(True, force_tty=True)
             print_msg(msg, *args, **kwargs)
             stdout = self.get_stdout()
             stderr = self.get_stderr()

--- a/test/framework/lib.py
+++ b/test/framework/lib.py
@@ -72,7 +72,7 @@ class EasyBuildLibTest(TestCase):
     def test_run_cmd(self):
         """Test use of run_cmd function in the context of using EasyBuild framework as a library."""
 
-        error_pattern = r"Undefined build option: .*"
+        error_pattern = r"Build options are not initialized yet, or undefined build option used: .*"
         error_pattern += r" Make sure you have set up the EasyBuild configuration using set_up_configuration\(\)"
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, error_pattern, run_cmd, "echo hello")
@@ -88,7 +88,7 @@ class EasyBuildLibTest(TestCase):
     def test_run_shell_cmd(self):
         """Test use of run_shell_cmd function in the context of using EasyBuild framework as a library."""
 
-        error_pattern = r"Undefined build option: .*"
+        error_pattern = r"Build options are not initialized yet, or undefined build option used: .*"
         error_pattern += r" Make sure you have set up the EasyBuild configuration using set_up_configuration\(\)"
         self.assertErrorRegex(EasyBuildError, error_pattern, run_shell_cmd, "echo hello")
 
@@ -106,7 +106,7 @@ class EasyBuildLibTest(TestCase):
 
         test_dir = os.path.join(self.tmpdir, 'test123')
 
-        error_pattern = r"Undefined build option: .*"
+        error_pattern = r"Build options are not initialized yet, or undefined build option used: .*"
         error_pattern += r" Make sure you have set up the EasyBuild configuration using set_up_configuration\(\)"
         self.assertErrorRegex(EasyBuildError, error_pattern, mkdir, test_dir)
 
@@ -120,7 +120,7 @@ class EasyBuildLibTest(TestCase):
     def test_modules_tool(self):
         """Test use of modules_tool function in the context of using EasyBuild framework as a library."""
 
-        error_pattern = r"Undefined build option: .*"
+        error_pattern = r"Build options are not initialized yet, or undefined build option used: .*"
         error_pattern += r" Make sure you have set up the EasyBuild configuration using set_up_configuration\(\)"
         self.assertErrorRegex(EasyBuildError, error_pattern, modules_tool)
 

--- a/test/framework/output.py
+++ b/test/framework/output.py
@@ -157,6 +157,7 @@ class OutputTest(EnhancedTestCase):
         """
         Test print_error function
         """
+        update_build_option('output_style', 'basic')
         msg = "This is yellow: " + colorize("a banana", color='yellow')
         self.mock_stderr(True)
         self.mock_stdout(True)
@@ -166,11 +167,25 @@ class OutputTest(EnhancedTestCase):
         self.mock_stderr(False)
         self.mock_stdout(False)
         self.assertEqual(stdout, '')
-        if use_rich():
-            # when using Rich, message printed to stderr won't have funny terminal escape characters for the color
-            expected = '\n\nThis is yellow: a banana\n\n'
-        else:
-            expected = '\nThis is yellow: \x1b[1;33ma banana\x1b[0m\n\n'
+        expected = '\n\nThis is yellow: \x1b[1;33ma banana\x1b[0m\n\n'
+        self.assertEqual(stderr, expected)
+
+    @only_if_module_is_available('rich')
+    def test_print_error_rich(self):
+        """
+        Test print_error function
+        """
+        update_build_option('output_style', 'rich')
+        msg = "This is yellow: " + colorize("a banana", color='yellow')
+        self.mock_stderr(True)
+        self.mock_stdout(True)
+        print_error(msg)
+        stderr = self.get_stderr()
+        stdout = self.get_stdout()
+        self.mock_stderr(False)
+        self.mock_stdout(False)
+        self.assertEqual(stdout, '')
+        expected = '\n\nThis is yellow: a banana\n\n'
         self.assertEqual(stderr, expected)
 
     def test_get_progress_bar(self):

--- a/test/framework/output.py
+++ b/test/framework/output.py
@@ -37,7 +37,6 @@ from easybuild.tools.config import build_option, get_output_style, update_build_
 from easybuild.tools.output import PROGRESS_BAR_EXTENSIONS, PROGRESS_BAR_TYPES
 from easybuild.tools.output import DummyRich, colorize, get_progress_bar, print_error, show_progress_bars
 from easybuild.tools.output import start_progress_bar, status_bar, stop_progress_bar, update_progress_bar, use_rich
-from easybuild.tools.utilities import only_if_module_is_available
 
 try:
     import rich.progress
@@ -142,11 +141,15 @@ class OutputTest(EnhancedTestCase):
 
         self.assertErrorRegex(EasyBuildError, "Unknown color: nosuchcolor", colorize, 'test', 'nosuchcolor')
 
-    @only_if_module_is_available('rich')
     def test_colorize_rich(self):
         """
         Test colorize function
         """
+        try:
+            import rich
+            print(rich)
+        except ImportError:
+            self.skipTest("rich not available")
         update_build_option('output_style', 'rich')
         for color in ('blue', 'cyan', 'green', 'purple', 'red', 'yellow'):
             self.assertEqual(colorize('test', color), '[bold %s]test[/bold %s]' % (color, color))
@@ -170,11 +173,14 @@ class OutputTest(EnhancedTestCase):
         expected = '\n\nThis is yellow: \x1b[1;33ma banana\x1b[0m\n\n'
         self.assertEqual(stderr, expected)
 
-    @only_if_module_is_available('rich')
     def test_print_error_rich(self):
         """
         Test print_error function
         """
+        try:
+            import rich
+        except ImportError:
+            self.skipTest("rich not available")
         update_build_option('output_style', 'rich')
         msg = "This is yellow: " + colorize("a banana", color='yellow')
         self.mock_stderr(True)

--- a/test/framework/output.py
+++ b/test/framework/output.py
@@ -146,8 +146,7 @@ class OutputTest(EnhancedTestCase):
         Test colorize function
         """
         try:
-            import rich
-            print(rich)
+            import rich  # noqa # pylint:disable=unused-import
         except ImportError:
             self.skipTest("rich not available")
         update_build_option('output_style', 'rich')
@@ -178,7 +177,7 @@ class OutputTest(EnhancedTestCase):
         Test print_error function
         """
         try:
-            import rich
+            import rich  # noqa # pylint:disable=unused-import
         except ImportError:
             self.skipTest("rich not available")
         update_build_option('output_style', 'rich')

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -147,6 +147,8 @@ class EnhancedTestCase(TestCase):
         os.environ['EASYBUILD_DISABLE_SHOW_PROGRESS_BAR'] = '1'
         # Also disable trace output to keep stdout clean during tests
         os.environ['EASYBUILD_DISABLE_TRACE'] = '1'
+        # Disable color output to ensure that stdout is clean during tests
+        os.environ['EASYBUILD_OUTPUT_STYLE'] = 'no_color'
 
         # Store the environment as setup (including the above paths) for tests to restore
         self.orig_environ = copy.deepcopy(os.environ)
@@ -519,6 +521,7 @@ def init_config(args=None, build_options=None, with_include=True, clear_caches=T
         'external_modules_metadata': ConfigObj(),
         'local_var_naming_check': 'error',
         'show_progress_bar': False,
+        'output_style': 'no_color',
         'silence_deprecation_warnings': eb_go.options.silence_deprecation_warnings,
         'suffix_modules_path': GENERAL_CLASS,
         'trace': False,


### PR DESCRIPTION
This PR is a proof of concept for adding rich coloring to the console output printed through `print_msg`

Rich will auto-recognize common patterns (eg dates, file paths) in the printed text and highlight them accordingly

Example:
<img width="1891" height="1151" alt="image" src="https://github.com/user-attachments/assets/075397c7-16f7-4632-b308-f7b506d3898f" />

NOTE:

Would need to adapt test to either not use `rich` or be aware of the coloring, otherwise most regex check on stdout will fail
