### PR TITLE
deprecate useless `EasyBlock.exts_all` class variable

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -214,7 +214,6 @@ class EasyBlock:
 
         # extensions
         self.exts = []
-        self.exts_all = None
         self.ext_instances = []
         self.skip = None
         self.module_extra_extensions = ''  # extra stuff for module file required by extensions
@@ -357,6 +356,12 @@ class EasyBlock:
             self.init_dry_run()
 
         self.log.info("Init completed for application name %s version %s" % (self.name, self.version))
+
+    @property
+    def exts_all(self):
+        """DEPRECATED: Get extensions"""
+        self.log.deprecated("self.exts_all was the same as self.exts so self.exts should always be used", '6.0')
+        return self.exts[:]
 
     def post_init(self):
         """
@@ -2344,7 +2349,7 @@ class EasyBlock:
         running_exts = []
         installed_ext_names = []
 
-        all_ext_names = [x['name'] for x in self.exts_all]
+        all_ext_names = [x['name'] for x in self.exts]
         self.log.debug("List of names of all extensions: %s", all_ext_names)
 
         # take into account that some extensions may be installed already
@@ -3428,8 +3433,6 @@ class EasyBlock:
         if fetch:
             self.update_exts_progress_bar("fetching extension sources/patches")
             self.exts = self.collect_exts_file_info(fetch_files=True)
-
-        self.exts_all = self.exts[:]  # retain a copy of all extensions, regardless of filtering/skipping
 
         # actually install extensions
         if install:


### PR DESCRIPTION
This is always equal to `self.exts` as skipping is done on `self.ext_instances`.