### PR TITLE
deprecate passing `extension` option to `sanity_check_step` & `sanity_check_load_module` methods in `EasyBlock` class

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -3444,6 +3444,16 @@ class EasyBlock:
 
     def _dispatch_sanity_check_step(self, *args, **kwargs):
         """Decide whether to run the dry-run or the real version of the sanity-check step"""
+        if 'extension' in kwargs:
+            extension = kwargs.pop('extension')
+            self.log.deprecated(
+                "Passing `extension` to `sanity_check_step` is no longer necessary "
+                f"(Easyblock: {self.__class__.__name__}).",
+                '6.0',
+            )
+            if extension != self.is_extension:
+                raise EasyBuildError('Unexpected value for `extension` argument. '
+                                     f'Should be: {self.is_extension}, got:  {extension}')
         if self.dry_run:
             self._sanity_check_step_dry_run(*args, **kwargs)
         else:
@@ -4316,6 +4326,8 @@ class EasyBlock:
         """
         Load module to prepare environment for sanity check
         """
+        if extension != self.is_extension:
+            raise RuntimeError(f"{self} {self.name} {extension}!={self.is_extension}")
 
         # skip loading of fake module when using --sanity-check-only, load real module instead
         if build_option('sanity_check_only') and not extension:
@@ -4340,15 +4352,30 @@ class EasyBlock:
 
         return self.fake_mod_data
 
-    def _sanity_check_step(self, custom_paths=None, custom_commands=None, extension=False, extra_modules=None):
+    def _sanity_check_step(self, custom_paths=None, custom_commands=None, extension=None, extra_modules=None):
         """
         Real version of sanity_check_step method.
 
         :param custom_paths: custom sanity check paths to check existence for
         :param custom_commands: custom sanity check commands to run
-        :param extension: indicates whether or not sanity check is run for an extension
+        :param extension: DEPRECATED: indicated whether sanity check is run for an extension, now ignored
         :param extra_modules: extra modules to load before running sanity check commands
         """
+        if extension is not None:
+            if extra_modules is None and isinstance(extension, list):
+                # 3-parameter form intended as-if `extension` was already removed
+                extra_modules = extension
+            else:
+                self.log.deprecated(
+                    "Passing `extension` to `sanity_check_step` is no longer necessary "
+                    f"(Easyblock: {self.__class__.__name__}).",
+                    '6.0',
+                )
+                if extension != self.is_extension:
+                    raise EasyBuildError('Unexpected value for `extension` argument. '
+                                         f'Should be: {self.is_extension}, got:  {extension}')
+        del extension  # Avoid accidental use
+
         paths, path_keys_and_check, commands = self._sanity_check_step_common(custom_paths, custom_commands)
 
         # helper function to sanity check (alternatives for) one particular path
@@ -4406,7 +4433,7 @@ class EasyBlock:
                 trace_msg("%s %s found: %s" % (typ, xs2str(xs), ('FAILED', 'OK')[found]))
 
         if not self.sanity_check_module_loaded:
-            self.sanity_check_load_module(extension=extension, extra_modules=extra_modules)
+            self.sanity_check_load_module(extension=self.is_extension, extra_modules=extra_modules)
 
         # allow oversubscription of P processes on C cores (P>C) for software installed on top of Open MPI;
         # this is useful to avoid failing of sanity check commands that involve MPI
@@ -4435,7 +4462,7 @@ class EasyBlock:
             trace_msg(f"result for command '{cmd}': {cmd_result_str}")
 
         # also run sanity check for extensions (unless we are an extension ourselves)
-        if not extension:
+        if not self.is_extension:
             if build_option('skip_extensions'):
                 self.log.info("Skipping sanity check for extensions since skip-extensions is enabled...")
             else:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4322,25 +4322,35 @@ class EasyBlock:
             self.sanity_check_fail_msgs.append(overall_fail_msg + ', '.join(x[0] for x in failed_exts))
             self.sanity_check_fail_msgs.extend(x[1] for x in failed_exts)
 
