### PR TITLE
update actions used in CI workflows to latest versions

### DIFF
--- a/.github/workflows/container_tests.yml
+++ b/.github/workflows/container_tests.yml
@@ -17,7 +17,7 @@ jobs:
         python: [3.9]
       fail-fast: false
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
 
     - name: set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/container_tests_apptainer.yml
+++ b/.github/workflows/container_tests_apptainer.yml
@@ -18,7 +18,7 @@ jobs:
         apptainer: [1.0.0, 1.3.6, 1.5.1]
       fail-fast: false
     steps:
-    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
 
     - name: set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -20,10 +20,10 @@ jobs:
       fail-fast: false
     runs-on: ${{matrix.os || 'ubuntu-24.04'}}
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
 
     - name: set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -20,7 +20,7 @@ jobs:
       image: ghcr.io/easybuilders/${{ matrix.container }}-amd64
     steps:
       - name: Check out the repo
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # 6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
 
       - name: download and unpack easyblocks and easyconfigs repositories
         run: |

--- a/.github/workflows/end2end_bwrap.yml
+++ b/.github/workflows/end2end_bwrap.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
 
       - name: Install system packages
         run: sudo apt-get install -y lmod bubblewrap

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,10 +19,10 @@ jobs:
       fail-fast: false
     runs-on: ${{matrix.os || 'ubuntu-24.04'}}
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
 
     - name: set up Python
-      uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python }}
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -62,7 +62,7 @@ jobs:
             modules_tool: ${{needs.setup.outputs.lmod9}}
       fail-fast: false
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
 
     - name: install OS packages
       run: |
@@ -93,7 +93,7 @@ jobs:
 
     - name: set up Python
       if: '!matrix.use_pyenv'
-      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{matrix.python}}
         architecture: x64


### PR DESCRIPTION
Mostly triggered by these warnings popping up in CI:
```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24:
actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683,
actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065.
For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```