### PR TITLE
Only make use of `graphviz` to generate dependency graphs instead of `pygraph`

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -25,7 +25,7 @@ jobs:
   build:
     needs: setup
     runs-on: ${{matrix.os || 'ubuntu-24.04'}}
-    env: 
+    env:
       JOB_OS: ${{matrix.os || 'ubuntu-24.04'}}
     strategy:
       matrix:
@@ -81,6 +81,8 @@ jobs:
           # Avoid segfault with older Pythons: https://github.com/pyenv/pyenv/issues/2239#issuecomment-1079275184
           APT_PKGS+=" clang"
         fi
+        # graphviz is needed for test_dep_graph
+        APT_PKGS+=" graphviz"
         # Avoid apt-get update, as we don't really need it,
         # and it does more harm than good (it's fairly expensive, and it results in flaky test runs)
         if ! sudo apt-get install $APT_PKGS; then
@@ -245,7 +247,6 @@ jobs:
             # try and make sure output of running tests is clean (no printed messages/warnings)
             IGNORE_PATTERNS="no GitHub token available"
             IGNORE_PATTERNS+="|skipping SvnRepository test"
-            IGNORE_PATTERNS+="|Skipping test_dep_graph"
             IGNORE_PATTERNS+="|requires Lmod as modules tool"
             IGNORE_PATTERNS+="|stty: 'standard input': Inappropriate ioctl for device"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 3.7"

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -160,6 +160,7 @@ def find_resolved_modules(easyconfigs, avail_modules, modtool, retain_all_deps=F
 
     return ordered_ecs, new_easyconfigs, avail_modules
 
+
 @only_if_module_is_available('graphviz', pkgname='graphviz')
 def dep_graph(filename, specs):
     """
@@ -202,7 +203,7 @@ def dep_graph(filename, specs):
     silent = build_option('silent')
     try:
         dep_graph.render(base, cleanup=True)
-    except:
+    except Exception:
         print_error_and_exit("Failed writing " + what, silent=silent)
     else:
         print_msg("Wrote " + what, silent=silent)

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -74,11 +74,6 @@ from easybuild.tools.version import VERSION as EASYBUILD_VERSION
 # a NameError should be caught where these are used
 
 try:
-    # PyGraph (used for generating dependency graphs)
-    # https://pypi.python.org/pypi/python-graph-core
-    from pygraph.classes.digraph import digraph
-    # https://pypi.python.org/pypi/python-graph-dot
-    import pygraph.readwrite.dot as dot
     # graphviz (used for creating dependency graph images)
     import graphviz
 except ImportError:
@@ -165,8 +160,7 @@ def find_resolved_modules(easyconfigs, avail_modules, modtool, retain_all_deps=F
 
     return ordered_ecs, new_easyconfigs, avail_modules
 
-
-@only_if_module_is_available('pygraph.classes.digraph', pkgname='python-graph-core')
+@only_if_module_is_available('graphviz', pkgname='graphviz')
 def dep_graph(filename, specs):
     """
     Create a dependency graph for the given easyconfigs.
@@ -188,63 +182,30 @@ def dep_graph(filename, specs):
 
         return node_name
 
-    # enhance list of specs
-    all_nodes = set()
+    base, ext = os.path.splitext(filename)
+
+    dep_graph = graphviz.Digraph(format=ext[1:], name=os.path.basename(base))
+    builddep_edge_attrs = {'style': 'dotted', 'color': 'blue', 'arrowhead': 'diamond'}
     for spec in specs:
-        spec['module'] = mk_node_name(spec['ec'])
-        all_nodes.add(spec['module'])
-        spec['ec']._all_dependencies = [mk_node_name(s) for s in spec['ec'].all_dependencies]
-        all_nodes.update(spec['ec'].all_dependencies)
+        node = mk_node_name(spec['ec'])
+        dep_graph.node(node)
+        for dep in spec['ec'].dependencies(runtime_only=True):
+            node_dep = mk_node_name(dep)
+            dep_graph.node(node_dep)
+            dep_graph.edge(node, node_dep)
+        for dep in spec['ec'].dependencies(build_only=True):
+            node_dep = mk_node_name(dep)
+            dep_graph.node(node_dep)
+            dep_graph.edge(node, node_dep, **builddep_edge_attrs)
 
-        # Get the build dependencies for each spec so we can distinguish them later
-        spec['ec'].build_dependencies = [mk_node_name(s) for s in spec['ec'].builddependencies()]
-        all_nodes.update(spec['ec'].build_dependencies)
-
-    # build directed graph
-    edge_attrs = [('style', 'dotted'), ('color', 'blue'), ('arrowhead', 'diamond')]
-    dgr = digraph()
-    dgr.add_nodes(all_nodes)
-    edge_attrs = [('style', 'dotted'), ('color', 'blue'), ('arrowhead', 'diamond')]
-    for spec in specs:
-        for dep in spec['ec'].all_dependencies:
-            dgr.add_edge((spec['module'], dep))
-            if dep in spec['ec'].build_dependencies:
-                dgr.add_edge_attributes((spec['module'], dep), attrs=edge_attrs)
-
-    what = "dependency graph for %d easyconfigs to %s" % (len(specs), filename)
+    what = f"dependency graph for {len(specs)} easyconfigs to {filename}"
     silent = build_option('silent')
-    if _dep_graph_dump(dgr, filename):
-        print_msg("Wrote " + what, silent=silent)
-    else:
+    try:
+        dep_graph.render(base, cleanup=True)
+    except:
         print_error_and_exit("Failed writing " + what, silent=silent)
-
-
-@only_if_module_is_available('pygraph.readwrite.dot', pkgname='python-graph-dot')
-def _dep_graph_dump(dgr, filename):
-    """Dump dependency graph to file, in specified format."""
-    # write to file
-    dottxt = dot.write(dgr)
-    if os.path.splitext(filename)[-1] == '.dot':
-        # create .dot file
-        try:
-            write_file(filename, dottxt)
-        except EasyBuildError as e:
-            print(str(e))
-            return False
-        else:
-            return True
     else:
-        return _dep_graph_gv(dottxt, filename)
-
-
-@only_if_module_is_available('graphviz', pkgname='graphviz')
-def _dep_graph_gv(dottxt, filename):
-    """Render dependency graph to file using graphviz."""
-    # try and render graph in specified file format
-    gvv = graphviz.Source(dottxt)
-    if gvv.pipe():
-        name, ext = os.path.splitext(filename)
-        return gvv.render(filename=name, format=ext[1:], cleanup=True)
+        print_msg("Wrote " + what, silent=silent)
 
 
 def get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None):

