### PR TITLE
Enhance error message when creating symlink where a file is already

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -355,6 +355,11 @@ def symlink(source_path, symlink_path, use_abspath_source=True):
 
     if os.path.exists(symlink_path):
         abs_source_path = os.path.abspath(source_path)
+        if not os.path.islink(symlink_path):
+            raise EasyBuildError("Trying to symlink %s to %s, but there already is a %s at %s.",
+                                 source_path, symlink_path, "file" if os.path.isfile(symlink_path) else "folder",
+                                 symlink_path)
+
         symlink_target_path = os.path.abspath(os.readlink(symlink_path))
         if abs_source_path != symlink_target_path:
             raise EasyBuildError("Trying to symlink %s to %s, but the symlink already exists and points to %s.",

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -944,6 +944,12 @@ class FileToolsTest(EnhancedTestCase):
                               (test_file2, link, test_file),
                               ft.symlink, test_file2, link)
 
+        # Test when symlink is an existing file
+        self.assertErrorRegex(EasyBuildError,
+                              "Trying to symlink %s to %s, but there already is a file at %s." %
+                              (test_file2, test_file, test_file),
+                              ft.symlink, test_file2, test_file)
+
         # test resolve_path
         self.assertEqual(test_dir, ft.resolve_path(link_dir))
         self.assertEqual(os.path.join(os.path.realpath(self.test_prefix), 'test', 'test.txt'), ft.resolve_path(link))


### PR DESCRIPTION
Currently creating a symlink will check existing symlinks if they point to the same location.
This fails if the existing path is not a link: `readlink` raises `InvalidArgumentError`

As this is not user-friendly check the path for being a link first.