### PR TITLE
Avoid crash when running extension installation in `--dry-run` mode

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2221,6 +2221,8 @@ class EasyBlock:
         after installing extension(s)
         """
         res = None
+        if self.dry_run:
+            return res  # No module file is written, so no changes. See _install_extensions_det_init_build_env
 
         self.log.debug(f"Checking whether contents of fake module file {fake_mod_file_path} have changed...")
 


### PR DESCRIPTION
In dry-run mode `_install_extensions_det_init_build_env` yields None values. `_install_extensions_check_fake_mod_file` will then try to read the module file which does not exist and its path is that `None` which crashes in `read_file`

Always treat the module file as unchanged in dry-run mode to avoid that.

Fix for regression since #5211

`--dry-run` for extensions is not well tested (if at all)  and has other issues. This just addresses the regression in EB 5.4.0
For further enhancements see #5223