-    def sanity_check_load_module(self, extension=False, extra_modules=None):
+    def sanity_check_load_module(self, extension=None, extra_modules=None):
         """
         Load module to prepare environment for sanity check
+        extension - DEPRECATED
         """
-        if extension != self.is_extension:
-            raise RuntimeError(f"{self} {self.name} {extension}!={self.is_extension}")
+        if extension is not None:
+            if extra_modules is None and isinstance(extension, list):
+                # 2-parameter form intended as-if `extension` was already removed
+                extra_modules = extension
+            else:
+                self.log.deprecated(
+                    "Passing `extension` to `sanity_check_load_module` is no longer necessary "
+                    f"(Easyblock: {self.__class__.__name__}).",
+                    '6.0',
+                )
+                if extension != self.is_extension:
+                    raise EasyBuildError('Unexpected value for `extension` argument. '
+                                         f'Should be: {self.is_extension}, got:  {extension}')
+        del extension  # Avoid accidental use
 
         # skip loading of fake module when using --sanity-check-only, load real module instead
-        if build_option('sanity_check_only') and not extension:
+        if build_option('sanity_check_only') and not self.is_extension:
             self.log.info("Loading real module for %s %s: %s", self.name, self.version, self.short_mod_name)
             self.load_module(extra_modules=extra_modules)
             self.sanity_check_module_loaded = True
-
         # only load fake module for non-extensions, and not during dry run
-        elif not (extension or self.dry_run):
-
+        elif not (self.is_extension or self.dry_run):
             if extra_modules:
                 self.log.info("Loading extra modules for sanity check: %s", ', '.join(extra_modules))
-
             try:
                 # unload all loaded modules before loading fake module
                 # this ensures that loading of dependencies is tested, and avoids conflicts with build dependencies
@@ -4433,7 +4443,7 @@ class EasyBlock:
                 trace_msg("%s %s found: %s" % (typ, xs2str(xs), ('FAILED', 'OK')[found]))
 
         if not self.sanity_check_module_loaded:
-            self.sanity_check_load_module(extension=self.is_extension, extra_modules=extra_modules)
+            self.sanity_check_load_module(extra_modules=extra_modules)
 
         # allow oversubscription of P processes on C cores (P>C) for software installed on top of Open MPI;
         # this is useful to avoid failing of sanity check commands that involve MPI

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4326,18 +4326,14 @@ class EasyBlock:
         extension - DEPRECATED
         """
         if extension is not None:
-            if extra_modules is None and isinstance(extension, list):
-                # 2-parameter form intended as-if `extension` was already removed
-                extra_modules = extension
-            else:
-                self.log.deprecated(
-                    "Passing `extension` to `sanity_check_load_module` is no longer necessary "
-                    f"(Easyblock: {self.__class__.__name__}).",
-                    '6.0',
-                )
-                if extension != self.is_extension:
-                    raise EasyBuildError('Unexpected value for `extension` argument. '
-                                         f'Should be: {self.is_extension}, got:  {extension}')
+            self.log.deprecated(
+                "Passing `extension` to `sanity_check_load_module` is no longer necessary "
+                f"(Easyblock: {self.__class__.__name__}).",
+                '6.0',
+            )
+            if extension != self.is_extension:
+                raise EasyBuildError('Unexpected value for `extension` argument. '
+                                     f'Should be: {self.is_extension}, got:  {extension}')
         del extension  # Avoid accidental use
 
         if self.is_extension:
@@ -4373,18 +4369,14 @@ class EasyBlock:
         :param extra_modules: extra modules to load before running sanity check commands
         """
         if extension is not None:
