### PR TITLE
Don't check for lib and bin paths in sanity check step for each extension

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -4183,8 +4183,10 @@ class EasyBlock:
                 paths = {}
                 for key in path_keys_and_check:
                     paths.setdefault(key, [])
-                paths.update({SANITY_CHECK_PATHS_DIRS: ['bin', ('lib', 'lib64')]})
-                self.log.info("Using default sanity check paths: %s", paths)
+                # Default paths for extensions are handled in the parent easyconfig if desired
+                if not self.is_extension:
+                    paths.update({SANITY_CHECK_PATHS_DIRS: ['bin', ('lib', 'lib64')]})
+                    self.log.info("Using default sanity check paths: %s", paths)
 
             # if enhance_sanity_check is enabled *and* sanity_check_paths are specified in the easyconfig,
             # those paths are used to enhance the paths provided by the easyblock
@@ -4204,9 +4206,11 @@ class EasyBlock:
         # verify sanity_check_paths value: only known keys, correct value types, at least one non-empty value
         only_list_values = all(isinstance(x, list) for x in paths.values())
         only_empty_lists = all(not x for x in paths.values())
-        if sorted_keys != known_keys or not only_list_values or only_empty_lists:
+        if sorted_keys != known_keys or not only_list_values or (only_empty_lists and not self.is_extension):
             error_msg = "Incorrect format for sanity_check_paths: should (only) have %s keys, "
-            error_msg += "values should be lists (at least one non-empty)."
+            error_msg += "values should be lists"
+            if not self.is_extension:
+                error_msg += " (at least one non-empty)."
             raise EasyBuildError(error_msg % ', '.join("'%s'" % k for k in known_keys))
 
         # Resolve arch specific entries

--- a/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
@@ -45,6 +45,7 @@ class Toy_Extension(ExtensionEasyBlock):
         extra_vars = {
             'toy_ext_param': ['', "Toy extension parameter", CUSTOM],
             'toy_custom_sanity_check_cmds': [None, "Optional list of custom command to run in sanity check", CUSTOM],
+            'use_custom_sanity_check_paths': [True, "Add default paths to check for in sanity check", CUSTOM],
         }
         return ExtensionEasyBlock.extra_options(extra_vars=extra_vars)
 
@@ -107,11 +108,14 @@ class Toy_Extension(ExtensionEasyBlock):
     def sanity_check_step(self, *args, **kwargs):
         """Custom sanity check for toy extensions."""
         self.log.info("Loaded modules: %s", self.modules_tool.list())
-        custom_paths = {
-            'files': [],
-            'dirs': ['.'],  # minor hack to make sure there's always a non-empty list
-        }
-        if self.src:
-            custom_paths['files'].extend(['bin/%s' % self.name, 'lib/lib%s.a' % self.name])
+        if self.cfg['use_custom_sanity_check_paths']:
+            custom_paths = {
+                'files': [],
+                'dirs': ['.'],  # minor hack to make sure there's always a non-empty list
+            }
+            if self.src:
+                custom_paths['files'].extend(['bin/%s' % self.name, 'lib/lib%s.a' % self.name])
+        else:
+            custom_paths = None
         return super().sanity_check_step(custom_paths=custom_paths,
                                          custom_commands=self.cfg['toy_custom_sanity_check_cmds'])

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2496,29 +2496,34 @@ class ToyBuildTest(EnhancedTestCase):
 
     def test_toy_extension_sanity_check(self):
         """Check sanity check for extensions:
-        Custom_commands from easyblocks are run."""
+        Custom_commands from easyblocks are run.
+        Paths are checked only once: The default for sanity_check_paths in extensions is empty."""
         test_ec_txt = TOY_EC_TXT
         test_ec_txt += '\n' + textwrap.dedent("""
             exts_list = [
                 ('barbar', '0.0', {
                     'exts_filter': ('ls -l lib/lib%(ext_name)s.a', ''),
                     'toy_custom_sanity_check_cmds': ['echo "Run-Custom-Cmd for %(name)s" && PLACEHOLDER'],
-                    'sanity_check_paths': {'dirs': [], 'files': ['lib/libbarbar.a']},
+                    'use_custom_sanity_check_paths': False,
                 })
             ]
         """)
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         write_file(test_ec, test_ec_txt.replace('PLACEHOLDER', 'false'))
         error_pattern = 'sanity check command echo "Run-Custom-Cmd for barbar" && false failed with exit code 1'
-        with self.mocked_stdout_stderr():
+        with self.mocked_stdout_stderr(), self.log_to_testlogfile() as logfile:
             self.assertErrorRegex(EasyBuildError, error_pattern, self._test_toy_build, ec_file=test_ec,
                                   raise_error=True, verbose=False)
+            logtxt = read_file(logfile)
+        check_bin_msg = 'Sanity check: found (non-empty) directory bin'
+        self.assertEqual(logtxt.count(check_bin_msg), 1, "Check for 'bin' folder should only be done once")
 
         write_file(test_ec, test_ec_txt.replace('PLACEHOLDER', 'true'))
         with self.mocked_stdout_stderr(), self.log_to_testlogfile() as logfile:
             self._test_toy_build(ec_file=test_ec, raise_error=True)
             logtxt = read_file(logfile)
         self.assertRegex(logtxt, 'sanity check command .*Run-Custom-Cmd for barbar.*ran successfully',)
+        self.assertEqual(logtxt.count(check_bin_msg), 1, "Check for 'bin' folder should only be done once")
 
     def test_sanity_check_paths_lib64(self):
         """Test whether fallback in sanity check for lib64/ equivalents of library files works."""


### PR DESCRIPTION
We currently set defaults for paths checked in sanity check step if:
- `sanity_check_paths` is not given or `enhance_sanity_check`
- AND `custom_paths` from the easyblock is not given/empty

This is the case in general, so for a bundle with 100 extensions we will do ~ 200 redundant checks where each will walk the folders to determine if they are empty

This change might miss checking bin & lib now if the easyconfig:
- uses `exts_list`
- `enhance_sanity_check` is not set
- `sanity_check_paths` is used at the top level and does not include bin & lib or subfolders/files, like `bin/toy`, `lib/python`
- (parent) easyblock passes `custom_paths` without such folders/files
- all easyblocks used for extensions do not pass `custom_paths` or do not check for such folders/files


Reason: If e.g. the parent easyconfig/block does pass `custom_paths` then we will not check the defaults in the parent. And with the change we don't check the default in the extensions anymore and hence may not check it at all.
