### PR TITLE
Lift fallback for PyPI package names to `obtain_file`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1051,20 +1051,27 @@ class EasyBlock:
             failedpaths.extend(failed_urls)
 
             # Usual PYPI sources have a format of '<name>-version.ext', with '<name>' has dashes replaced by underscores
-            num_dashes = download_filename.count('-')
-            if num_dashes >= 2 and any(PYPI_PKG_URL_PATTERN in url for url in source_urls):
+            if download_filename.count('-') >= 2 and any(PYPI_PKG_URL_PATTERN in url for url in source_urls):
                 # Last dash is the separator between name and version
-                alt_download_filename = download_filename.replace('-', '_', num_dashes - 1)
+                dl_name, dl_suffix = download_filename.rsplit('-', maxsplit=1)
+                # Guide https://packaging.python.org/en/latest/specifications/binary-distribution-format
+                # "any run of -_. characters [...] should be replaced with _".
+                # Account for different "compliance levels" and deduplicate (if only dashes were used all are the same)
+                alt_download_filenames = nub(f'{name}-{dl_suffix}' for name in (
+                    re.sub('[.-_]+', '_', dl_name),  # Fully compliant
+                    re.sub('-+', '_', dl_name),  # Only dashes
+                    re.sub(r'\.+', '_', dl_name),  # Only dots
+                ))
                 self.log.warning("Could not download %s (%s) from any of %s.\n"
-                                 "Retrying with alternative download filename '%s' as it looks like a PYPI source.",
-                                 filename, download_filename, ', '.join(source_urls), alt_download_filename)
-                # retry with alternative download_filename
-                downloaded, failed_urls = self.download_file(target_path, alt_download_filename, urls=source_urls,
-                                                             # Only log when extensions have explicit URLs
-                                                             log_url_in_dry_run=extension and urls)
-                if downloaded:
-                    return target_path
-                failedpaths.extend(failed_urls)
+                                 "Retrying with alternative download filenames '%s' as it looks like a PYPI source.",
+                                 filename, download_filename, ', '.join(source_urls), ', '.join(alt_download_filenames))
+                for alt_download_filename in alt_download_filenames:
+                    downloaded, failed_urls = self.download_file(target_path, alt_download_filename, urls=source_urls,
+                                                                 # Only log when extensions have explicit URLs
+                                                                 log_url_in_dry_run=extension and urls)
+                    if downloaded:
+                        return target_path
+                    failedpaths.extend(failed_urls)
 
             if self.dry_run:
                 self.dry_run_msg("  * %s (MISSING)", filename)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1051,64 +1051,18 @@ class EasyBlock:
 
             mkdir(targetdir, parents=True)
 
-            for url in source_urls:
+            if extension:
+                target_path = os.path.join(targetdir, "extensions", filename)
+            else:
+                target_path = os.path.join(targetdir, filename)
+            downloaded, failed_urls = self.download_file(target_path, download_filename=download_filename or filename,
+                                                         urls=source_urls,
+                                                         # Only log when extensions have explicit URLs
+                                                         log_url_in_dry_run=extension and urls)
+            if downloaded:
+                return target_path
 
