### PR TITLE
Add hardlink function in filetools

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -357,6 +357,25 @@ def symlink(source_path, symlink_path, use_abspath_source=True):
         except OSError as err:
             raise EasyBuildError("Symlinking %s to %s failed: %s", source_path, symlink_path, err)
 
+def hardlink(source_path, link_path):
+    """
+    Create a hard link at the specified path to the given path.
+
+    :param source_path: source file path
+    :param link_path: hard link file path
+    """
+    if os.path.exists(link_path):
+        if not os.path.samefile(source_path, link_path):
+            raise EasyBuildError(
+                f"Trying to hardlink {source_path} to {link_path}, but the link already exists and is different."
+            )
+        _log.info(f"Skipping hard linking {source_path} to {link_path}, link already exists")
+    else:
+        try:
+            os.link(source_path, link_path)
+            _log.info(f"Linked {source_path} to {link_path}")
+        except OSError as err:
+            raise EasyBuildError(f"Linking {source_path} to {link_path} failed: {err}")
 
 def remove_file(path):
     """Remove file at specified path."""

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -357,6 +357,7 @@ def symlink(source_path, symlink_path, use_abspath_source=True):
         except OSError as err:
             raise EasyBuildError("Symlinking %s to %s failed: %s", source_path, symlink_path, err)
 
+
 def hardlink(source_path, link_path):
     """
     Create a hard link at the specified path to the given path.
@@ -376,6 +377,7 @@ def hardlink(source_path, link_path):
             _log.info(f"Linked {source_path} to {link_path}")
         except OSError as err:
             raise EasyBuildError(f"Linking {source_path} to {link_path} failed: {err}")
+
 
 def remove_file(path):
     """Remove file at specified path."""

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -924,6 +924,24 @@ class FileToolsTest(EnhancedTestCase):
         self.assertFalse(os.path.islink(link))
         self.assertNotExists(link)
 
+    def test_remove_hardlinks(self):
+        """Test remove hardlinks"""
+
+        # creating test file
+        fp = os.path.join(self.test_prefix, 'test.txt')
+        txt = "test_my_link_file"
+        ft.write_file(fp, txt)
+
+        # creating the link
+        link = os.path.join(self.test_prefix, 'test.link')
+        ft.hardlink(fp, link)
+
+        # Attempting to remove a valid symlink
+        ft.remove_file(link)
+        self.assertFalse(os.path.islink(link))
+        self.assertNotExists(link)
+        self.assertExists(fp)
+
     def test_read_write_file(self):
         """Test reading/writing files."""
 


### PR DESCRIPTION
Not heavily tested. Tried to mimic behavior of symlink function, but unsure if behavior is same when link_path is a existing broken symlink (overwrite attempt will be made, but unsure if it will be successful).