### PR TITLE
Do not duplicate sanity checks in each extension

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4455,32 +4455,32 @@ class EasyBlock:
                     else:
                         print_warning(mod_files_found_msg)
 
+            if self.toolchain.use_rpath:
+                rpath_fails = self.sanity_check_rpath()
+                if rpath_fails:
+                    self.log.warning("RPATH sanity check failed!")
+                    self.sanity_check_fail_msgs.extend(rpath_fails)
+            else:
+                self.log.debug("Skipping RPATH sanity check")
+
+            if 'CUDA' in [dep['name'] for dep in self.cfg.dependencies()]:
+                if shutil.which('cuobjdump'):
+                    cuda_fails = self.sanity_check_cuda()
+                    if cuda_fails:
+                        self.log.warning("CUDA device code sanity check failed!")
+                        self.sanity_check_fail_msgs.extend(cuda_fails)
+                else:
+                    msg = "Failed to execute CUDA sanity check: cuobjdump not found\n"
+                    msg += "CUDA module must be loaded for sanity check (or cuobjdump available in PATH)"
+                    raise EasyBuildError(msg)
+            else:
+                self.log.debug("Skipping CUDA sanity check: CUDA is not in dependencies")
+
         # cleanup
         if self.fake_mod_data:
             self.clean_up_fake_module(self.fake_mod_data)
             self.sanity_check_module_loaded = False
             self.fake_mod_data = None
-
-        if self.toolchain.use_rpath:
-            rpath_fails = self.sanity_check_rpath()
-            if rpath_fails:
-                self.log.warning("RPATH sanity check failed!")
-                self.sanity_check_fail_msgs.extend(rpath_fails)
-        else:
-            self.log.debug("Skipping RPATH sanity check")
-
-        if 'CUDA' in [dep['name'] for dep in self.cfg.dependencies()]:
-            if shutil.which('cuobjdump'):
-                cuda_fails = self.sanity_check_cuda()
-                if cuda_fails:
-                    self.log.warning("CUDA device code sanity check failed!")
-                    self.sanity_check_fail_msgs.extend(cuda_fails)
-            else:
-                msg = "Failed to execute CUDA sanity check: cuobjdump not found\n"
-                msg += "CUDA module must be loaded for sanity check (or cuobjdump available in PATH)"
-                raise EasyBuildError(msg)
-        else:
-            self.log.debug("Skipping CUDA sanity check: CUDA is not in dependencies")
 
         # pass or fail
         if self.sanity_check_fail_msgs:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4439,20 +4439,21 @@ class EasyBlock:
             else:
                 self._sanity_check_step_extensions()
 
-        linked_shared_lib_fails = self.sanity_check_linked_shared_libs()
-        if linked_shared_lib_fails:
-            self.log.warning("Check for required/banned linked shared libraries failed!")
-            self.sanity_check_fail_msgs.append(linked_shared_lib_fails)
+            # Do not do those checks for extensions, only in the main easyconfig
+            linked_shared_lib_fails = self.sanity_check_linked_shared_libs()
+            if linked_shared_lib_fails:
+                self.log.warning("Check for required/banned linked shared libraries failed!")
+                self.sanity_check_fail_msgs.append(linked_shared_lib_fails)
 
-        # software installed with GCCcore toolchain should not have Fortran module files (.mod),
-        # unless that's explicitly allowed
-        if self.toolchain.name in ('GCCcore',) and not self.cfg['skip_mod_files_sanity_check']:
-            mod_files_found_msg = self.sanity_check_mod_files()
-            if mod_files_found_msg:
-                if build_option('fail_on_mod_files_gcccore'):
-                    self.sanity_check_fail_msgs.append(mod_files_found_msg)
-                else:
-                    print_warning(mod_files_found_msg)
+            # software installed with GCCcore toolchain should not have Fortran module files (.mod),
+            # unless that's explicitly allowed
+            if self.toolchain.name in ('GCCcore',) and not self.cfg['skip_mod_files_sanity_check']:
+                mod_files_found_msg = self.sanity_check_mod_files()
+                if mod_files_found_msg:
+                    if build_option('fail_on_mod_files_gcccore'):
+                        self.sanity_check_fail_msgs.append(mod_files_found_msg)
+                    else:
+                        print_warning(mod_files_found_msg)
 
         # cleanup
         if self.fake_mod_data:

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3087,6 +3087,8 @@ class ToyBuildTest(EnhancedTestCase):
             "    'cp %s %s/pytoy-cuda.cpython-39-x86_64-linux-gnu.%s'," % (toy_bin, py_site_pkgs, shlib_ext),
             "    'cp %s %s/plugins/libpytoy_cuda.%s'," % (toy_bin, py_site_pkgs, shlib_ext),
             "]",
