### PR TITLE
Add default EBlock parameter to generalize EULA handling in EasyBlocks/EasyConfigs

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -174,7 +174,13 @@ class EasyBlock:
             _log.nosupport("Found 'extra' value of type '%s' in extra_options, should be 'dict'" % type(extra), '2.0')
 
         extra_vars = {
-            'requires_eula': [None, "TEST", CUSTOM],
+            'requires_eula': [
+                None,
+                "Determines whether to check if a EULA for the code is required to be acceppted. Can be one of: "
+                "True: Enable check with default name/message, False: disable check, 1/2-list/tuple: "
+                "Enable check with custom name/message. List/tuple longer than 2 while be truncated and give a warning",
+                CUSTOM
+            ],
         }
         extra_vars.update(extra or {})
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -176,9 +176,7 @@ class EasyBlock:
         extra_vars = {
             'requires_eula': [
                 None,
-                "Determines whether to check if a EULA for the code is required to be acceppted. Can be one of: "
-                "True: Enable check with default name/message, False: disable check, 1/2-list/tuple: "
-                "Enable check with custom name/message. List/tuple longer than 2 while be truncated and give a warning",
+                "Determines whether to check if a EULA for the code is required to be accepted.",
                 CUSTOM
             ],
         }

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -71,7 +71,7 @@ from textwrap import indent
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
 from easybuild.base import fancylogger
-from easybuild.framework.easyconfig import EASYCONFIGS_PKG_SUBDIR
+from easybuild.framework.easyconfig import EASYCONFIGS_PKG_SUBDIR, CUSTOM
 from easybuild.framework.easyconfig.easyconfig import ITERATE_OPTIONS, EasyConfig, ActiveMNS, get_easyblock_class
 from easybuild.framework.easyconfig.easyconfig import get_module_path, letter_dir_for, resolve_template
 from easybuild.framework.easyconfig.format.format import SANITY_CHECK_PATHS_DIRS, SANITY_CHECK_PATHS_FILES
@@ -173,7 +173,12 @@ class EasyBlock:
         if not isinstance(extra, dict):
             _log.nosupport("Found 'extra' value of type '%s' in extra_options, should be 'dict'" % type(extra), '2.0')
 
-        return extra
+        extra_vars = {
+            'requires_eula': [None, "TEST", CUSTOM],
+        }
+        extra_vars.update(extra or {})
+
+        return extra_vars
 
     @staticmethod
     def src_parameter_names():
@@ -2694,6 +2699,32 @@ class EasyBlock:
             elif LooseVersion(easybuild_version) > VERSION:
                 raise EasyBuildError("EasyBuild-version %s is newer than the currently running one. Aborting!",
                                      easybuild_version)
+
+        # Run EULA check if requested through `requires_eula`
+        check_eula = False
+        check_args = [None, None]
+        requires_eula = self.cfg['requires_eula']
+        if isinstance(requires_eula, (bool)):
+            check_eula = requires_eula
+        elif isinstance(requires_eula, (list, tuple)):
+            check_eula = True
+            if len(requires_eula) > 2:
+                self.log.warning(
+                    "Too many arguments provided for 'requires_eula' (expected at most 2), ignoring extra ones"
+                )
+            for idx, arg in enumerate(requires_eula[:2]):
+                check_args[idx] = arg
+        elif requires_eula is not None:
+            raise EasyBuildError(
+                "Invalid value for 'requires_eula' easyconfig parameter: expected bool or list/tuple, got %s",
+                type(requires_eula).__name__,
+            )
+        if check_eula:
+            self.log.info(
+                "Checking EULA acceptance for %s per 'requires_eula' easyconfig parameter: `%s`",
+                self.name, requires_eula,
+            )
+            self.check_accepted_eula(*check_args)
 
         start_progress_bar(PROGRESS_BAR_DOWNLOAD_ALL, self.cfg.count_files())
 

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -764,6 +764,8 @@ class DocsTest(EnhancedTestCase):
         eb_overview = gen_easyblocks_overview_rst(gen_easyblocks_pkg, 'easyconfigs', common_params, doc_functions)
         ebdoc = '\n'.join(eb_overview)
 
