### PR TITLE
also bwrap module installpath

### DIFF
--- a/.github/workflows/end2end_bwrap.yml
+++ b/.github/workflows/end2end_bwrap.yml
@@ -54,6 +54,143 @@ jobs:
               bash -lc "source /tmp/eb_env; $cmd"
           done
 
+      - name: Define bwrap validation helper
+        shell: bash
+        run: |
+          cat > /tmp/check_bwrap_install.sh <<'EOF'
+          #!/usr/bin/env bash
+
+          check_no_dir() {
+              local label="$1"
+              local path="$2"
+
+              echo ">>> CHECK: $label"
+              echo "    path: $path"
+
+              if [[ -d "$path" ]]; then
+                  echo "FAIL: directory exists"
+                  echo "Directory details:"
+                  ls -ld "$path" || true
+                  echo "Contents:"
+                  find "$path" -maxdepth 4 -print || true
+                  return 1
+              fi
+
+              echo "PASS: directory does not exist"
+              echo
+          }
+
+          check_no_glob_matches() {
+              local label="$1"
+              local pattern="$2"
+
+              echo ">>> CHECK: $label"
+              echo "    glob: $pattern"
+
+              if compgen -G "$pattern" > /dev/null; then
+                  echo "FAIL: files/directories matched"
+                  compgen -G "$pattern" | sort
+                  return 1
+              fi
+
+              echo "PASS: no files/directories matched"
+              echo
+          }
+
+          check_path_exists() {
+              local label="$1"
+              local path="$2"
+
+              echo ">>> CHECK: $label"
+              echo "    path: $path"
+
+              if [[ -e "$path" ]]; then
+                  echo "PASS: path exists"
+                  ls -ld "$path"
+                  echo
+                  return 0
+              fi
+
+              echo "FAIL: path does not exist"
+              echo "Parent contents:"
+              ls -la "$(dirname "$path")" || true
+              echo
+              return 1
+          }
+
+          check_glob_exists() {
+              local label="$1"
+              local pattern="$2"
+
+              echo ">>> CHECK: $label"
+              echo "    glob: $pattern"
+
+              if compgen -G "$pattern" > /dev/null; then
+                  echo "PASS: matches found"
+                  compgen -G "$pattern" | sort | xargs -r ls -l
+                  echo
+                  return 0
+              fi
+
+              echo "FAIL: no matches found"
+              echo
+              return 1
+          }
+
+          main() {
+              local failures=0
+
+              echo "=== Host-side EasyBuild path state ==="
+              find "$HOME/.local/easybuild" -maxdepth 5 -print || true
+              echo
+
+              echo "=== bwrap install path state ==="
+              find /tmp/bwrap-installpath -maxdepth 5 -print || true
+              echo
+
+              check_no_dir "no host UnZip module dir" \
+                  "$HOME/.local/easybuild/modules/all/UnZip" || failures=$((failures + 1))
+
+              check_no_dir "no host bzip2 module dir" \
+                  "$HOME/.local/easybuild/modules/all/bzip2" || failures=$((failures + 1))
+
+              check_no_glob_matches "no host UnZip software payload" \
+                  "$HOME/.local/easybuild/software/UnZip/6.0/*" || failures=$((failures + 1))
+
+              check_no_glob_matches "no host bzip2 software payload" \
+                  "$HOME/.local/easybuild/software/bzip2/1.0.8/*" || failures=$((failures + 1))
+
+              check_path_exists "bwrap bzip2 module file exists" \
+                  "/tmp/bwrap-installpath/modules/all/bzip2/1.0.8.lua" || failures=$((failures + 1))
+
+              check_path_exists "bwrap UnZip module file exists" \
+                  "/tmp/bwrap-installpath/modules/all/UnZip/6.0.lua" || failures=$((failures + 1))
+
+              check_glob_exists "bwrap UnZip installed binaries exist" \
+                  "/tmp/bwrap-installpath/software/UnZip/*/bin/*" || failures=$((failures + 1))
+
+              check_glob_exists "bwrap bzip2 installed binaries exist" \
+                  "/tmp/bwrap-installpath/software/bzip2/*/bin/*" || failures=$((failures + 1))
+
+              check_glob_exists "bwrap UnZip EasyBuild logs exist" \
+                  "/tmp/bwrap-installpath/software/UnZip/*/easybuild/*log*" || failures=$((failures + 1))
+
+              check_glob_exists "bwrap bzip2 EasyBuild logs exist" \
+                  "/tmp/bwrap-installpath/software/bzip2/*/easybuild/*log*" || failures=$((failures + 1))
+
+              if [[ "$failures" -ne 0 ]]; then
+                  echo "ERROR: $failures bwrap validation check(s) failed"
+                  return 1
+              fi
+
+              echo "All bwrap validation checks passed"
+          }
+
+          main "$@"
+          EOF
+
+          chmod +x /tmp/check_bwrap_install.sh
+
       - name: End-to-end test of installing UnZip with EasyBuild in bwrap namespace
         shell: bash
         run: |
