### PR TITLE
raise error if `'filename'` is missing in source dict

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -518,6 +518,9 @@ class EasyBlock:
             # Making a copy to avoid modifying the object with pops
             src = source.copy()
             filename = src.pop('filename', None)
+            if filename is None:
+                raise EasyBuildError(f"Missing required 'filename' for source {source}")
+
             extract_cmd = src.pop('extract_cmd', None)
             download_filename = src.pop('download_filename', None)
             source_urls = src.pop('source_urls', None)
@@ -528,9 +531,6 @@ class EasyBlock:
 
         else:
             raise EasyBuildError("Unexpected source spec, not a string or dict: %s", source)
-
-        if filename is None:
-            raise EasyBuildError(f"Missing required 'filename' for source {source}")
 
         # check if the sources can be located
         force_download = build_option('force_download') in [FORCE_DOWNLOAD_ALL, FORCE_DOWNLOAD_SOURCES]

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -516,18 +516,18 @@ class EasyBlock:
             filename = source
         elif isinstance(source, dict):
             # Making a copy to avoid modifying the object with pops
-            src = source.copy()
-            filename = src.pop('filename', None)
+            source = source.copy()
+            filename = source.pop('filename', None)
             if filename is None:
                 raise EasyBuildError(f"Missing required 'filename' for source {source}")
 
-            extract_cmd = src.pop('extract_cmd', None)
-            download_filename = src.pop('download_filename', None)
-            source_urls = src.pop('source_urls', None)
-            git_config = src.pop('git_config', None)
-            alt_location = src.pop('alt_location', None)
-            if src:
-                raise EasyBuildError("Found one or more unexpected keys in 'sources' specification: %s", src)
+            extract_cmd = source.pop('extract_cmd', None)
+            download_filename = source.pop('download_filename', None)
+            source_urls = source.pop('source_urls', None)
+            git_config = source.pop('git_config', None)
+            alt_location = source.pop('alt_location', None)
+            if source:
+                raise EasyBuildError("Found one or more unexpected keys in 'sources' specification: %s", source)
 
         else:
             raise EasyBuildError("Unexpected source spec, not a string or dict: %s", source)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -516,15 +516,15 @@ class EasyBlock:
             filename = source
         elif isinstance(source, dict):
             # Making a copy to avoid modifying the object with pops