-            if extra_modules is None and isinstance(extension, list):
-                # 3-parameter form intended as-if `extension` was already removed
-                extra_modules = extension
-            else:
-                self.log.deprecated(
-                    "Passing `extension` to `sanity_check_step` is no longer necessary "
-                    f"(Easyblock: {self.__class__.__name__}).",
-                    '6.0',
-                )
-                if extension != self.is_extension:
-                    raise EasyBuildError('Unexpected value for `extension` argument. '
-                                         f'Should be: {self.is_extension}, got:  {extension}')
+            self.log.deprecated(
+                "Passing `extension` to `sanity_check_step` is no longer necessary "
+                f"(Easyblock: {self.__class__.__name__}).",
+                '6.0',
+            )
+            if extension != self.is_extension:
+                raise EasyBuildError('Unexpected value for `extension` argument. '
+                                     f'Should be: {self.is_extension}, got:  {extension}')
         del extension  # Avoid accidental use
 
         paths, path_keys_and_check, commands = self._sanity_check_step_common(custom_paths, custom_commands)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4323,7 +4323,7 @@ class EasyBlock:
     def sanity_check_load_module(self, extension=None, extra_modules=None):
         """
         Load module to prepare environment for sanity check
-        extension - DEPRECATED
+        :param extension: DEPRECATED: indicates whether this method is called for an extension
         """
         if extension is not None:
             self.log.deprecated(

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -85,7 +85,7 @@ from easybuild.tools.build_details import get_build_stats
 from easybuild.tools.build_log import EasyBuildError, EasyBuildExit, dry_run_msg, dry_run_warning, dry_run_set_dirs
 from easybuild.tools.build_log import print_error_and_exit, print_msg, print_warning
 from easybuild.tools.config import CHECKSUM_PRIORITY_JSON, DEFAULT_ENVVAR_USERS_MODULES
-from easybuild.tools.config import EASYBUILD_SOURCES_URL, EBPYTHONPREFIXES  # noqa
+from easybuild.tools.config import EASYBUILD_SOURCES_URL, EBPYTHONPREFIXES  # noqa # pylint:disable=unused-import
 from easybuild.tools.config import FORCE_DOWNLOAD_ALL, FORCE_DOWNLOAD_PATCHES, FORCE_DOWNLOAD_SOURCES
 from easybuild.tools.config import MOD_SEARCH_PATH_HEADERS, PYTHONPATH, SEARCH_PATH_BIN_DIRS, SEARCH_PATH_LIB_DIRS
 from easybuild.tools.config import build_option, build_path, get_failed_install_build_dirs_path
@@ -4342,8 +4342,11 @@ class EasyBlock:
                                          f'Should be: {self.is_extension}, got:  {extension}')
         del extension  # Avoid accidental use
 
+        if self.is_extension:
+            return self.fake_mod_data
+
         # skip loading of fake module when using --sanity-check-only, load real module instead
-        if build_option('sanity_check_only') and not self.is_extension:
+        if build_option('sanity_check_only'):
             self.log.info("Loading real module for %s %s: %s", self.name, self.version, self.short_mod_name)
             self.load_module(extra_modules=extra_modules)
             self.sanity_check_module_loaded = True

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -194,8 +194,7 @@ class ExtensionEasyBlock(EasyBlock, Extension):
 
         if custom_paths or custom_commands or not self.is_extension:
             super().sanity_check_step(custom_paths=custom_paths,
-                                      custom_commands=custom_commands,
-                                      extension=self.is_extension)
+                                      custom_commands=custom_commands)
 
         # pass or fail sanity check
         if sanity_check_ok:


### PR DESCRIPTION
This removes the superflous parameter which is always set to `self.extension` anyway.
It looks like an artifact from when that member didn't exist or was not set consistently.

I did this in a PR prior to the 5.3.0 release but took out to get that PR merged without this change.
Reason is to avoid potential mismatches, e.g. by forgetting to pass the parameter.
Ultimately I want to use `self.is_extension` to allow multiple extension to fail their sanity check step and having a "parallel" source of truth makes that harder.
The cause here is that the failing exts_filter allows to check other extensions but failing commands does not as that aborts directly. Easy to fix when relying on `self.is_extension`

I'll also removed it from `sanity_check_load_module` which is similarly simple but requires an [update to the easyblocks](https://github.com/easybuilders/easybuild-easyblocks/pull/4184) that use it. 