### PR TITLE
Remove repetition of shell command in log

### DIFF
--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -449,16 +449,16 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
     cmd_str = to_cmd_str(cmd)
     cmd_name = cmd_str.split(' ', 1)[0]
     cmd_type_msg = ('interactive ' if interactive else '') + ('shell command' if use_bash else 'command')
-    short_cmd_msg = f"'{cmd_name} ...' {cmd_type_msg}"  # E.g. "'gcc ...' shell command"
+    short_cmd_msg = f"{cmd_type_msg} '{cmd_name} ...'"  # E.g. "shell command 'gcc ...'"
 
     thread_id = None
     if asynchronous:
         thread_id = get_thread_id()
-        _log.info(f"Initiating running of shell command '{short_cmd_msg}' via thread with ID {thread_id}")
+        _log.info(f"Initiating running of {short_cmd_msg} via thread with ID {thread_id}")
 
     # auto-enable streaming of command output under --logtostdout/-l, unless it was disabled explicitely
     if stream_output is None and build_option('logtostdout'):
-        _log.info(f"Auto-enabling streaming output of '{short_cmd_msg}' command because logging to stdout is enabled")
+        _log.info(f"Auto-enabling streaming output of {short_cmd_msg} because logging to stdout is enabled")
         stream_output = True
 
     # temporary output file(s) for command output, along with helper scripts
@@ -520,7 +520,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
     stderr_handle = subprocess.PIPE if split_stderr else subprocess.STDOUT
     stdin_handle = subprocess.PIPE if stdin or qa_patterns else subprocess.DEVNULL
 
-    log_msg = f"Running {short_cmd_msg} in {work_dir}:\n\t{cmd_str}"
+    log_msg = f"Running {cmd_type_msg} in {work_dir}:\n\t{cmd_str}"
     if thread_id:
         log_msg += f" (via thread with ID {thread_id})"
     _log.info(log_msg)
@@ -632,19 +632,19 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
 
     # log command output (unless command was successful and log_output_on_success is disabled)
     if split_stderr:
-        log_msg = f"Output of {short_cmd_msg} (stdout only):\n{res.output}\n\n"
-        log_msg += f"Warnings and errors of {short_cmd_msg} (stderr only):\n{res.stderr}"
+        log_msg = f"Output (stdout only):\n{res.output}\n\n"
+        log_msg += f"Warnings and errors (stderr only):\n{res.stderr}"
     else:
-        log_msg = f"Output of {short_cmd_msg} (stdout + stderr):\n{res.output}"
+        log_msg = f"Output (stdout + stderr):\n{res.output}"
 
-    cmd_type_msg = cmd_type_msg[:1].upper() + cmd_type_msg[1:]  # capitalize first letter
+    short_cmd_msg_cap = short_cmd_msg[:1].upper() + short_cmd_msg[1:]  # capitalize first letter
     if res.exit_code == EasyBuildExit.SUCCESS:
-        _log.info(f"{short_cmd_msg} completed successfully")
+        msg = f"{short_cmd_msg_cap} completed successfully"
         if log_output_on_success:
-            _log.info(log_msg)
+            msg += f'\n{log_msg}'
+        _log.info(msg)
     else:
-        _log.warning(f"{short_cmd_msg} FAILED (exit code {res.exit_code})")
-        _log.info(log_msg)
+        _log.warning(f"{short_cmd_msg_cap} FAILED (exit code {res.exit_code})\n{log_msg}")
         if fail_on_error:
             raise_run_shell_cmd_error(res)
 
@@ -654,7 +654,7 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
         os.getcwd()
     except FileNotFoundError:
         _log.warning(
-            f"{short_cmd_msg} completed successfully but left the system in an unknown working directory. "
+            f"{short_cmd_msg_cap} completed successfully but left the system in an unknown working directory. "
             f"Changing back to initial working directory: {initial_work_dir}"
         )
         try:

--- a/easybuild/tools/run.py
+++ b/easybuild/tools/run.py
@@ -67,7 +67,7 @@ from easybuild.tools.build_log import dry_run_msg, time_str_since
 from easybuild.tools.config import build_option
 from easybuild.tools.hooks import RUN_SHELL_CMD, load_hooks, run_hook
 from easybuild.tools.output import COLOR_RED, COLOR_YELLOW, colorize, escape_for_rich, print_error