+        eula_info = r"Determines whether to check if a EULA for the code is required to be accepted\."
+
         # extensive check for ConfigureMake easyblock
         check_configuremake = '\n'.join([
             ".. _ConfigureMake:",
@@ -771,20 +773,21 @@ class DocsTest(EnhancedTestCase):
             "``ConfigureMake``",
             "=================",
             '',
-            "(derives from EasyBlock)",
+            r"\(derives from EasyBlock\)",
             '',
             "Dummy support for building and installing applications with configure/make/make install.",
             '',
             "Extra easyconfig parameters specific to ``ConfigureMake`` easyblock",
             "-------------------------------------------------------------------",
             '',
-            "====================    ============    =============",
-            "easyconfig parameter    description     default value",
-            "====================    ============    =============",
-            '``test_123``            Test 1, 2, 3    ``""``',
-            "``test_bool``           Just a test     ``False``",
-            "``test_none``           Another test    ``None``",
-            "====================    ============    =============",
+            "=+ +=+ +=+",
+            "easyconfig parameter +description +default value",
+            "=+ +=+ +=+",
+            f"``requires_eula`` +{eula_info} +``None``",
+            '``test_123`` +Test 1, 2, 3 +``""``',
+            "``test_bool`` +Just a test +``False``",
+            "``test_none`` +Another test +``None``",
+            "=+ +=+ +=+",
             '',
             "Commonly used easyconfig parameters with ``ConfigureMake`` easyblock",
             "--------------------------------------------------------------------",
@@ -792,13 +795,13 @@ class DocsTest(EnhancedTestCase):
             "====================    ================================================================",
             "easyconfig parameter    description",
             "====================    ================================================================",
-            "configopts              Extra options passed to configure (default already has --prefix)",
-            "buildopts               Extra options passed to make step (default already has -j X)",
+            r"configopts              Extra options passed to configure \(default already has --prefix\)",
+            r"buildopts               Extra options passed to make step \(default already has -j X\)",
             "installopts             Extra options for installation",
             "====================    ================================================================",
         ])
 
-        self.assertIn(check_configuremake, ebdoc)
+        self.assertRegex(ebdoc, check_configuremake)
 
         for name in names:
             self.assertIn(name, ebdoc)
@@ -817,28 +820,29 @@ class DocsTest(EnhancedTestCase):
         check_configuremake = '\n'.join([
             "## ``ConfigureMake``",
             '',
-            "(derives from ``EasyBlock``)",
+            r"\(derives from ``EasyBlock``\)",
             '',
             "Dummy support for building and installing applications with configure/make/make install.",
             '',
             "### Extra easyconfig parameters specific to ``ConfigureMake`` easyblock",
             '',
-            "easyconfig parameter|description |default value",
+            "easyconfig parameter|description +|default value",
             "--------------------|------------|-------------",
-            '``test_123``        |Test 1, 2, 3|``""``',
-            "``test_bool``       |Just a test |``False``",
-            "``test_none``       |Another test|``None``",
+            f'``requires_eula``   |{eula_info}|``None``',
+            '``test_123``        |Test 1, 2, 3 +|``""``',
+            "``test_bool``       |Just a test +|``False``",
+            "``test_none``       |Another test +|``None``",
             '',
             "### Commonly used easyconfig parameters with ``ConfigureMake`` easyblock",
             '',
             "easyconfig parameter|description",
             "--------------------|----------------------------------------------------------------",
-            "configopts          |Extra options passed to configure (default already has --prefix)",
-            "buildopts           |Extra options passed to make step (default already has -j X)",
+            r"configopts          |Extra options passed to configure \(default already has --prefix\)",
+            r"buildopts           |Extra options passed to make step \(default already has -j X\)",
             "installopts         |Extra options for installation",
         ])
 
