### PR TITLE
Replace `assertTrue`/`assertFalse` with `assertRegex` in easyblock test

### DIFF
--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -123,9 +123,8 @@ class EasyBlockTest(EnhancedTestCase):
 
         # check whether 'This is easyblock' log message is there
         tup = ('EasyBlock', 'easybuild.framework.easyblock', '.*easybuild/framework/easyblock.pyc*')
-        eb_log_msg_re = re.compile(r"INFO This is easyblock %s from module %s (%s)" % tup, re.M)
         logtxt = read_file(eb.logfile)
-        self.assertTrue(eb_log_msg_re.search(logtxt), "Pattern '%s' found in: %s" % (eb_log_msg_re.pattern, logtxt))
+        self.assertRegex(logtxt, r"INFO This is easyblock %s from module %s (%s)" % tup)
 
         # test extensioneasyblock, as extension
         exeb1 = ExtensionEasyBlock(eb, {'name': 'foo', 'version': '0.0'})
@@ -353,9 +352,7 @@ class EasyBlockTest(EnhancedTestCase):
         else:
             self.fail("Unknown module syntax: %s" % module_syntax)
 
-        for regex in regexs:
-            regex = re.compile(regex, re.M)
-            self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
+        self.assert_multi_regex(regexs, txt)
 
         # Repeat this but using an alternative envvars (instead of $HOME)
         list_of_envvars = ['SITE_INSTALLS', 'USER_INSTALLS']
@@ -401,9 +398,7 @@ class EasyBlockTest(EnhancedTestCase):
             else:
                 self.fail("Unknown module syntax: %s" % module_syntax)
 
-            for regex in regexs:
-                regex = re.compile(regex, re.M)
-                self.assertTrue(regex.search(txt), "Pattern '%s' found in: %s" % (regex.pattern, txt))
+            self.assert_multi_regex(regexs, txt)
             os.unsetenv(envvar)
 
         # Check behaviour when directories do and do not exist
@@ -491,25 +486,25 @@ class EasyBlockTest(EnhancedTestCase):
             guess = eb.make_module_req()
 
         if get_module_syntax() == 'Tcl':
-            self.assertTrue(re.search(r"^prepend-path\s+CLASSPATH\s+\$root/bla.jar$", guess, re.M))
-            self.assertTrue(re.search(r"^prepend-path\s+CLASSPATH\s+\$root/foo.jar$", guess, re.M))
-            self.assertTrue(re.search(r"^prepend-path\s+MANPATH\s+\$root/share/man$", guess, re.M))
-            self.assertTrue(re.search(r"^prepend-path\s+CMAKE_PREFIX_PATH\s+\$root$", guess, re.M))
+            self.assertRegex(guess, re.compile(r"^prepend-path\s+CLASSPATH\s+\$root/bla.jar$", re.M))
+            self.assertRegex(guess, re.compile(r"^prepend-path\s+CLASSPATH\s+\$root/foo.jar$", re.M))
+            self.assertRegex(guess, re.compile(r"^prepend-path\s+MANPATH\s+\$root/share/man$", re.M))
+            self.assertRegex(guess, re.compile(r"^prepend-path\s+CMAKE_PREFIX_PATH\s+\$root$", re.M))
             # bin/ is not added to $PATH if it doesn't include files
-            self.assertFalse(re.search(r"^prepend-path\s+PATH\s+\$root/bin$", guess, re.M))
-            self.assertFalse(re.search(r"^prepend-path\s+PATH\s+\$root/sbin$", guess, re.M))
+            self.assertNotRegex(guess, re.compile(r"^prepend-path\s+PATH\s+\$root/bin$", re.M))
+            self.assertNotRegex(guess, re.compile(r"^prepend-path\s+PATH\s+\$root/sbin$", re.M))
             # no include/ subdirectory, so no $CPATH update statement
-            self.assertFalse(re.search(r"^prepend-path\s+CPATH\s+.*$", guess, re.M))
+            self.assertNotRegex(guess, re.compile(r"^prepend-path\s+CPATH\s+.*$", re.M))
         elif get_module_syntax() == 'Lua':
-            self.assertTrue(re.search(r'^prepend_path\("CLASSPATH", pathJoin\(root, "bla.jar"\)\)$', guess, re.M))
-            self.assertTrue(re.search(r'^prepend_path\("CLASSPATH", pathJoin\(root, "foo.jar"\)\)$', guess, re.M))
-            self.assertTrue(re.search(r'^prepend_path\("MANPATH", pathJoin\(root, "share", "man"\)\)$', guess, re.M))
+            self.assertRegex(guess, re.compile(r'^prepend_path\("CLASSPATH", pathJoin\(root, "bla.jar"\)\)$', re.M))
+            self.assertRegex(guess, re.compile(r'^prepend_path\("CLASSPATH", pathJoin\(root, "foo.jar"\)\)$', re.M))
+            self.assertRegex(guess, re.compile(r'^prepend_path\("MANPATH", pathJoin\(root, "share", "man"\)\)$', re.M))
             self.assertIn('prepend_path("CMAKE_PREFIX_PATH", root)', guess)
             # bin/ is not added to $PATH if it doesn't include files