-from easybuild.tools.utilities import trace_msg
+from easybuild.tools.utilities import capitalize_first_letter, trace_msg
 
 
 _log = fancylogger.getLogger('run', fname=False)
@@ -637,14 +637,14 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
     else:
         log_msg = f"Output (stdout + stderr):\n{res.output}"
 
-    short_cmd_msg_cap = short_cmd_msg[:1].upper() + short_cmd_msg[1:]  # capitalize first letter
+    cmd_status_msg = capitalize_first_letter(short_cmd_msg if stream_output or qa_patterns else cmd_type_msg)
     if res.exit_code == EasyBuildExit.SUCCESS:
-        msg = f"{short_cmd_msg_cap} completed successfully"
+        msg = f"{cmd_status_msg} completed successfully"
         if log_output_on_success:
             msg += f'\n{log_msg}'
         _log.info(msg)
     else:
-        _log.warning(f"{short_cmd_msg_cap} FAILED (exit code {res.exit_code})\n{log_msg}")
+        _log.warning(f"{cmd_status_msg} FAILED (exit code {res.exit_code})\n{log_msg}")
         if fail_on_error:
             raise_run_shell_cmd_error(res)
 
@@ -654,13 +654,14 @@ def run_shell_cmd(cmd, fail_on_error=True, split_stderr=False, stdin=None, env=N
         os.getcwd()
     except FileNotFoundError:
         _log.warning(
-            f"{short_cmd_msg_cap} completed successfully but left the system in an unknown working directory. "
+            f"{capitalize_first_letter(cmd_type_msg)} completed successfully "
+            "but left the system in an unknown working directory. "
             f"Changing back to initial working directory: {initial_work_dir}"
         )
         try:
             os.chdir(initial_work_dir)
         except OSError as err:
-            raise EasyBuildError(f"Failed to return to {initial_work_dir} after executing {short_cmd_msg}: {err}")
+            raise EasyBuildError(f"Failed to return to {initial_work_dir} after executing {cmd_type_msg}: {err}")
 
     if not hidden:
         time_since_start = time_str_since(start_time)

--- a/easybuild/tools/utilities.py
+++ b/easybuild/tools/utilities.py
@@ -125,6 +125,13 @@ def remove_unwanted_chars(inputstring):
     return ''.join(c for c in inputstring if c in (ascii_letters + digits + '_'))
 
 
+def capitalize_first_letter(string: str) -> str:
+    """Capitalize the first letter of the given string."""
+    if not string:
+        return string
+    return string[0].upper() + string[1:]
+
+
 def import_available_modules(namespace):
     """
     Import all available module in the specified namespace.

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1573,10 +1573,10 @@ class EasyBlockTest(EnhancedTestCase):
             eb.extensions_step(fetch=True)
             stdout = self.get_stdout()
         logtxt = read_file(eb.logfile)
-        regexs = [r'Running .* shell command in .*:\n\sif \[ %s' % ext for ext in ['ext1', 'ext_2', 'real_ext']]
+        regexs = [r'Running shell command .* in .*:\n\sif \[ %s' % ext for ext in ['ext1', 'ext_2', 'real_ext']]
         self.assert_multi_regex(regexs, logtxt)
         # modulename: False skips the check
-        self.assertNotRegex(logtxt, r"Running .* shell command in .*:\n\sif \[ (False|ext4)")
+        self.assertNotRegex(logtxt, r"Running shell command .* in .*:\n\sif \[ (False|ext4)")
 
         patterns = [
             r"^== skipping extension EXT-2",

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1573,7 +1573,7 @@ class EasyBlockTest(EnhancedTestCase):
             eb.extensions_step(fetch=True)
             stdout = self.get_stdout()
         logtxt = read_file(eb.logfile)
-        regexs = [r'Running shell command .* in .*:\n\sif \[ %s' % ext for ext in ['ext1', 'ext_2', 'real_ext']]
+        regexs = [r'Running shell command in .*:\n\sif \[ %s' % ext for ext in ['ext1', 'ext_2', 'real_ext']]
         self.assert_multi_regex(regexs, logtxt)
         # modulename: False skips the check
         self.assertNotRegex(logtxt, r"Running shell command .* in .*:\n\sif \[ (False|ext4)")

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5734,7 +5734,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
     def test_debug_module_cmds(self):
         """Test use of --debug-module-cmds."""
         patterns = [
-            "Output of ",
+            r"Output \(stdout only\):",
             r"os\.env.*EBROOTGCC.*=",
             r"os\.env.*PATH.*=",
         ]

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -493,9 +493,9 @@ class RunTest(EnhancedTestCase):
         fd, logfile = tempfile.mkstemp(suffix='.log', prefix='eb-test-')
         os.close(fd)
 
-        regex_start_cmd = re.compile(r"Running 'echo ...' shell command in .*:\n\techo hello", re.M)
-        regex_cmd_exit = re.compile(r"'echo ...' shell command completed successfully")
-        regex_cmd_output = re.compile(r"Output of 'echo \.\.\.' shell command \(stdout \+ stderr\):\nhello", re.M)
+        regex_start_cmd = re.compile(r"Running shell command in .*:\n\techo hello", re.M)
+        regex_cmd_exit = re.compile(r"Shell command 'echo ...' completed successfully")
+        regex_cmd_output = re.compile(r"Output \(stdout \+ stderr\):\nhello", re.M)
 
         # command output is logged
         init_logging(logfile, silent=True)
@@ -2297,7 +2297,7 @@ class RunTest(EnhancedTestCase):
         )
 
         error_pattern = rf"Failed to return to .*/{os.path.basename(self.test_prefix)}/workdir "
-        error_pattern += r"after executing 'echo ...' shell command"
+        error_pattern += r"after executing shell command 'echo ...'"
 
         mkdir(workdir, parents=True)
         with self.mocked_stdout_stderr():

--- a/test/framework/run.py
+++ b/test/framework/run.py
@@ -494,7 +494,7 @@ class RunTest(EnhancedTestCase):
         os.close(fd)
 
         regex_start_cmd = re.compile(r"Running shell command in .*:\n\techo hello", re.M)
-        regex_cmd_exit = re.compile(r"Shell command 'echo ...' completed successfully")
+        regex_cmd_exit = re.compile(r"Shell command completed successfully")
         regex_cmd_output = re.compile(r"Output \(stdout \+ stderr\):\nhello", re.M)
 
         # command output is logged
@@ -2297,7 +2297,7 @@ class RunTest(EnhancedTestCase):
         )
 
         error_pattern = rf"Failed to return to .*/{os.path.basename(self.test_prefix)}/workdir "
-        error_pattern += r"after executing shell command 'echo ...'"
+        error_pattern += r"after executing shell command"
 
         mkdir(workdir, parents=True)
         with self.mocked_stdout_stderr():


### PR DESCRIPTION
Only mention the command once to avoid cluttering the log. Also moves the command around, i.e. not "foo shell command" but "shell command foo"

Result:

> == 2026-06-11 11:15:57,014 run.py:486 INFO run_shell_cmd: Script to start debug shell for shell command 'echo ...'
> 	will be saved to /tmp/eb-sqv44xur/eb-jt25_0o7/eb-8cg0xkof/eb-tbmdi883/run-shell-cmd-output/echo-_nwcdoh_/cmd.sh
> 	output will be logged to /tmp/eb-sqv44xur/eb-jt25_0o7/eb-8cg0xkof/eb-tbmdi883/run-shell-cmd-output/echo-_nwcdoh_/out.txt
> == 2026-06-11 11:15:57,015 run.py:512 INFO Path to bash that will be used to run shell commands: /usr/bin/bash
> == 2026-06-11 11:15:57,015 run.py:526 INFO Running shell command in /home/alex/git/easybuild-framework:
> 	echo hello
> == 2026-06-11 11:16:04,875 run.py:645 INFO Shell command completed successfully
> Output (stdout + stderr):
> hello
> 


This allows to find it more easily by grepping for e.g. "Running shell command" and avoids repeating the same command multiple times which makes it harder to find the actual command