### PR TITLE
Allow using `ec.dependency_names` inside parse_hook

### DIFF
--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -1225,6 +1225,9 @@ class EasyConfig:
             # use += rather than .extend to get a new list rather than updating list of build deps in place...
             deps += self['dependencies']
 
+        if not self.get('parsed'):
+            self.log.debug("Easyconfig not fully parsed yet, returning unparsed dependencies")
+            return deps  # Cannot filter dependencies until the easyconfig has been fully parsed
         # if filter-deps option is provided we "clean" the list of dependencies for
         # each processed easyconfig to remove the unwanted dependencies
         self.log.debug("Dependencies BEFORE filtering: %s", deps)
@@ -1242,8 +1245,10 @@ class EasyConfig:
         :param build_only: only return build dependencies, discard others
         :param runtime_only: only return runtime dependencies, discard others
         """
-        return {dep['name'] for dep in self.dependencies(build_only=build_only, runtime_only=runtime_only)
-                if dep['name']}
+        deps = self.dependencies(build_only=build_only, runtime_only=runtime_only)
+        if self.get('parsed'):
+            return {dep['name'] for dep in deps if dep['name']}
+        return {dep[0] for dep in deps}  # Unparsed dependencies are still tuples of (name, version, [...])
 
     def builddependencies(self):
         """

--- a/test/framework/modules/FFTW/3.3.7
+++ b/test/framework/modules/FFTW/3.3.7
@@ -13,10 +13,6 @@ set root    /home-2/khoste/.local/easybuild/software/FFTW/3.3.7
 
 conflict    FFTW
 
-if { ![is-loaded gompi/2018a] } {
-    module load gompi/2018a
-}
-
 prepend-path	CPATH		$root/include
 prepend-path	LD_LIBRARY_PATH		$root/lib
 prepend-path	MANPATH		$root/share/man

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3559,7 +3559,10 @@ class ToyBuildTest(EnhancedTestCase):
     def test_toy_build_hooks(self):
         """Test use of --hooks."""
         test_ec = os.path.join(self.test_prefix, 'test.eb')
+        # Using some dependencies where we have (test) modules installed
         test_ec_txt = TOY_EC_TXT + '\n'.join([
+            "builddependencies = [('icc', '11.1.073', '', SYSTEM), ('FFTW', '3.3.7', '', SYSTEM)]",
+            "dependencies = [('GCCcore', '12.3.0', '', SYSTEM), ('imkl', '2021.4.0', '', SYSTEM)]",
             "exts_list = [('bar', '0.0'), ('toy', '0.0')]",
             "exts_defaultclass = 'DummyExtension'",
         ])
@@ -3583,6 +3586,7 @@ class ToyBuildTest(EnhancedTestCase):
                # (required templating to be disabled before parse_hook is called)
                ec['postinstallcmds'].append('echo toy')
                print(ec['postinstallcmds'][-1])
+               print('Deps:', ', '.join(sorted(ec.dependency_names())))
 
             def pre_build_and_install_loop_hook(ecs):
                 mod_names = ' '.join(ec['full_mod_name'] for ec in ecs)
@@ -3678,6 +3682,7 @@ class ToyBuildTest(EnhancedTestCase):
             Parse Hook toy 0.0
             ['%(name)s-%(version)s.tar.gz']
             echo toy
+            Deps: FFTW, GCCcore, icc, imkl
             installing 1 easyconfigs: toy/0.0
             starting installation of toy 0.0
             pre-configure: toy.source: True
@@ -3689,9 +3694,11 @@ class ToyBuildTest(EnhancedTestCase):
             Parse Hook toy 0.0
             ['%(name)s-%(version)s.tar.gz']
             echo toy
+            Deps: FFTW, GCCcore, icc, imkl
             Parse Hook toy 0.0
             ['%(name)s-%(version)s.tar.gz']
             echo toy
+            Deps: FFTW, GCCcore, icc, imkl
             in module-write hook hook for {mod_name}
             installing of extension bar is done!
             in module-write hook hook for {mod_name}


### PR DESCRIPTION
This is useful to avoid boilerplate when checking for existance of a specific dependency. Even though the dependency might be filtered out later it is better than nothing.