-            self.assertFalse(re.search(r'^prepend_path\("PATH", pathJoin\(root, "bin"\)\)$', guess, re.M))
-            self.assertFalse(re.search(r'^prepend_path\("PATH", pathJoin\(root, "sbin"\)\)$', guess, re.M))
+            self.assertNotRegex(guess, re.compile(r'^prepend_path\("PATH", pathJoin\(root, "bin"\)\)$', re.M))
+            self.assertNotRegex(guess, re.compile(r'^prepend_path\("PATH", pathJoin\(root, "sbin"\)\)$', re.M))
             # no include/ subdirectory, so no $CPATH update statement
-            self.assertFalse(re.search(r'^prepend_path\("CPATH", .*\)$', guess, re.M))
+            self.assertNotRegex(guess, re.compile(r'^prepend_path\("CPATH", .*\)$', re.M))
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
 
@@ -518,11 +513,11 @@ class EasyBlockTest(EnhancedTestCase):
         with eb.module_generator.start_module_creation():
             guess = eb.make_module_req()
         if get_module_syntax() == 'Tcl':
-            self.assertTrue(re.search(r"^prepend-path\s+PATH\s+\$root/bin$", guess, re.M))
-            self.assertFalse(re.search(r"^prepend-path\s+PATH\s+\$root/sbin$", guess, re.M))
+            self.assertRegex(guess, re.compile(r"^prepend-path\s+PATH\s+\$root/bin$", re.M))
+            self.assertNotRegex(guess, re.compile(r"^prepend-path\s+PATH\s+\$root/sbin$", re.M))
         elif get_module_syntax() == 'Lua':
-            self.assertTrue(re.search(r'^prepend_path\("PATH", pathJoin\(root, "bin"\)\)$', guess, re.M))
-            self.assertFalse(re.search(r'^prepend_path\("PATH", pathJoin\(root, "sbin"\)\)$', guess, re.M))
+            self.assertRegex(guess, re.compile(r'^prepend_path\("PATH", pathJoin\(root, "bin"\)\)$', re.M))
+            self.assertNotRegex(guess, re.compile(r'^prepend_path\("PATH", pathJoin\(root, "sbin"\)\)$', re.M))
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
 
@@ -530,8 +525,8 @@ class EasyBlockTest(EnhancedTestCase):
         # but only if it is not a symlink to lib
         # -- No Files
         if get_module_syntax() == 'Tcl':
