### PR TITLE
Fix `fake_module` dependencies for `ExtensionsEasyblock` with `--sanity-check-only`

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1461,7 +1461,7 @@ class EasyBlock:
         # include load/unload statements for dependencies
         deps = []
         self.log.debug("List of deps considered to load in generated module: %s", self.toolchain.dependencies)
-        for dep in self.toolchain.dependencies:
+        for dep in self.cfg.dependencies():
             if dep['build_only']:
                 self.log.debug("Skipping build dependency %s", dep)
             else:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1460,7 +1460,7 @@ class EasyBlock:
 
         # include load/unload statements for dependencies
         deps = []
-        self.log.debug("List of deps considered to load in generated module: %s", self.toolchain.dependencies)
+        self.log.debug("List of deps considered to load in generated module: %s", self.cfg.dependencies())
         for dep in self.cfg.dependencies():
             if dep['build_only']:
                 self.log.debug("Skipping build dependency %s", dep)

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -581,6 +581,12 @@ class EasyConfigTest(EnhancedTestCase):
         toy_patch = os.path.join(self.test_sourcepath, 'toy', toy_patch_fn)
         copy_file(toy_patch, self.test_prefix)
 
+        # Creates empty module files for expected dependencies, needed for `load_fake_module`
+        tmpdir = tempfile.mkdtemp()
+        for dep_mod_name in ('Python/3.6.6', ):
+            write_file(os.path.join(tmpdir, dep_mod_name), "#%Module")
+        os.environ['MODULEPATH'] = tmpdir
+
         os.environ['EASYBUILD_SOURCEPATH'] = self.test_prefix
         init_config(build_options={'silent': True})
 
@@ -592,6 +598,7 @@ class EasyConfigTest(EnhancedTestCase):
             'homepage = "http://example.com"',
             'description = "test easyconfig"',
             'toolchain = SYSTEM',
+            # Needed to resolve %(pymajver)s template in exts_list
             'dependencies = [("Python", "3.6.6")]',
             # bogus, but useful to check whether this get resolved
             'exts_default_options = {"source_urls": [PYPI_SOURCE]}',


### PR DESCRIPTION
Currently the `sanity_check_step`  of `ExtensionEasyBlock` uses

https://github.com/easybuilders/easybuild-framework/blob/632d4d24ca91f19077aaa52c52020791d82596a3/easybuild/framework/extensioneasyblock.py#L184

to run the sanity check on the main bundle before doing the sanity checks for each individual extension

At this point when running with `--sanity-check-only` the `prepare_step` is skipped and hence the call to

https://github.com/easybuilders/easybuild-framework/blob/632d4d24ca91f19077aaa52c52020791d82596a3/easybuild/framework/easyblock.py#L3054

which causes `self.toolcahain.dependencies` to be an empty list.

This causes problems when the sanity check commands of the main bundle requires one of the dependencies to be loaded, see for example https://github.com/easybuilders/easybuild-easyblocks/pull/4122#issuecomment-4351222291

As far as i can tell `toolchain.prepare_step` is always called passing `Easyconfig.dependencies()` (in general `self.cfg`) and this only does some checks on the deps passed without modifying them.

I think `self.cfg.dependencies()` should be used here directly unless there was ever a reason to not load the Bundle dependencies when running the main `sanity_check_step` of a Bundle with extensions

Tested this w.r.t. https://github.com/easybuilders/easybuild-easyblocks/pull/4122#issuecomment-4351222291 and it fixes the problem