### PR TITLE
don't call `render` when using `--dep-graph` to create `.dot` file

### DIFF
--- a/easybuild/framework/easyconfig/tools.py
+++ b/easybuild/framework/easyconfig/tools.py
@@ -203,7 +203,10 @@ def dep_graph(filename, specs):
     what = f"dependency graph for {len(specs)} easyconfigs to {filename}"
     silent = build_option('silent')
     try:
-        dep_graph.render(base, cleanup=True)
+        if ext in ['.dot']:
+            dep_graph.save(filename)
+        else:
+            dep_graph.render(base, cleanup=True)
     except Exception as err:
         print_error_and_exit(f"Failed writing {what}: {err}", silent=silent)
     else:

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -3301,12 +3301,12 @@ class EasyConfigTest(EnhancedTestCase):
         patterns = [
             rf"digraph {graphname} {{",
             # 3 nodes should be there: 'GCC/6.4.0-2.28 (EXT)', 'toy', and 'intel/2018a'
-            r"^\s*intel\s+\[",
-            r"^\s*toy\s+\[",
-            r"^\s*\"GCC/6\.4\.0-2\.28 \(EXT\)\"\s+\[",
+            r"^\s*intel",
+            r"^\s*toy",
+            r"^\s*\"GCC/6\.4\.0-2\.28 \(EXT\)\"",
             # and 2 edges: 'toy -> intel' and 'toy -> "GCC/6.4.0-2.28 (EXT)"'
-            r"^\s*toy -> intel\s+\[",
-            r"^\s*toy -> \"GCC/6\.4\.0-2\.28 \(EXT\)\"\s+\[",
+            r"^\s*toy -> intel",
+            r"^\s*toy -> \"GCC/6\.4\.0-2\.28 \(EXT\)\"",
         ]
         self.assert_multi_regex(patterns, dottxt)
 


### PR DESCRIPTION
Fix for 

- https://github.com/easybuilders/easybuild-easyconfigs/pull/25699
- https://github.com/easybuilders/easybuild-easyconfigs/pull/25700

Do not use the `render` methods for saving `.dot` files which also calculates the position of the elements in the graph.