### PR TITLE
fix duplicate counting of download progress in `obtain_file`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -144,14 +144,13 @@ _log = fancylogger.getLogger('easyblock')
 def _obtain_file_update_progress_bar_on_return(func):
     """Decorator for obtain_file() to update the progress bar upon return"""
     @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        result = func(*args, **kwargs)
-        filename = args[1]
-
-        # We don't account for the checksums file in the progress bar
-        if filename != CHECKSUMS_JSON:
-            update_progress_bar(PROGRESS_BAR_DOWNLOAD_ALL)
-
+    def wrapper(self, filename, *args, **kwargs):
+        try:
+            result = func(self, filename, *args, **kwargs)
+        finally:
+            # We don't account for the checksums file in the progress bar
+            if filename != CHECKSUMS_JSON:
+                update_progress_bar(PROGRESS_BAR_DOWNLOAD_ALL)
         return result
     return wrapper
 
@@ -862,7 +861,6 @@ class EasyBlock:
 
         return exts_sources
 
-    @_obtain_file_update_progress_bar_on_return
     def obtain_file(self, filename, **kwargs):
         """
         Locate file with given name.

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -40,6 +40,7 @@ import stat
 import sys
 import tempfile
 import textwrap
+import unittest.mock
 from inspect import cleandoc
 from test.framework.github import requires_github_access
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
@@ -59,6 +60,7 @@ from easybuild.tools.filetools import adjust_permissions, change_dir, copy_dir, 
 from easybuild.tools.filetools import remove_dir, remove_file, symlink, verify_checksum, write_file
 from easybuild.tools.module_generator import module_generator
 from easybuild.tools.modules import EnvironmentModules, Lmod, reset_module_caches
+from easybuild.tools.output import PROGRESS_BAR_DOWNLOAD_ALL
 from easybuild.tools.run import RunShellCmdError
 from easybuild.tools.version import get_git_revision, this_is_easybuild
 
@@ -1268,6 +1270,55 @@ class EasyBlockTest(EnhancedTestCase):
         eb.post_iter_step()
         self.assertEqual(eb.cfg.iterating, False)
         self.assertEqual(eb.cfg['configopts'], ["--opt1 --anotheropt", "--opt2", "--opt3 --optbis"])
+
+    def test_fetch_step(self):
+        """Test fetching sources."""
+        init_config([f'--sourcepath={self.test_prefix}'])
+        url = 'https://dummy-url-for-testing'
+        source_fn = 'mysource.tar.gz'
+        patch_fn = 'my_fix.patch'
+        self.contents = textwrap.dedent(f"""
+            easyblock = "ConfigureMake"
+            name = "Uniq_1"
+            version = "3.14"
+            homepage = "http://example.com"
+            description = "test"
+            toolchain = SYSTEM
+            source_urls = ['{url}']
+            sources = ['{source_fn}']
+            patches = ['{patch_fn}']
+        """)
+        expected_path_src = os.path.join(self.test_prefix, 'u', 'Uniq_1', source_fn)
+        expected_path_patch = os.path.join(self.test_prefix, 'u', 'Uniq_1', patch_fn)
+        self.writeEC()
+        eb = EasyBlock(EasyConfig(self.eb_file))
+
+        def create_file(_filename, _url, path, *_args, **_kwargs):
+            write_file(path, 'content')
+            return True
+        mocked_pg = unittest.mock.MagicMock()
+        with unittest.mock.patch('easybuild.framework.easyblock.download_file',
+                                 side_effect=create_file) as mocked_download, \
+             unittest.mock.patch.dict('easybuild.tools.output.PROGRESS_BAR_TYPES',
+                                      {PROGRESS_BAR_DOWNLOAD_ALL: lambda *_args, **_kwargs: mocked_pg}):
+            eb.fetch_step()
+            call = unittest.mock.call
+            self.assertEqual(mocked_download.call_args_list, [
+                call(source_fn, f'{url}/{source_fn}', expected_path_src),
+                call(patch_fn, f'{url}/{patch_fn}', expected_path_patch),
+            ])
+            mocked_pg.add_task.assert_called_once()
+            task = mocked_pg.add_task.return_value
+            self.assertEqual(mocked_pg.update.call_args_list, [
+                call(task, total=2),
+                call(task, description=source_fn),
+                call(task, advance=1),
+                call(task, description=patch_fn),
+                call(task, advance=1),
+                call(task, visible=False),
+            ])
+        self.assertTrue(os.path.samefile(eb.src[0]['path'], expected_path_src))
+        self.assertTrue(os.path.samefile(eb.patches[0]['path'], expected_path_patch))
 
     def test_test_cases_step(self):
         """Test test_cases_step"""


### PR DESCRIPTION
`obtain_file` calls `obtain_file_raise_on_failure` but both are wrapped in a decorator that increases the progress of the RICH progressbar. This causes it to be incremented twice for each file.

Add a test for the `fetch_step` which also verifies this behavior.

Note that I'm using `unittest.mock` to verify the progressbar calls and avoid actually downloading anything.