-                if extension:
-                    targetpath = os.path.join(targetdir, "extensions", filename)
-                else:
-                    targetpath = os.path.join(targetdir, filename)
-
-                url_filename = download_filename or filename
-
-                if isinstance(url, str):
-                    if url[-1] in ['=', '/']:
-                        fullurl = "%s%s" % (url, url_filename)
-                    else:
-                        fullurl = "%s/%s" % (url, url_filename)
-                elif isinstance(url, tuple):
-                    # URLs that require a suffix, e.g., SourceForge download links
-                    # e.g. http://sourceforge.net/projects/math-atlas/files/Stable/3.8.4/atlas3.8.4.tar.bz2/download
-                    fullurl = "%s/%s/%s" % (url[0], url_filename, url[1])
-                else:
-                    self.log.warning("Source URL %s is of unknown type, so ignoring it." % url)
-                    continue
-
-                # PyPI URLs may need to be converted due to change in format of these URLs,
-                # cfr. https://bitbucket.org/pypa/pypi/issues/438
-                if PYPI_PKG_URL_PATTERN in fullurl and not is_alt_pypi_url(fullurl):
-                    alt_url = derive_alt_pypi_url(fullurl)
-                    if alt_url:
-                        _log.debug("Using alternative PyPI URL for %s: %s", fullurl, alt_url)
-                        fullurl = alt_url
-                    else:
-                        _log.debug("Failed to derive alternative PyPI URL for %s, so retaining the original",
-                                   fullurl)
-
-                if self.dry_run:
-                    self.dry_run_msg("  * %s will be downloaded to %s", filename, targetpath)
-                    if extension and urls:
-                        # extensions typically have custom source URLs specified, only mention first
-                        self.dry_run_msg("    (from %s, ...)", fullurl)
-                    downloaded = True
-
-                else:
-                    self.log.debug("Trying to download file %s from %s to %s ..." % (filename, fullurl, targetpath))
-                    downloaded = False
-                    try:
-                        if download_file(filename, fullurl, targetpath):
-                            downloaded = True
-
-                    except IOError as err:
-                        self.log.debug("Failed to download %s from %s: %s" % (filename, url, err))
-                        failedpaths.append(fullurl)
-                        continue
-
-                if downloaded:
-                    # if fetching from source URL worked, we're done
-                    self.log.info("Successfully downloaded source file %s from %s" % (filename, fullurl))
-                    return targetpath
-                else:
-                    failedpaths.append(fullurl)
+            failedpaths.extend(failed_urls)
 
             if self.dry_run:
                 self.dry_run_msg("  * %s (MISSING)", filename)
@@ -1134,6 +1088,68 @@ class EasyBlock:
                 else:
                     self.log.warning(error_msg, filename)
                     return None
+
+    def download_file(self, target_path, download_filename, urls, log_url_in_dry_run):
+        """Try downloading a file from multiple source URLs, until one works.
+
+        :param target_path: Full path where the file should be stored (including filename)
+        :param download_filename: Name of the file on the server (which may differ from the target filename)
+        :param source_urls: list of URLs to try downloading from
+        :param log_url_in_dry_run: whether to log each URL in dry-run mode
+
+        Returns a tuple of (success, failed_urls), where
+            success is True if the file was successfully downloaded from any of the source URLs
+            failed_urls is a list of (full) URLs that were attempted but failed to download from
+        """
+        failed_urls = []
+        filename = os.path.basename(target_path)
+        for url in urls:
+            if isinstance(url, str):
+                if url[-1] in ['=', '/']:
+                    full_url = "%s%s" % (url, download_filename)
+                else:
+                    full_url = "%s/%s" % (url, download_filename)
+            elif isinstance(url, tuple):
+                # URLs that require a suffix, e.g., SourceForge download links
+                # e.g. http://sourceforge.net/projects/math-atlas/files/Stable/3.8.4/atlas3.8.4.tar.bz2/download
+                full_url = "%s/%s/%s" % (url[0], download_filename, url[1])
+            else:
+                self.log.warning("Source URL %s is of unknown type, so ignoring it." % url)
+                continue
+
+            # PyPI URLs may need to be converted due to change in format of these URLs,
+            # cfr. https://bitbucket.org/pypa/pypi/issues/438
+            if PYPI_PKG_URL_PATTERN in full_url and not is_alt_pypi_url(full_url):
+                alt_url = derive_alt_pypi_url(full_url)
+                if alt_url:
+                    _log.debug("Using alternative PyPI URL for %s: %s", full_url, alt_url)
+                    full_url = alt_url
+                else:
+                    _log.debug("Failed to derive alternative PyPI URL for %s, so retaining the original",
+                               full_url)
+
+            if self.dry_run:
+                msg = f"  * {filename} will be downloaded to {target_path}"
+                if log_url_in_dry_run:
+                    msg += f" from {full_url}"
+                self.dry_run_msg(msg)
+                downloaded = True
+
+            else:
+                self.log.debug("Trying to download file %s from %s to %s ..." % (filename, full_url, target_path))
+                try:
+                    downloaded = download_file(filename, full_url, target_path)
+                except IOError as err:
+                    self.log.debug("Failed to download %s from %s: %s" % (filename, url, err))
+                    downloaded = False
+
+            if downloaded:
+                # if fetching from source URL worked, we're done
+                self.log.info("Successfully downloaded source file %s from %s" % (filename, full_url))
+                return True, failed_urls
+            else:
+                failed_urls.append(full_url)
+        return False, failed_urls
 
     #
     # GETTER/SETTER UTILITY FUNCTIONS

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1050,18 +1050,22 @@ class EasyBlock:
                 return target_path
             failedpaths.extend(failed_urls)
 
