### PR TITLE
Bring back `async_cmd_check` to check for parallel extension install completion and fix dry-run mode with parallel extensions

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2227,6 +2227,8 @@ class EasyBlock:
         after installing extension(s)
         """
         res = None
+        if self.dry_run:
+            return res  # No module file is written, so no changes. See _install_extensions_det_init_build_env
 
         self.log.debug(f"Checking whether contents of fake module file {fake_mod_file_path} have changed...")
 
@@ -2419,15 +2421,8 @@ class EasyBlock:
                     else:
                         pending_deps = []
 
-                if self.dry_run:
-                    tup = (ext.name, ext.version, ext.__class__.__name__)
-                    msg = "\n* installing extension %s %s using '%s' easyblock\n" % tup
-                    self.dry_run_msg(msg)
-                    running_exts.append(ext)
-
                 # if some of the required dependencies are not installed yet, requeue this extension
-                elif pending_deps:
-
+                if pending_deps:
                     # check whether all required dependency extensions are actually going to be installed;
                     # if not, we assume that they are provided by dependencies;
                     missing_deps = [x for x in required_deps if x not in all_ext_names]
@@ -2443,33 +2438,37 @@ class EasyBlock:
                         msg = f"Pending dependencies for {ext.name} after taking into account missing dependencies: "
                         self.log.debug(msg + ', '.join(pending_deps))
 
-                    if pending_deps:
-                        msg = f"Required dependencies not installed yet for extension {ext.name} ("
-                        msg += ', '.join(pending_deps)
-                        msg += "), adding it back to queue..."
-                        self.log.info(msg)
-                        # purposely adding extension back in the queue at Nth place rather than at the end,
-                        # since we assume that the required dependencies will be installed soon...
-                        exts_queue.insert(max_iter, ext)
-
                 # list of pending dependencies may be empty now after taking into account required extensions
                 # that are not being installed above, so extension may be ready to install
-                if not pending_deps:
+                if pending_deps:
+                    msg = f"Required dependencies not installed yet for extension {ext.name} ("
+                    msg += ', '.join(pending_deps)
+                    msg += "), adding it back to queue..."
+                    self.log.info(msg)
+                    # purposely adding extension back in the queue at Nth place rather than at the end,
+                    # since we assume that the required dependencies will be installed soon...
+                    exts_queue.insert(max_iter, ext)
+                else:
                     tup = (ext.name, ext.version or '')
                     print_msg("starting installation of extension %s %s..." % tup, silent=self.silent, log=self.log)
 
-                    if install and not self.dry_run:
-                        # restore build environment for this extension
-                        restore_env(build_env, log_changes=False)
+                    if install:
+                        if self.dry_run:
+                            self.dry_run_msg(f"\n* installing extension {ext.name} {ext.version} using "
+                                             f"'{ext.__class__.__name__}' easyblock\n")
+                            running_exts.append(ext)
+                        else:
+                            # restore build environment for this extension
+                            restore_env(build_env, log_changes=False)
 
-                        ext.install_extension_substep("pre_install_extension")
+                            ext.install_extension_substep("pre_install_extension")
 
-                        # note: current build environment is copied when install_extension_async is called
-                        ext.async_cmd_task = ext.install_extension_substep("install_extension_async", thread_pool)
-                        running_exts.append(ext)
+                            # note: current build environment is copied when install_extension_async is called
+                            ext.async_cmd_task = ext.install_extension_substep("install_extension_async", thread_pool)
+                            running_exts.append(ext)
 
-                        self.log.info(f"Started installation of extension {ext.name} in the background...")
-                        update_exts_progress_bar_helper(running_exts, 0)
+                            self.log.info(f"Started installation of extension {ext.name} in the background...")
+                            update_exts_progress_bar_helper(running_exts, 0)
 
             # check for extension installations that have completed
             installs_completed = False

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2471,7 +2471,7 @@ class EasyBlock:
             if running_exts:
                 self.log.info(f"Checking for completed extension installations ({len(running_exts)} running)...")
                 for ext in running_exts[:]:
-                    if self.dry_run or ext.async_cmd_task.done():
+                    if self.dry_run or ext.async_cmd_check():
                         installs_completed = True
                         res = ext.async_cmd_task.result()
                         if res.exit_code == EasyBuildExit.SUCCESS:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -68,6 +68,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from string import ascii_letters
 from textwrap import indent
+from typing import List
 
 import easybuild.tools.environment as env
 import easybuild.tools.toolchain as toolchain
@@ -108,7 +109,7 @@ from easybuild.tools.hooks import (
     MODULE_STEP, MODULE_WRITE, PACKAGE_STEP, PATCH_STEP, PERMISSIONS_STEP, POSTITER_STEP, POSTPROC_STEP, PREPARE_STEP,
     READY_STEP, SANITYCHECK_STEP, SINGLE_EXTENSION, TEST_STEP, TESTCASES_STEP, load_hooks, run_hook,
 )
-from easybuild.tools.run import RunShellCmdError, raise_run_shell_cmd_error, run_shell_cmd
+from easybuild.tools.run import RunShellCmdError, RunShellCmdResult, raise_run_shell_cmd_error, run_shell_cmd
 from easybuild.tools.jenkins import write_to_xml
 from easybuild.tools.module_generator import ModuleGeneratorLua, ModuleGeneratorTcl, module_generator, dependencies_for
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
@@ -2335,7 +2336,11 @@ class EasyBlock:
         :param install: actually install extensions, don't just prepare environment for installing
         """
         self.log.info("Installing extensions in parallel...")
