### PR TITLE
Use `obtain_file` to get file for `test_cases_step`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4725,6 +4725,7 @@ class EasyBlock:
             else:
                 original_perms = None
             try:
+                self.log.debug(f"Running test {test_cmd}")
                 run_shell_cmd(test_cmd)
             except RunShellCmdError:
                 raise  # Let that propagate which will report more information

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4707,14 +4707,9 @@ class EasyBlock:
             if os.path.isabs(test):
                 test_cmd = test
             else:
-                for source_path in source_paths():
-                    test_cmd = os.path.join(source_path, self.name, test)
-                    if os.path.exists(test_cmd):
-                        break
-                else:
-                    test_cmd = test
+                test_cmd = self.obtain_file(test, no_download=True, warning_only=True) or test
             if not os.path.exists(test_cmd):
-                raise EasyBuildError(f"Test specifies non-existing path: {test_cmd}")
+                raise EasyBuildError(f"Test specifies non-existing path: {test}")
 
             if os.path.isfile(test_cmd):
                 original_perms = os.lstat(test_cmd).st_mode
@@ -4724,8 +4719,8 @@ class EasyBlock:
                     adjust_permissions(test_cmd, stat.S_IEXEC, add=True, recursive=False)
             else:
                 original_perms = None
+            self.log.debug(f"Running test {test_cmd}")
             try:
-                self.log.debug(f"Running test {test_cmd}")
                 run_shell_cmd(test_cmd)
             except RunShellCmdError:
                 raise  # Let that propagate which will report more information

--- a/easybuild/tools/variables.py
+++ b/easybuild/tools/variables.py
@@ -54,7 +54,7 @@ def get_class(name, default_class, map_class=None):
     if name is not None:
         try:
             klass = map_class[name]
-        except BaseException:
+        except KeyError:
             for k, v in map_class.items():
                 if type(k) in (type,) and name in v:
                     klass = k

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1286,7 +1286,8 @@ class EasyBlockTest(EnhancedTestCase):
         eb.cfg['tests'] = ['/abs/path/does-not-exist']
         self.assertRaisesRegex(EasyBuildError, 'non-existing path: /abs/path/does-not-exist', eb.test_cases_step)
 
-        mock_test_bin = os.path.join(self.test_prefix, 'pi', 'test_me')
+        new_source_path = os.path.join(tempfile.mkdtemp(), 'sources')
+        mock_test_bin = os.path.join(new_source_path, 'pi', 'test_me')
         os.environ['PATH'] += f':{os.path.dirname(mock_test_bin)}'
         write_file(mock_test_bin, "#!/bin/bash\necho 'Test case success'")
 
@@ -1295,10 +1296,12 @@ class EasyBlockTest(EnhancedTestCase):
         fn = os.path.basename(mock_test_bin)
         self.assertRaisesRegex(EasyBuildError, f'non-existing path: {fn}', eb.test_cases_step)
 
-        init_config(args=[f"--sourcepath={self.test_prefix}"])
+        init_config(args=[f"--sourcepath={new_source_path}", "--debug"])
         write_file(eb.logfile, '')
         eb.test_cases_step()
-        self.assertIn('Test case success', read_file(eb.logfile))
+        logtxt = read_file(eb.logfile)
+        self.assertIn(f'Running test {mock_test_bin}', logtxt)
+        self.assertIn('Test case success', logtxt)
 
         # Also works with non-executable file
         perms = stat.S_IREAD
@@ -1321,13 +1324,17 @@ class EasyBlockTest(EnhancedTestCase):
         eb.cfg['tests'] = [mock_test_bin_fail]
         write_file(eb.logfile, '')
         self.assertRaisesRegex(RunShellCmdError, f"'{os.path.basename(mock_test_bin_fail)}' failed", eb.test_cases_step)
-        self.assertIn('Test case failure', read_file(eb.logfile))
+        logtxt = read_file(eb.logfile)
+        self.assertIn(f'Running test {mock_test_bin_fail}', logtxt)
+        self.assertIn('Test case failure', logtxt)
 
         # Multiple tests
         eb.cfg['tests'] = [mock_test_bin, mock_test_bin_fail]
         write_file(eb.logfile, '')
         self.assertRaisesRegex(RunShellCmdError, f"'{os.path.basename(mock_test_bin_fail)}' failed", eb.test_cases_step)
         log_txt = read_file(eb.logfile)
+        self.assertIn(f'Running test {mock_test_bin}', logtxt)
+        self.assertIn(f'Running test {mock_test_bin_fail}', logtxt)
         self.assertIn('Test case success', log_txt)
         self.assertIn('Test case failure', log_txt)
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1338,6 +1338,21 @@ class EasyBlockTest(EnhancedTestCase):
         self.assertIn('Test case success', log_txt)
         self.assertIn('Test case failure', log_txt)
 
+        # Test is found when put next to easyconfig file, and preferred
+        new_mock_test_bin = os.path.join(os.path.dirname(self.eb_file), os.path.basename(mock_test_bin))
+        write_file(new_mock_test_bin, '#!/bin/bash\necho "new test passed"')
+        new_mock_test_bin2 = os.path.join(os.path.dirname(self.eb_file), 'example_test2')
+        write_file(new_mock_test_bin2, '#!/bin/bash\necho "additional test passed"')
+        eb.cfg['tests'] = [os.path.basename(new_mock_test_bin), os.path.basename(new_mock_test_bin2)]
+
+        write_file(eb.logfile, '')  # reset log file
+        eb.test_cases_step()
+        logtxt = read_file(eb.logfile)
+        self.assertIn(f'Running test {new_mock_test_bin}', logtxt)
+        self.assertIn(f'Running test {new_mock_test_bin2}', logtxt)
+        self.assertIn("new test passed", logtxt)
+        self.assertIn("additional test passed", logtxt)
+
     def test_post_processing_step(self):
         """Test post_processing_step and deprecated post_install_step."""
         init_config(build_options={'silent': True})

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -639,7 +639,7 @@ class RunTest(EnhancedTestCase):
             # check error reporting output when stdout/stderr are collected separately
             try:
                 run_shell_cmd(cmd, split_stderr=True)
-                self.assertFalse("This should never be reached, RunShellCmdError should occur!")
+                self.fail("This should never be reached, RunShellCmdError should occur!")
             except RunShellCmdError as err:
                 self.assertEqual(str(err), "Shell command 'kill' failed!")
                 self.assertEqual(err.cmd, "kill -9 $$")


### PR DESCRIPTION
Searching only `source_paths` is inconsistent with how patches etc. are located making it impossible to place tests e.g. next to easyconfigs or in software-specific source folders.


Also fix some small issues:

- `RunShellCmdError` [should be derived from](https://docs.python.org/3/library/exceptions.html#built-in-exceptions) `Exception` not `BaseException`
- As our `RunShellCmdError` prints some information on invocation when "escaped" I kept the `except EasyBuildError` purposely not catching the former
- The original command specified for `tests` is now reported when not found instead of whatever path was last checked