### PR TITLE
add `get_ptrace_scope` function to `systemtools` to determine value for `ptrace_scope`

### DIFF
--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -145,6 +145,7 @@ ETC_OS_RELEASE = '/etc/os-release'
 MAX_FREQ_FP = '/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq'
 PROC_CPUINFO_FP = '/proc/cpuinfo'
 PROC_MEMINFO_FP = '/proc/meminfo'
+PTRACE_SCOPE_FP = '/proc/sys/kernel/yama/ptrace_scope'
 
 CPU_ARCHITECTURES = [AARCH32, AARCH64, POWER, RISCV32, RISCV64, X86_64]
 CPU_FAMILIES = [AMD, ARM, INTEL, POWER, POWER_LE, RISCV]
@@ -1364,6 +1365,40 @@ def get_system_info():
         'system_python_path': which('python'),
         'system_gcc_path': which('gcc'),
     }
+
+
+def get_ptrace_scope():
+    """
+    Returns the ptrace_scope value set by the currently running operating system session.
+    Depending on the OS, this can either be read through a file, or has to be obtained
+    via sysctl.
+    If no ptrace_scope value can be determined, return 0 and warn about the failed
+    detection.
+
+    This can e.g., be used by debugger EasyBlocks to determine functionality of attaching
+    to a process before running tests, which will fail for ptrace_scope > 1.
+    """
+    try:
+        ptrace_scope_file = read_file(PTRACE_SCOPE_FP)
+        return int(ptrace_scope_file)
+    except EasyBuildError:
+        # File might not exist, hence skip a potential error
+        _log.warning(f"Could not find or open {PTRACE_SCOPE_FP}")
+    except ValueError:
+        _log.warning(f"Could not parse value of ptrace_scope file in {PTRACE_SCOPE_FP}")
+
+    result = run_shell_cmd("sysctl kernel.yama.ptrace_scope", fail_on_error=False, split_stderr=True)
+    if result:
+        try:
+            # Expected output: kernel.yama.ptrace_scope = 3
+            return int(result.output.split("=")[-1])
+        except ValueError:
+            _log.warning("Could not determine ptrace_scope value from sysctl output. Output was %s", result.output)
+    else:
+        _log.warning("Running sysctl kernel.yama.ptrace_scope failed: %s", result.stderr)
+
+    _log.warning("Could not determine ptrace_scope. Assuming 0.")
+    return 0
 
 
 def use_group(group_name):

--- a/test/framework/systemtools.py
+++ b/test/framework/systemtools.py
@@ -46,7 +46,7 @@ from easybuild.tools.run import RunShellCmdResult, run_shell_cmd
 from easybuild.tools.systemtools import CPU_ARCHITECTURES, AARCH32, AARCH64, POWER, RISCV, X86_64
 from easybuild.tools.systemtools import CPU_FAMILIES, POWER_LE, DARWIN, LINUX, UNKNOWN
 from easybuild.tools.systemtools import CPU_VENDORS, AMD, APM, ARM, CAVIUM, IBM, INTEL
-from easybuild.tools.systemtools import MAX_FREQ_FP, PROC_CPUINFO_FP, PROC_MEMINFO_FP
+from easybuild.tools.systemtools import MAX_FREQ_FP, PROC_CPUINFO_FP, PROC_MEMINFO_FP, PTRACE_SCOPE_FP
 from easybuild.tools.systemtools import check_linked_shared_libs, check_os_dependency, check_python_version
 from easybuild.tools.systemtools import det_parallelism, det_pypkg_version, get_avail_core_count
 from easybuild.tools.systemtools import get_cuda_object_dump_raw, get_cuda_architectures, get_cpu_arch_name
@@ -534,6 +534,7 @@ def mocked_read_file(fp):
         MAX_FREQ_FP: '2850000',
         PROC_CPUINFO_FP: PROC_CPUINFO_TXT,
         PROC_MEMINFO_FP: PROC_MEMINFO_TXT,
+        PTRACE_SCOPE_FP: '4',
     }
     if fp in known_fps:
         return known_fps[fp]
@@ -581,6 +582,7 @@ def mocked_run_shell_cmd(cmd, **kwargs):
         "amd-smi static --driver --board --asic --csv": AMD_SMI_DRIVER,
         "rocm-smi --showdriverversion --csv": ROCM_SMI_DRIVER_VERSION,
         "rocm-smi --showproductname --csv": ROCM_SMI_PRODUCT_NAME,
+        "sysctl kernel.yama.ptrace_scope": '5',
     }
 
     if os.getenv('MOCKED_BROKEN_ROCM_SMI'):
@@ -1665,6 +1667,43 @@ class SystemToolsTest(EnhancedTestCase):
             'AMD': {'AMD Instinct MI250X/MI250 (model: 0x740c, driver: UNKNOWN)': 4},
         }
         self.assertEqual(get_gpu_info(), expected)
+
+    def test_get_ptrace_scope(self):
+        st.read_file = mocked_read_file
+        st.run_shell_cmd = mocked_run_shell_cmd
+
+        # Try read_file approach. Always tried first, if file exists
+        result = st.get_ptrace_scope()
+        expected = 4
+        self.assertEqual(result, expected)
+
+        # Now, explicitly break read_file and use run_shell_cmd instead.
+        def broken_read_file(*args, **kwargs):
+            raise EasyBuildError('Mocked read file error')
+        st.read_file = broken_read_file
+
+        result = st.get_ptrace_scope()
+        expected = 5
+        self.assertEqual(result, expected)
+
+        # Now also break run_shell_cmd. pthread_trace should yield 0.
+        def broken_run_shell_cmd(*args, **kwargs):
+            return RunShellCmdResult(
+                cmd="",
+                exit_code=1,
+                output="",
+                stderr="Mocked run_shell_cmd error",
+                work_dir="",
+                out_file="",
+                err_file="",
+                cmd_sh="",
+                thread_id="",
+                task_id="")
+        st.run_shell_cmd = broken_run_shell_cmd
+
+        result = st.get_ptrace_scope()
+        expected = 0
+        self.assertEqual(result, expected)
 
 
 def suite(loader=None):


### PR DESCRIPTION
See https://github.com/easybuilders/easybuild-easyblocks/pull/4159, https://github.com/easybuilders/easybuild-easyconfigs/issues/26257.

Allows to determine the current value of `ptrace_scope`, to e.g. add expected test failures to an EasyBlock (LLVM), or not run tests altogether.