-        self.assertIn(check_configuremake, ebdoc)
+        self.assertRegex(ebdoc, check_configuremake)
 
         for name in names:
             self.assertIn(name, ebdoc)

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1640,6 +1640,93 @@ class EasyBlockTest(EnhancedTestCase):
         pattern = r">> running shell command:\n\s+bar.sh(\n\s+\[.*\]){3}\n\s+>> command completed: exit 0"
         self.assertRegex(stdout, re.compile(pattern, re.M))
 
+    def test_fetch_step_eula(self):
+        """Test that the `requires_eula` extra option is properly handled."""
+        name = "toy"
+        custom_name = "abc123"
+        custom_info = "Please contact XXX_YYY to get access to this software."
+
+        base = [
+            "easyblock = 'ConfigureMake'",
+            f"name = '{name}'",
+            "version = '0.0'",
+            "homepage = 'https://example.com'",
+            "description = 'test'",
+            "toolchain = SYSTEM",
+            "exts_list = [",
+            "    ('bar', '0.0', {",
+            "        'source_tmpl': SOURCE_TAR_GZ,",
+            "    }),",
+            "]",
+        ]
+
+        def run_check_fetch(extra = ''):
+            """Convenience method to run the check for a given EC file"""
+            self.contents = '\n'.join(base + [extra])
+            self.writeEC()
+            eb = EasyBlock(EasyConfig(self.eb_file))
+            eb.fetch_step()
+
+        def run_check_full(extra = '', accept_eula = False, exp_stdout = None, exp_stderr = None):
+            """Convenience method to run the full process for a given EC file"""
+            self.contents = '\n'.join(base + [extra])
+            self.writeEC()
+
+            args = [
+                '--rebuild',
+                # Required since here we are using a mocked ConfigureMake without a configure_step defined
+                '--stop', 'fetch',
+                self.eb_file,
+            ]
+
+            if accept_eula:
+                args.insert(0, f"--accept-eula-for=.*")
+
+            with self.mocked_stdout_stderr() as (stdout, stderr):
+                self.eb_main(args, raise_error=False, verbose=True, do_build=True)
+
+            if exp_stdout is not None:
+                self.assertIn(exp_stdout, stdout.getvalue())
+            if exp_stderr is not None:
+                self.assertIn(exp_stderr, stderr.getvalue())
+
+        # Test that `requires_eula` does not cause issues when set to False
+        run_check_fetch('requires_eula = False')
+
+        # Test that passing a non-supported value for `requires_eula` raises an error
+        exp = r"Invalid value for 'requires_eula' easyconfig parameter: expected bool or list/tuple, got int"
+        with self.assertRaisesRegex(EasyBuildError, exp):
+            run_check_fetch('requires_eula = 123')
+
+        # Test that `requires_eula` set to True raises an error (when EULA is not accepted)
+        exp = rf"The End User License Agreement \(EULA\) for {name} is currently not accepted!"
+        with self.assertRaisesRegex(EasyBuildError, exp):
+             run_check_fetch('requires_eula = True')
+
+        # Test that `requires_eula` with a custom name works as intended
+        exp = rf"The End User License Agreement \(EULA\) for {custom_name} is currently not accepted!"
+        with self.assertRaisesRegex(EasyBuildError, exp):
+             run_check_fetch(f'requires_eula = ["{custom_name}"]')
+
+        # Test that `requires_eula` with a custom message_info works as intended
+        with self.assertRaisesRegex(EasyBuildError, custom_info):
+             run_check_fetch(f'requires_eula = ["{custom_name}", "{custom_info}"]')
+
+        # Test that `requires_eula` with a custom message_info ONLY works as intended
+        exp = rf"The End User License Agreement \(EULA\) for {name} is currently not accepted!"
+        with self.assertRaisesRegex(EasyBuildError, f'{exp}.*\n.*{custom_info}'):
+             run_check_fetch(f'requires_eula = [None, "{custom_info}"]')
+
+        # Check a full run with no EULA check
+        run_check_full()
+
+        # Check a full run with EULA check, but no acceptance
+        exp = f'The End User License Agreement (EULA) for {name} is currently not accepted!'
+        run_check_full('requires_eula = True', exp_stdout=exp)
+
+        # Check a full run with EULA check, and acceptance via command line
+        run_check_full('requires_eula = True', accept_eula=True)
+
     def test_make_module_step(self):
         """Test the make_module_step"""
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1660,14 +1660,14 @@ class EasyBlockTest(EnhancedTestCase):
             "]",
         ]
 
