### PR TITLE
use flex instead of bzip2 for end-to-end tests in CI (+ update CI workflows)

### DIFF
--- a/.github/workflows/container_tests.yml
+++ b/.github/workflows/container_tests.yml
@@ -11,16 +11,16 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python: [3.7]
+        python: [3.9]
       fail-fast: false
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
 
     - name: set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{matrix.python}}
         architecture: x64
@@ -93,11 +93,11 @@ jobs:
           # create $HOME/.rpmmacros, see also https://github.com/apptainer/singularity/issues/241
           echo '%_var /var' > $HOME/.rpmmacros
           echo '%_dbpath %{_var}/lib/rpm' >> $HOME/.rpmmacros
-          # build CentOS 7 container image for bzip2 1.0.8 using EasyBuild;
+          # build CentOS 7 container image for flex 2.6.4 using EasyBuild;
           # see https://docs.easybuild.io/en/latest/Containers.html
-          curl -OL https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/develop/easybuild/easyconfigs/b/bzip2/bzip2-1.0.8.eb
+          curl -OL https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/develop/easybuild/easyconfigs/f/flex/flex-2.6.4.eb
           export EASYBUILD_CONTAINERPATH=$PWD
           export EASYBUILD_CONTAINER_CONFIG='bootstrap=docker,from=ghcr.io/easybuilders/rockylinux-8.10-amd64'
-          eb bzip2-1.0.8.eb --containerize --experimental --container-build-image
-          singularity exec bzip2-1.0.8.sif command -v bzip2 | grep '/app/software/bzip2/1.0.8/bin/bzip2' || (echo "Path to bzip2 '$which_bzip2' is not correct" && exit 1)
-          singularity exec bzip2-1.0.8.sif bzip2 --help
+          eb flex-2.6.4.eb --containerize --experimental --container-build-image
+          singularity exec flex-2.6.4.sif command -v flex | grep '/app/software/flex/2.6.4/bin/flex' || (echo "Path to flex is not correct" && exit 1)
+          singularity exec flex-2.6.4.sif flex --help

--- a/.github/workflows/container_tests_apptainer.yml
+++ b/.github/workflows/container_tests_apptainer.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python: [3.9]
-        apptainer: [1.0.0, 1.1.7, 1.3.6, 1.5.1]
+        apptainer: [1.0.0, 1.3.6, 1.5.1]
       fail-fast: false
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3

--- a/.github/workflows/container_tests_apptainer.yml
+++ b/.github/workflows/container_tests_apptainer.yml
@@ -11,17 +11,17 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python: [3.7]
-        apptainer: [1.0.0, 1.1.7, 1.3.6]
+        python: [3.9]
+        apptainer: [1.0.0, 1.1.7, 1.3.6, 1.5.1]
       fail-fast: false
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
 
     - name: set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{matrix.python}}
         architecture: x64
@@ -87,12 +87,12 @@ jobs:
           # create $HOME/.rpmmacros, see also https://github.com/apptainer/singularity/issues/241
           echo '%_var /var' > $HOME/.rpmmacros
           echo '%_dbpath %{_var}/lib/rpm' >> $HOME/.rpmmacros
-          # build CentOS 7 container image for bzip2 1.0.8 using EasyBuild;
+          # build CentOS 7 container image for flex 2.6.4 using EasyBuild;
           # see https://docs.easybuild.io/en/latest/Containers.html
-          curl -OL https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/develop/easybuild/easyconfigs/b/bzip2/bzip2-1.0.8.eb
+          curl -OL https://raw.githubusercontent.com/easybuilders/easybuild-easyconfigs/develop/easybuild/easyconfigs/f/flex/flex-2.6.4.eb
           export EASYBUILD_CONTAINERPATH=$PWD
           export EASYBUILD_CONTAINER_CONFIG='bootstrap=docker,from=ghcr.io/easybuilders/rockylinux-8.10-amd64'
           export EASYBUILD_CONTAINER_TYPE='apptainer'
-          eb bzip2-1.0.8.eb --containerize --experimental --container-build-image
-          apptainer exec bzip2-1.0.8.sif command -v bzip2 | grep '/app/software/bzip2/1.0.8/bin/bzip2' || (echo "Path to bzip2 '$which_bzip2' is not correct" && exit 1)
-          apptainer exec bzip2-1.0.8.sif bzip2 --help
+          eb flex-2.6.4.eb --containerize --experimental --container-build-image
+          apptainer exec flex-2.6.4.sif command -v flex | grep '/app/software/flex/2.6.4/bin/flex' || (echo "Path to flex '$which_flex' is not correct" && exit 1)
+          apptainer exec flex-2.6.4.sif flex --help

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -11,8 +11,8 @@ jobs:
           - fedora-41
           - opensuse-15.4
           - rockylinux-8.10
-          - rockylinux-9.5
-          - ubuntu-20.04
+          - rockylinux-9.7
+          - rockylinux-10.1
           - ubuntu-22.04
           - ubuntu-24.04
       fail-fast: false
@@ -20,7 +20,7 @@ jobs:
       image: ghcr.io/easybuilders/${{ matrix.container }}-amd64
     steps:
       - name: Check out the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
 
       - name: download and unpack easyblocks and easyconfigs repositories
         run: |
@@ -49,18 +49,14 @@ jobs:
             "eb --show-system-info"
             "eb --check-eb-deps"
             "eb --show-config"
-            "eb -x bzip2-1.0.8.eb"
+            "eb -x flex-2.6.4.eb"
           )
           for cmd in "${cmds[@]}"; do
               echo ">>> $cmd"
               sudo -u easybuild bash -l -c "source /tmp/eb_env; $cmd"
           done
 
-      - name: End-to-end test of installing bzip2 with EasyBuild
+      - name: End-to-end test of installing flex with EasyBuild
         shell: bash
         run: |
-          EB_ARGS=''
-          if [[ "${{ matrix.container }}" == "fedora-41" ]] || [[ "${{ matrix.container }}" == "ubuntu-24.04" ]]; then
-              EB_ARGS='--filter-deps=binutils'
-          fi
-          sudo -u easybuild bash -l -c "source /tmp/eb_env; eb bzip2-1.0.8.eb --trace --robot ${EB_ARGS}"
+          sudo -u easybuild bash -l -c "source /tmp/eb_env; eb flex-2.6.4.eb --trace --robot"


### PR DESCRIPTION
Motivation by the observation that building `binutils` takes ~4min out of the 6min for an end-to-end test, using flex brings it down to only ~2min