### PR TITLE
avoid excessive creating of EasyConfig instances when copies are created

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -2329,7 +2329,7 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
     if not build_specs:
         cache_key = (path, validate, hidden, parse_only)
         if cache_key in _easyconfigs_cache:
-            return _copy_ec_dicts(_easyconfigs_cache[cache_key])
+            return [e.copy() for e in _easyconfigs_cache[cache_key]]
 
     easyconfigs = []
     for spec in blocks:
@@ -2354,7 +2354,7 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
         easyconfigs.append(easyconfig)
 
     if cache_key is not None:
-        _easyconfigs_cache[cache_key] = _copy_ec_dicts(easyconfigs)
+        _easyconfigs_cache[cache_key] = [e.copy() for e in easyconfigs]
 
     return easyconfigs
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -666,6 +666,7 @@ class EasyConfig:
             validate = self.validation
 
         # create a new EasyConfig instance
+        self.log.info(f"Creating new EasyConfig instance for {self.path} while copying")
         ec = EasyConfig(self.path, validate=validate, hidden=self.hidden, rawtxt=self.rawtxt)
         # take a copy of the actual config dictionary (which already contains the extra options)
         ec._config = copy.deepcopy(self._config)
@@ -2337,6 +2338,7 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
 
         # create easyconfig
         try:
+            _log.info(f"Creating EasyConfig instance for {spec}")
             ec = EasyConfig(spec, build_specs=build_specs, validate=validate, hidden=hidden)
         except EasyBuildError as err:
             try:

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -2329,6 +2329,9 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
     if not build_specs:
         cache_key = (path, validate, hidden, parse_only)
         if cache_key in _easyconfigs_cache:
+            # Note: This does NOT copy EasyConfig instances but the dict containing an instance in the 'ec' key.
+            # So modifications to the `EasyConfig` instance will be shared.
+            # TODO: Implement proper (deep)-copy
             return [e.copy() for e in _easyconfigs_cache[cache_key]]
 
     easyconfigs = []
@@ -2354,6 +2357,9 @@ def process_easyconfig(path, build_specs=None, validate=True, parse_only=False, 
         easyconfigs.append(easyconfig)
 
     if cache_key is not None:
+        # Note: This does NOT copy EasyConfig instances but the dict containing an instance in the 'ec' key.
+        # So modifications to the `EasyConfig` instance will be shared.
+        # TODO: Implement proper (deep)-copy
         _easyconfigs_cache[cache_key] = [e.copy() for e in easyconfigs]
 
     return easyconfigs

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -5342,13 +5342,15 @@ class EasyConfigTest(EnhancedTestCase):
         self.assertEqual(ec3['ec'].version, '99.1234')
         self.assertEqual(ec3['spec'], 'non-existing.eb')
         self.assertEqual(ec3['dependencies'], ['Dummy'])
-        # Neither the previously returned nor newly requested ECs are modified by the above
+        # Neither the previously returned nor newly requested easyconfigs are modified by the above
+        # FIXME checks below are disabled, because fix in framework PR #4818 led to excessive
+        #       creation of EasyConfig instances, so it was reverted in framework PR #5166
         ec2_2 = process_easyconfig(toy_ec)[0]
         for orig_ec in (ec2, ec2_2):
-            self.assertEqual(orig_ec['ec'].name, 'toy')
-            self.assertEqual(orig_ec['ec'].version, '0.0')
+            # FIXME self.assertEqual(orig_ec['ec'].name, 'toy')
+            # FIXME self.assertEqual(orig_ec['ec'].version, '0.0')
             self.assertEqual(orig_ec['spec'], toy_ec)
-            self.assertEqual(orig_ec['dependencies'], [])
+            # FIXME self.assertEqual(orig_ec['dependencies'], [])
 
         # also check whether easyconfigs cache works with end-to-end test
         args = [libtoy_ec, '--trace']

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3678,9 +3678,6 @@ class ToyBuildTest(EnhancedTestCase):
             Parse Hook toy 0.0
             ['%(name)s-%(version)s.tar.gz']
             echo toy
-            Parse Hook toy 0.0
-            ['%(name)s-%(version)s.tar.gz']
-            echo toy
             installing 1 easyconfigs: toy/0.0
             starting installation of toy 0.0
             pre-configure: toy.source: True


### PR DESCRIPTION
This is a more minimal fix for the excessive re-parsing of easyconfigs that somehow got introduced via #4818, an alternative to:
- https://github.com/easybuilders/easybuild-framework/pull/5164

Grepping the log for `Creating.*EasyConfig instance` shows that when running `eb PyTorch-bundle-2.1.2-foss-2023a-CUDA-12.1.1.eb -Dr --disable-cleanup-tmpdir` the number of `EasyConfig` instances being created is reduced from 745 to 177 with this change.

It effectively rolls back the part of #4818 that introduced the problem, by not using the `_copy_ec_dict(s)` functions that were added.