### PR TITLE
format extension names in module files with `exts_formatter` function

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2020,7 +2020,10 @@ class EasyBlock:
                 if not callable(formatter):
                     raise EasyBuildError("Parameter exts_formatter should be a function that accepts the extension name"
                                          "and returns the formatted name.")
+                self.log.debug(f"Using provided function to format extension names: {formatter}")
                 exts_list = [(formatter(x), y) for (x, y) in exts_list]
+            else:
+                self.log.debug("No formatter function for extension names specified")
 
         return exts_list
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2012,6 +2012,11 @@ class EasyBlock:
             else:
                 exts_list.append((resolve_template(ext[0], self.cfg.template_values),
                                   resolve_template(ext[1], self.cfg.template_values)))
+
+        formatter = self.cfg.get('exts_formatter')
+        if formatter:
+            exts_list = [(formatter(x), y) for (x, y) in exts_list]
+
         return exts_list
 
     def prepare_for_extensions(self):

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1996,7 +1996,7 @@ class EasyBlock:
         Each entry should be a (name, version) tuple or just (name, ) if no version exists.
         Custom EasyBlocks may override this to add extensions that cannot be found automatically.
 
-        :param formatted: boolean indicating whether to format the extension name. If True, format using
+        :param formatted: boolean indicating whether the extension name should be formatted. If True, format using
                           the function defined by the exts_formatter parameter.
         """
         # Each extension in exts_list is either a string or a list/tuple with name, version as first entries
@@ -2017,6 +2017,9 @@ class EasyBlock:
         if formatted:
             formatter = self.cfg.get('exts_formatter')
             if formatter:
+                if not callable(formatter):
+                    raise EasyBuildError("Parameter exts_formatter should be a function that accepts the extension name"
+                                         "and returns the formatted name.")
                 exts_list = [(formatter(x), y) for (x, y) in exts_list]
 
         return exts_list

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1995,6 +1995,9 @@ class EasyBlock:
 
         Each entry should be a (name, version) tuple or just (name, ) if no version exists.
         Custom EasyBlocks may override this to add extensions that cannot be found automatically.
+
+        :param formatted: boolean indicating whether to format the extension name. If True, format using
+                          the function defined by the exts_formatter parameter.
         """
         # Each extension in exts_list is either a string or a list/tuple with name, version as first entries
         # As name can be a templated value we must resolve templates

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2021,7 +2021,9 @@ class EasyBlock:
                     raise EasyBuildError("Parameter exts_formatter should be a function that accepts the extension name"
                                          "and returns the formatted name.")
                 self.log.debug(f"Using provided function to format extension names: {formatter}")
-                exts_list = [(formatter(x), y) for (x, y) in exts_list]
+                self.log.debug("Original extension names: " + ', '.join(x[0] for x in exts_list))
+                exts_list = [(formatter(x[0]), ) + x[1:] for x in exts_list]
+                self.log.debug("Re-formatted extension names: " + ', '.join(x[0] for x in exts_list))
             else:
                 self.log.debug("No formatter function for extension names specified")
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -1991,7 +1991,7 @@ class EasyBlock:
             exts_list = sorted(exts_list, key=str.lower)
         return ext_sep.join(exts_list)
 
-    def make_extension_list(self):
+    def make_extension_list(self, formatted=True):
         """
         Return a list of extension names and their versions included in this installation
 
@@ -2013,9 +2013,10 @@ class EasyBlock:
                 exts_list.append((resolve_template(ext[0], self.cfg.template_values),
                                   resolve_template(ext[1], self.cfg.template_values)))
 
-        formatter = self.cfg.get('exts_formatter')
-        if formatter:
-            exts_list = [(formatter(x), y) for (x, y) in exts_list]
+        if formatted:
+            formatter = self.cfg.get('exts_formatter')
+            if formatter:
+                exts_list = [(formatter(x), y) for (x, y) in exts_list]
 
         return exts_list
 

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -190,12 +190,13 @@ DEFAULT_CONFIG = {
     'license_server_port': [None, 'Port for license server', LICENSE],
 
     # EXTENSIONS easyconfig parameters
-    'exts_download_dep_fail': [False, "Fail if downloaded dependencies are detected for extensions", EXTENSIONS],
     'exts_classmap': [{}, "Map of extension name to class for handling build and installation.", EXTENSIONS],
     'exts_defaultclass': [None, "Name of default easyblock for extensions", EXTENSIONS],
     'exts_default_options': [{}, "List of default options for extensions", EXTENSIONS],
+    'exts_download_dep_fail': [False, "Fail if downloaded dependencies are detected for extensions", EXTENSIONS],
     'exts_filter': [None, ("Extension filter details: template for cmd and input to cmd "
                            "(templates for ext_name, ext_version and src)."), EXTENSIONS],
+    'exts_formatter': [None, "Function to format extension names in module file", EXTENSIONS],
     'exts_list': [[], 'List with extensions added to the base installation', EXTENSIONS],
 
     # MODULES easyconfig parameters


### PR DESCRIPTION
will do nothing without companion easyblock PR (so can be safely merged):
- https://github.com/easybuilders/easybuild-easyblocks/pull/4125

but it needs to be merged to make the easyblock PR work.