@@ -66,16 +203,8 @@ jobs:
             # test installation of UnZip + bzip2 dependency
             eb UnZip-6.0.eb --trace --robot --experimental --bwrap --bwrap-installpath /tmp/bwrap-installpath --filter-deps=binutils
 
-            # no module files should be created in configured install path (default: $HOME/.local/easybuild),
-            # not for UnZip, nor for bzip2 dependency
-            (test -d $HOME/.local/easybuild/modules/all/UnZip || echo 'no UnZip module dir found: OK') > /tmp/out-UnZip-mod
-            (test -d $HOME/.local/easybuild/modules/all/bzip2 || echo 'no bzip2 module dir found: OK') > /tmp/out-bzip2-mod
+            /tmp/check_bwrap_install.sh
 
-            # software subdirectories in configured install path should be empty
-            (test -e $HOME/.local/easybuild/software/UnZip/6.0/* || echo 'UnZip software dir in $HOME/.local/easybuild is empty: OK') > /tmp/out-UnZip-sw-dir
-            (test -e $HOME/.local/easybuild/software/bzip2/1.0.8/* || echo 'bzip2 software dir in $HOME/.local/easybuild is empty: OK') > /tmp/out-bzip2-sw-dir
-
-            grep 'no UnZip module dir found: OK' /tmp/out-UnZip-mod && grep 'no bzip2 module dir found: OK' /tmp/out-bzip2-mod && grep 'UnZip software dir in .* is empty' /tmp/out-UnZip-sw-dir && grep 'bzip2 software dir in .* is empty' /tmp/out-bzip2-sw-dir && ls -l /tmp/bwrap-installpath/modules/all/{bzip2/1.0.8.lua,UnZip/6.0.lua} && ls -l /tmp/bwrap-installpath/software/{UnZip,bzip2}/*/bin/* && ls -l /tmp/bwrap-installpath/software/{UnZip,bzip2}/*/easybuild/*log*
           EOF
 
       - name: End-to-end test of installing UnZip with EasyBuild in bwrap namespace with overlay
@@ -97,14 +226,6 @@ jobs:
             # test installation of UnZip + bzip2 dependency
             eb UnZip-6.0.eb --trace --robot --experimental --bwrap --bwrap-installpath /tmp/bwrap-installpath --filter-deps=binutils
 
-            # no module files should be created in configured install path (default: $HOME/.local/easybuild),
-            # not for UnZip, nor for bzip2 dependency
-            (test -d $HOME/.local/easybuild/modules/all/UnZip || echo 'no UnZip module dir found: OK') > /tmp/out-UnZip-mod
-            (test -d $HOME/.local/easybuild/modules/all/bzip2 || echo 'no bzip2 module dir found: OK') > /tmp/out-bzip2-mod
+            /tmp/check_bwrap_install.sh
 
-            # software subdirectories in configured install path should be empty
-            (test -e $HOME/.local/easybuild/software/UnZip/6.0/* || echo 'UnZip software dir in $HOME/.local/easybuild is empty: OK') > /tmp/out-UnZip-sw-dir
-            (test -e $HOME/.local/easybuild/software/bzip2/1.0.8/* || echo 'bzip2 software dir in $HOME/.local/easybuild is empty: OK') > /tmp/out-bzip2-sw-dir
-
-            grep 'no UnZip module dir found: OK' /tmp/out-UnZip-mod && grep 'no bzip2 module dir found: OK' /tmp/out-bzip2-mod && grep 'UnZip software dir in .* is empty' /tmp/out-UnZip-sw-dir && grep 'bzip2 software dir in .* is empty' /tmp/out-bzip2-sw-dir && ls -l /tmp/bwrap-installpath/modules/all/{bzip2/1.0.8.lua,UnZip/6.0.lua} && ls -l /tmp/bwrap-installpath/software/{UnZip,bzip2}/*/bin/* && ls -l /tmp/bwrap-installpath/software/{UnZip,bzip2}/*/easybuild/*log*
           EOF

--- a/.github/workflows/end2end_bwrap.yml
+++ b/.github/workflows/end2end_bwrap.yml
@@ -197,6 +197,9 @@ jobs:
           bash -l <<EOF
             source /tmp/eb_env
 
+            # remove previously created install directories
+            rm -r $HOME/.local/easybuild/{software,modules}/*
+
             # make sure that --prefix also determines default value for bwrap-installpath
             eb --show-config --prefix /tmp | grep "bwrap-installpath [ ]* \(C\) = /tmp/bwrap"
 
@@ -218,7 +221,7 @@ jobs:
             source /tmp/eb_env
 
             # remove previously created install directories
-            rm -r $HOME/.local/easybuild/software/* /tmp/bwrap-installpath
+            rm -r $HOME/.local/easybuild/{software,modules}/* /tmp/bwrap-installpath
 
             # make install directory read-only to force using overlay
             chmod -w $HOME/.local/easybuild/software

--- a/.github/workflows/end2end_bwrap.yml
+++ b/.github/workflows/end2end_bwrap.yml
@@ -60,26 +60,6 @@ jobs:
           cat > /tmp/check_bwrap_install.sh <<'EOF'
           #!/usr/bin/env bash
 
-          check_no_dir() {
-              local label="$1"
-              local path="$2"
-
-              echo ">>> CHECK: $label"
-              echo "    path: $path"
-
-              if [[ -d "$path" ]]; then
-                  echo "FAIL: directory exists"
-                  echo "Directory details:"
-                  ls -ld "$path" || true
-                  echo "Contents:"
-                  find "$path" -maxdepth 4 -print || true
-                  return 1
-              fi
-
-              echo "PASS: directory does not exist"
-              echo
-          }
-
           check_no_glob_matches() {
               local label="$1"
               local pattern="$2"
@@ -148,16 +128,16 @@ jobs:
               find /tmp/bwrap-installpath -maxdepth 5 -print || true
               echo
 
-              check_no_dir "no host UnZip module dir" \
-                  "$HOME/.local/easybuild/modules/all/UnZip" || failures=$((failures + 1))
+              check_no_glob_matches "no host UnZip modules" \
+                  "$HOME/.local/easybuild/modules/all/UnZip/*" || failures=$((failures + 1))
 
-              check_no_dir "no host bzip2 module dir" \
-                  "$HOME/.local/easybuild/modules/all/bzip2" || failures=$((failures + 1))
+              check_no_glob_matches "no host bzip2 modules" \
+                  "$HOME/.local/easybuild/modules/all/bzip2/*" || failures=$((failures + 1))
 
-              check_no_glob_matches "no host UnZip software payload" \
+              check_no_glob_matches "no host UnZip software files" \
                   "$HOME/.local/easybuild/software/UnZip/6.0/*" || failures=$((failures + 1))
 
-              check_no_glob_matches "no host bzip2 software payload" \
+              check_no_glob_matches "no host bzip2 software files" \
                   "$HOME/.local/easybuild/software/bzip2/1.0.8/*" || failures=$((failures + 1))
 
               check_path_exists "bwrap bzip2 module file exists" \
@@ -196,9 +176,6 @@ jobs:
         run: |
           bash -l <<EOF
             source /tmp/eb_env
-
-            # remove previously created install directories
-            rm -r $HOME/.local/easybuild/{software,modules}/*
 
             # make sure that --prefix also determines default value for bwrap-installpath
             eb --show-config --prefix /tmp | grep "bwrap-installpath [ ]* \(C\) = /tmp/bwrap"

--- a/.github/workflows/end2end_bwrap.yml
+++ b/.github/workflows/end2end_bwrap.yml
@@ -201,7 +201,7 @@ jobs:
             rm -r $HOME/.local/easybuild/{software,modules}/* /tmp/bwrap-installpath
 
             # make install directory read-only to force using overlay
-            chmod -w $HOME/.local/easybuild/software
+            chmod -w $HOME/.local/easybuild/{software,modules}
 
             # test installation of UnZip + bzip2 dependency
             eb UnZip-6.0.eb --trace --robot --experimental --bwrap --bwrap-installpath /tmp/bwrap-installpath --filter-deps=binutils

--- a/easybuild/tools/bwrap.py
+++ b/easybuild/tools/bwrap.py
@@ -35,8 +35,8 @@ import os
 
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError, print_msg
-from easybuild.tools.config import install_path, ConfigurationVariables
-from easybuild.tools.filetools import mkdir, write_file
+from easybuild.tools.config import build_option, install_path, ConfigurationVariables
+from easybuild.tools.filetools import copy_dir, mkdir, write_file
 from easybuild.tools.utilities import trace_msg
 
 
@@ -107,7 +107,8 @@ def prepare_bwrap(bwrap_installpath):
     installpath_software = install_path(typ='software')
     set_bwrap_info('installpath_software', installpath_software)
 
-    set_bwrap_info('installpath_modules', install_path(typ='modules'))
+    installpath_modules = install_path(typ='modules')
+    set_bwrap_info('installpath_modules', installpath_modules)
 
     variables = ConfigurationVariables()
     bwrap_installpath_software = os.path.join(bwrap_installpath, variables['subdir_software'])
@@ -115,7 +116,11 @@ def prepare_bwrap(bwrap_installpath):
     set_bwrap_info('bwrap_installpath_software', bwrap_installpath_software)
     set_bwrap_info('bwrap_installpath_modules', bwrap_installpath_modules)
 
+    sufmodpath = build_option('suffix_modules_path')
+
     bwrap_cmd = ['bwrap', '--dev-bind', '/', '/']
+    # use a set to eliminate duplicate binds
+    bwrap_opts = set()
 
     # bind mount all software directories
     for mod in sorted(get_bwrap_info('modules_to_install')):
@@ -128,6 +133,14 @@ def prepare_bwrap(bwrap_installpath):
             # if we can't create the external installation directory, try to use overlayfs
             use_overlayfs = True
         mkdir(bwrap_installdir, parents=True)
+        moddir = mod.split('/')[0]
+        moduledir = os.path.join(os.path.realpath(installpath_modules), sufmodpath, moddir)
+        bwrap_moduledir = os.path.join(bwrap_installpath_modules, sufmodpath, moddir)
+        mkdir(moduledir, parents=True)
+        mkdir(bwrap_moduledir, parents=True)
+        # copy module files from moduledir to bwrap_moduledir to ensure all installed modules are available
+        # required for building multiple unrelated easyconfigs (e.g. easystacks)
+        copy_dir(moduledir, bwrap_moduledir, dirs_exist_ok=True)
         if use_overlayfs:
             bwrap_workdir = os.path.join(bwrap_installpath, 'workdir', mod)
             mkdir(bwrap_workdir, parents=True)
@@ -135,16 +148,24 @@ def prepare_bwrap(bwrap_installpath):
             while not os.path.exists(installdir):
                 installdir = os.path.dirname(installdir)
                 bwrap_installdir = os.path.dirname(bwrap_installdir)
-            opts = ['--overlay-src', installdir, '--overlay', bwrap_installdir, bwrap_workdir, installdir]
+            bwrap_opts.update({
+                f'--overlay-src {installdir} --overlay {bwrap_installdir} {bwrap_workdir} {installdir}',
+                f'--overlay-src {moduledir} --overlay {bwrap_moduledir} {bwrap_workdir} {moduledir}',
+            })
         else:
-            opts = ['--bind', bwrap_installdir, installdir]
-        bwrap_cmd.extend(opts)
+            bwrap_opts.update({
+                f'--bind {bwrap_installdir} {installdir}',
+                f'--bind {bwrap_moduledir} {moduledir}',
+            })
+
+    for x in bwrap_opts:
+        bwrap_cmd.extend(x.split())
 
     set_bwrap_info('bwrap_cmd', bwrap_cmd)
     bwrap_cmd_str = ' '.join(bwrap_cmd)
 
     # disable `--bwrap` to prepare for a real installation (in bwrap namespace)
-    bwrap_eb_options = ['--disable-bwrap', f'--installpath-modules={bwrap_installpath_modules}']
+    bwrap_eb_options = ['--disable-bwrap']
     set_bwrap_info('bwrap_eb_options', bwrap_eb_options)
 
     _log.info(f'Info needed for bwrap: {_bwrap_info}')

--- a/easybuild/tools/bwrap.py
+++ b/easybuild/tools/bwrap.py
@@ -130,8 +130,7 @@ def prepare_bwrap(bwrap_installpath):
             copy_dir(installpath_modules, bwrap_installpath_modules, dirs_exist_ok=True)
         # bind mount the modules installpath
         bwrap_cmd.extend([
-            '--bind', bwrap_installpath_modules, installpath_modules,
-        ])
+            '--bind', bwrap_installpath_modules, installpath_modules])
 
     except EasyBuildError:
         # if we can't create the external modules directory, try to use overlayfs
@@ -139,8 +138,7 @@ def prepare_bwrap(bwrap_installpath):
         bwrap_cmd.extend([
             '--overlay-src', installpath_modules,
             '--overlay', bwrap_installpath_modules,
-            bwrap_workdir, installpath_modules,
-        ])
+            bwrap_workdir, installpath_modules])
 
     # store bwrap options in a set to avoid duplicate binds
     bwrap_opts = set()
@@ -167,12 +165,10 @@ def prepare_bwrap(bwrap_installpath):
             bwrap_opts.add((
                 '--overlay-src', installdir,
                 '--overlay', bwrap_installdir,
-                bwrap_workdir, installdir
-            ))
+                bwrap_workdir, installdir))
         else:
             bwrap_opts.add((
-                '--bind', bwrap_installdir, installdir,
-            ))
+                '--bind', bwrap_installdir, installdir))
 
     for x in bwrap_opts:
         bwrap_cmd.extend(x)

--- a/easybuild/tools/bwrap.py
+++ b/easybuild/tools/bwrap.py
@@ -124,7 +124,7 @@ def prepare_bwrap(bwrap_installpath):
 
     try:
         mkdir(installpath_modules, parents=True)
-        # copy installpath_modules to bwrap_installpath_moduleto ensure all installed modules are available
+        # copy installpath_modules to bwrap_installpath_modules to ensure all installed modules are available
         # required for building multiple unrelated easyconfigs (e.g. easystacks)
         if os.path.exists(installpath_modules):
             copy_dir(installpath_modules, bwrap_installpath_modules, dirs_exist_ok=True)

--- a/easybuild/tools/bwrap.py
+++ b/easybuild/tools/bwrap.py
@@ -137,8 +137,7 @@ def prepare_bwrap(bwrap_installpath):
         mkdir(bwrap_workdir, parents=True)
         bwrap_cmd.extend([
             '--overlay-src', installpath_modules,
-            '--overlay', bwrap_installpath_modules,
-            bwrap_workdir, installpath_modules])
+            '--overlay', bwrap_installpath_modules, bwrap_workdir, installpath_modules])
 
     # store bwrap options in a set to avoid duplicate binds
     bwrap_opts = set()
@@ -164,8 +163,7 @@ def prepare_bwrap(bwrap_installpath):
             mkdir(bwrap_workdir, parents=True)
             bwrap_opts.add((
                 '--overlay-src', installdir,
-                '--overlay', bwrap_installdir,
-                bwrap_workdir, installdir))
+                '--overlay', bwrap_installdir, bwrap_workdir, installdir))
         else:
             bwrap_opts.add((
                 '--bind', bwrap_installdir, installdir))

--- a/easybuild/tools/bwrap.py
+++ b/easybuild/tools/bwrap.py
@@ -35,7 +35,7 @@ import os
 
 from easybuild.base import fancylogger
 from easybuild.tools.build_log import EasyBuildError, print_msg
-from easybuild.tools.config import build_option, install_path, ConfigurationVariables
+from easybuild.tools.config import install_path, ConfigurationVariables
 from easybuild.tools.filetools import copy_dir, mkdir, write_file
 from easybuild.tools.utilities import trace_msg
 
@@ -104,10 +104,10 @@ def prepare_bwrap(bwrap_installpath):
 
     set_bwrap_info('bwrap_installpath', bwrap_installpath)
 
-    installpath_software = install_path(typ='software')
+    installpath_software = os.path.realpath(install_path(typ='software'))
     set_bwrap_info('installpath_software', installpath_software)
 
-    installpath_modules = install_path(typ='modules')
+    installpath_modules = os.path.realpath(install_path(typ='modules'))
     set_bwrap_info('installpath_modules', installpath_modules)
 
     variables = ConfigurationVariables()
@@ -116,11 +116,30 @@ def prepare_bwrap(bwrap_installpath):
     set_bwrap_info('bwrap_installpath_software', bwrap_installpath_software)
     set_bwrap_info('bwrap_installpath_modules', bwrap_installpath_modules)
 
-    sufmodpath = build_option('suffix_modules_path')
-
     bwrap_cmd = ['bwrap', '--dev-bind', '/', '/']
-    # use a set to eliminate duplicate binds
+    # store bwrap options in a set to avoid duplicate binds
     bwrap_opts = set()
+
+    mkdir(bwrap_installpath_modules, parents=True)
+
+    try:
+        mkdir(installpath_modules, parents=True)
+        # copy installpath_modules to bwrap_installpath_moduleto ensure all installed modules are available
+        # required for building multiple unrelated easyconfigs (e.g. easystacks)
+        if os.path.exists(installpath_modules):
+            copy_dir(installpath_modules, bwrap_installpath_modules, dirs_exist_ok=True)
+        # bind mount the modules installpath
+        bwrap_opts.update({
+            f'--bind {bwrap_installpath_modules} {installpath_modules}',
+        })
+    except EasyBuildError:
+        # if we can't create the external modules directory, try to use overlayfs
+        bwrap_workdir = os.path.join(bwrap_installpath, 'workdir')
+        mkdir(bwrap_workdir, parents=True)
+        bwrap_opts.update({
+            f'--overlay-src {installpath_modules} --overlay {bwrap_installpath_modules} {bwrap_workdir} '
+            f'{installpath_modules}',
+        })
 
     # bind mount all software directories
     for mod in sorted(get_bwrap_info('modules_to_install')):
@@ -128,42 +147,24 @@ def prepare_bwrap(bwrap_installpath):
         bwrap_installdir = os.path.join(bwrap_installpath_software, mod)
         mkdir(bwrap_installdir, parents=True)
 
-        moddir = mod.split('/')[0]
-        bwrap_moduledir = os.path.join(bwrap_installpath_modules, sufmodpath, moddir)
-        mkdir(bwrap_moduledir, parents=True)
-        moduledir = os.path.join(os.path.realpath(installpath_modules), sufmodpath, moddir)
-
         use_overlayfs = False
         try:
             mkdir(installdir, parents=True)
-            mkdir(moduledir, parents=True)
         except EasyBuildError:
             # if we can't create the external installation directory, try to use overlayfs
             use_overlayfs = True
 
-        # copy module files from moduledir to bwrap_moduledir to ensure all installed modules are available
-        # required for building multiple unrelated easyconfigs (e.g. easystacks)
-        if os.path.exists(moduledir):
-            copy_dir(moduledir, bwrap_moduledir, dirs_exist_ok=True)
-
         if use_overlayfs:
-            bwrap_workdir = os.path.join(bwrap_installpath, 'workdir', mod)
-            mkdir(bwrap_workdir, parents=True)
             # go up the tree until we find a directory that exists
             while not os.path.exists(installdir):
                 installdir = os.path.dirname(installdir)
                 bwrap_installdir = os.path.dirname(bwrap_installdir)
-            while not os.path.exists(moduledir):
-                moduledir = os.path.dirname(moduledir)
-                bwrap_moduledir = os.path.dirname(bwrap_moduledir)
             bwrap_opts.update({
                 f'--overlay-src {installdir} --overlay {bwrap_installdir} {bwrap_workdir} {installdir}',
-                f'--overlay-src {moduledir} --overlay {bwrap_moduledir} {bwrap_workdir} {moduledir}',
             })
         else:
             bwrap_opts.update({
                 f'--bind {bwrap_installdir} {installdir}',
-                f'--bind {bwrap_moduledir} {moduledir}',
             })
 
     for x in bwrap_opts:

--- a/easybuild/tools/bwrap.py
+++ b/easybuild/tools/bwrap.py
@@ -143,7 +143,8 @@ def prepare_bwrap(bwrap_installpath):
 
         # copy module files from moduledir to bwrap_moduledir to ensure all installed modules are available
         # required for building multiple unrelated easyconfigs (e.g. easystacks)
-        copy_dir(moduledir, bwrap_moduledir, dirs_exist_ok=True)
+        if os.path.exists(moduledir):
+            copy_dir(moduledir, bwrap_moduledir, dirs_exist_ok=True)
 
         if use_overlayfs:
             bwrap_workdir = os.path.join(bwrap_installpath, 'workdir', mod)

--- a/easybuild/tools/bwrap.py
+++ b/easybuild/tools/bwrap.py
@@ -153,6 +153,9 @@ def prepare_bwrap(bwrap_installpath):
             while not os.path.exists(installdir):
                 installdir = os.path.dirname(installdir)
                 bwrap_installdir = os.path.dirname(bwrap_installdir)
+            while not os.path.exists(moduledir):
+                moduledir = os.path.dirname(moduledir)
+                bwrap_moduledir = os.path.dirname(bwrap_moduledir)
             bwrap_opts.update({
                 f'--overlay-src {installdir} --overlay {bwrap_installdir} {bwrap_workdir} {installdir}',
                 f'--overlay-src {moduledir} --overlay {bwrap_moduledir} {bwrap_workdir} {moduledir}',

--- a/easybuild/tools/bwrap.py
+++ b/easybuild/tools/bwrap.py
@@ -122,6 +122,8 @@ def prepare_bwrap(bwrap_installpath):
 
     mkdir(bwrap_installpath_modules, parents=True)
 
+    bwrap_workdir = os.path.join(bwrap_installpath, 'workdir')
+
     try:
         mkdir(installpath_modules, parents=True)
         # copy installpath_modules to bwrap_installpath_moduleto ensure all installed modules are available
@@ -134,7 +136,6 @@ def prepare_bwrap(bwrap_installpath):
         })
     except EasyBuildError:
         # if we can't create the external modules directory, try to use overlayfs
-        bwrap_workdir = os.path.join(bwrap_installpath, 'workdir')
         mkdir(bwrap_workdir, parents=True)
         bwrap_opts.update({
             f'--overlay-src {installpath_modules} --overlay {bwrap_installpath_modules} {bwrap_workdir} '

--- a/easybuild/tools/bwrap.py
+++ b/easybuild/tools/bwrap.py
@@ -159,6 +159,7 @@ def prepare_bwrap(bwrap_installpath):
             while not os.path.exists(installdir):
                 installdir = os.path.dirname(installdir)
                 bwrap_installdir = os.path.dirname(bwrap_installdir)
+            mkdir(bwrap_workdir, parents=True)
             bwrap_opts.update({
                 f'--overlay-src {installdir} --overlay {bwrap_installdir} {bwrap_workdir} {installdir}',
             })

--- a/easybuild/tools/bwrap.py
+++ b/easybuild/tools/bwrap.py
@@ -126,21 +126,25 @@ def prepare_bwrap(bwrap_installpath):
     for mod in sorted(get_bwrap_info('modules_to_install')):
         installdir = os.path.join(os.path.realpath(installpath_software), mod)
         bwrap_installdir = os.path.join(bwrap_installpath_software, mod)
+        mkdir(bwrap_installdir, parents=True)
+
+        moddir = mod.split('/')[0]
+        bwrap_moduledir = os.path.join(bwrap_installpath_modules, sufmodpath, moddir)
+        mkdir(bwrap_moduledir, parents=True)
+        moduledir = os.path.join(os.path.realpath(installpath_modules), sufmodpath, moddir)
+
         use_overlayfs = False
         try:
             mkdir(installdir, parents=True)
+            mkdir(moduledir, parents=True)
         except EasyBuildError:
             # if we can't create the external installation directory, try to use overlayfs
             use_overlayfs = True
-        mkdir(bwrap_installdir, parents=True)
-        moddir = mod.split('/')[0]
-        moduledir = os.path.join(os.path.realpath(installpath_modules), sufmodpath, moddir)
-        bwrap_moduledir = os.path.join(bwrap_installpath_modules, sufmodpath, moddir)
-        mkdir(moduledir, parents=True)
-        mkdir(bwrap_moduledir, parents=True)
+
         # copy module files from moduledir to bwrap_moduledir to ensure all installed modules are available
         # required for building multiple unrelated easyconfigs (e.g. easystacks)
         copy_dir(moduledir, bwrap_moduledir, dirs_exist_ok=True)
+
         if use_overlayfs:
             bwrap_workdir = os.path.join(bwrap_installpath, 'workdir', mod)
             mkdir(bwrap_workdir, parents=True)

--- a/easybuild/tools/bwrap.py
+++ b/easybuild/tools/bwrap.py
@@ -117,8 +117,6 @@ def prepare_bwrap(bwrap_installpath):
     set_bwrap_info('bwrap_installpath_modules', bwrap_installpath_modules)
 
     bwrap_cmd = ['bwrap', '--dev-bind', '/', '/']
-    # store bwrap options in a set to avoid duplicate binds
-    bwrap_opts = set()
 
     mkdir(bwrap_installpath_modules, parents=True)
 
@@ -131,16 +129,21 @@ def prepare_bwrap(bwrap_installpath):
         if os.path.exists(installpath_modules):
             copy_dir(installpath_modules, bwrap_installpath_modules, dirs_exist_ok=True)
         # bind mount the modules installpath
-        bwrap_opts.update({
-            f'--bind {bwrap_installpath_modules} {installpath_modules}',
-        })
+        bwrap_cmd.extend([
+            '--bind', bwrap_installpath_modules, installpath_modules,
+        ])
+
     except EasyBuildError:
         # if we can't create the external modules directory, try to use overlayfs
         mkdir(bwrap_workdir, parents=True)
-        bwrap_opts.update({
-            f'--overlay-src {installpath_modules} --overlay {bwrap_installpath_modules} {bwrap_workdir} '
-            f'{installpath_modules}',
-        })
+        bwrap_cmd.extend([
+            '--overlay-src', installpath_modules,
+            '--overlay', bwrap_installpath_modules,
+            bwrap_workdir, installpath_modules,
+        ])
+
+    # store bwrap options in a set to avoid duplicate binds
+    bwrap_opts = set()
 
     # bind mount all software directories
     for mod in sorted(get_bwrap_info('modules_to_install')):
@@ -161,16 +164,18 @@ def prepare_bwrap(bwrap_installpath):
                 installdir = os.path.dirname(installdir)
                 bwrap_installdir = os.path.dirname(bwrap_installdir)
             mkdir(bwrap_workdir, parents=True)
-            bwrap_opts.update({
-                f'--overlay-src {installdir} --overlay {bwrap_installdir} {bwrap_workdir} {installdir}',
-            })
+            bwrap_opts.add((
+                '--overlay-src', installdir,
+                '--overlay', bwrap_installdir,
+                bwrap_workdir, installdir
+            ))
         else:
-            bwrap_opts.update({
-                f'--bind {bwrap_installdir} {installdir}',
-            })
+            bwrap_opts.add((
+                '--bind', bwrap_installdir, installdir,
+            ))
 
     for x in bwrap_opts:
-        bwrap_cmd.extend(x.split())
+        bwrap_cmd.extend(x)
 
     set_bwrap_info('bwrap_cmd', bwrap_cmd)
     bwrap_cmd_str = ' '.join(bwrap_cmd)

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -877,6 +877,8 @@ class ModulesTool:
             self.set_mod_paths()
             self.log.debug("self.mod_paths set based on $MODULEPATH: %s" % self.mod_paths)
 
+            # avoid creating the module path when in --bwrap mode (before actually running with bwrap),
+            # in case the user does not have the necessary write permissions
             if not build_option('bwrap'):
                 # determine module path for EasyBuild install path to be included in $MODULEPATH
                 eb_modpath = os.path.join(install_path(typ='modules'), build_option('suffix_modules_path'))

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -877,13 +877,14 @@ class ModulesTool:
             self.set_mod_paths()
             self.log.debug("self.mod_paths set based on $MODULEPATH: %s" % self.mod_paths)
 
-            # determine module path for EasyBuild install path to be included in $MODULEPATH
-            eb_modpath = os.path.join(install_path(typ='modules'), build_option('suffix_modules_path'))
+            if not build_option('bwrap'):
+                # determine module path for EasyBuild install path to be included in $MODULEPATH
+                eb_modpath = os.path.join(install_path(typ='modules'), build_option('suffix_modules_path'))
 
-            # make sure EasyBuild module path is in 1st place
-            mkdir(eb_modpath, parents=True)
-            self.prepend_module_path(eb_modpath)
-            self.log.info("Prepended list of module paths with path used by EasyBuild: %s" % eb_modpath)
+                # make sure EasyBuild module path is in 1st place
+                mkdir(eb_modpath, parents=True)
+                self.prepend_module_path(eb_modpath)
+                self.log.info("Prepended list of module paths with path used by EasyBuild: %s" % eb_modpath)
 
         # set the module path environment accordingly
         curr_mod_paths = curr_module_paths()


### PR DESCRIPTION
this PR also `bwrap`s the module installpath (and removes `--installpath-modules` from `bwrap_eb_options` as it's no longer needed).

this change is required for making bwrap work with HMNS: for a compiler module the HMNS has to know the non-bwrapped location, instead of what is passed to `--installpath-modules`

the main issue blocking this change was that bwrapping a module installpath causes the already installed modules to become unavailable. this is solved by copying the full module installpath to the bwrap module installpath (with overlayfs this is not necessary). the overhead of this should be fairly limited - on our systems the size is < 25MB and <2000 files.

other changes:
- update the bwrap github action to print success/failure for each individual check.
- avoid creating the modulepath directory when in `--bwrap` mode (before actually running with bwrap) in case the user does not have write permissions.
- avoid adding duplicate bwrap binds (with e.g. easystacks).