-            source = source.copy()
-            filename = source.pop('filename', None)
-            extract_cmd = source.pop('extract_cmd', None)
-            download_filename = source.pop('download_filename', None)
-            source_urls = source.pop('source_urls', None)
-            git_config = source.pop('git_config', None)
-            alt_location = source.pop('alt_location', None)
-            if source:
-                raise EasyBuildError("Found one or more unexpected keys in 'sources' specification: %s", source)
+            src = source.copy()
+            filename = src.pop('filename', None)
+            extract_cmd = src.pop('extract_cmd', None)
+            download_filename = src.pop('download_filename', None)
+            source_urls = src.pop('source_urls', None)
+            git_config = src.pop('git_config', None)
+            alt_location = src.pop('alt_location', None)
+            if src:
+                raise EasyBuildError("Found one or more unexpected keys in 'sources' specification: %s", src)
 
         elif isinstance(source, (list, tuple)) and len(source) == 2:
             self.log.deprecated("Using a 2-element list/tuple to specify sources is deprecated, "
@@ -532,6 +532,9 @@ class EasyBlock:
             filename, extract_cmd = source
         else:
             raise EasyBuildError("Unexpected source spec, not a string or dict: %s", source)
+
+        if filename is None:
+            raise EasyBuildError(f"Missing required 'filename' for source {source}")
 
         # check if the sources can be located
         force_download = build_option('force_download') in [FORCE_DOWNLOAD_ALL, FORCE_DOWNLOAD_SOURCES]


### PR DESCRIPTION
avoids ugly crash:

```
EasyBuild crashed! Please consider reporting a bug, this should not happen...                                                                                                                                                                                                
                                                                                                                                                                                                                                                                             
Traceback (most recent call last):                                                                                                                                                                                                                                           
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main                                                                                                                                                                                                     
    return _run_code(code, main_globals, None,                                                                                                                                                                                                                               
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code                                                                                                                                                                                                                
    exec(code, run_globals)                                                                                                                                                                                                                                                  
  File "/scratch/brussel/100/vsc10009/easybuild-framework/easybuild/main.py", line 862, in <module>                                                                                                                                                                          
    main_with_hooks()                                                                                                                                                                                                                                                        
  File "/scratch/brussel/100/vsc10009/easybuild-framework/easybuild/main.py", line 847, in main_with_hooks                                                                                                                                                                   
    exit_code: EasyBuildExit = main(args=args, prepared_cfg_data=(init_session_state, eb_go, cfg_settings))                                                                                                                                                                  
  File "/scratch/brussel/100/vsc10009/easybuild-framework/easybuild/main.py", line 798, in main                                                                                                                                                                              
    is_successful = process_eb_args(orig_paths, eb_go, cfg_settings, modtool, testing, init_session_state,                                                                                                                                                                   
  File "/scratch/brussel/100/vsc10009/easybuild-framework/easybuild/main.py", line 614, in process_eb_args                                                                                                                                                                   
    ecs_with_res = build_and_install_software(                                                                                                                                                                                                                               
  File "/scratch/brussel/100/vsc10009/easybuild-framework/easybuild/main.py", line 226, in build_and_install_software                                                                                                                                                        
    raise error                                                                                                                                                                                                                                                              
  File "/scratch/brussel/100/vsc10009/easybuild-framework/easybuild/main.py", line 180, in build_and_install_software                                                                                                                                                        
    (ec_res['success'], app_log, err_msg, err_code) = build_and_install_one(ec, init_env)                                                                                                                                                                                    
  File "/scratch/brussel/100/vsc10009/easybuild-framework/easybuild/framework/easyblock.py", line 5135, in build_and_install_one                                                                                                                                             
    result = app.run_all_steps(run_test_cases=run_test_cases)                                                                                                                                                                                                                
  File "/scratch/brussel/100/vsc10009/easybuild-framework/easybuild/framework/easyblock.py", line 4947, in run_all_steps                                                                                                                                                     
    self.run_step(step_name, step_methods)                                                                                                                                                                                                                                   
  File "/scratch/brussel/100/vsc10009/easybuild-framework/easybuild/framework/easyblock.py", line 4788, in run_step                                                                                                                                                          
    current_method()                                                                                                                                                                                                                                                         
  File "/scratch/brussel/100/vsc10009/easybuild-framework/easybuild/framework/easyblock.py", line 2684, in fetch_step                                                                                                                                                        
    self.fetch_sources(self.cfg['sources'], checksums=self.cfg['checksums'])                                                                                                                                                                                                 
  File "/scratch/brussel/100/vsc10009/easybuild-framework/easybuild/framework/easyblock.py", line 582, in fetch_sources                                                                                                                                                      
    src_spec = self.fetch_source(source, checksum=checksum)                                                                           
  File "/scratch/brussel/100/vsc10009/easybuild-framework/easybuild/framework/easyblock.py", line 538, in fetch_source
    path = self.obtain_file(filename, extension=extension, download_filename=download_filename,                                       
  File "/scratch/brussel/100/vsc10009/easybuild-framework/easybuild/framework/easyblock.py", line 146, in wrapper
    result = func(*args, **kwargs)                                                                                                    
  File "/scratch/brussel/100/vsc10009/easybuild-framework/easybuild/framework/easyblock.py", line 887, in obtain_file                                                                                                                                                            if re.match(r"^(https?|ftp)://", filename):                                                                                                                                                                                                                              
  File "/usr/lib64/python3.9/re.py", line 191, in match                                                                                                                                                                                                                      
    return _compile(pattern, flags).match(string)                                                                                                                                                                                                                            
TypeError: expected string or bytes-like object                                                                                                                                                                                                                              
```