-
+        if self.dry_run:
+            # No tasks started in dry-run so use dummy result
+            dry_run_mock_result = RunShellCmdResult(cmd='dummy', output="bar", exit_code=0, stderr=None,
+                                                    work_dir='/test_cat', out_file='/tmp/cat.out', err_file=None,
+                                                    cmd_sh='/tmp/cmd.sh', thread_id=None, task_id=None)
         thread_pool = ThreadPoolExecutor(max_workers=self.cfg.parallel)
 
         # path to fake module file, so we can check if contents change after installing extensions
@@ -2344,8 +2349,8 @@ class EasyBlock:
         self.log.debug("Determining build environment for extensions...")
         build_env, fake_mod_file_txt = self._install_extensions_det_init_build_env(fake_mod_file_path)
 
-        running_exts = []
-        installed_ext_names = []
+        running_exts: List[Extension] = []
+        installed_ext_names: List[str] = []
 
         all_ext_names = [x['name'] for x in self.exts]
         self.log.debug("List of names of all extensions: %s", all_ext_names)
@@ -2355,7 +2360,7 @@ class EasyBlock:
         installed_ext_names = [n for n in all_ext_names if n not in to_install_ext_names]
 
         exts_cnt = len(all_ext_names)
-        exts_queue = self.ext_instances[:]
+        exts_queue: List[Extension] = self.ext_instances[:]
 
         def update_exts_progress_bar_helper(running_exts, progress_size):
             """Helper function to update extensions progress bar."""
@@ -2472,15 +2477,19 @@ class EasyBlock:
                 self.log.info(f"Checking for completed extension installations ({len(running_exts)} running)...")
                 for ext in running_exts[:]:
                     if self.dry_run or ext.async_cmd_check():
+                        if self.dry_run:
+                            res = dry_run_mock_result
+                        else:
+                            res = ext.async_cmd_task.result()
                         installs_completed = True
-                        res = ext.async_cmd_task.result()
                         if res.exit_code == EasyBuildExit.SUCCESS:
                             print_msg(f"installation of extension {ext.name} {ext.version or ''} completed!",
                                       silent=self.silent, log=self.log)
-                            # run post-install method for extension from same working dir as installation of extension
-                            cwd = change_dir(res.work_dir)
-                            ext.install_extension_substep("post_install_extension")
-                            change_dir(cwd)
+                            if not self.dry_run:
+                                # run post-install method for extension from same working dir as installation of it
+                                cwd = change_dir(res.work_dir)
+                                ext.install_extension_substep("post_install_extension")
+                                change_dir(cwd)
                             running_exts.remove(ext)
                             installed_ext_names.append(ext.name)
                             update_exts_progress_bar_helper(running_exts, 1)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2281,7 +2281,7 @@ class EasyBlock:
 
         build_env, fake_mod_file_txt = self._install_extensions_det_init_build_env(fake_mod_file_path)
 
