### PR TITLE
copy `Toolchain` instance into `Extension` instances after reset & prepare

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2203,6 +2203,11 @@ class EasyBlock:
                                        rpath_include_dirs=self.rpath_include_dirs,
                                        rpath_wrappers_dir=self.rpath_wrappers_dir)
 
+                # copy Toolchain instance into Extension instances,
+                # to ensure they get the correct values for variables, etc.
+                for ext in self.ext_instances:
+                    ext.cfg._toolchain = copy.copy(self.toolchain)
+
                 # note: we must grab contents of fake module file within context of fake_module_environment
                 fake_mod_file_txt = read_file(fake_mod_file_path)
 
@@ -2239,6 +2244,11 @@ class EasyBlock:
                                        rpath_filter_dirs=self.rpath_filter_dirs,
                                        rpath_include_dirs=self.rpath_include_dirs,
                                        rpath_wrappers_dir=self.rpath_wrappers_dir)
+
+                # copy Toolchain instance into Extension instances,
+                # to ensure they get the correct values for variables, etc.
+                for ext in self.ext_instances:
+                    ext.cfg._toolchain = copy.copy(self.toolchain)
 
                 build_env = copy_current_env()
 


### PR DESCRIPTION
During regression test for the EasyBuild v5.4.0, the installation of `SciPy-bundle-2023.07-gfbf-2023a.eb` failed with an error for the `numpy` extension:
```
An error was raised during test step: Time for 1000x1000 matrix dot product: 832 msec >= 500 msec => ERROR
```

This check, which is part of the test step of the custom easyblock for `numpy`, indicates that linking to the provided BLAS library didn't happen, and the (very slow) fallback library is used instead.

The problem is that the `numpy` easyblock uses `self.toolchain.get_variable` to determine the value of variables like `LIBLAPACK_MT`, and that the variables of the `Toolchain` instance used by the `numpy` extension are empty (because a `prepare` was never called on them, and hence `set_variables` was never called on them either).

The easiest fix for this is to copy the `Toolchain` instance into the `Extension` instances after a reset & prepare, as is done in `EasyBlock._install_extensions_det_init_build_env` and `EasyBlock._install_extensions_check_fake_mod_file`.