### PR TITLE
Remove uneccessary use of dunder methods

### DIFF
--- a/easybuild/framework/easyconfig/format/format.py
+++ b/easybuild/framework/easyconfig/format/format.py
@@ -99,7 +99,7 @@ class NestedDict(dict):
 
     def __init__(self, parent, depth):
         """Initialise NestedDict instance"""
-        dict.__init__(self)
+        super().__init__()
         self.depth = depth
         self.parent = parent
 

--- a/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
+++ b/easybuild/framework/easyconfig/format/pyheaderconfigobj.py
@@ -130,13 +130,13 @@ class DeprecatedDict(dict):
         if args:
             if isinstance(args[0], dict):
                 for key, value in args[0].items():
-                    self.__setitem__(key, value)
+                    self[key] = value
             else:
                 for key, value in args[0]:
-                    self.__setitem__(key, value)
+                    self[key] = value
 
         for key, value in kwargs.items():
-            self.__setitem__(key, value)
+            self[key] = value
 
 
 class EasyConfigFormatConfigObj(EasyConfigFormat):

--- a/easybuild/toolchains/fft/intelfftw.py
+++ b/easybuild/toolchains/fft/intelfftw.py
@@ -107,9 +107,9 @@ class IntelFFTW(Fftw):
 
         fftw_mt_libs = fftw_libs + [x % self.BLAS_LIB_MAP for x in self.BLAS_LIB_MT]
 
-        self.log.debug('fftw_libs %s' % fftw_libs.__repr__())
+        self.log.debug('fftw_libs %s', fftw_libs)
         fftw_libs.extend(self.variables['LIBBLAS'].flatten())  # add BLAS libs (contains dft)
-        self.log.debug('fftw_libs %s' % fftw_libs.__repr__())
+        self.log.debug('fftw_libs %s', fftw_libs)
 
         # building the FFTW interfaces is optional,
         # so make sure libraries are there before FFT_LIB is set

--- a/easybuild/tools/configobj.py
+++ b/easybuild/tools/configobj.py
@@ -502,7 +502,7 @@ class Section(dict):
         """
         if indict is None:
             indict = {}
-        dict.__init__(self)
+        super().__init__()
         # used for nesting level *and* interpolation
         self.parent = parent
         # used for the interpolation attribute
@@ -514,7 +514,7 @@ class Section(dict):
         #
         self._initialise()
         # we do this explicitly so that __setitem__ is used properly
-        # (rather than just passing to ``dict.__init__``)
+        # (rather than just passing to ``super().__init__``)
         for entry in indict:
             self[entry] = indict[entry]
 
@@ -558,7 +558,7 @@ class Section(dict):
 
     def __getitem__(self, key):
         """Fetch the item and do string interpolation."""
-        val = dict.__getitem__(self, key)
+        val = super().__getitem__(key)
         if self.main.interpolation:
             if isinstance(val, str):
                 return self._interpolate(key, val)
@@ -600,15 +600,14 @@ class Section(dict):
         if isinstance(value, Section):
             if key not in self:
                 self.sections.append(key)
-            dict.__setitem__(self, key, value)
+            super().__setitem__(key, value)
         elif isinstance(value, dict) and not unrepr:
             # First create the new depth level,
             # then create the section
             if key not in self:
                 self.sections.append(key)
             new_depth = self.depth + 1
-            dict.__setitem__(
-                self,
+            super().__setitem__(
                 key,
                 Section(
                     self,
@@ -628,7 +627,7 @@ class Section(dict):
                             raise TypeError('Value is not a string "%s".' % entry)
                 else:
                     raise TypeError('Value is not a string "%s".' % value)
-            dict.__setitem__(self, key, value)
+            super().__setitem__(key, value)
 
     def __delitem__(self, key):
         """Remove items from the sequence when deleting."""
@@ -687,7 +686,7 @@ class Section(dict):
         Leaves other attributes alone :
             depth/main/parent are not affected
         """
-        dict.clear(self)
+        super().clear()
         self.scalars = []
         self.sections = []
         self.comments = {}

--- a/easybuild/tools/toolchain/options.py
+++ b/easybuild/tools/toolchain/options.py
@@ -67,8 +67,8 @@ class ToolchainOptions(dict):
                 raise EasyBuildError("_add_options: option name %s has to be 2 element list (%s)", name, value)
             if name in self:
                 self.log.devel("_add_options: redefining previous name %s (previous value %s)", name, self.get(name))