-            # Usual PYPI sources have a format of '<name>-version.ext', with '<name>' has dashes replaced by underscores
-            if download_filename.count('-') >= 2 and any(PYPI_PKG_URL_PATTERN in url for url in source_urls):
-                # Last dash is the separator between name and version
+            # Usual PYPI sources have a format of '<name>-version.ext'
+            # Last dash is the separator between name and version
+            if '-' in download_filename:
                 dl_name, dl_suffix = download_filename.rsplit('-', maxsplit=1)
+                pypi_like_fn = '-' in dl_name or '.' in dl_name
+            else:
+                pypi_like_fn = False
+            if pypi_like_fn and any(PYPI_PKG_URL_PATTERN in url for url in source_urls):
                 # Guide https://packaging.python.org/en/latest/specifications/binary-distribution-format
                 # "any run of -_. characters [...] should be replaced with _".
                 # Account for different "compliance levels" and deduplicate (if only dashes were used all are the same)
                 alt_download_filenames = nub(f'{name}-{dl_suffix}' for name in (
-                    re.sub('[.-_]+', '_', dl_name),  # Fully compliant
-                    re.sub('-+', '_', dl_name),  # Only dashes
-                    re.sub(r'\.+', '_', dl_name),  # Only dots
-                ))
+                    re.sub('[-._]+', '_', dl_name),  # Fully compliant
+                    re.sub('[-_]+', '_', dl_name),  # Only dashes
+                    re.sub(r'[\._]+', '_', dl_name),  # Only dots
+                ) if name != dl_name)
                 self.log.warning("Could not download %s (%s) from any of %s.\n"
                                  "Retrying with alternative download filenames '%s' as it looks like a PYPI source.",
                                  filename, download_filename, ', '.join(source_urls), ', '.join(alt_download_filenames))

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -749,13 +749,9 @@ class EasyBlock:
 
                         # if no sources are specified via 'sources', fall back to 'source_tmpl'
                         src_fn = ext_options.get('source_tmpl')
-                        is_pypi_source = False
                         if src_fn is None:
                             # use default template for name of source file if none is specified
                             src_fn = '%(name)s-%(version)s.tar.gz'
-                            if len(source_urls) == 1 and PYPI_PKG_URL_PATTERN in source_urls[0]:
-                                # allow retrying with alternative download_filename
-                                is_pypi_source = True
                         elif not isinstance(src_fn, str):
                             error_msg = "source_tmpl value must be a string! (found value of type '%s'): %s"
                             raise EasyBuildError(error_msg, type(src_fn).__name__, src_fn)
@@ -766,17 +762,7 @@ class EasyBlock:
                         if fetch_files:
                             src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,
                                                         force_download=force_download,
-                                                        download_instructions=download_instructions,
-                                                        warning_only=is_pypi_source)
-                            if not src_path and is_pypi_source:
-                                # retry with alternative download_filename
-                                alt_name = resolve_template('%(name)s', template_values).replace("-", "_")
-                                src_version = resolve_template('%(version)s', template_values)
-                                alt_download_fn = f'{alt_name}-{src_version}.tar.gz'
-                                src_path = self.obtain_file(src_fn, extension=True, urls=source_urls,
-                                                            force_download=force_download,
-                                                            download_instructions=download_instructions,
-                                                            download_filename=alt_download_fn)
+                                                        download_instructions=download_instructions)
                             if src_path:
                                 ext_src.update({'src': src_path})
                             else:
