### PR TITLE
Cater for Python 3.8 deprecation in cryptography package

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -249,7 +249,7 @@ jobs:
             IGNORE_PATTERNS+="|skipping SvnRepository test"
             IGNORE_PATTERNS+="|requires Lmod as modules tool"
             IGNORE_PATTERNS+="|stty: 'standard input': Inappropriate ioctl for device"
-            IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 3.7"
+            IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 3.[78]"
             IGNORE_PATTERNS+="|from cryptography.* import "
             IGNORE_PATTERNS+="|Blowfish"
             IGNORE_PATTERNS+="|GC3Pie not available, skipping test"


### PR DESCRIPTION
> /opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/site-packages/secretstorage/util.py:23: CryptographyDeprecationWarning: Python 3.8 is no longer supported by the Python core team and support for it is deprecated in cryptography. The next release of cryptography will remove support for Python 3.8.

https://github.com/easybuilders/easybuild-framework/actions/runs/27402149691/job/81016566511?pr=4188