### PR TITLE
prefer `bsdtar` for unpacking ISO files, keep `7z` as fallback

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -69,7 +69,7 @@ jobs:
         # for modules tool
         APT_PKGS="lua5.3 liblua5.3-dev lua-filesystem lua-posix tcl tcl-dev"
         # for GitPython, python-hglib
-        APT_PKGS+=" git mercurial bsdtar"
+        APT_PKGS+=" git mercurial"
         # dep for GC3Pie
         APT_PKGS+=" time"
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -69,7 +69,7 @@ jobs:
         # for modules tool
         APT_PKGS="lua5.3 liblua5.3-dev lua-filesystem lua-posix tcl tcl-dev"
         # for GitPython, python-hglib
-        APT_PKGS+=" git mercurial"
+        APT_PKGS+=" git mercurial bsdtar"
         # dep for GC3Pie
         APT_PKGS+=" time"
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -69,7 +69,7 @@ jobs:
         # for modules tool
         APT_PKGS="lua5.3 liblua5.3-dev lua-filesystem lua-posix tcl tcl-dev"
         # for GitPython, python-hglib
-        APT_PKGS+=" git mercurial"
+        APT_PKGS+=" git mercurial libarchive-tools"
         # dep for GC3Pie
         APT_PKGS+=" time"
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -69,7 +69,7 @@ jobs:
         # for modules tool
         APT_PKGS="lua5.3 liblua5.3-dev lua-filesystem lua-posix tcl tcl-dev"
         # for GitPython, python-hglib
-        APT_PKGS+=" git mercurial libarchive-tools"
+        APT_PKGS+=" git mercurial"
         # dep for GC3Pie
         APT_PKGS+=" time"
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -175,12 +175,17 @@ EXTRACT_CMDS = {
     # zip file
     '.zip': "unzip -qq %(filepath)s",
     # iso file
-    '.iso': "7z x %(filepath)s",
+    '.iso': "bsdtar xf %(filepath)s",
     # tar.Z: using compress (LZW), but can be handled with gzip so use 'z'
     '.tar.z': "tar xzf %(filepath)s",
     # shell scripts don't need to be unpacked, just copy there
     '.sh': "cp -dR %(filepath)s .",
 }
+
+# 7z can also extract iso files, use it as a fallback
+if not shutil.which('bsdtar') and shutil.which('7z'):
+    _log.info("Did not find bsdtar, switching to 7z for iso files")
+    EXTRACT_CMDS['.iso'] = "7z x %(filepath)s"
 
 ZIPPED_PATCH_EXTS = ('.bz2', '.gz', '.xz')
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -183,7 +183,7 @@ EXTRACT_CMDS = {
 }
 
 # 7z can also extract iso files, use it as a fallback
-if not shutil.which('bsdtar') and shutil.which('7z'):
+if not shutil.which('bsdtar'):
     _log.info("Did not find bsdtar, switching to 7z for iso files")
     EXTRACT_CMDS['.iso'] = "7z x %(filepath)s"
 