@@ -1055,14 +1041,30 @@ class EasyBlock:
                 target_path = os.path.join(targetdir, "extensions", filename)
             else:
                 target_path = os.path.join(targetdir, filename)
-            downloaded, failed_urls = self.download_file(target_path, download_filename=download_filename or filename,
-                                                         urls=source_urls,
+            if download_filename is None:
+                download_filename = filename
+            downloaded, failed_urls = self.download_file(target_path, download_filename, urls=source_urls,
                                                          # Only log when extensions have explicit URLs
                                                          log_url_in_dry_run=extension and urls)
             if downloaded:
                 return target_path
-
             failedpaths.extend(failed_urls)
+
+            # Usual PYPI sources have a format of '<name>-version.ext', with '<name>' has dashes replaced by underscores
+            num_dashes = download_filename.count('-')
+            if num_dashes >= 2 and any(PYPI_PKG_URL_PATTERN in url for url in source_urls):
+                # Last dash is the separator between name and version
+                alt_download_filename = download_filename.replace('-', '_', num_dashes - 1)
+                self.log.warning("Could not download %s (%s) from any of %s.\n"
+                                 "Retrying with alternative download filename '%s' as it looks like a PYPI source.",
+                                 filename, download_filename, ', '.join(source_urls), alt_download_filename)
+                # retry with alternative download_filename
+                downloaded, failed_urls = self.download_file(target_path, alt_download_filename, urls=source_urls,
+                                                             # Only log when extensions have explicit URLs
+                                                             log_url_in_dry_run=extension and urls)
+                if downloaded:
+                    return target_path
+                failedpaths.extend(failed_urls)
 
             if self.dry_run:
                 self.dry_run_msg("  * %s (MISSING)", filename)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -2389,7 +2389,7 @@ class EasyBlockTest(EnhancedTestCase):
         # file specifications via URL also work, are downloaded to (first) sourcepath
         init_config(args=["--sourcepath=%s:/no/such/dir:%s" % (tmpdir, sandbox_sources)])
         urls = [
-            "https://easybuilders.github.io/easybuild/index.html",
+            "http://easybuilders.github.io/easybuild/index.html",
             "https://easybuilders.github.io/easybuild/index.html",
         ]
         for file_url in urls:

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -51,6 +51,7 @@ from easybuild.base import fancylogger
 from easybuild.framework.easyblock import EasyBlock, get_easyblock_instance, BUILD_STEP
 from easybuild.framework.easyconfig import CUSTOM
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, ITERATE_OPTIONS
+from easybuild.framework.easyconfig.templates import PYPI_SOURCE
 from easybuild.framework.easyconfig.tools import avail_easyblocks, process_easyconfig
 from easybuild.framework.extensioneasyblock import ExtensionEasyBlock
 from easybuild.tools import LooseVersion, config
@@ -2413,6 +2414,61 @@ class EasyBlockTest(EnhancedTestCase):
                 print("ignoring failure to download %s in test_obtain_file, testing offline?" % file_url)
 
         shutil.rmtree(tmpdir)
+
+    def test_obtain_file_pypi_fallback_name(self):
+        ANY = unittest.mock.ANY
+        # Avoid it finding the source and only try specified URLs
+        init_config([f'--sourcepath={self.test_prefix}'], build_options={'extra_source_urls': []})
+        self.contents = textwrap.dedent("""
+            easyblock = "ConfigureMake"
+            name = "foo"
+            version = "3.14"
+            homepage = "http://example.com"
+            description = "test"
+            toolchain = SYSTEM
+        """)
+        self.writeEC()
+        eb = EasyBlock(EasyConfig(self.eb_file))
+
+        error_tmpl = "Couldn't find file %s anywhere, and downloading it didn't work either"
+        test_cases = (
+            ('foo.zip', []),
+            ('foo-1.23.zip', []),
+            ('foo-bar-1.23.zip', ['foo_bar-1.23.zip']),
+            # Only single underscore as fallback will be tried
+            ('foo_-bar-1.23.zip', ['foo_bar-1.23.zip']),
+            ('foo-bar-baz-1.23.zip', ['foo_bar_baz-1.23.zip']),
+            # Dots
+            ('foo.bar-1.23.zip', ['foo_bar-1.23.zip']),
+            # Variant order when mixing - and .
+            ('foo.bar-baz-1.23.zip', ['foo_bar_baz-1.23.zip', 'foo.bar_baz-1.23.zip', 'foo_bar-baz-1.23.zip']),
+            ('foo-.bar-1.23.zip', ['foo_bar-1.23.zip', 'foo_.bar-1.23.zip', 'foo-_bar-1.23.zip']),
+        )
+        # Note: Mocking the IMPORTED functions, not the original as we already imported easybuild.framework.easyblock
+        with unittest.mock.patch.multiple('easybuild.framework.easyblock',
+                                          download_file=unittest.mock.DEFAULT,
+                                          derive_alt_pypi_url=unittest.mock.DEFAULT) as mocks:
+            base_url = 'https://any'
+            pypi_url = eb.cfg.resolve_template(PYPI_SOURCE)
+            mocked_download_file = mocks['download_file']
+            mocked_download_file.return_value = False  # Simulate failure so all alternatives will be tried
+            # Mocked too as this would try downloading the alternative URL list
+            mocks['derive_alt_pypi_url'].return_value = None  # Simulate failure, will use original URL
+            for orig_fn, fallback_fns in test_cases:
+                with self.subTest(filename=orig_fn):
+                    # With a non-PYPI URL only a single download attempt is done
+                    eb.cfg['source_urls'] = [base_url]
+                    mocked_download_file.reset_mock()
+                    self.assertRaisesRegex(EasyBuildError, error_tmpl % orig_fn, eb.obtain_file, orig_fn)
+                    mocked_download_file.assert_called_once_with(orig_fn, f"{base_url}/{orig_fn}", ANY)
+
+                    # For PYPI URLs the original name and then the fallbacks are tried
+                    eb.cfg['source_urls'] = [pypi_url]
+                    mocked_download_file.reset_mock()
+                    self.assertRaisesRegex(EasyBuildError, error_tmpl % orig_fn, eb.obtain_file, orig_fn)
+                    expected = [unittest.mock.call(orig_fn, f"{pypi_url}/{fn}", ANY)
+                                for fn in [orig_fn] + fallback_fns]
+                    self.assertEqual(mocked_download_file.call_args_list, expected)
 
     def test_fallback_source_url(self):
         """Check whether downloading from fallback source URL https://sources.easybuild.io works."""


### PR DESCRIPTION
Followup to #4943

When the download URLs include a PYPI source and the download filename looks like a pypi source where the package name contains dashes then retry downloading with dashes replaced by underscores.

This is more generic than #4943 as it handles e.g. PythonPackage easyconfigs, not just extensions with defaulted names.

Done in 2 steps for easier checking:
1. Factor out a "wrapper" for `download_file` as a `EasyBlock` method from `obtain_file` without any significant changes
    Small change to dry-run logging as `"extensions typically have custom source URLs specified, only mention first"` didn't seem to match behavior so removed the comment and add the URL to the initial message instead of a second one
3. Call this again if we have a PYPI URL and at least 2 dashes in the download filename (last is assumed to be the version delimiter)

This is broader than #4943
- Handle not only extensions but any `obtain_file` calls, especially top-level easyconfig sources
- Trigger when PYPI URL appears anywhere in the URLs, not only in first position
- Trigger when there are at least 2 dashes not only when the extensions source name is defaulted and also for dots and combinations of dashes, dots and underscores. Specs say runs of those should be replaced by single underscore

Issue I had was that at this point we do not know anymore where the (download)filename came from and which template values (for name & version) we should use as extensions temporarily update the easyconfig templates.



Example easyconfig PR that makes use of this: https://github.com/easybuilders/easybuild-easyconfigs/pull/25682