-        for idx, ext in enumerate(self.ext_instances):
+        for idx, ext in enumerate(self.ext_instances, start=1):
             self.log.info("Starting extension %s", ext.name)
 
             run_hook(SINGLE_EXTENSION, self.hooks, pre_step_hook=True, args=[ext])
@@ -2289,18 +2289,17 @@ class EasyBlock:
             # always go back to original work dir to avoid running stuff from a dir that no longer exists
             change_dir(self.orig_workdir)
 
-            progress_info = "Installing '%s' extension (%s/%s)" % (ext.name, idx + 1, exts_cnt)
+            progress_info = f"Installing '{ext.name}' extension ({idx}/{exts_cnt})"
             self.update_exts_progress_bar(progress_info)
 
-            tup = (ext.name, ext.version or '', idx + 1, exts_cnt)
-            print_msg("installing extension %s %s (%d/%d)..." % tup, silent=self.silent, log=self.log)
+            print_msg(f"installing extension {ext.name} {ext.version or ''} ({idx}/{exts_cnt})...",
+                      silent=self.silent, log=self.log)
             start_time = datetime.now()
 
             if install:
                 if self.dry_run:
-                    tup = (ext.name, ext.version, ext.__class__.__name__)
-                    msg = "\n* installing extension %s %s using '%s' easyblock\n" % tup
-                    self.dry_run_msg(msg)
+                    self.dry_run_msg(f"\n* installing extension {ext.name} {ext.version} "
+                                     f"using '{ext.__class__.__name__}' easyblock\n")
                 else:  # actual installation of the extension
                     # restore build environment for this extension
                     restore_env(build_env, log_changes=False)
@@ -2449,8 +2448,8 @@ class EasyBlock:
                     # since we assume that the required dependencies will be installed soon...
                     exts_queue.insert(max_iter, ext)
                 else:
-                    tup = (ext.name, ext.version or '')
-                    print_msg("starting installation of extension %s %s..." % tup, silent=self.silent, log=self.log)
+                    print_msg(f"starting installation of extension {ext.name} {ext.version or ''}...",
+                              silent=self.silent, log=self.log)
 
                     if install:
                         if self.dry_run:

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2339,8 +2339,9 @@ class EasyBlock:
         self.log.info("Installing extensions in parallel...")
         if self.dry_run:
             # No tasks started in dry-run so use dummy result
