### PR TITLE
remove CI workflow for Hound style checker

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,4 +1,0 @@
-# configuration for houndci, see https://houndci.com/configuration#python
-flake8:
-  enabled: true
-  config_file: setup.cfg


### PR DESCRIPTION
We do `flake8` linting in https://github.com/easybuilders/easybuild-framework/blob/develop/.github/workflows/linting.yml so we no longer need the hound.

Picked up from @Flamefire's comment at https://github.com/easybuilders/easybuild-framework/pull/5174#discussion_r3086368636

From http://help.houndci.com/en/articles/2138537-flake8 it looks like we have `flake8` 3.6.0 and that was [released in 2018](https://flake8.pycqa.org/en/3.6.0/release-notes/index.html).