-            self.__setitem__(name, value[0])
-            self.description.__setitem__(name, value[1])
+            self[name] = value[0]
+            self.description[name] = value[1]
 
     def _add_options_map(self, options_map):
         """Add map dict between options and values

--- a/easybuild/tools/toolchain/toolchain.py
+++ b/easybuild/tools/toolchain/toolchain.py
@@ -429,9 +429,9 @@ class Toolchain:
         for v in var_names:
             res.append("%s=%s" % (v, self.variables[v]))
             if verbose:
-                res.append("# type %s" % (type(self.variables[v])))
-                res.append("# %s" % (self.variables[v].show_el()))
-                res.append("# repr %s" % (repr(self.variables[v])))
+                res.append("# type %s" % type(self.variables[v]))
+                res.append("# %s" % self.variables[v].show_el())
+                res.append("# repr %s" % repr(self.variables[v]))
 
         if offset is None:
             offset = ''

--- a/easybuild/tools/variables.py
+++ b/easybuild/tools/variables.py
@@ -267,7 +267,7 @@ class ListOfLists(list):
             self.log.devel("_is_protected: %s value %s (%s)", self.protected_instances, value, type(value))
             res = True
 
-        self.log.devel("_is_protected: %s value %s (%s)", res, value, value.__repr__())
+        self.log.devel("_is_protected: %s value %s (%s)", res, value, repr(value))
         return res
 
     def nappend(self, value, **kwargs):
@@ -298,11 +298,11 @@ class ListOfLists(list):
         if self._str_ok(newvalue) or append_empty:
             self.append(newvalue)
             self.log.devel("nappend: value %s newvalue %s position %s",
-                           value.__repr__(), newvalue.__repr__(), position)
+                           repr(value), repr(newvalue), position)
             return newvalue
         else:
             self.log.devel("nappend: ignoring value %s newvalue %s (not _str_ok)",
-                           value.__repr__(), newvalue.__repr__())
+                           repr(value), repr(newvalue))
 
     def nextend(self, value=None, **kwargs):
         """Named extend, value is list type (TODO: tighten the allowed values)
@@ -316,7 +316,7 @@ class ListOfLists(list):
         else:
             for el in value:
                 if not self._str_ok(el):
-                    self.log.devel("nextend: ignoring el %s from value %s (not _str_ok)", el, value.__repr__())
+                    self.log.devel("nextend: ignoring el %s from value %s (not _str_ok)", el, repr(value))
                     continue
 
                 if type(el) in self.PROTECTED_CLASSES:
@@ -338,7 +338,7 @@ class ListOfLists(list):
                 res.append(newvalue)
 
         self.extend(res)
-        self.log.devel("nextend: value %s res %s", value.__repr__(), res.__repr__())
+        self.log.devel("nextend: value %s res %s", repr(value), repr(res))
         return res
 
     def str_convert(self, x):
@@ -406,7 +406,7 @@ class ListOfLists(list):
 
         if self._first is None:
             # return empty string
-            self.log.devel("__str__: first is None (self %s)", self.__repr__())
+            self.log.devel("__str__: first is None (self %s)", repr(self))
             return ''
         else:
             sep = self.SEPARATOR
@@ -416,7 +416,7 @@ class ListOfLists(list):
                 # reverse list to mimic prepend_paths in module files
                 listoflists = reversed(self)
             txt = str(sep).join([self.str_convert(x) for x in listoflists if self._str_ok(x)])
-            self.log.devel("__str__: return %s (self: %s)", txt, self.__repr__())
+            self.log.devel("__str__: return %s (self: %s)", txt, repr(self))
             return txt
 
     def try_function_on_element(self, function_name, names=None, args=None, kwargs=None):
@@ -499,7 +499,7 @@ class Variables(dict):
 
         for other in others:
             if other in self:
-                self.log.devel("join other %s in self: other %s", other, self.get(other).__repr__())
+                self.log.devel("join other %s in self: other %s", other, repr(self.get(other)))
                 for el in self.get(other):
                     self.nappend(name, el)
             else:

--- a/test/framework/toolchainvariables.py
+++ b/test/framework/toolchainvariables.py
@@ -63,15 +63,15 @@ class ToolchainVariablesTest(EnhancedTestCase):
         self.assertEqual(str(tcv['MPICC']), "gcc")
 
         tcv['F90'] = ['gfortran', '-foo', '-bar']
-        self.assertEqual(tcv['F90'].__repr__(), "[['gfortran', '-foo', '-bar']]")
+        self.assertEqual(repr(tcv['F90']), "[['gfortran', '-foo', '-bar']]")
         self.assertEqual(str(tcv['F90']), "gfortran -foo -bar")
 
         tcv.nappend('FLAGS', ['-one', '-two'])
         x = tcv.nappend('FLAGS', ['-three', '-four'])
         x.POSITION = -5  # sanitize will reorder, default POSITION is 0
-        self.assertEqual(tcv['FLAGS'].__repr__(), "[['-one', '-two'], ['-three', '-four']]")
+        self.assertEqual(repr(tcv['FLAGS']), "[['-one', '-two'], ['-three', '-four']]")
         tcv['FLAGS'].sanitize()  # sort on position, called by __str__ also
-        self.assertEqual(tcv['FLAGS'].__repr__(), "[['-three', '-four'], ['-one', '-two']]")
+        self.assertEqual(repr(tcv['FLAGS']), "[['-three', '-four'], ['-one', '-two']]")
         self.assertEqual(str(tcv['FLAGS']), "-three -four -one -two")
 
         # LIBBLAS is a LibraryList