--- a/easybuild/tools/systemtools.py
+++ b/easybuild/tools/systemtools.py
@@ -192,6 +192,7 @@ ZYPPER = 'zypper'
 
 SYSTEM_TOOLS = {
     '7z': "extracting sources (.iso)",
+    'bsdtar': "extracting sources (.iso)",
     'bunzip2': "decompressing sources (.bz2, .tbz, .tbz2, ...)",
     DPKG: "checking OS dependencies (Debian, Ubuntu, ...)",
     'git': "downloading sources using 'git clone'",

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -121,7 +121,7 @@ class FileToolsTest(EnhancedTestCase):
 
         # Fake 7z command to test fallback
         fake_7z = os.path.join(self.test_prefix, 'bin', '7z')
-        ft.write_file(fake_eb, '#!/bin/bash\necho "fake 7z"')
+        ft.write_file(fake_7z, '#!/bin/bash\necho "fake 7z"')
         ft.adjust_permissions(fake_7z, stat.S_IXUSR)
         os.environ['PATH'] = '%s:%s' % (os.path.dirname(fake_7z), os.getenv('PATH', ''))
         self.assertEqual("7z x test.iso", ft.extract_cmd('test.iso'))

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -107,7 +107,7 @@ class FileToolsTest(EnhancedTestCase):
             ('test.xz', "unxz test.xz"),
             ('test.tar.xz', "unset TAPE; unxz test.tar.xz --stdout | tar x"),
             ('test.txz', "unset TAPE; unxz test.txz --stdout | tar x"),
-            ('test.iso', "7z x test.iso"),
+            ('test.iso', "bsdtar xf test.iso"),
             ('test.tar.Z', "tar xzf test.tar.Z"),
             ('test.foo.bar.sh', "cp -dR test.foo.bar.sh ."),
             # check whether extension is stripped correct to determine name of target file
@@ -118,6 +118,10 @@ class FileToolsTest(EnhancedTestCase):
         for (fn, expected_cmd) in tests:
             cmd = ft.extract_cmd(fn)
             self.assertEqual(expected_cmd, cmd)
+
+        # Fake 7z command to test fallback
+        # Help me boegel, you're my only hope
+        self.assertEqual("7z x test.iso", ft.extract_cmd('test.iso'))
 
         self.assertEqual("unzip -qq -o test.zip", ft.extract_cmd('test.zip', True))
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -120,7 +120,10 @@ class FileToolsTest(EnhancedTestCase):
             self.assertEqual(expected_cmd, cmd)
 
         # Fake 7z command to test fallback
-        # Help me boegel, you're my only hope
+        fake_7z = os.path.join(self.test_prefix, 'bin', '7z')
+        ft.write_file(fake_eb, '#!/bin/bash\necho "fake 7z"')
+        ft.adjust_permissions(fake_7z, stat.S_IXUSR)
+        os.environ['PATH'] = '%s:%s' % (os.path.dirname(fake_7z), os.getenv('PATH', ''))
         self.assertEqual("7z x test.iso", ft.extract_cmd('test.iso'))
 
         self.assertEqual("unzip -qq -o test.zip", ft.extract_cmd('test.zip', True))

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -107,7 +107,7 @@ class FileToolsTest(EnhancedTestCase):
             ('test.xz', "unxz test.xz"),
             ('test.tar.xz', "unset TAPE; unxz test.tar.xz --stdout | tar x"),
             ('test.txz', "unset TAPE; unxz test.txz --stdout | tar x"),
-            ('test.iso', "7z x test.iso"),
+            ('test.iso', "bsdtar xf test.iso"),
             ('test.tar.Z', "tar xzf test.tar.Z"),
             ('test.foo.bar.sh', "cp -dR test.foo.bar.sh ."),
             # check whether extension is stripped correct to determine name of target file

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -107,7 +107,7 @@ class FileToolsTest(EnhancedTestCase):
             ('test.xz', "unxz test.xz"),
             ('test.tar.xz', "unset TAPE; unxz test.tar.xz --stdout | tar x"),
             ('test.txz', "unset TAPE; unxz test.txz --stdout | tar x"),
-            ('test.iso', "bsdtar xf test.iso"),
+            ('test.iso', "7z x test.iso"),
             ('test.tar.Z', "tar xzf test.tar.Z"),
             ('test.foo.bar.sh', "cp -dR test.foo.bar.sh ."),
             # check whether extension is stripped correct to determine name of target file

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -34,6 +34,7 @@ Unit tests for filetools.py
 import datetime
 import filecmp
 import glob
+import importlib
 import logging
 import os
 import re
@@ -107,7 +108,7 @@ class FileToolsTest(EnhancedTestCase):
             ('test.xz', "unxz test.xz"),
             ('test.tar.xz', "unset TAPE; unxz test.tar.xz --stdout | tar x"),
             ('test.txz', "unset TAPE; unxz test.txz --stdout | tar x"),
-            ('test.iso', "bsdtar xf test.iso"),
+            ('test.iso', "7z x test.iso"),
             ('test.tar.Z', "tar xzf test.tar.Z"),
             ('test.foo.bar.sh', "cp -dR test.foo.bar.sh ."),
             # check whether extension is stripped correct to determine name of target file
@@ -119,12 +120,13 @@ class FileToolsTest(EnhancedTestCase):
             cmd = ft.extract_cmd(fn)
             self.assertEqual(expected_cmd, cmd)
 
-        # Fake 7z command to test fallback
-        fake_7z = os.path.join(self.test_prefix, 'bin', '7z')
-        ft.write_file(fake_7z, '#!/bin/bash\necho "fake 7z"')
-        ft.adjust_permissions(fake_7z, stat.S_IXUSR)
-        os.environ['PATH'] = '%s:%s' % (os.path.dirname(fake_7z), os.getenv('PATH', ''))
-        self.assertEqual("7z x test.iso", ft.extract_cmd('test.iso'))
+        # Fake bsdtar command, if exists, is preferred
+        fake_bsdtar = os.path.join(self.test_prefix, 'bin', 'bsdtar')
+        ft.write_file(fake_bsdtar, '#!/bin/bash\necho "fake bsdtar"')
+        ft.adjust_permissions(fake_bsdtar, stat.S_IXUSR)
+        os.environ['PATH'] = '%s:%s' % (os.path.dirname(fake_bsdtar), os.getenv('PATH', ''))
+        ft = importlib.reload(ft)  # Force reload to get new EXTRACT_CMDS
+        self.assertEqual("bsdtar xf test.iso", ft.extract_cmd('test.iso'))
 
         self.assertEqual("unzip -qq -o test.zip", ft.extract_cmd('test.zip', True))
 

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -125,8 +125,8 @@ class FileToolsTest(EnhancedTestCase):
         ft.write_file(fake_bsdtar, '#!/bin/bash\necho "fake bsdtar"')
         ft.adjust_permissions(fake_bsdtar, stat.S_IXUSR)
         os.environ['PATH'] = '%s:%s' % (os.path.dirname(fake_bsdtar), os.getenv('PATH', ''))
-        ft = importlib.reload(ft)  # Force reload to get new EXTRACT_CMDS
-        self.assertEqual("bsdtar xf test.iso", ft.extract_cmd('test.iso'))
+        new_ft = importlib.reload(ft)  # Force reload to get new EXTRACT_CMDS
+        self.assertEqual("bsdtar xf test.iso", new_ft.extract_cmd('test.iso'))
 
         self.assertEqual("unzip -qq -o test.zip", ft.extract_cmd('test.zip', True))
 


### PR DESCRIPTION
Fixes #5212