### PR TITLE
[1/8] Use `assert(Not)Regex` instead of `assertTrue` or `assertFalse` in tests

### DIFF
--- a/easybuild/base/testing.py
+++ b/easybuild/base/testing.py
@@ -36,7 +36,6 @@ Authors:
 import difflib
 import os
 import pprint
-import re
 import sys
 from contextlib import contextmanager
 from io import StringIO
@@ -173,10 +172,7 @@ class TestCase(OrigTestCase):
             str_args = ', '.join(list(map(str, args)) + str_kwargs)
             self.fail("Expected errors with %s(%s) call should occur" % (call.__name__, str_args))
         except error as err:
-            msg = self.convert_exception_to_str(err)
-            if isinstance(regex, str):
-                regex = re.compile(regex)
-            self.assertTrue(regex.search(msg), "Pattern '%s' is found in '%s'" % (regex.pattern, msg))
+            self.assertRegex(self.convert_exception_to_str(err), regex)
 
     def mock_stdout(self, enable, force_tty=False):
         """Enable/disable mocking stdout."""

--- a/test/framework/easystack.py
+++ b/test/framework/easystack.py
@@ -29,7 +29,6 @@ Unit tests for easystack files
 @author: Kenneth Hoste (Ghent University)
 """
 import os
-import re
 import sys
 import tempfile
 from unittest import TextTestRunner
@@ -158,8 +157,7 @@ class EasyStackTest(EnhancedTestCase):
         with self.mocked_stdout():
             stdout = self.eb_main(args, do_build=True, raise_error=True)
             stdout = self.eb_main(args, do_build=True, raise_error=True, reset_env=False, redo_init_config=False)
-        regex = re.compile(r"WARNING Loaded modules detected: \[.*gompi/2018.*\]\n")
-        self.assertFalse(regex.search(stdout), "Pattern '%s' should not be found in: %s" % (regex.pattern, stdout))
+        self.assertNotRegex(stdout, r"WARNING Loaded modules detected: \[.*gompi/2018.*\]\n")
 
         # temporary directory after run should be exactly 2 levels deeper than original one:
         # - 1 level added by setting up configuration in EasyBuild main function

--- a/test/framework/modulestool.py
+++ b/test/framework/modulestool.py
@@ -123,8 +123,7 @@ class ModulesToolTest(EnhancedTestCase):
 
         mt = MockModulesTool(testing=True)
         logtxt = read_file(self.logfile)
-        warn_regex = re.compile("WARNING .*pattern .* not found in defined 'module' function")
-        self.assertTrue(warn_regex.search(logtxt), "Found pattern '%s' in: %s" % (warn_regex.pattern, logtxt))
+        self.assertRegex(logtxt, "WARNING .*pattern .* not found in defined 'module' function")
 
         # redefine 'module' function with correct module command
         os.environ['module'] = "() {  eval `/bin/echo $*`\n}"
@@ -135,8 +134,7 @@ class ModulesToolTest(EnhancedTestCase):
         del os.environ['module']
         mt = MockModulesTool(testing=True)
         logtxt = read_file(self.logfile)
-        warn_regex = re.compile("WARNING No 'module' function defined, can't check if it matches .*")
-        self.assertTrue(warn_regex.search(logtxt), "Pattern %s found in %s" % (warn_regex.pattern, logtxt))
+        self.assertRegex(logtxt, re.compile("WARNING No 'module' function defined, can't check if it matches .*"))
 
         fancylogger.logToFile(self.logfile, enable=False)
 

--- a/test/framework/repository.py
+++ b/test/framework/repository.py
@@ -28,7 +28,6 @@ Unit tests for repository.py.
 @author: Toon Willems (Ghent University)
 """
 import os
-import re
 import shutil
 import sys
 import tempfile
@@ -88,7 +87,7 @@ class RepositoryTest(EnhancedTestCase):
             shutil.rmtree(repo.wc)
         except EasyBuildError as err:
             print("ignoring failed subtest in test_gitrepo, testing offline?")
-            self.assertTrue(re.search("pull in working copy .* went wrong", str(err)))
+            self.assertRegex(str(err, "pull in working copy .* went wrong"))
 
         # filepath
         tmpdir = tempfile.mkdtemp()
@@ -106,9 +105,8 @@ class RepositoryTest(EnhancedTestCase):
                                               'GIT_COMMITTER_NAME': 'test', 'GIT_COMMITTER_EMAIL': 'test@test.org'}):
                 repo.commit("toy/0.0")
 
-            log_regex = re.compile(r"toy/0.0 with EasyBuild v%s @ .* \(time: .*, user: .*\)" % VERSION, re.M)
             logmsg = repo.client.log('HEAD^!')
-            self.assertTrue(log_regex.search(logmsg), "Pattern '%s' found in %s" % (log_regex.pattern, logmsg))
+            self.assertRegex(logmsg, r"toy/0.0 with EasyBuild v%s @ .* \(time: .*, user: .*\)" % VERSION)
 
             shutil.rmtree(repo.wc)
             shutil.rmtree(tmpdir)

--- a/test/framework/repository.py
+++ b/test/framework/repository.py
@@ -87,7 +87,7 @@ class RepositoryTest(EnhancedTestCase):
             shutil.rmtree(repo.wc)
         except EasyBuildError as err:
             print("ignoring failed subtest in test_gitrepo, testing offline?")
-            self.assertRegex(str(err, "pull in working copy .* went wrong"))
+            self.assertRegex(str(err), "pull in working copy .* went wrong")
 
         # filepath
         tmpdir = tempfile.mkdtemp()

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -450,10 +450,10 @@ class EnhancedTestCase(TestCase):
                               line)
                 sys.stdout.write(line)
 
-    def assert_multi_regex(self, regexs, txt, assert_true=True):
+    def assert_multi_regex(self, regexs, txt, assert_true=True, flags=re.M):
         """Helper function to assert presence/absence of list of regex patterns in a text"""
         for regex in regexs:
-            regex = re.compile(regex, re.M)
+            regex = re.compile(regex, flags)
             if assert_true:
                 self.assertRegex(txt, regex)
             else:


### PR DESCRIPTION
This makes the tests shorter and hence easier to read, avoids `re.compile` calls and manual failure message composing. In some cases `assert_multi_regex` could be used to avoid the explicit loops.