+            "exts_list = [('bar', '0.0')]",
+            "exts_defaultclass = 'DummyExtension'",
         ])
         write_file(toy_ec_cuda, toy_ec_txt)
 
@@ -3235,7 +3237,7 @@ class ToyBuildTest(EnhancedTestCase):
         with self.mocked_stdout_stderr():
             outtxt = self._test_toy_build(ec_file=toy_ec_cuda, extra_args=args, raise_error=True)
             stdout = self.get_stdout()
-        assert_cuda_report(missing_cc=0, additional_cc=0, missing_ptx=3, log=outtxt, stdout=stdout)
+        assert_cuda_report(missing_cc=0, additional_cc=0, missing_ptx=4, log=outtxt, stdout=stdout)
 
         # Test case 1b: test with default options, --cuda-compute-capabilities=8.0 and a binary that contains
         # 7.0 and 9.0 device code and 8.0 PTX code.
@@ -3256,13 +3258,13 @@ class ToyBuildTest(EnhancedTestCase):
             stdout = self.get_stdout()
         self.assertIn(device_additional_70_90_code_msg, outtxt)
         self.assertIn(device_missing_80_code_msg, outtxt)
-        assert_cuda_report(missing_cc=3, additional_cc=3, missing_ptx=0, log=outtxt, stdout=stdout)
+        assert_cuda_report(missing_cc=4, additional_cc=4, missing_ptx=0, log=outtxt, stdout=stdout)
 
         # Test case 2: same as Test case 1, but add --cuda-sanity-check-error-on-failed-checks
         # This is expected to fail since there is missing device code for CC80
         args = ['--cuda-compute-capabilities=8.0', '--cuda-sanity-check-error-on-failed-checks']
         # We expect this to fail, so first check error, then run again to check output
-        error_pattern = r"Files missing CUDA device code: 3."
+        error_pattern = r"Files missing CUDA device code: 4."
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, error_pattern, self._test_toy_build, ec_file=toy_ec_cuda,
                                   extra_args=args, raise_error=True)
@@ -3270,7 +3272,7 @@ class ToyBuildTest(EnhancedTestCase):
             stdout = self.get_stdout()
         self.assertIn(device_additional_70_90_code_msg, outtxt)
         self.assertIn(device_missing_80_code_msg, outtxt)
-        assert_cuda_report(missing_cc=3, additional_cc=3, missing_ptx=0, log=outtxt, stdout=stdout)
+        assert_cuda_report(missing_cc=4, additional_cc=4, missing_ptx=0, log=outtxt, stdout=stdout)
 
         # Test case 3: same as Test case 2, but add --cuda-sanity-check-accept-ptx-as-devcode
         # This is expected to succeed, since now the PTX code for CC80 will be accepted as
@@ -3284,14 +3286,14 @@ class ToyBuildTest(EnhancedTestCase):
             stdout = self.get_stdout()
         self.assertIn(device_additional_70_90_code_msg, outtxt)
         self.assertIn(device_missing_80_code_msg, outtxt)
-        assert_cuda_report(missing_cc=0, additional_cc=3, missing_ptx=0, log=outtxt, stdout=stdout,
-                           missing_cc_but_ptx=3)
+        assert_cuda_report(missing_cc=0, additional_cc=4, missing_ptx=0, log=outtxt, stdout=stdout,
+                           missing_cc_but_ptx=4)
 
         # Test case 4: same as Test case 2, but run with --cuda-compute-capabilities=9.0
         # This is expected to fail: device code is present, but PTX code for the highest CC (9.0) is missing
         args = ['--cuda-compute-capabilities=9.0', '--cuda-sanity-check-error-on-failed-checks']
         # We expect this to fail, so first check error, then run again to check output