--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -203,8 +203,8 @@ def dep_graph(filename, specs):
     silent = build_option('silent')
     try:
         dep_graph.render(base, cleanup=True)
-    except Exception:
-        print_error_and_exit("Failed writing " + what, silent=silent)
+    except Exception as err:
+        print_error_and_exit(f"Failed writing {what}: {err}", silent=silent)
     else:
         print_msg("Wrote " + what, silent=silent)
 

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -221,8 +221,6 @@ EASYBUILD_OPTIONAL_DEPENDENCIES = {
     'pbs-python': ('pbs', "using Torque as --job backend"),
     'pycodestyle': (None, "code style checking: --check-style, --check-contrib"),
     'pysvn': (None, "using SVN repository as easyconfigs archive"),
-    'python-graph-core': ('pygraph.classes.digraph', "creating dependency graph: --dep-graph"),
-    'python-graph-dot': ('pygraph.readwrite.dot', "saving dependency graph as dot file: --dep-graph"),
     'python-hglib': ('hglib', "using Mercurial repository as easyconfigs archive"),
     'requests': (None, "fallback library for downloading files"),
     'Rich': (None, "eb command rich terminal output"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ PyYAML
 flake8
 
 GC3Pie; python_version < '3.11'
-python-graph-dot
+graphviz
 python-hglib
 requests
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -87,15 +87,6 @@ try:
 except ImportError:
     pass
 
-EXPECTED_DOTTXT_TOY_DEPS = """digraph graphname {
-toy;
-"GCC/6.4.0-2.28 (EXT)";
-intel;
-toy -> intel;
-toy -> "GCC/6.4.0-2.28 (EXT)";
-}
-"""
-
 
 class EasyConfigTest(EnhancedTestCase):
     """ easyconfig tests """

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3324,7 +3324,7 @@ class EasyConfigTest(EnhancedTestCase):
         Test for dep_graph using easyconfig that uses multi_deps.
         """
         try:
-            import graphviz
+            import graphviz  # noqa # pylint:disable=unused-import
         except ImportError:
             print("Skipping test_dep_graph_multi_deps, since graphviz is not available")
             return

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3281,12 +3281,9 @@ class EasyConfigTest(EnhancedTestCase):
     def test_dep_graph(self):
         """Test for dep_graph."""
         try:
-            # do specific import, since python-graph-dot is not compatible with setuptools >= 82.0.0
-            # in which pkg_resources was removed;
-            # see also https://github.com/easybuilders/easybuild-framework/issues/5110
-            import pygraph.classes.digraph  # noqa # pylint:disable=unused-import
+            import graphviz  # noqa # pylint:disable=unused-import
         except ImportError:
-            print("Skipping test_dep_graph, since pygraph is not available")
+            print("Skipping test_dep_graph, since graphviz is not available")
             return
 
         test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
@@ -3302,34 +3299,34 @@ class EasyConfigTest(EnhancedTestCase):
         ec_files = [(ec_file, False)]
         ecs, _ = parse_easyconfigs(ec_files)
 
-        dot_file = os.path.join(self.test_prefix, 'test.dot')
+        graphname = 'testgraph'
+        dot_file = os.path.join(self.test_prefix, f'{graphname}.dot')
         ordered_ecs = resolve_dependencies(ecs, self.modtool, retain_all_deps=True)
         dep_graph(dot_file, ordered_ecs)
 
-        # hard check for expect .dot file contents
-        # 3 nodes should be there: 'GCC/6.4.0-2.28 (EXT)', 'toy', and 'intel/2018a'
-        # and 2 edges: 'toy -> intel' and 'toy -> "GCC/6.4.0-2.28 (EXT)"'
         dottxt = read_file(dot_file)
 
-        self.assertTrue(dottxt.startswith('digraph graphname {'))
-
-        # compare sorted output, since order of lines can change
-        ordered_dottxt = '\n'.join(sorted(dottxt.split('\n')))
-        ordered_expected = '\n'.join(sorted(EXPECTED_DOTTXT_TOY_DEPS.split('\n')))
-        self.assertEqual(ordered_dottxt, ordered_expected)
+        # hard check for expect .dot file contents
+        patterns = [
+            rf"digraph {graphname} {{",
+            # 3 nodes should be there: 'GCC/6.4.0-2.28 (EXT)', 'toy', and 'intel/2018a'
+            r"^\s*intel\s+\[",
+            r"^\s*toy\s+\[",
+            r"^\s*\"GCC/6\.4\.0-2\.28 \(EXT\)\"\s+\[",
+            # and 2 edges: 'toy -> intel' and 'toy -> "GCC/6.4.0-2.28 (EXT)"'
+            r"^\s*toy -> intel\s+\[",
+            r"^\s*toy -> \"GCC/6\.4\.0-2\.28 \(EXT\)\"\s+\[",
+        ]
+        self.assert_multi_regex(patterns, dottxt)
 
     def test_dep_graph_multi_deps(self):
         """
         Test for dep_graph using easyconfig that uses multi_deps.
         """
         try:
-            # do specific import, since python-graph-dot is not compatible with setuptools >= 82.0.0
-            # in which pkg_resources was removed;
-            # see also https://github.com/easybuilders/easybuild-framework/issues/5110
-            import pygraph.classes.digraph  # noqa # pylint:disable=unused-import
-
+            import graphviz
         except ImportError:
-            print("Skipping test_dep_graph_multi_deps, since pygraph is not available")
+            print("Skipping test_dep_graph_multi_deps, since graphviz is not available")
             return
 
         test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
@@ -3351,7 +3348,8 @@ class EasyConfigTest(EnhancedTestCase):
         ec_files = [(test_ec, False)]
         ecs, _ = parse_easyconfigs(ec_files)
 
-        dot_file = os.path.join(self.test_prefix, 'test.dot')
+        graphname = 'testgraph_multi_deps'
+        dot_file = os.path.join(self.test_prefix, f'{graphname}.dot')
         ordered_ecs = resolve_dependencies(ecs, self.modtool, retain_all_deps=True)
         dep_graph(dot_file, ordered_ecs)
 
@@ -3360,13 +3358,13 @@ class EasyConfigTest(EnhancedTestCase):
         # and 2 edges: 'toy -> intel' and 'toy -> "GCC/6.4.0-2.28 (EXT)"'
         dottxt = read_file(dot_file)
 
-        self.assertTrue(dottxt.startswith('digraph graphname {'))
+        self.assertTrue(dottxt.startswith(f'digraph {graphname} {{'))
 
         # just check for toy -> GCC deps
         # don't bother doing full output check
         # (different order for fields depending on Python version makes that tricky)
         for gccver in ['4.6.3', '4.8.3', '7.3.0-2.30']:
-            self.assertTrue('"GCC/%s";' % gccver in dottxt)
+            self.assertTrue('"GCC/%s"' % gccver in dottxt)
             self.assertTrue('"toy/0.0" -> "GCC/%s"' % gccver in dottxt)
 
     def test_ActiveMNS_singleton(self):


### PR DESCRIPTION
Remove use of old/unmaintained [pygraph](https://github.com/pmatiello/python-graph/tree/master) from optional dependencies

Should be a better more robust fix for
- https://github.com/easybuilders/easybuild-framework/issues/5110

NOTE

- [X] For the CI we would want to also install `graphviz` on the machines and add `graphviz` to the requirements instead of `pygraph` to test it