### PR TITLE
Warn when using `get_cpu_arch_name` when archspec is not installed

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -478,7 +478,8 @@ def get_cpu_arch_name(show_warning=True):
     if cpu_arch_name is None:
         if show_warning and not HAVE_ARCHSPEC:
             print_warning("Could not detect CPU architecture name which may affect functionality. "
-                          "Please install the 'archspec' Python package into the same Python environment as EasyBuild.")
+                          "Please install the 'archspec' Python package into the same Python environment as EasyBuild.",
+                          log=_log)
         cpu_arch_name = UNKNOWN
 
     return cpu_arch_name

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -465,7 +465,7 @@ def get_cpu_family():
     return family
 
 
-def get_cpu_arch_name():
+def get_cpu_arch_name(show_warning=True):
     """
     Determine CPU architecture name via archspec (if available).
     """
@@ -476,6 +476,9 @@ def get_cpu_arch_name():
             cpu_arch_name = str(res.name)
 
     if cpu_arch_name is None:
+        if show_warning and not HAVE_ARCHSPEC:
+            print_warning("Could not detect CPU architecture name which may affect functionality. "
+                          "Please install the 'archspec' Python package into the same Python environment as EasyBuild.")
         cpu_arch_name = UNKNOWN
 
     return cpu_arch_name
@@ -1345,7 +1348,7 @@ def get_system_info():
         'core_count': get_avail_core_count(),
         'total_memory': get_total_memory(),
         'cpu_arch': get_cpu_architecture(),
-        'cpu_arch_name': get_cpu_arch_name(),
+        'cpu_arch_name': get_cpu_arch_name(show_warning=False),
         'cpu_model': get_cpu_model(),
         'cpu_speed': get_cpu_speed(),
         'cpu_vendor': get_cpu_vendor(),

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -872,8 +872,12 @@ class SystemToolsTest(EnhancedTestCase):
 
     def test_cpu_arch_name_native(self):
         """Test getting CPU arch name."""
-        arch_name = get_cpu_arch_name()
+        with self.mocked_stderr():
+            arch_name = get_cpu_arch_name()
+            stderr = self.get_stderr()
         self.assertIsInstance(arch_name, str)
+        if st.HAVE_ARCHSPEC:
+            self.assertEqual(stderr, "")
 
     def test_cpu_arch_name(self):
         """Test getting CPU arch name."""
@@ -890,6 +894,17 @@ class SystemToolsTest(EnhancedTestCase):
         st.archspec_cpu_host = lambda: None
         arch_name = get_cpu_arch_name()
         self.assertEqual(arch_name, 'UNKNOWN')
+
+        # When archspec is unavailable, direct calls should warn the user.
+        st.HAVE_ARCHSPEC = False
+        try:
+            with self.mocked_stderr():
+                arch_name = get_cpu_arch_name()
+                stderr = self.get_stderr()
+            self.assertEqual(arch_name, 'UNKNOWN')
+            self.assertRegex(stderr, r"Could not detect CPU architecture.*install the 'archspec' Python package")
+        finally:
+            st.HAVE_ARCHSPEC = True
 
     def test_cpu_vendor_native(self):
         """Test getting CPU vendor."""


### PR DESCRIPTION
Some easyblocks rely on that so warn the user that this may cause issues.