@@ -79,13 +79,13 @@ class ToolchainVariablesTest(EnhancedTestCase):
         lib.POSITION = 5  # relative position after default
         lib = tcv.nappend('LIBBLAS', ['a', 'b', 'c'])
         tcv.add_begin_end_linkerflags(lib, toggle_startstopgroup=True, toggle_staticdynamic=True)
-        self.assertEqual(lib.BEGIN.__repr__(), "['-Bstatic', '-Xstart']")
-        self.assertEqual(tcv['LIBBLAS'].__repr__(), "[['d', 'e', 'f'], ['a', 'b', 'c']]")
+        self.assertEqual(repr(lib.BEGIN), "['-Bstatic', '-Xstart']")
+        self.assertEqual(repr(tcv['LIBBLAS']), "[['d', 'e', 'f'], ['a', 'b', 'c']]")
         # str calls sanitize
         self.assertEqual(str(tcv['LIBBLAS']),
                          "-Wl,-Bstatic -Wl,-Xstart -la -lb -lc -Wl,-Xstop -Wl,-Bdynamic -ld -le -lf")
         # sanitize is on self
-        self.assertEqual(tcv['LIBBLAS'].__repr__(), "[['a', 'b', 'c'], ['d', 'e', 'f']]")
+        self.assertEqual(repr(tcv['LIBBLAS']), "[['a', 'b', 'c'], ['d', 'e', 'f']]")
 
         # make copies for later
         copy_blas = tcv['LIBBLAS'].copy()
@@ -138,23 +138,23 @@ class ToolchainVariablesTest(EnhancedTestCase):
 
         # test try remove
         copy_blas.try_remove(['a', 'f'])
-        self.assertEqual(copy_blas.__repr__(), "[['b', 'c'], ['d', 'e']]")
+        self.assertEqual(repr(copy_blas), "[['b', 'c'], ['d', 'e']]")
 
         # test join
         tcv.join('LIBLAPACK', 'LIBBLAS')
-        self.assertEqual(tcv['LIBLAPACK'].__repr__(), "[['a', 'b', 'c'], ['d', 'e', 'f']]")
+        self.assertEqual(repr(tcv['LIBLAPACK']), "[['a', 'b', 'c'], ['d', 'e', 'f']]")
         lib = tcv.nappend('LIBLAPACK', ['g', 'h'])
         tcv.add_begin_end_linkerflags(lib, toggle_startstopgroup=True)
-        self.assertEqual(tcv['LIBLAPACK'].__repr__(), "[['a', 'b', 'c'], ['d', 'e', 'f'], ['g', 'h']]")
+        self.assertEqual(repr(tcv['LIBLAPACK']), "[['a', 'b', 'c'], ['d', 'e', 'f'], ['g', 'h']]")
         # sanitize will reorder wrt POSISTION but not join the start/stop group (blas has also statc/dynamic)
         tcv['LIBLAPACK'].sanitize()
-        self.assertEqual(tcv['LIBLAPACK'].__repr__(), "[['a', 'b', 'c'], ['g', 'h'], ['d', 'e', 'f']]")
+        self.assertEqual(repr(tcv['LIBLAPACK']), "[['a', 'b', 'c'], ['g', 'h'], ['d', 'e', 'f']]")
 
         # run both toggle, not just static/dynamic one.
         tcv.add_begin_end_linkerflags(lib, toggle_startstopgroup=True, toggle_staticdynamic=True)
         # sanitize will reorder wrt POSISTION and join the start/stop group
         tcv['LIBLAPACK'].sanitize()
-        self.assertEqual(tcv['LIBLAPACK'].__repr__(), "[['a', 'b', 'c', 'g', 'h'], ['d', 'e', 'f']]")
+        self.assertEqual(repr(tcv['LIBLAPACK']), "[['a', 'b', 'c', 'g', 'h'], ['d', 'e', 'f']]")
         self.assertEqual(str(tcv['LIBLAPACK']), "-Wl,-Bstatic,-Xstart,-la,-lb,-lc,-lg,-lh,-Xstop,-Bdynamic -ld -le -lf")
 
         tcv.nappend('MPICH_CC', 'icc', var_class=CommandFlagList)

--- a/test/framework/variables.py
+++ b/test/framework/variables.py
@@ -66,10 +66,10 @@ class VariablesTest(EnhancedTestCase):
         self.assertEqual(str(v['FOO']), "0,1,2")
 
         v['BARSTR'] = 'XYZ'
-        self.assertEqual(v['BARSTR'].__repr__(), "[['XYZ']]")
+        self.assertEqual(repr(v['BARSTR']), "[['XYZ']]")
 
         v['BARINT'] = 0
-        self.assertEqual(v['BARINT'].__repr__(), "[[0]]")
+        self.assertEqual(repr(v['BARINT']), "[[0]]")
 
         v.join('BAR2', 'FOO', 'BARINT')
         self.assertEqual(str(v['BAR2']), "0,1,2 0")


### PR DESCRIPTION
Replace use of "dunder methods" (`__foo__`) by the canonical equivalents. E.g. ` value.__repr__())` -> `repr(value)`

Cleanup suggested by PyLint