-            dry_run_mock_result = RunShellCmdResult(cmd='dummy', output="bar", exit_code=0, stderr=None,
-                                                    work_dir='/test_cat', out_file='/tmp/cat.out', err_file=None,
+            dry_run_mock_result = RunShellCmdResult(cmd='dummy', exit_code=EasyBuildExit.SUCCESS,
+                                                    output="bar", stderr=None, work_dir='/test_cat',
+                                                    out_file='/tmp/cat.out', err_file=None,
                                                     cmd_sh='/tmp/cmd.sh', thread_id=None, task_id=None)
         thread_pool = ThreadPoolExecutor(max_workers=self.cfg.parallel)
 

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -37,13 +37,15 @@ Authors:
 """
 import copy
 import os
+from concurrent.futures import Future
+from typing import Optional
 
 from easybuild.framework.easyconfig.default import get_easyconfig_parameter_default
 from easybuild.framework.easyconfig.easyconfig import resolve_template
 from easybuild.framework.easyconfig.templates import TEMPLATE_NAMES_EASYBLOCK_RUN_STEP, template_constant_dict
 from easybuild.tools.build_log import EasyBuildError, EasyBuildExit
 from easybuild.tools.filetools import change_dir
-from easybuild.tools.run import run_shell_cmd
+from easybuild.tools.run import run_shell_cmd, RunShellCmdResult
 from easybuild.tools.utilities import trace_msg
 
 
@@ -125,6 +127,7 @@ class Extension:
         self.cfg = self.master.cfg.copy(validate=False)
         self.ext = copy.deepcopy(ext)
         self.dry_run = self.master.dry_run
+        self.async_cmd_task: Optional[Future[RunShellCmdResult]] = None
 
         if 'name' not in self.ext:
             raise EasyBuildError("'name' is missing in supplied class instance 'ext'.")

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -253,6 +253,20 @@ class Extension:
         """
         raise NotImplementedError
 
+    def async_cmd_check(self):
+        """
+        Check progress of installation command that was started asynchronously.
+        :return: True if command completed, False otherwise
+        """
+        if not self.async_cmd_task.done():
+            return False
+        res: RunShellCmdResult = self.async_cmd_task.result()
+        self.log.debug(f"Asynchronous command for {self.name} finished with exit code {res.exit_code}")
+        self.async_cmd_output = res.output
+        if res.stderr:
+            self.async_cmd_output += res.stderr
+        return True
+
     def postrun(self):
         """
         [DEPRECATED][6.0] Stuff to do after installing a extension.

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -201,8 +201,6 @@ class Extension:
         self.sanity_check_module_loaded = False
         self.fake_mod_data = None
 
-        self.async_cmd_task = None
-
     @property
     def name(self):
         """
@@ -256,19 +254,20 @@ class Extension:
         """
         raise NotImplementedError
 
-    def async_cmd_check(self):
+    def async_cmd_check(self) -> Optional[RunShellCmdResult]:
         """
         Check progress of installation command that was started asynchronously.
         :return: True if command completed, False otherwise
         """
+        if self.async_cmd_task is None:
+            raise EasyBuildError(f"async_cmd_check was called, but no asynchronous command running for {self.name}")
+
         if not self.async_cmd_task.done():
-            return False
+            return None
+
         res: RunShellCmdResult = self.async_cmd_task.result()
-        self.log.debug(f"Asynchronous command for {self.name} finished with exit code {res.exit_code}")
-        self.async_cmd_output = res.output
-        if res.stderr:
-            self.async_cmd_output += res.stderr
-        return True
+        self.log.info(f"Asynchronous command for {self.name} finished with exit code {res.exit_code}")
+        return res
 
     def postrun(self):
         """

--- a/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
@@ -97,6 +97,13 @@ class Toy_Extension(ExtensionEasyBlock):
         return thread_pool.submit(run_shell_cmd, cmd, asynchronous=True, env=os.environ.copy(),
                                   fail_on_error=False, task_id=task_id, work_dir=os.getcwd())
 
+    def async_cmd_check(self):
+        """Show success"""
+        done = super().async_cmd_check()
+        if done:
+            print("Async toy extension build done")
+        return done
+
     def post_install_extension(self):
         """
         Wrap up installation of toy extension.

--- a/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
+++ b/test/framework/sandbox/easybuild/easyblocks/generic/toy_extension.py
@@ -99,10 +99,10 @@ class Toy_Extension(ExtensionEasyBlock):
 
     def async_cmd_check(self):
         """Show success"""
-        done = super().async_cmd_check()
-        if done:
-            print("Async toy extension build done")
-        return done
+        res = super().async_cmd_check()
+        if res:
+            print(f"Async toy extension build done, exit code: {res.exit_code}")
+        return res
 
     def post_install_extension(self):
         """

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2000,7 +2000,7 @@ class ToyBuildTest(EnhancedTestCase):
 
         logtxt = read_file(self.logfile)
 
-        return logtxt
+        return stdout, logtxt
 
     def test_toy_exts_sequential(self):
         """
@@ -2010,7 +2010,7 @@ class ToyBuildTest(EnhancedTestCase):
         # but also test with it disable explicitly
         for args in ([], ['--disable-parallel-extensions-install']):
 
-            logtxt = self._test_toy_exts_common(args=args)
+            logtxt = self._test_toy_exts_common(args=args)[1]
 
             self.assertRegex(logtxt, "INFO Installing extensions sequentially")
 
@@ -2052,7 +2052,7 @@ class ToyBuildTest(EnhancedTestCase):
             # also test skipping of extensions in parallel
             args.append('--skip')
 
-            logtxt = self._test_toy_exts_common(args=args)
+            logtxt = self._test_toy_exts_common(args=args)[1]
 
             # order in which these patterns occur is not fixed, so check them one by one
             patterns = [
@@ -2070,7 +2070,7 @@ class ToyBuildTest(EnhancedTestCase):
         """
         args = ['--parallel-extensions-install']
 
-        logtxt = self._test_toy_exts_common(args=args)
+        stdout, logtxt = self._test_toy_exts_common(args=args)
 
         # take into account that each of these lines may appear multiple times,
         # in case no progress was made between checks
@@ -2109,11 +2109,12 @@ class ToyBuildTest(EnhancedTestCase):
             "toy/0.0-GCC-12.3.0",
         ]
         self.assertEqual(res, expected)