-        error_pattern = r"Files missing CUDA PTX code: 3"
+        error_pattern = r"Files missing CUDA PTX code: 4"
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, error_pattern, self._test_toy_build, ec_file=toy_ec_cuda,
                                   extra_args=args, raise_error=True)
@@ -3299,7 +3301,7 @@ class ToyBuildTest(EnhancedTestCase):
             stdout = self.get_stdout()
         self.assertIn(device_additional_70_code_msg, outtxt)
 
-        assert_cuda_report(missing_cc=0, additional_cc=3, missing_ptx=3, log=outtxt, stdout=stdout)
+        assert_cuda_report(missing_cc=0, additional_cc=4, missing_ptx=4, log=outtxt, stdout=stdout)
 
         # Test case 5: same as Test case 4, but add --cuda-sanity-check-accept-missing-ptx
         # This is expected to succeed: device code is present, PTX code is missing, but that's accepted
@@ -3314,7 +3316,7 @@ class ToyBuildTest(EnhancedTestCase):
             stdout = self.get_stdout()
         self.assertIn(device_additional_70_code_msg, outtxt)
         self.assertRegex(outtxt, warning_pattern)
-        assert_cuda_report(missing_cc=0, additional_cc=3, missing_ptx=3, log=outtxt, stdout=stdout)
+        assert_cuda_report(missing_cc=0, additional_cc=4, missing_ptx=4, log=outtxt, stdout=stdout)
 
         # Test case 6: same as Test case 5, but add --cuda-sanity-check-strict
         # This is expected to fail: device code is present, PTX code is missing (but accepted due to option)
@@ -3322,14 +3324,14 @@ class ToyBuildTest(EnhancedTestCase):
         args = ['--cuda-compute-capabilities=9.0', '--cuda-sanity-check-error-on-failed-checks',
                 '--cuda-sanity-check-accept-missing-ptx', '--cuda-sanity-check-strict']
         # We expect this to fail, so first check error, then run again to check output
-        error_pattern = r"Files with additional CUDA device code: 3"
+        error_pattern = r"Files with additional CUDA device code: 4"
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, error_pattern, self._test_toy_build, ec_file=toy_ec_cuda,
                                   extra_args=args, raise_error=True)
             outtxt = self._test_toy_build(ec_file=toy_ec_cuda, extra_args=args, raise_error=False, verify=False)
             stdout = self.get_stdout()
         self.assertIn(device_additional_70_code_msg, outtxt)
-        assert_cuda_report(missing_cc=0, additional_cc=3, missing_ptx=3, log=outtxt, stdout=stdout)
+        assert_cuda_report(missing_cc=0, additional_cc=4, missing_ptx=4, log=outtxt, stdout=stdout)
 
         # Test case 7: same as Test case 6, but add the failing file to the cuda_sanity_ignore_files
         # This is expected to succeed: the individual file which _would_ cause the sanity check to fail is

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -3238,6 +3238,8 @@ class ToyBuildTest(EnhancedTestCase):
             outtxt = self._test_toy_build(ec_file=toy_ec_cuda, extra_args=args, raise_error=True)
             stdout = self.get_stdout()
         assert_cuda_report(missing_cc=0, additional_cc=0, missing_ptx=4, log=outtxt, stdout=stdout)
+        self.assertEqual(outtxt.count("CUDA sanity check summary report"), 1,
+                         "CUDA sanity check should be done exactly once")
 
         # Test case 1b: test with default options, --cuda-compute-capabilities=8.0 and a binary that contains
         # 7.0 and 9.0 device code and 8.0 PTX code.


### PR DESCRIPTION
We have some checks that are run on the whole install folder:

- required/banned libraries
- (Fortran) module files
- RPATHs
- CUDA compute capabilities

It does not make sense to run those in the extensions which would duplicate the work. All those checks involve calling external binaries which takes time and doing that for 10s of extensions needlessly increases the time to build/check the module

Move them all into the check that the step is not ran for an extension.

Includes/Requires:
- [x] https://github.com/easybuilders/easybuild-framework/pull/5183