-        def run_check_fetch(extra = ''):
+        def run_check_fetch(extra=''):
             """Convenience method to run the check for a given EC file"""
             self.contents = '\n'.join(base + [extra])
             self.writeEC()
             eb = EasyBlock(EasyConfig(self.eb_file))
             eb.fetch_step()
 
-        def run_check_full(extra = '', accept_eula = False, exp_stdout = None, exp_stderr = None):
+        def run_check_full(extra='', accept_eula=False, exp_stdout=None, exp_stderr=None):
             """Convenience method to run the full process for a given EC file"""
             self.contents = '\n'.join(base + [extra])
             self.writeEC()
@@ -1680,7 +1680,7 @@ class EasyBlockTest(EnhancedTestCase):
             ]
 
             if accept_eula:
-                args.insert(0, f"--accept-eula-for=.*")
+                args.insert(0, "--accept-eula-for=.*")
 
             with self.mocked_stdout_stderr() as (stdout, stderr):
                 self.eb_main(args, raise_error=False, verbose=True, do_build=True)
@@ -1701,21 +1701,21 @@ class EasyBlockTest(EnhancedTestCase):
         # Test that `requires_eula` set to True raises an error (when EULA is not accepted)
         exp = rf"The End User License Agreement \(EULA\) for {name} is currently not accepted!"
         with self.assertRaisesRegex(EasyBuildError, exp):
-             run_check_fetch('requires_eula = True')
+            run_check_fetch('requires_eula = True')
 
         # Test that `requires_eula` with a custom name works as intended
         exp = rf"The End User License Agreement \(EULA\) for {custom_name} is currently not accepted!"
         with self.assertRaisesRegex(EasyBuildError, exp):
-             run_check_fetch(f'requires_eula = ["{custom_name}"]')
+            run_check_fetch(f'requires_eula = ["{custom_name}"]')
 
         # Test that `requires_eula` with a custom message_info works as intended
         with self.assertRaisesRegex(EasyBuildError, custom_info):
-             run_check_fetch(f'requires_eula = ["{custom_name}", "{custom_info}"]')
+            run_check_fetch(f'requires_eula = ["{custom_name}", "{custom_info}"]')
 
         # Test that `requires_eula` with a custom message_info ONLY works as intended
         exp = rf"The End User License Agreement \(EULA\) for {name} is currently not accepted!"
         with self.assertRaisesRegex(EasyBuildError, f'{exp}.*\n.*{custom_info}'):
-             run_check_fetch(f'requires_eula = [None, "{custom_info}"]')
+            run_check_fetch(f'requires_eula = [None, "{custom_info}"]')
 
         # Check a full run with no EULA check
         run_check_full()


### PR DESCRIPTION
This change centralizes the check for the EULA in the fetch_step of an easyblock, the behavior of which can be modified by an EasyConfig by modifying the `requires_eula` EC parameter which can have the following values:

- True: Enable check with default accept name/message
- False: Disable check (can overwrite one set by the EB if properly checked
- list/tuple of length 1/2: the first argument defines the name passed to `check_accepted_eula`, the seconds define the custom info message

# TODO

- [x] dedicated tests