+        self.assertIn("Async toy extension build done", stdout)  # async_cmd_check of custom easyblock called
 
         # also test skipping of extensions in parallel
         args.append('--skip')
 
-        logtxt = self._test_toy_exts_common(args=args)
+        logtxt = self._test_toy_exts_common(args=args)[1]
 
         # order in which these patterns occur is not fixed, so check them one by one
         patterns = [
@@ -2136,7 +2137,7 @@ class ToyBuildTest(EnhancedTestCase):
 
         args[-1] = '--include-easyblocks=%s' % toy_ext_eb
 
-        logtxt = self._test_toy_exts_common(args=args)
+        logtxt = self._test_toy_exts_common(args=args)[1]
 
         # take into account that each of these lines may appear multiple times,
         # in case no progress was made between checks

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -112,7 +112,8 @@ class ToyBuildTest(EnhancedTestCase):
         if os.path.exists(self.dummylogfn):
             os.remove(self.dummylogfn)
 
-    def check_toy(self, installpath, outtxt, name='toy', version='0.0', versionprefix='', versionsuffix='', error=None):
+    def check_toy(self, installpath, outtxt, name='toy', version='0.0', versionprefix='', versionsuffix='', error=None,
+                  args=None):
         """Check whether toy build succeeded."""
 
         full_version = ''.join([versionprefix, version, versionsuffix])
@@ -125,6 +126,8 @@ class ToyBuildTest(EnhancedTestCase):
         # check for success
         success = re.compile(r"COMPLETED: Installation (ended|STOPPED) successfully \(took .* secs?\)")
         self.assertTrue(success.search(outtxt), "COMPLETED message found in '%s'%s" % (outtxt, error_msg))
+        if args and any(arg in args for arg in ('--dry-run', '--extended-dry-run')):
+            return  # No module created
 
         # if the module exists, it should be fine
         toy_module = os.path.join(installpath, 'modules', 'all', name, full_version)
@@ -195,7 +198,8 @@ class ToyBuildTest(EnhancedTestCase):
                 raise myerr
 
         if verify:
-            self.check_toy(self.test_installpath, outtxt, name=name, versionsuffix=versionsuffix, error=myerr)
+            self.check_toy(self.test_installpath, outtxt, name=name, versionsuffix=versionsuffix, error=myerr,
+                           args=args)
 
         if test_readme:
             # make sure postinstallcmds were used
@@ -1988,7 +1992,7 @@ class ToyBuildTest(EnhancedTestCase):
         ])
         write_file(test_ec, test_ec_txt)
 
-        extra_args = ['--force', '--parallel=3']
+        extra_args = ['--rebuild', '--parallel=3']
         if args:
             extra_args.extend(args)
 
@@ -2110,6 +2114,23 @@ class ToyBuildTest(EnhancedTestCase):
         ]
         self.assertEqual(res, expected)
         self.assertIn("Async toy extension build done", stdout)  # async_cmd_check of custom easyblock called
+
+        dry_run_args = args + [
+            '--extended-dry-run',
+            # Start clean, otherwise the existing dir is detected as a ghost directory
+            f'--installpath={tempfile.mkdtemp()}'
+        ]
+        logtxt = self._test_toy_exts_common(args=dry_run_args)[1]
+        # Compare those to the patterns in real mod above
+        patterns = [
+            "INFO Installing extensions in parallel",
+            # In dry-run mode extension installations complete immediately, so bar is finished already
+            r"INFO 2 out of 4 extensions installed \(2 queued, 0 running: \)$",
+            # Same for toy
+            r"INFO 3 out of 4 extensions installed \(1 queued, 0 running: \)$",
+            r"INFO 4 out of 4 extensions installed \(0 queued, 0 running: \)$",
+        ]
+        self.assert_multi_regex(patterns, logtxt)
 
         # also test skipping of extensions in parallel
         args.append('--skip')

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -2113,24 +2113,9 @@ class ToyBuildTest(EnhancedTestCase):
             "toy/0.0-GCC-12.3.0",
         ]
         self.assertEqual(res, expected)
