### PR TITLE
use fallback mechanism that relies on `$USER` or `$LOGNAME` when determining username via `pwd.getpwuid` fails

### DIFF
--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -244,12 +244,14 @@ class EasyBuildOptions(GeneralOption):
         self.default_robot_paths = get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None) or []
 
         # set up constants to seed into config files parser, by section
-        user = "unknown_userid"
         try:
             user = pwd.getpwuid(os.geteuid()).pw_name
         except KeyError:
-            # On some systems you may not have NSS on compute nodes, but the envvars will be available
-            user = os.getenv("USER") or os.getenv("LOGNAME") or str(os.geteuid())
+            # On some systems you may not have NSS on compute nodes, but the env vars should be available
+            try:
+                user = os.getenv("USER") or os.getenv("LOGNAME") or str(os.geteuid())
+            except:
+                user = "unknown_userid"
         self.go_cfg_constants = {
             self.DEFAULTSECT: {
                 'DEFAULT_REPOSITORYPATH': (self.default_repositorypath[0],

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -244,14 +244,19 @@ class EasyBuildOptions(GeneralOption):
         self.default_robot_paths = get_paths_for(subdir=EASYCONFIGS_PKG_SUBDIR, robot_path=None) or []
 
         # set up constants to seed into config files parser, by section
+        user = "unknown_userid"
+        try:
+            user = pwd.getpwuid(os.geteuid()).pw_name
+        except KeyError:
+            # On some systems you may not have NSS on compute nodes, but the envvars will be available
+            user = os.getenv("USER") or os.getenv("LOGNAME") or str(os.geteuid())
         self.go_cfg_constants = {
             self.DEFAULTSECT: {
                 'DEFAULT_REPOSITORYPATH': (self.default_repositorypath[0],
                                            "Default easyconfigs repository path"),
                 'DEFAULT_ROBOT_PATHS': (os.pathsep.join(self.default_robot_paths),
                                         "List of default robot paths ('%s'-separated)" % os.pathsep),
-                'USER': (pwd.getpwuid(os.geteuid()).pw_name,
-                         "Current username, translated uid from password file"),
+                'USER': (user, "Current username, translated uid from password file (when available)"),
                 'HOME': (os.path.expanduser('~'),
                          "Current user's home directory, expanded '~'")
             }

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -246,12 +246,13 @@ class EasyBuildOptions(GeneralOption):
         # set up constants to seed into config files parser, by section
         try:
             user = pwd.getpwuid(os.geteuid()).pw_name
-        except KeyError:
+        except Exception:
             # On some systems you may not have NSS on compute nodes, but the env vars should be available
             try:
                 user = os.getenv("USER") or os.getenv("LOGNAME") or str(os.geteuid())
             except Exception:
                 user = "unknown_userid"
+
         self.go_cfg_constants = {
             self.DEFAULTSECT: {
                 'DEFAULT_REPOSITORYPATH': (self.default_repositorypath[0],

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -250,7 +250,7 @@ class EasyBuildOptions(GeneralOption):
             # On some systems you may not have NSS on compute nodes, but the env vars should be available
             try:
                 user = os.getenv("USER") or os.getenv("LOGNAME") or str(os.geteuid())
-            except:
+            except Exception:
                 user = "unknown_userid"
         self.go_cfg_constants = {
             self.DEFAULTSECT: {

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -1036,7 +1036,8 @@ class DocsTest(EnhancedTestCase):
             r"^syntax: %\(CONSTANT_NAME\)s",
             r"^only in 'DEFAULT' section:",
             r"^\* HOME: Current user's home directory, expanded '~' \[value: %s\]" % os.getenv('HOME'),
-            r"^\* USER: Current username, translated uid from password file \[value: %s\]" % os.getenv('USER'),
+            r"^\* USER: Current username, translated uid from password file \(when available\) \[value: %s\]" %
+            os.getenv('USER'),
         ]
         txt = avail_cfgfile_constants(option_parser.go_cfg_constants)
         for pattern in txt_patterns:
@@ -1052,7 +1053,8 @@ class DocsTest(EnhancedTestCase):
             r"^# Constants available \(only\) in configuration files",
             r"^## Only in 'DEFAULT' section:",
             r"^``HOME``\s*\|Current user's home directory, expanded '~'\s*\|``%s``$" % os.getenv('HOME'),
-            r"^``USER``\s*\|Current username, translated uid from password file\s*\|``%s``" % os.getenv('USER'),
+            r"^``USER``\s*\|Current username, translated uid from password file \(when available\)\s*\|``%s``" %
+            os.getenv('USER'),
         ]
         txt_md = avail_cfgfile_constants(option_parser.go_cfg_constants, output_format='md')
         for pattern in md_patterns:
@@ -1063,7 +1065,8 @@ class DocsTest(EnhancedTestCase):
             r"^Constants available \(only\) in configuration files\n-{49}\n",
             r"^Only in 'DEFAULT' section:\n-{26}",
             r"^``HOME``\s*Current user's home directory, expanded '~'\s*``%s``$" % os.getenv('HOME'),
-            r"^``USER``\s*Current username, translated uid from password file\s*``%s``" % os.getenv('USER'),
+            r"^``USER``\s*Current username, translated uid from password file \(when available\)\s*``%s``" %
+            os.getenv('USER'),
         ]
         txt_rst = avail_cfgfile_constants(option_parser.go_cfg_constants, output_format='rst')
         for pattern in rst_patterns:


### PR DESCRIPTION
Currently on Lumi, you get a hard failure when trying to do an EasyBuild installation on a compute node (in the EESSI environment):
```bash
{EESSI/2025.06} alanocai@nid005125:~/mpi_inject> id -un
id: cannot find name for user ID 327004947
327004947
{EESSI/2025.06} alanocai@nid005125:~/mpi_inject> eb --missing libcxi.eb 
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/amd/zen3/software/EasyBuild/5.2.1/lib/python3.13/site-packages/easybuild/main.py", line 862, in <module>
    main_with_hooks()
    ~~~~~~~~~~~~~~~^^
  File "/cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/amd/zen3/software/EasyBuild/5.2.1/lib/python3.13/site-packages/easybuild/main.py", line 840, in main_with_hooks
    init_session_state, eb_go, cfg_settings = prepare_main(args=args)
                                              ~~~~~~~~~~~~^^^^^^^^^^^
  File "/cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/amd/zen3/software/EasyBuild/5.2.1/lib/python3.13/site-packages/easybuild/main.py", line 832, in prepare_main
    eb_go, cfg_settings = set_up_configuration(args=args, logfile=logfile, testing=testing)
                          ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/amd/zen3/software/EasyBuild/5.2.1/lib/python3.13/site-packages/easybuild/tools/options.py", line 1822, in set_up_configuration
    eb_go = parse_options(args=args)
  File "/cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/amd/zen3/software/EasyBuild/5.2.1/lib/python3.13/site-packages/easybuild/tools/options.py", line 1691, in parse_options
    eb_go = EasyBuildOptions(usage=usage, description=description, prog='eb', envvar_prefix=CONFIG_ENV_VAR_PREFIX,
                             go_args=eb_args, error_env_options=True, error_env_option_method=raise_easybuilderror,
                             with_include=with_include)
  File "/cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/amd/zen3/software/EasyBuild/5.2.1/lib/python3.13/site-packages/easybuild/tools/options.py", line 253, in __init__
    'USER': (pwd.getpwuid(os.geteuid()).pw_name,
             ~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: 'getpwuid(): uid not found: 327004947'
```