### PR TITLE
Use bounded `git rev-list` for version detection

### DIFF
--- a/easybuild/tools/version.py
+++ b/easybuild/tools/version.py
@@ -64,7 +64,7 @@ def get_git_revision():
     try:
         path = os.path.dirname(__file__)
         gitrepo = Git(path)
-        res = gitrepo.rev_list('HEAD').splitlines()[0]
+        res = gitrepo.rev_list('-n', '1', 'HEAD').splitlines()[0]
         # 'encode' may be required to make sure a regular string is returned rather than a unicode string
         # (only needed in Python 2; in Python 3, regular strings are already unicode)
         if not isinstance(res, str):


### PR DESCRIPTION
EasyBuild only needs the current HEAD commit hash for version detection,
but git rev-list HEAD walks the full commit history and can be slow on
large repositories or high-latency filesystems.

Limit rev-list to one commit via git rev-list -n 1 HEAD. This preserves
the existing GitPython-based implementation while avoiding unnecessary
history traversal.

*this PR was created with help of ChatGPT5.5

easyblocks PR:
- https://github.com/easybuilders/easybuild-easyblocks/pull/4163