### PR TITLE
filter out NVHPC toolchains that share name from the toolchain hierarchy

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -324,7 +324,7 @@ def get_toolchain_hierarchy(parent_toolchain, incl_capabilities=False):
     # TODO: delete with EasyBuild 6.0
     if parent_toolchain['name'] == "NVHPC":
         wrong_nvhpc_tc_class_name = "NVHPCToolchain"
-        if LooseVersion(parent_toolchain['version']) < '25.0':
+        if LooseVersion(parent_toolchain['version']) < LooseVersion('25.0'):
             wrong_nvhpc_tc_class_name = "NVHPC"
         wrong_nvhpc_tc_class = [tc for tc in all_tc_classes if tc.__name__ == wrong_nvhpc_tc_class_name]
         all_tc_classes = set(all_tc_classes) - set(wrong_nvhpc_tc_class)

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -317,6 +317,18 @@ def get_toolchain_hierarchy(parent_toolchain, incl_capabilities=False):
     """
     # obtain list of all possible subtoolchains
     _, all_tc_classes = search_toolchain('')
+
+    # Stopgap solution until deprecated compiler-only NVHPC toolchain is removed
+    # Both the new and old NVHPC toolchains share the same name, we need to
+    # selectively filter one out based on the version of the toolchain
+    # TODO: delete with EasyBuild 6.0
+    if parent_toolchain['name'] == "NVHPC":
+        wrong_nvhpc_tc_class_name = "NVHPCToolchain"
+        if LooseVersion(parent_toolchain['version']) < '25.0':
+            wrong_nvhpc_tc_class_name = "NVHPC"
+        wrong_nvhpc_tc_class = [tc for tc in all_tc_classes if tc.__name__ == wrong_nvhpc_tc_class_name]
+        all_tc_classes = set(all_tc_classes) - set(wrong_nvhpc_tc_class)
+
     subtoolchains = {tc_class.NAME: getattr(tc_class, 'SUBTOOLCHAIN', None) for tc_class in all_tc_classes}
     optional_toolchains = {tc_class.NAME for tc_class in all_tc_classes if getattr(tc_class, 'OPTIONAL', False)}
     composite_toolchains = {tc_class.NAME for tc_class in all_tc_classes if len(tc_class.__bases__) > 1}


### PR DESCRIPTION
Fixes CI in `easybuild-easyconfigs`.
See https://github.com/easybuilders/easybuild-easyconfigs/pull/25125

Wrong toolchain hierarchy returned by `get_toolchain_hierarchy` in `develop`:

```
* NVHPC/22.7-CUDA-11.7.0: [
    {'name': 'GCCcore', 'version': '11.3.0'},
    {'name': 'NVHPC', 'version': '22.7-CUDA-11.7.0'},
  ]
* NVHPC/24.9-CUDA-12.6.0: [
    {'name': 'GCCcore', 'version': '13.3.0'},
    {'name': 'NVHPC', 'version': '24.9-CUDA-12.6.0'},
  ]
* NVHPC/25.1: [
    {'name': 'GCCcore', 'version': '13.3.0'},
    {'name': 'NVHPC', 'version': '25.1'},
  ]
* NVHPC/25.3-CUDA-12.8.0: [
    {'name': 'GCCcore', 'version': '14.2.0'},
    {'name': 'NVHPC', 'version': '25.3-CUDA-12.8.0'},
  ]
```

Correct toolchain hierarchy returned by `get_toolchain_hierarchy`:

```
* NVHPC/22.7-CUDA-11.7.0: [
    {'name': 'GCCcore', 'version': '11.3.0'},
    {'name': 'NVHPC', 'version': '22.7-CUDA-11.7.0'},
  ]
* NVHPC/24.9-CUDA-12.6.0: [
    {'name': 'GCCcore', 'version': '13.3.0'},
    {'name': 'NVHPC', 'version': '24.9-CUDA-12.6.0'},
  ]
* NVHPC/25.1: [
    {'name': 'GCCcore', 'version': '13.3.0'},
    {'name': 'nvidia-compilers', 'version': '25.1'},
    {'name': 'NVHPC', 'version': '25.1'},
  ]
* NVHPC/25.3-CUDA-12.8.0 hierarchy: [
    {'name': 'GCCcore', 'version': '14.2.0'},
    {'name': 'nvidia-compilers', 'version': '25.3-CUDA-12.8.0'},
    {'name': 'NVHPC', 'version': '25.3-CUDA-12.8.0'},
  ]
```