### PR TITLE
fix `test_github_merge_pr` by using more recent easyblocks PR

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5193,7 +5193,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # --merge-pr also works on easyblocks (& framework) PRs
         args = [
             '--merge-pr',
-            '3582',
+            '4067',
             '--pr-target-repo=easybuild-easyblocks',
             '-D',
             '--github-user=%s' % GITHUB_TEST_ACCOUNT,
@@ -5201,12 +5201,12 @@ class CommandLineOptionsTest(EnhancedTestCase):
         stdout, stderr = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False)
         self.assertEqual(stderr.strip(), '')
         expected_stdout = '\n'.join([
-            "Checking eligibility of easybuilders/easybuild-easyblocks PR #3582 for merging...",
+            "Checking eligibility of easybuilders/easybuild-easyblocks PR #4067 for merging...",
             "* targets develop branch: OK",
             "* test suite passes: OK",
             "* no pending change requests: OK",
-            "* approved review: OK (by hajgato)",
-            "* milestone is set: OK (5.0.0)",
+            "* approved review: OK (by boegel)",
+            "* milestone is set: OK (5.2.1)",
             "* mergeable state is clean: PR is already merged",
             '',
             "Review OK, merging pull request!",


### PR DESCRIPTION
fix for failing test (only run when GitHub token is available):
```
FAIL: test_github_merge_pr (test.framework.options.CommandLineOptionsTest)
Test use of --merge-pr (dry run)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/runner/f01e237ed81d4cd06ba0b277d08ceab13c8fd57b/lib/python3.9/site-packages/test/framework/options.py", line 5202, in test_github_merge_pr
    self.assertEqual(stderr.strip(), '')
  File "/tmp/runner/f01e237ed81d4cd06ba0b277d08ceab13c8fd57b/lib/python3.9/site-packages/easybuild/base/testing.py", line 89, in assertEqual
    super().assertEqual(a, b, msg=msg)
AssertionError: '* test suite passes: (status: None) => no[110 chars]way)' != ''
- * test suite passes: (status: None) => not eligible for merging!
- 
- WARNING: Review indicates this PR should not be merged (use -f/--force to do so anyway)
```