### PR TITLE
switch native flag from `-march=native` to `-mcpu=native` for LLVM compilers on Arm 64-bit (aarch64)

### DIFF
--- a/easybuild/toolchains/compiler/llvm_compilers.py
+++ b/easybuild/toolchains/compiler/llvm_compilers.py
@@ -143,8 +143,9 @@ class LLVMCompilers(Compiler):
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {
         **(Compiler.COMPILER_OPTIMAL_ARCHITECTURE_OPTION or {}),
-        # -march=native may not include all CPU features on aarch64, e.g. missing bf16 on Grace for LLVM 21.1.8
-        (systemtools.AARCH64, systemtools.ARM): '-mcpu=native -mtune=native',
+        # -mcpu=native is recommended way to specify feature set for aarch64, see:
+        # https://github.com/easybuilders/easybuild-framework/pull/5139#issuecomment-3961654073
+        (systemtools.AARCH64, systemtools.ARM): '-mcpu=native',
         (systemtools.POWER, systemtools.POWER): '-mcpu=native',  # no support for march=native on POWER
         (systemtools.POWER, systemtools.POWER_LE): '-mcpu=native',  # no support for march=native on POWER
         (systemtools.X86_64, systemtools.AMD): '-march=native',

--- a/easybuild/toolchains/compiler/llvm_compilers.py
+++ b/easybuild/toolchains/compiler/llvm_compilers.py
@@ -143,7 +143,8 @@ class LLVMCompilers(Compiler):
     # used when 'optarch' toolchain option is enabled (and --optarch is not specified)
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {
         **(Compiler.COMPILER_OPTIMAL_ARCHITECTURE_OPTION or {}),
-        (systemtools.AARCH64, systemtools.ARM): '-march=native',
+        # -march=native may not include all CPU features on aarch64, e.g. missing bf16 on Grace for LLVM 21.1.8
+        (systemtools.AARCH64, systemtools.ARM): '-mcpu=native -mtune=native',
         (systemtools.POWER, systemtools.POWER): '-mcpu=native',  # no support for march=native on POWER
         (systemtools.POWER, systemtools.POWER_LE): '-mcpu=native',  # no support for march=native on POWER
         (systemtools.X86_64, systemtools.AMD): '-march=native',

--- a/easybuild/toolchains/compiler/llvm_compilers.py
+++ b/easybuild/toolchains/compiler/llvm_compilers.py
@@ -144,7 +144,8 @@ class LLVMCompilers(Compiler):
     COMPILER_OPTIMAL_ARCHITECTURE_OPTION = {
         **(Compiler.COMPILER_OPTIMAL_ARCHITECTURE_OPTION or {}),
         # -mcpu=native is recommended way to specify feature set for aarch64, see:
-        # https://github.com/easybuilders/easybuild-framework/pull/5139#issuecomment-3961654073
+        # https://github.com/easybuilders/easybuild-framework/pull/5139#issuecomment-3961654073 and
+        # https://developer.arm.com/community/arm-community-blogs/b/tools-software-ides-blog/posts/compiler-flags-across-architectures-march-mtune-and-mcpu
         (systemtools.AARCH64, systemtools.ARM): '-mcpu=native',
         (systemtools.POWER, systemtools.POWER): '-mcpu=native',  # no support for march=native on POWER
         (systemtools.POWER, systemtools.POWER_LE): '-mcpu=native',  # no support for march=native on POWER


### PR DESCRIPTION
It was observed that `-march=native` does not actually provide all the CPU features on e.g. GH200, missing bf16 when building OpenBLAS 0.3.31 with LLVM 21.1.8. This causes build failures like:

```
../kernel/arm64/sbgemv_n_neon.c:146:14: error: '__builtin_neon_vld1q_bf16' needs target feature bf16,neon
  146 |         a3 = vld1q_bf16(a_ptr3);
      |              ^
```

Switching to `-mtune=native -mcpu=native` solves this issue. Therefore, apply this option generally.