### PR TITLE
remove deprecated 2-element list/tuple for specifying sources

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -526,10 +526,6 @@ class EasyBlock:
             if source:
                 raise EasyBuildError("Found one or more unexpected keys in 'sources' specification: %s", source)
 
-        elif isinstance(source, (list, tuple)) and len(source) == 2:
-            self.log.deprecated("Using a 2-element list/tuple to specify sources is deprecated, "
-                                "use a dictionary with 'filename', 'extract_cmd' keys instead", '4.0')
-            filename, extract_cmd = source
         else:
             raise EasyBuildError("Unexpected source spec, not a string or dict: %s", source)
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1969,12 +1969,6 @@ class EasyBlockTest(EnhancedTestCase):
         orig_toy_extra_txt = read_file(os.path.join(os.path.dirname(toy_source), 'toy-extra.txt'))
         self.assertNotEqual(read_file(eb.src[0]['path']), orig_toy_extra_txt)
 
-        # old format for specifying source with custom extract command is deprecated
-        eb.src = []
-        error_msg = r"DEPRECATED \(since v4.0\).*Using a 2-element list/tuple.*"
-        self.assertErrorRegex(EasyBuildError, error_msg, eb.fetch_sources,
-                              [('toy-0.0_gzip.patch.gz', "gunzip %s")], checksums=[])
-
         # unknown dict keys in sources are reported
         sources[0]['nosuchkey'] = 'foobar'
         error_pattern = "Found one or more unexpected keys in 'sources' specification: {'nosuchkey': 'foobar'}"


### PR DESCRIPTION
This was deprecated for EB4, but the removal was missed. As that is sufficiently long ago I consider it reasonable to remove at any time.