### PR TITLE
Add support for non-path variables in `module_load_environment`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1770,14 +1770,6 @@ class EasyBlock:
             if envar_val.is_path
         }
         self.log.debug(f"Tentative module environment requirements before path expansion: {env_var_requirements}")
-        # TODO: handle non-path variables in make_module_extra
-        # in the meantime, just report if any is found
-        non_path_envars = set(self.module_load_environment) - set(env_var_requirements)
-        if non_path_envars:
-            self.log.warning(
-                f"Non-path variables found in module load environment: {non_path_envars}."
-                "This is not yet supported by this version of EasyBuild."
-            )
 
         mod_lines = ['\n']
 
@@ -1801,6 +1793,10 @@ class EasyBlock:
                                                                      prepend=search_paths.mod_prepend,
                                                                      delim=search_paths.delimiter)
                 mod_lines.append(extra_mod_lines)
+
+        for env_var, value in sorted(self.module_load_environment.items()):
+            if env_var not in env_var_requirements:
+                mod_lines.append(self.module_generator.set_environment(env_var, value.delimiter.join(value.contents)))
 
         if self.dry_run:
             self.dry_run_msg('')

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -654,7 +654,6 @@ class EasyBlockTest(EnhancedTestCase):
                 r'prepend_path\("PATH", pathJoin\(root, "%s"\)\)\n' % sub_path_path, re.M))
 
         # Module load environement may contain non-path variables
-        # TODO: remove whenever this is properly supported, in the meantime check warning
         eb.module_load_environment.NONPATH = {'contents': 'non_path', 'var_type': "STRING"}
         eb.module_load_environment.PATH = ['bin']
         with self.mocked_stdout_stderr():
@@ -663,16 +662,16 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertEqual(list(eb.module_load_environment), ['PATH', 'LD_LIBRARY_PATH', 'NONPATH'])
 
         if get_module_syntax() == 'Tcl':
-            self.assertTrue(re.match(r"^\nprepend-path\s+PATH\s+\$root/bin\n$", txt, re.M))
-            self.assertFalse(re.match(r"^\nprepend-path\s+NONPATH\s+\$root/non_path\n$", txt, re.M))
+            self.assertRegex(txt, re.compile(r"^\nprepend-path\s+PATH\s+\$root/bin\n", re.M))
+            self.assertRegex(txt, re.compile(r'^setenv\s+NONPATH\s+"non_path"\s*$', re.M))
         elif get_module_syntax() == 'Lua':
-            self.assertTrue(re.match(r'^\nprepend_path\("PATH", pathJoin\(root, "bin"\)\)\n$', txt, re.M))
-            self.assertFalse(re.match(r'^\nprepend_path\("NONPATH", pathJoin\(root, "non_path"\)\)\n$', txt, re.M))
+            self.assertRegex(txt, re.compile(r'^prepend_path\("PATH", pathJoin\(root, "bin"\)\)$', re.M))
+            self.assertRegex(txt, re.compile(r'^setenv\("NONPATH", "non_path"\)$', re.M))
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         logtxt = read_file(eb.logfile)
-        self.assertRegex(logtxt, r"WARNING Non-path variables found in module load env.*NONPATH")
+        self.assertNotRegex(logtxt, r"WARNING Non-path variables found in module load env.*NONPATH")
 
         eb.module_load_environment.remove('NONPATH')
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -670,9 +670,6 @@ class EasyBlockTest(EnhancedTestCase):
         else:
             self.fail("Unknown module syntax: %s" % get_module_syntax())
 
-        logtxt = read_file(eb.logfile)
-        self.assertNotRegex(logtxt, r"WARNING Non-path variables found in module load env.*NONPATH")
-
         eb.module_load_environment.remove('NONPATH')
 
         # make sure that entries that symlink to another directory are retained;


### PR DESCRIPTION
Useful for simple values.
Using existing logic. If the value is a list elements are joined using
the delimiter.


Includes:
- [x] https://github.com/easybuilders/easybuild-framework/pull/5137