-            self.assertFalse(re.search(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib64$", guess, re.M))
-            self.assertFalse(re.search(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib$", guess, re.M))
+            self.assertNotRegex(guess, re.compile(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib64$", re.M))
+            self.assertNotRegex(guess, re.compile(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib$", re.M))
         elif get_module_syntax() == 'Lua':
             self.assertNotIn('prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib64"))', guess)
             self.assertNotIn('prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib"))', guess)
@@ -540,8 +535,8 @@ class EasyBlockTest(EnhancedTestCase):
         with eb.module_generator.start_module_creation():
             guess = eb.make_module_req()
         if get_module_syntax() == 'Tcl':
-            self.assertTrue(re.search(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib64$", guess, re.M))
-            self.assertFalse(re.search(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib$", guess, re.M))
+            self.assertRegex(guess, re.compile(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib64$", re.M))
+            self.assertNotRegex(guess, re.compile(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib$", re.M))
         elif get_module_syntax() == 'Lua':
             self.assertIn('prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib64"))', guess)
             self.assertNotIn('prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib"))', guess)
@@ -552,8 +547,8 @@ class EasyBlockTest(EnhancedTestCase):
         with eb.module_generator.start_module_creation():
             guess = eb.make_module_req()
         if get_module_syntax() == 'Tcl':
-            self.assertFalse(re.search(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib64$", guess, re.M))
-            self.assertFalse(re.search(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib$", guess, re.M))
+            self.assertNotRegex(guess, re.compile(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib64$", re.M))
+            self.assertNotRegex(guess, re.compile(r"^prepend-path\s+CMAKE_LIBRARY_PATH\s+\$root/lib$", re.M))
         elif get_module_syntax() == 'Lua':
             self.assertNotIn('prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib64"))', guess)
             self.assertNotIn('prepend_path("CMAKE_LIBRARY_PATH", pathJoin(root, "lib"))', guess)
@@ -562,10 +557,10 @@ class EasyBlockTest(EnhancedTestCase):
         # pointing to /lib
         for var in ('LIBRARY_PATH', 'LD_LIBRARY_PATH'):
             if get_module_syntax() == 'Tcl':
-                self.assertFalse(re.search(r"^prepend-path\s+%s\s+\$root/lib64$" % var, guess, re.M))
+                self.assertNotRegex(guess, re.compile(r"^prepend-path\s+%s\s+\$root/lib64$" % var, re.M))
                 self.assertEqual(len(re.findall(r"^prepend-path\s+%s\s+\$root/lib$" % var, guess, re.M)), 1)
             elif get_module_syntax() == 'Lua':
-                self.assertFalse(re.search(r'^prepend_path\("%s", pathJoin\(root, "lib64"\)\)$' % var, guess, re.M))
+                self.assertNotRegex(guess, re.compile(r'^prepend_path\("%s", pathJoin\(root, "lib64"\)\)$' % var, re.M))
                 self.assertEqual(len(re.findall(r'^prepend_path\("%s", pathJoin\(root, "lib"\)\)$' % var,
                                                 guess, re.M)), 1)
 
@@ -596,11 +591,11 @@ class EasyBlockTest(EnhancedTestCase):
         with eb.module_generator.start_module_creation():
             txt = eb.make_module_req()
         if get_module_syntax() == 'Tcl':
-            self.assertTrue(re.search(r"\nprepend-path\s+PATH\s+\$root/bin\n", txt, re.M))
-            self.assertTrue(re.search(r"\nprepend-path\s+PATH\s+\$root\n", txt, re.M))
+            self.assertRegex(txt, re.compile(r"\nprepend-path\s+PATH\s+\$root/bin\n", re.M))
+            self.assertRegex(txt, re.compile(r"\nprepend-path\s+PATH\s+\$root\n", re.M))
         elif get_module_syntax() == 'Lua':
-            self.assertTrue(re.search(r'\nprepend_path\("PATH", pathJoin\(root, "bin"\)\)\n', txt, re.M))
-            self.assertTrue(re.search(r'\nprepend_path\("PATH", root\)\n', txt, re.M))
+            self.assertRegex(txt, re.compile(r'\nprepend_path\("PATH", pathJoin\(root, "bin"\)\)\n', re.M))
+            self.assertRegex(txt, re.compile(r'\nprepend_path\("PATH", root\)\n', re.M))
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
 
@@ -612,21 +607,23 @@ class EasyBlockTest(EnhancedTestCase):
         with eb.module_generator.start_module_creation():
             txt = eb.make_module_req()
         if get_module_syntax() == 'Tcl':
-            self.assertTrue(re.search(r"\nprepend-path\s+LD_LIBRARY_PATH\s+\$root/lib/pathC\n" +
-                                      r"prepend-path\s+LD_LIBRARY_PATH\s+\$root/lib/pathA\n" +
-                                      r"prepend-path\s+LD_LIBRARY_PATH\s+\$root/lib/pathB\n",
-                                      txt, re.M))
-            self.assertFalse(re.search(r"\nprepend-path\s+LD_LIBRARY_PATH\s+\$root/lib/pathB\n" +
-                                       r"prepend-path\s+LD_LIBRARY_PATH\s+\$root/lib/pathA\n",
-                                       txt, re.M))
+            self.assertRegex(txt, re.compile(r"\nprepend-path\s+LD_LIBRARY_PATH\s+\$root/lib/pathC\n" +
+                                             r"prepend-path\s+LD_LIBRARY_PATH\s+\$root/lib/pathA\n" +
+                                             r"prepend-path\s+LD_LIBRARY_PATH\s+\$root/lib/pathB\n",
+                                             re.M))
+            self.assertNotRegex(txt, re.compile(r"\nprepend-path\s+LD_LIBRARY_PATH\s+\$root/lib/pathB\n" +
+                                                r"prepend-path\s+LD_LIBRARY_PATH\s+\$root/lib/pathA\n",
+                                                re.M))
         elif get_module_syntax() == 'Lua':
-            self.assertTrue(re.search(r'\nprepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathC"\)\)\n' +
-                                      r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathA"\)\)\n' +
-                                      r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathB"\)\)\n',
-                                      txt, re.M))
-            self.assertFalse(re.search(r'\nprepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathB"\)\)\n' +
-                                       r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathA"\)\)\n',
-                                       txt, re.M))
+            self.assertRegex(txt,
+                             re.compile(r'\nprepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathC"\)\)\n' +
+                                        r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathA"\)\)\n' +
+                                        r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathB"\)\)\n',
+                                        re.M))
+            self.assertNotRegex(txt,
+                                re.compile(r'\nprepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathB"\)\)\n' +
+                                           r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "lib", "pathA"\)\)\n',
+                                           re.M))
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
 
@@ -642,14 +639,15 @@ class EasyBlockTest(EnhancedTestCase):
         with eb.module_generator.start_module_creation():
             txt = eb.make_module_req()
         if get_module_syntax() == 'Tcl':
-            self.assertFalse(re.search(r"prepend-path\s+LD_LIBRARY_PATH\s+\$%s\n" % sub_lib_path,
-                                       txt, re.M))
-            self.assertFalse(re.search(r"prepend-path\s+PATH\s+\$%s\n" % sub_path_path, txt, re.M))
+            self.assertNotRegex(txt,
+                                re.compile(r"prepend-path\s+LD_LIBRARY_PATH\s+\$%s\n" % sub_lib_path, re.M))
+            self.assertNotRegex(txt, re.compile(r"prepend-path\s+PATH\s+\$%s\n" % sub_path_path, re.M))
         else:
             assert get_module_syntax() == 'Lua'
-            self.assertFalse(re.search(r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "%s"\)\)\n' % sub_lib_path,
-                                       txt, re.M))
-            self.assertFalse(re.search(r'prepend_path\("PATH", pathJoin\(root, "%s"\)\)\n' % sub_path_path, txt, re.M))
+            self.assertNotRegex(txt, re.compile(
+                r'prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "%s"\)\)\n' % sub_lib_path, re.M))
+            self.assertNotRegex(txt, re.compile(
+                r'prepend_path\("PATH", pathJoin\(root, "%s"\)\)\n' % sub_path_path, re.M))
 
         # Module load environement may contain non-path variables
         # TODO: remove whenever this is properly supported, in the meantime check warning
@@ -670,7 +668,7 @@ class EasyBlockTest(EnhancedTestCase):
             self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         logtxt = read_file(eb.logfile)
-        self.assertTrue(re.search(r"WARNING Non-path variables found in module load env.*NONPATH", logtxt, re.M))
+        self.assertRegex(logtxt, r"WARNING Non-path variables found in module load env.*NONPATH")
 
         eb.module_load_environment.remove('NONPATH')
 
@@ -695,14 +693,14 @@ class EasyBlockTest(EnhancedTestCase):
             txt = eb.make_module_req()
 
         if get_module_syntax() == 'Tcl':
-            self.assertTrue(re.search(r"^prepend-path\s+LD_LIBRARY_PATH\s+\$root/libraries/intel64_lin$", txt, re.M))
-            self.assertTrue(re.search(r"^prepend-path\s+LIBRARY_PATH\s+\$root/libraries/intel64_lin\n$", txt, re.M))
+            self.assertRegex(txt, re.compile(r"^prepend-path\s+LD_LIBRARY_PATH\s+\$root/libraries/intel64_lin$", re.M))
+            self.assertRegex(txt, re.compile(r"^prepend-path\s+LIBRARY_PATH\s+\$root/libraries/intel64_lin\n$", re.M))
         elif get_module_syntax() == 'Lua':
-            self.assertTrue(re.search(
-                r'^prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "libraries", "intel64_lin"\)\)$', txt, re.M
+            self.assertRegex(txt, re.compile(
+                r'^prepend_path\("LD_LIBRARY_PATH", pathJoin\(root, "libraries", "intel64_lin"\)\)$', re.M
             ))
-            self.assertTrue(re.search(
-                r'^prepend_path\("LIBRARY_PATH", pathJoin\(root, "libraries", "intel64_lin"\)\)$', txt, re.M
+            self.assertRegex(txt, re.compile(
+                r'^prepend_path\("LIBRARY_PATH", pathJoin\(root, "libraries", "intel64_lin"\)\)$', re.M
             ))
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
@@ -714,9 +712,9 @@ class EasyBlockTest(EnhancedTestCase):
             txt = eb.make_module_req()
 
         if get_module_syntax() == 'Tcl':
-            self.assertTrue(re.search(r"^prepend-path\s+PATH\s+/bin$", txt, re.M))
+            self.assertRegex(txt, re.compile(r"^prepend-path\s+PATH\s+/bin$", re.M))
         elif get_module_syntax() == 'Lua':
-            self.assertTrue(re.search(r'^prepend_path\("PATH", "/bin"\)$', txt, re.M))
+            self.assertRegex(txt, re.compile(r'^prepend_path\("PATH", "/bin"\)$', re.M))
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
 
@@ -774,16 +772,14 @@ class EasyBlockTest(EnhancedTestCase):
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
 
-        for pattern in expected_patterns:
-            self.assertTrue(re.search(pattern, txt, re.M), "Pattern '%s' found in: %s" % (pattern, txt))
+        self.assert_multi_regex(expected_patterns, txt)
 
         non_expected_patterns = [
             r"^append[-_]path.*TEST_VAR_APPEND.*root.*baz",
             r"^prepend[-_]path.*CPATH.*root.*include/bar.*",
             r"^prepend[-_]path.*TEST_VAR.*root.*baz",
         ]
-        for pattern in non_expected_patterns:
-            self.assertFalse(re.search(pattern, txt, re.M), "Pattern '%s' found in: %s" % (pattern, txt))
+        self.assert_multi_regex(non_expected_patterns, txt, assert_true=False)
 
         # cleanup
         eb.close_log()
@@ -823,18 +819,18 @@ class EasyBlockTest(EnhancedTestCase):
                 # none option adds nothing to module file
                 if get_module_syntax() == 'Tcl':
                     tcl_ref_pattern = r"^prepend-path\s+CPATH\s+\$root/include$"
-                    self.assertFalse(re.search(tcl_ref_pattern, guess, re.M))
+                    self.assertRegex(guess, re.compile(tcl_ref_pattern, re.M))
                 elif get_module_syntax() == 'Lua':
                     lua_ref_pattern = r'^prepend_path\("CPATH", pathJoin\(root, "include"\)\)$'
-                    self.assertFalse(re.search(lua_ref_pattern, guess, re.M))
+                    self.assertRegex(guess, re.compile(lua_ref_pattern, re.M))
             else:
                 for env_var in sp_headers:
                     if get_module_syntax() == 'Tcl':
                         tcl_ref_pattern = rf"^prepend-path\s+{env_var}\s+\$root/include$"
-                        self.assertTrue(re.search(tcl_ref_pattern, guess, re.M))
+                        self.assertRegex(guess, re.compile(tcl_ref_pattern, re.M))
                     elif get_module_syntax() == 'Lua':
                         lua_ref_pattern = rf'^prepend_path\("{env_var}", pathJoin\(root, "include"\)\)$'
-                        self.assertTrue(re.search(lua_ref_pattern, guess, re.M))
+                        self.assertRegex(guess, re.compile(lua_ref_pattern, re.M))
 
         # test with easyconfig parameter
         for ec_param, sp_headers in sp_headers_mode.items():
@@ -856,18 +852,18 @@ class EasyBlockTest(EnhancedTestCase):
                     # none option adds nothing to module file
                     if get_module_syntax() == 'Tcl':
                         tcl_ref_pattern = r"^prepend-path\s+CPATH\s+\$root/include$"
-                        self.assertFalse(re.search(tcl_ref_pattern, guess, re.M))
+                        self.assertNotRegex(guess, re.compile(tcl_ref_pattern, re.M))
                     elif get_module_syntax() == 'Lua':
                         lua_ref_pattern = r'^prepend_path\("CPATH", pathJoin\(root, "include"\)\)$'
-                        self.assertFalse(re.search(lua_ref_pattern, guess, re.M))
+                        self.assertNotRegex(guess, re.compile(lua_ref_pattern, re.M))
                 else:
                     for env_var in sp_headers:
                         if get_module_syntax() == 'Tcl':
                             tcl_ref_pattern = rf"^prepend-path\s+{env_var}\s+\$root/include$"
-                            self.assertTrue(re.search(tcl_ref_pattern, guess, re.M))
+                            self.assertRegex(guess, re.compile(tcl_ref_pattern, re.M))
                         elif get_module_syntax() == 'Lua':
                             lua_ref_pattern = rf'^prepend_path\("{env_var}", pathJoin\(root, "include"\)\)$'
-                            self.assertTrue(re.search(lua_ref_pattern, guess, re.M))
+                            self.assertRegex(guess, re.compile(lua_ref_pattern, re.M))
 
         # test wrong easyconfig parameter
         self.contents += '\nmodule_search_path_headers = "WRONG_OPT"'
@@ -928,12 +924,10 @@ class EasyBlockTest(EnhancedTestCase):
             self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         defaulttxt = eb.make_module_extra().strip()
-        self.assertTrue(expected_default.match(defaulttxt),
-                        "Pattern %s found in %s" % (expected_default.pattern, defaulttxt))
+        self.assertRegex(defaulttxt, expected_default)
 
         alttxt = eb.make_module_extra(altroot='/opt/software/tau/6.28', altversion='6.28').strip()
-        self.assertTrue(expected_alt.match(alttxt),
-                        "Pattern %s found in %s" % (expected_alt.pattern, alttxt))
+        self.assertRegex(alttxt, expected_alt)
 
     def test_make_module_deppaths(self):
         """Test for make_module_deppaths"""
@@ -1119,10 +1113,10 @@ class EasyBlockTest(EnhancedTestCase):
             mod_dep_txt = eb.make_module_dep()
         for mod in ['GCC/6.4.0-2.28', 'OpenMPI/2.1.2']:
             regex = re.compile('(load|depends[-_]on).*%s' % mod)
-            self.assertFalse(regex.search(mod_dep_txt), "Pattern '%s' found in: %s" % (regex.pattern, mod_dep_txt))
+            self.assertNotRegex(mod_dep_txt, regex)
 
         regex = re.compile('(load|depends[-_]on).*FFTW/3.3.7')
-        self.assertTrue(regex.search(mod_dep_txt), "Pattern '%s' found in: %s" % (regex.pattern, mod_dep_txt))
+        self.assertRegex(mod_dep_txt, regex)
 
     def test_make_module_dep_of_dep_hmns(self):
         """Test for make_module_dep under HMNS with dependencies of dependencies"""
@@ -1165,7 +1159,7 @@ class EasyBlockTest(EnhancedTestCase):
         mod_dep_txt = eb.make_module_dep()
         for mod in ['GCC/6.4.0-2.28', 'OpenMPI/2.1.2', 'hwloc/1.11.8']:
             regex = re.compile('load.*%s' % mod)
-            self.assertFalse(regex.search(mod_dep_txt), "Pattern '%s' found in: %s" % (regex.pattern, mod_dep_txt))
+            self.assertNotRegex(mod_dep_txt, regex)
 
     def test_det_iter_cnt(self):
         """Test det_iter_cnt method."""
@@ -1316,11 +1310,10 @@ class EasyBlockTest(EnhancedTestCase):
         with self.mocked_stdout_stderr() as (stdout, stderr), self.saved_env():
             eb.run_all_steps(True)
 
-            regex = re.compile(depr_msg, re.M)
             stdout = stdout.getvalue()
-            self.assertTrue("This step is deprecated.\n" in stdout)
+            self.assertIn("This step is deprecated.\n", stdout)
             stderr = stderr.getvalue()
-            self.assertTrue(regex.search(stderr), f"Pattern {regex.pattern} found in: {stderr}")
+            self.assertRegex(stderr, depr_msg)
 
         self.assertExists(libtoy_post_a)
 
@@ -1525,8 +1518,7 @@ class EasyBlockTest(EnhancedTestCase):
             r"^== installing extension ext1  \(1/2\)\.\.\.",
             r"^== installing extension ext4 0.2 \(2/2\)\.\.\.",
         ]
-        for pattern in patterns:
-            self.assertRegex(stdout, re.compile(pattern, re.M))
+        self.assert_multi_regex(patterns, stdout)
 
         # 'ext1' should be in eb.ext_instances
         eb_exts = [x.name for x in eb.ext_instances]
@@ -1580,7 +1572,7 @@ class EasyBlockTest(EnhancedTestCase):
         self.mock_stdout(False)
 
         pattern = r">> running shell command:\n\s+bar.sh(\n\s+\[.*\]){3}\n\s+>> command completed: exit 0"
-        self.assertTrue(re.search(pattern, stdout, re.M))
+        self.assertRegex(stdout, re.compile(pattern, re.M))
 
     def test_make_module_step(self):
         """Test the make_module_step"""
@@ -1651,18 +1643,16 @@ class EasyBlockTest(EnhancedTestCase):
         # verify contents of module
         txt = read_file(modpath)
         if get_module_syntax() == 'Tcl':
-            self.assertTrue(re.search(r"^#%Module", txt.split('\n')[0]))
-            self.assertTrue(re.search(r"^conflict\s+%s$" % name, txt, re.M))
+            self.assertRegex(txt.split('\n')[0], r"^#%Module")
+            self.assertRegex(txt, re.compile(r"^conflict\s+%s$" % name, re.M))
 
-            self.assertTrue(re.search(r"^set\s+root\s+%s$" % eb.installdir, txt, re.M))
-            ebroot_regex = re.compile(r'^setenv\s+EBROOT%s\s+"\$root"\s*$' % name.upper(), re.M)
-            self.assertTrue(ebroot_regex.search(txt), "%s in %s" % (ebroot_regex.pattern, txt))
-            self.assertTrue(re.search(r'^setenv\s+EBVERSION%s\s+"%s"$' % (name.upper(), version), txt, re.M))
+            self.assertRegex(txt, re.compile(r"^set\s+root\s+%s$" % eb.installdir, re.M))
+            self.assertRegex(txt, re.compile(r'^setenv\s+EBROOT%s\s+"\$root"\s*$' % name.upper(), re.M))
+            self.assertRegex(txt, re.compile(r'^setenv\s+EBVERSION%s\s+"%s"$' % (name.upper(), version), re.M))
 
         elif get_module_syntax() == 'Lua':
-            ebroot_regex = re.compile(r'^setenv\("EBROOT%s", root\)$' % name.upper(), re.M)
-            self.assertTrue(ebroot_regex.search(txt), "%s in %s" % (ebroot_regex.pattern, txt))
-            self.assertTrue(re.search(r'^setenv\("EBVERSION%s", "%s"\)$' % (name.upper(), version), txt, re.M))
+            self.assertRegex(txt, re.compile(r'^setenv\("EBROOT%s", root\)$' % name.upper(), re.M))
+            self.assertRegex(txt, re.compile(r'^setenv\("EBVERSION%s", "%s"\)$' % (name.upper(), version), re.M))
 
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
@@ -1681,7 +1671,7 @@ class EasyBlockTest(EnhancedTestCase):
                 regex = re.compile(r'^%s\("%s", "%s"\)$' % (env_setter, key, val), re.M)
             else:
                 self.fail("Unknown module syntax: %s" % get_module_syntax())
-            self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
+            self.assertRegex(txt, regex)
 
         for (key, vals) in modextrapaths.items():
             placement = 'prepend'
@@ -1716,7 +1706,7 @@ class EasyBlockTest(EnhancedTestCase):
                     regex = re.compile(fr'^{placement}_path\("{key}", {full_val}{delim_lua}\)$', re.M)
                 else:
                     self.fail(f"Unknown module syntax: {get_module_syntax()}")
-                self.assertTrue(regex.search(txt), f"Pattern {regex.pattern} found in {txt}")
+                self.assertRegex(txt, regex)
                 # Check for duplicates
                 num_prepends = len(regex.findall(txt))
                 self.assertEqual(num_prepends, 1, f"Expected exactly 1 {regex.pattern} command in {txt}")
@@ -1728,7 +1718,7 @@ class EasyBlockTest(EnhancedTestCase):
                 regex = re.compile(r'^\s*(load|depends_on)\("%s"\)$' % os.path.join(name, ver), re.M)
             else:
                 self.fail("Unknown module syntax: %s" % get_module_syntax())
-            self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
+            self.assertRegex(txt, regex)
 
         for (name, ver) in [('test', '1.2.3')]:
             if get_module_syntax() == 'Tcl':
@@ -1737,7 +1727,7 @@ class EasyBlockTest(EnhancedTestCase):
                 regex = re.compile(r'^\s*(load|depends_on)\("%s/.%s"\)$' % (name, ver), re.M)
             else:
                 self.fail("Unknown module syntax: %s" % get_module_syntax())
-            self.assertTrue(regex.search(txt), "Pattern %s found in %s" % (regex.pattern, txt))
+            self.assertRegex(txt, regex)
 
         for (name, ver) in [('OpenMPI', '2.1.2-GCC-6.4.0-2.28')]:
             if get_module_syntax() == 'Tcl':
@@ -1746,7 +1736,7 @@ class EasyBlockTest(EnhancedTestCase):
                 regex = re.compile(r'^\s*(load|depends_on)\("%s/.?%s"\)$' % (name, ver), re.M)
             else:
                 self.fail("Unknown module syntax: %s" % get_module_syntax())
-            self.assertFalse(regex.search(txt), "Pattern '%s' *not* found in %s" % (regex.pattern, txt))
+            self.assertNotRegex(txt, regex)
 
         os.environ['TEST_PUSHENV'] = '0'
 
@@ -1899,7 +1889,7 @@ class EasyBlockTest(EnhancedTestCase):
         tup = ('EB_toy', 'easybuild.easyblocks.toy', '.*test/framework/sandbox/easybuild/easyblocks/t/toy.pyc*')
         eb_log_msg_re = re.compile(r"INFO This is easyblock %s from module %s (%s)" % tup, re.M)
         logtxt = read_file(eb.logfile)
-        self.assertTrue(eb_log_msg_re.search(logtxt), "Pattern '%s' found in: %s" % (eb_log_msg_re.pattern, logtxt))
+        self.assertRegex(logtxt, eb_log_msg_re)
 
     def test_fetch_sources(self):
         """Test fetch_sources method."""
@@ -2299,7 +2289,7 @@ class EasyBlockTest(EnhancedTestCase):
             except EasyBuildError as err:
                 # if this fails, it should be because there's no online access
                 download_fail_regex = re.compile('socket error')
-                self.assertTrue(download_fail_regex.search(str(err)))
+                self.assertRegex(str(err), download_fail_regex)
 
             # result may be None during offline testing
             if res is not None:
@@ -2307,8 +2297,7 @@ class EasyBlockTest(EnhancedTestCase):
                 self.assertEqual(res, loc)
                 self.assertExists(loc)
                 txt = read_file(loc)
-                eb_regex = re.compile("EasyBuild: building software with ease")
-                self.assertTrue(eb_regex.search(txt), "Pattern '%s' found in: %s" % (eb_regex.pattern, txt))
+                self.assertIn("EasyBuild: building software with ease", txt)
             else:
                 print("ignoring failure to download %s in test_obtain_file, testing offline?" % file_url)
 
@@ -2446,7 +2435,7 @@ class EasyBlockTest(EnhancedTestCase):
             eb.check_readiness_step()
         except EasyBuildError as err:
             err_regex = re.compile("Missing modules dependencies .*: nosuchsoftware/1.2.3-GCC-6.4.0-2.28")
-            self.assertTrue(err_regex.search(str(err)), "Pattern '%s' found in '%s'" % (err_regex.pattern, err))
+            self.assertRegex(str(err), err_regex)
 
         shutil.rmtree(tmpdir)
 
@@ -2493,12 +2482,10 @@ class EasyBlockTest(EnhancedTestCase):
             modtxt = read_file(modfile_path)
 
             for dep in excluded_deps:
-                tup = (dep, modfile_path, modtxt)
-                failmsg = "No 'module load' statement found for '%s' not found in module %s: %s" % tup
                 if get_module_syntax() == 'Tcl':
-                    self.assertFalse(re.search('module load %s' % dep, modtxt), failmsg)
+                    self.assertNotRegex(modtxt, re.compile(r'module load %s' % dep))
                 elif get_module_syntax() == 'Lua':
-                    self.assertFalse(re.search('load("%s")' % dep, modtxt), failmsg)
+                    self.assertNotRegex(modtxt, re.compile(r'load("%s")' % dep))
                 else:
                     self.fail("Unknown module syntax: %s" % get_module_syntax())
 
@@ -3221,8 +3208,7 @@ class EasyBlockTest(EnhancedTestCase):
 
             # make sure there's no error logged for not finding checksums.json,
             # see also https://github.com/easybuilders/easybuild-framework/issues/4301
-            regex = re.compile("ERROR .*Couldn't find file checksums.json anywhere", re.M)
-            self.assertFalse(regex.search(stdout), "Pattern '%s' should not be found in log" % regex.pattern)
+            self.assertNotRegex(stdout, "ERROR .*Couldn't find file checksums.json anywhere")
 
         # fiddle with checksum to check whether faulty checksum is catched
         copy_file(toy_ec, self.test_prefix)
@@ -3788,7 +3774,7 @@ class EasyBlockTest(EnhancedTestCase):
 
             # check whether $EBROOTZLIB is correctly set in build environment of 'bar' extension
             regex = re.compile(f"^EBROOTZLIB=.*/software/zlib/{zlib_fn}$", re.M)
-            self.assertTrue(regex.search(log_txt), f"Pattern '{regex.pattern}' not found in log output")
+            self.assertRegex(log_txt, regex)
 
             # check whether $C_INCLUDE_PATH is correctly set in build environment of 'bar' extension
             for env_var in env_vars[search_path_cpp_headers]:
@@ -3805,7 +3791,7 @@ class EasyBlockTest(EnhancedTestCase):
                     regex = re.compile(f'^{env_var}=' + ' '.join('-I/[^ ]+/' + p for p in paths) + '$', re.M)
                 else:
                     self.fail(f"Unknown type of environment variable: ${env_var}")
-                self.assertTrue(regex.search(log_txt), f"Pattern '{regex.pattern}' not found in log output")
+                self.assertRegex(log_txt, regex)
 
         # verify fix made in https://github.com/easybuilders/easybuild-framework/pull/5048
         test_ec_txt = read_file(toy_ec)
@@ -3824,8 +3810,7 @@ class EasyBlockTest(EnhancedTestCase):
 
         log_txt = read_file(self.logfile)
 
-        regex = re.compile(r"\[SUCCESS\] toy/0.0-GCCcore-12.3.0", re.M)
-        self.assertTrue(regex.search(log_txt), f"Pattern '{regex.pattern}' not found in log output")
+        self.assertRegex(log_txt, r"\[SUCCESS\] toy/0.0-GCCcore-12.3.0")
 
 
 def suite(loader=None):


### PR DESCRIPTION
Cleaner and avoids mentioning the pattern and text