### PR TITLE
add test to check how many `EasyConfig` instances are created when parsing a bunch of easyconfigs

### DIFF
--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -4893,7 +4893,7 @@ class ToyBuildTest(EnhancedTestCase):
         matches = regex.findall(logtxt)
         cnt = len(matches)
         # we expect to find 12 EasyConfig instances being created: gzip itself + full toolchain;
-        # note: multiple EasyConfig instances are currently reated for (sub)toolchains (like foss/2018a, gompi/2018a)
+        # note: multiple EasyConfig instances are currently created for (sub)toolchains (like foss/2018a, gompi/2018a)
         expected = 12
         error_msg = f"{cnt} EasyConfig instances created, expected {expected}:\n" + '\n'.join(matches)
         self.assertEqual(cnt, expected, error_msg)

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -4872,6 +4872,32 @@ class ToyBuildTest(EnhancedTestCase):
         self.assertFalse(regex.search(toy_app_modtxt),
                          f"Pattern '{regex.pattern}' should *not* be found in: {toy_app_modtxt}")
 
+    def test_easyconfig_instances(self):
+        """
+        Test to check how many EasyConfig instances get created when parsing a bunch of easyconfigs.
+        """
+        # main motivation for this test is a regression that got introduced with
+        # https://github.com/easybuilders/easybuild-framework/pull/4818,
+        # see also https://github.com/easybuilders/easybuild-framework/pull/5166
+        # and https://github.com/easybuilders/easybuild-framework/issues/5167
+
+        test_ec = os.path.join(TEST_ECS_DIR, 'g', 'gzip', 'gzip-1.5-foss-2018a.eb')
+
+        with self.log_to_testlogfile() as logfile:
+            self.run_test_toy_build_with_output(ec_file=test_ec, extra_args=['-Dr'], verify=False)
+
+        # count how many times an EasyConfig instance was created,
+        # either by process_easyconfig function or by EasyConfig.copy, based on log messages
+        regex = re.compile("Creating.* EasyConfig instance .*", re.M)
+        logtxt = read_file(logfile)
+        matches = regex.findall(logtxt)
+        cnt = len(matches)
+        # we expect to find 12 EasyConfig instances being created: gzip itself + full toolchain;
+        # note: multiple EasyConfig instances are currently reated for (sub)toolchains (like foss/2018a, gompi/2018a)
+        expected = 12
+        error_msg = f"{cnt} EasyConfig instances created, expected {expected}:\n" + '\n'.join(matches)
+        self.assertEqual(cnt, expected, error_msg)
+
 
 def suite(loader=None):
     """ return all the tests in this file """


### PR DESCRIPTION
Additional test to catch the regression that got introduced in #4818 (and was reverted via #5166), just so this doesn't happen again without us noticing...

edit: without the fix from #, this test will fail like:
```
FAIL: test_easyconfig_instances (test.framework.toy_build.ToyBuildTest)
Test to check how many EasyConfig instances get created when parsing a bunch of easyconfigs.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Volumes/work/EasyBuild/easybuild-framework/test/framework/toy_build.py", line 4902, in test_easyconfig_instances
    self.assertEqual(cnt, expected, error_msg)
  File "/Volumes/work/EasyBuild/easybuild-framework/easybuild/base/testing.py", line 89, in assertEqual
    super().assertEqual(a, b, msg=msg)
AssertionError: 39 != 12 : 39 EasyConfig instances created, expected 12:
Creating EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/gzip/gzip-1.5-foss-2018a.eb
Creating EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/f/foss/foss-2018a.eb
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/f/foss/foss-2018a.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/gzip/gzip-1.5-foss-2018a.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/f/foss/foss-2018a.eb while copying
Creating EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/f/foss/foss-2018a.eb
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/f/foss/foss-2018a.eb while copying
Creating EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb while copying
Creating EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-2.1.2-GCC-6.4.0-2.28.eb
Creating EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-2.1.2-GCC-6.4.0-2.28.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb while copying
Creating EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-6.4.0-2.28.eb
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/o/OpenBLAS/OpenBLAS-0.2.20-GCC-6.4.0-2.28.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb while copying
Creating EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/h/hwloc/hwloc-1.11.8-GCC-6.4.0-2.28.eb
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/h/hwloc/hwloc-1.11.8-GCC-6.4.0-2.28.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb while copying
Creating EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.7-gompi-2018a.eb
Creating EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/gompi/gompi-2018a.eb
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/gompi/gompi-2018a.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/f/FFTW/FFTW-3.3.7-gompi-2018a.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/gompi/gompi-2018a.eb while copying
Creating EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2018a-OpenBLAS-0.2.20.eb
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/gompi/gompi-2018a.eb while copying
Creating EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/gompi/gompi-2018a.eb
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/gompi/gompi-2018a.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/o/OpenMPI/OpenMPI-2.1.2-GCC-6.4.0-2.28.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/GCC/GCC-6.4.0-2.28.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/s/ScaLAPACK/ScaLAPACK-2.0.2-gompi-2018a-OpenBLAS-0.2.20.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/gompi/gompi-2018a.eb while copying
Creating new EasyConfig instance for /Volumes/work/EasyBuild/easybuild-framework/test/framework/easyconfigs/test_ecs/g/gompi/gompi-2018a.eb while copying
```