### PR TITLE
Be a bit more forgiving with `copy_file`

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -49,7 +49,6 @@ import inspect
 import itertools
 import os
 import pathlib
-import platform
 import re
 import shutil
 import signal
@@ -65,7 +64,6 @@ from html.parser import HTMLParser
 import urllib.request as std_urllib
 
 from easybuild.base import fancylogger
-from easybuild.tools import LooseVersion
 # import build_log must stay, to use of EasyBuildLog
 from easybuild.tools.build_log import EasyBuildError, EasyBuildExit, CWD_NOTFOUND_ERROR
 from easybuild.tools.build_log import dry_run_msg, print_msg, print_warning

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2550,14 +2550,12 @@ def copy_file(path, target_path, force_in_dry_run=False):
                         if os.path.exists(target_path) and os.stat(target_path).st_mode & stat.S_IWUSR:
                             raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
 
-                        pyver = LooseVersion(platform.python_version())
-                        if pyver >= LooseVersion('3.7'):
+                        # If we have anything other than a PermissionError we bail out
+                        if not isinstance(err, PermissionError):
                             raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
-                        elif LooseVersion('3.7') > pyver >= LooseVersion('3'):
-                            if not isinstance(err, PermissionError):
-                                raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
 
-                        # double-check whether the copy actually succeeded
+                        # double-check whether the copy actually succeeded (or may have already happened
+                        # if the contents are the same)
                         if not os.path.exists(target_path) or not filecmp.cmp(path, target_path, shallow=False):
                             raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
 
@@ -2569,8 +2567,10 @@ def copy_file(path, target_path, force_in_dry_run=False):
                         except OSError as err:
                             raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
 
-                        msg = ("Failed to copy extended attributes from file %s to %s, due to a bug in shutil (see "
-                               "https://bugs.python.org/issue24538). Copy successful with workaround.")
+                        msg = ("In some cases, we may fail to copy extended attributes from file %s to %s, due to a "
+                               "bug in shutil (see https://bugs.python.org/issue24538). We may also have already "
+                               "copied the file over so we just check the contents and update the xattrs. "
+                               "Copy successful with workaround.")
                         _log.info(msg, path, target_path)
 
                 elif os.path.islink(path):


### PR DESCRIPTION
I noticed that (in https://github.com/EESSI/software-layer/pull/1405), that `jupyter-server-2.16.0-GCCcore-14.2.0.eb` builds fine with `EasyBuild/5.2.0` but errors (in EESSI) due to a copy failure for one of the easyblocks used.

I tracked this down to https://github.com/easybuilders/easybuild-easyblocks/pull/3993/changes#diff-8c64eeef13a658d3b3982cea75b316a70b272ece82de8f5d1a634dd2252071f9 which seems to trigger attempting to copy the cargo easyblock twice to the `reprod` folder. Since the permissions in EESSI are read-only, the copy fails to overwrite the previously copied file. This change makes things more forgiving (if the contents are already the same, just update the `xattrs`).