-        self.assertIn("Async toy extension build done", stdout)  # async_cmd_check of custom easyblock called
 
-        dry_run_args = args + [
-            '--extended-dry-run',
-            # Start clean, otherwise the existing dir is detected as a ghost directory
-            f'--installpath={tempfile.mkdtemp()}'
-        ]
-        logtxt = self._test_toy_exts_common(args=dry_run_args)[1]
-        # Compare those to the patterns in real mod above
-        patterns = [
-            "INFO Installing extensions in parallel",
-            # In dry-run mode extension installations complete immediately, so bar is finished already
-            r"INFO 2 out of 4 extensions installed \(2 queued, 0 running: \)$",
-            # Same for toy
-            r"INFO 3 out of 4 extensions installed \(1 queued, 0 running: \)$",
-            r"INFO 4 out of 4 extensions installed \(0 queued, 0 running: \)$",
-        ]
-        self.assert_multi_regex(patterns, logtxt)
+        # check that async_cmd_check of custom easyblock (EB_Toy) was called
+        self.assertIn("Async toy extension build done, exit code: 0\n", stdout)
 
         # also test skipping of extensions in parallel
         args.append('--skip')
@@ -2168,6 +2153,25 @@ class ToyBuildTest(EnhancedTestCase):
             r"INFO 3 out of 4 extensions installed \(0 queued, 1 running: toy\)$",
             r"INFO 4 out of 4 extensions installed \(0 queued, 0 running: \)$",
             '',
+        ]
+        self.assert_multi_regex(patterns, logtxt)
+
+        # also check dry run output
+
+        # use clean install path, otherwise the existing dir is detected as a ghost directory
+        remove_dir(self.test_installpath)
+
+        dry_run_args = args + ['--extended-dry-run']
+        logtxt = self._test_toy_exts_common(args=dry_run_args)[1]
+
+        # Compare those to the patterns in real mod above
+        patterns = [
+            "INFO Installing extensions in parallel",
+            # In dry-run mode extension installations complete immediately, so bar is finished already
+            r"INFO 2 out of 4 extensions installed \(2 queued, 0 running: \)$",
+            # Same for toy
+            r"INFO 3 out of 4 extensions installed \(1 queued, 0 running: \)$",
+            r"INFO 4 out of 4 extensions installed \(0 queued, 0 running: \)$",
         ]
         self.assert_multi_regex(patterns, logtxt)
 


### PR DESCRIPTION
We currently have [this documentation](https://github.com/easybuilders/easybuild-docs/blob/83797988b1a18c2b7f090c2c9a3d2ae2e27baf49/docs/installing-extensions-in-parallel.md?plain=1#L26-L29)
> and check  whether the command has completed via the `async_cmd_check` method.

It is used by rpackage which calls into the super method:
https://github.com/easybuilders/easybuild-easyblocks/blob/e53ee56b0ddce722fb4b37371096b0eabae6cf6f/easybuild/easyblocks/generic/rpackage.py#L335

However it was removed by 36febd873 so the rpackage would crash.

This PR brings it back working together with this callback and the expectations:
- When done set `self.async_cmd_output`
- return `self.async_cmd_task.done()`

This allows rpackage to work again and makes the implementation match the documentation.

Additionally I found that `--extended-dry-run` would crash:
```
                    if self.dry_run or ext.async_cmd_task.done():
                        res = ext.async_cmd_task.result()
```
In the dry-run mode the task is never started.
I resolved that by using a dummy result

And finally dry-run did query the dependencies but then didn't use them yielding misleading output.
The fix is straight forward but changes indentation, so the diff looks larger than it is.