### PR TITLE
[2/6] Use constants for commonly used test easyconfig folders, files and content

### DIFF
--- a/test/framework/containers.py
+++ b/test/framework/containers.py
@@ -31,6 +31,7 @@ import os
 import re
 import stat
 import sys
+from test.framework import TEST_ECS_DIR, TOY_EC
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
 
@@ -89,9 +90,6 @@ class ContainersTest(EnhancedTestCase):
 
     def test_end2end_singularity_recipe_config(self):
         """End-to-end test for --containerize (recipe only), using --container-config."""
-        test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
-        toy_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
-
         containerpath = os.path.join(self.test_prefix, 'containers')
         os.environ['EASYBUILD_CONTAINERPATH'] = containerpath
         # --containerpath must be an existing directory (this is done to avoid misconfiguration)
@@ -100,7 +98,7 @@ class ContainersTest(EnhancedTestCase):
         test_container_recipe = os.path.join(self.test_prefix, 'containers', 'Singularity.toy-0.0')
 
         args = [
-            toy_ec,
+            TOY_EC,
             '--containerize',
             '--experimental',
         ]
@@ -257,9 +255,6 @@ class ContainersTest(EnhancedTestCase):
 
     def test_end2end_singularity_image(self):
         """End-to-end test for --containerize (recipe + image)."""
-        topdir = os.path.dirname(os.path.abspath(__file__))
-        toy_ec = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
-
         containerpath = os.path.join(self.test_prefix, 'containers')
         os.environ['EASYBUILD_CONTAINERPATH'] = containerpath
         # --containerpath must be an existing directory (this is done to avoid misconfiguration)
@@ -269,7 +264,7 @@ class ContainersTest(EnhancedTestCase):
         write_file(test_img, '')
 
         args = [
-            toy_ec,
+            TOY_EC,
             '-C',  # equivalent with --containerize
             '--experimental',
             '--container-config=bootstrap=localimage,from=%s' % test_img,
@@ -360,16 +355,13 @@ class ContainersTest(EnhancedTestCase):
         self.check_regexs(regexs, stdout)
 
     def test_end2end_dockerfile(self):
-        test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
-        toy_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
-
         containerpath = os.path.join(self.test_prefix, 'containers')
         os.environ['EASYBUILD_CONTAINERPATH'] = containerpath
         # --containerpath must be an existing directory (this is done to avoid misconfiguration)
         mkdir(containerpath)
 
         base_args = [
-            toy_ec,
+            TOY_EC,
             '--containerize',
             '--container-type=docker',
             '--experimental',
@@ -402,7 +394,7 @@ class ContainersTest(EnhancedTestCase):
 
         remove_file(os.path.join(self.test_prefix, 'containers', 'Dockerfile.toy-0.0'))
 
-        base_args.insert(1, os.path.join(test_ecs, 'g', 'GCC', 'GCC-4.9.2.eb'))
+        base_args.insert(1, os.path.join(TEST_ECS_DIR, 'g', 'GCC', 'GCC-4.9.2.eb'))
         self.run_main(base_args + ['--container-config=ubuntu:20.04'])
         def_file = read_file(os.path.join(self.test_prefix, 'containers', 'Dockerfile.toy-0.0'))
         regexs = [
@@ -419,16 +411,13 @@ class ContainersTest(EnhancedTestCase):
 
     def test_end2end_docker_image(self):
 
-        topdir = os.path.dirname(os.path.abspath(__file__))
-        toy_ec = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
-
         containerpath = os.path.join(self.test_prefix, 'containers')
         os.environ['EASYBUILD_CONTAINERPATH'] = containerpath
         # --containerpath must be an existing directory (this is done to avoid misconfiguration)
         mkdir(containerpath)
 
         args = [
-            toy_ec,
+            TOY_EC,
             '-C',  # equivalent with --containerize
             '--experimental',
             '--container-type=docker',

--- a/test/framework/docs.py
+++ b/test/framework/docs.py
@@ -39,6 +39,7 @@ from easybuild.tools.docs import md_title_and_table, rst_title_and_table
 from easybuild.tools.options import EasyBuildOptions
 from easybuild.tools.utilities import mk_md_table, mk_rst_table
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
+from test.framework import TEST_DIR, TEST_ECS_DIR
 
 
 LIST_EASYBLOCKS_SIMPLE_TXT = """EasyBlock
@@ -869,8 +870,7 @@ class DocsTest(EnhancedTestCase):
         """
         Tests for list_easyblocks function
         """
-        topdir = os.path.dirname(os.path.abspath(__file__))
-        topdir_easyblocks = os.path.join(topdir, 'sandbox', 'easybuild', 'easyblocks')
+        topdir_easyblocks = os.path.join(TEST_DIR, 'sandbox', 'easybuild', 'easyblocks')
 
         txt = list_easyblocks()
         self.assertEqual(txt, LIST_EASYBLOCKS_SIMPLE_TXT)
@@ -899,7 +899,7 @@ class DocsTest(EnhancedTestCase):
     def test_list_software(self):
         """Test list_software* functions."""
         build_options = {
-            'robot_path': [os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'v1.0')],
+            'robot_path': [os.path.join(TEST_DIR, 'easyconfigs', 'v1.0')],
             'silent': True,
             'valid_module_classes': module_classes(),
         }
@@ -933,7 +933,7 @@ class DocsTest(EnhancedTestCase):
 
         # check for specific patterns in output for larger set of test easyconfigs
         build_options = {
-            'robot_path': [os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')],
+            'robot_path': [TEST_ECS_DIR],
             'silent': True,
             'valid_module_classes': module_classes(),
         }

--- a/test/framework/include.py
+++ b/test/framework/include.py
@@ -29,6 +29,7 @@ Unit tests for eb command line options.
 """
 import os
 import sys
+from test.framework import TEST_DIR
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner
 
@@ -53,7 +54,7 @@ class IncludeTest(EnhancedTestCase):
 
     def test_include_easyblocks(self):
         """Test include_easyblocks()."""
-        test_easyblocks = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'sandbox', 'easybuild', 'easyblocks')
+        test_easyblocks = os.path.join(TEST_DIR, 'sandbox', 'easybuild', 'easyblocks')
 
         # put a couple of custom easyblocks in place, to test
         myeasyblocks = os.path.join(self.test_prefix, 'myeasyblocks')
@@ -119,7 +120,7 @@ class IncludeTest(EnhancedTestCase):
 
     def test_include_easyblocks_priority(self):
         """Test whether easyblocks included via include_easyblocks() get priority over others."""
-        test_easyblocks = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'sandbox', 'easybuild', 'easyblocks')
+        test_easyblocks = os.path.join(TEST_DIR, 'sandbox', 'easybuild', 'easyblocks')
 
         # make sure that test 'foo' easyblock is there
         import easybuild.easyblocks.foo
@@ -288,8 +289,7 @@ class IncludeTest(EnhancedTestCase):
 
         self.assertErrorRegex(EasyBuildError, "No such file", is_software_specific_easyblock, '/no/such/easyblock.py')
 
-        testdir = os.path.dirname(os.path.abspath(__file__))
-        test_easyblocks = os.path.join(testdir, 'sandbox', 'easybuild', 'easyblocks')
+        test_easyblocks = os.path.join(TEST_DIR, 'sandbox', 'easybuild', 'easyblocks')
 
         self.assertTrue(is_software_specific_easyblock(os.path.join(test_easyblocks, 'g', 'gcc.py')))
         self.assertTrue(is_software_specific_easyblock(os.path.join(test_easyblocks, 't', 'toy.py')))

--- a/test/framework/package.py
+++ b/test/framework/package.py
@@ -33,6 +33,7 @@ import stat
 import sys
 
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
+from test.framework import TEST_ECS_DIR
 from unittest import TextTestRunner
 
 from easybuild.framework.easyconfig.easyconfig import EasyConfig
@@ -181,9 +182,7 @@ class PackageTest(EnhancedTestCase):
             os.environ['EASYBUILD_PACKAGE_NAMING_SCHEME'] = pns_type
             init_config(build_options={'silent': True})
 
-            topdir = os.path.dirname(os.path.abspath(__file__))
-            test_easyconfigs = os.path.join(topdir, 'easyconfigs', 'test_ecs')
-            test_ec = os.path.join(test_easyconfigs, 'o', 'OpenMPI', 'OpenMPI-2.1.2-GCC-6.4.0-2.28.eb')
+            test_ec = os.path.join(TEST_ECS_DIR, 'o', 'OpenMPI', 'OpenMPI-2.1.2-GCC-6.4.0-2.28.eb')
             ec = EasyConfig(test_ec, validate=False)
 
             pns = ActivePNS()
@@ -206,9 +205,7 @@ class PackageTest(EnhancedTestCase):
         }
         init_config(build_options=build_options)
 
-        topdir = os.path.dirname(os.path.abspath(__file__))
-        test_easyconfigs = os.path.join(topdir, 'easyconfigs', 'test_ecs')
-        ec = EasyConfig(os.path.join(test_easyconfigs, 't', 'toy', 'toy-0.0-gompi-2018a-test.eb'), validate=False)
+        ec = EasyConfig(os.path.join(TEST_ECS_DIR, 't', 'toy', 'toy-0.0-gompi-2018a-test.eb'), validate=False)
 
         mock_fpm(self.test_prefix)
 
@@ -246,7 +243,7 @@ class PackageTest(EnhancedTestCase):
         res = no_logfiles_regex.search(pkgtxt)
         self.assertFalse(res, "Pattern not '%s' found in: %s" % (no_logfiles_regex.pattern, pkgtxt))
 
-        toy_txt = read_file(os.path.join(test_easyconfigs, 't', 'toy', 'toy-0.0-gompi-2018a-test.eb'))
+        toy_txt = read_file(os.path.join(TEST_ECS_DIR, 't', 'toy', 'toy-0.0-gompi-2018a-test.eb'))
         replace_str = '''description = """Toy C program, 100% toy. Now with `backticks'\n'''
         replace_str += '''and newlines"""'''
         toy_txt = re.sub('description = .*', replace_str, toy_txt)

--- a/test/framework/repository.py
+++ b/test/framework/repository.py
@@ -32,6 +32,7 @@ import re
 import shutil
 import sys
 import tempfile
+from test.framework import TOY_EC
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
 from unittest import TextTestRunner, mock
 
@@ -100,8 +101,7 @@ class RepositoryTest(EnhancedTestCase):
         if res.exit_code == 0:
             repo = GitRepository(os.path.join(tmpdir, 'testrepository.git'))
             repo.init()
-            toy_ec_file = os.path.join(os.path.dirname(__file__), 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
-            repo.add_easyconfig(toy_ec_file, 'test', '1.0', {}, None)
+            repo.add_easyconfig(TOY_EC, 'test', '1.0', {}, None)
             with mock.patch.dict(os.environ, {'GIT_AUTHOR_NAME': 'test', 'GIT_AUTHOR_EMAIL': 'test@test.org',
                                               'GIT_COMMITTER_NAME': 'test', 'GIT_COMMITTER_EMAIL': 'test@test.org'}):
                 repo.commit("toy/0.0")
@@ -146,7 +146,6 @@ class RepositoryTest(EnhancedTestCase):
     def test_add_easyconfig(self):
         """Test use of add_easyconfig method"""
         repo = init_repository('FileRepository', self.path)
-        test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs')
 
         def check_ec(path, expected_buildstats):
             """Check easyconfig at specified path"""
@@ -157,12 +156,10 @@ class RepositoryTest(EnhancedTestCase):
             ecdict = EasyConfigParser(path).get_config_dict()
             self.assertEqual(ecdict['buildstats'], expected_buildstats)
 
-        toy_eb_file = os.path.join(test_easyconfigs, 'test_ecs', 't', 'toy', 'toy-0.0.eb')
-
-        path = repo.add_easyconfig(toy_eb_file, 'test', '1.0', {'time': 1.23}, None)
+        path = repo.add_easyconfig(TOY_EC, 'test', '1.0', {'time': 1.23}, None)
         check_ec(path, [{'time': 1.23}])
 
-        path = repo.add_easyconfig(toy_eb_file, 'test', '1.0', {'time': 1.23, 'size': 123}, [{'time': 0.9, 'size': 2}])
+        path = repo.add_easyconfig(TOY_EC, 'test', '1.0', {'time': 1.23, 'size': 123}, [{'time': 0.9, 'size': 2}])
         check_ec(path, [{'time': 0.9, 'size': 2}, {'time': 1.23, 'size': 123}])
 
     def tearDown(self):

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -37,6 +37,7 @@ import tempfile
 import textwrap
 from itertools import product
 from unittest import TextTestRunner
+from test.framework import TEST_ECS_DIR, TEST_MODULES_DIR, TOY_EC, TOY_EC_TXT
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, find_full_path, init_config
 
 import easybuild.tools.modules as modules
@@ -92,8 +93,7 @@ class ToolchainTest(EnhancedTestCase):
 
     def test_toolchain(self):
         """Test whether toolchain is initialized correctly."""
-        test_ecs = os.path.join('test', 'framework', 'easyconfigs', 'test_ecs')
-        ec_file = find_full_path(os.path.join(test_ecs, 'g', 'gzip', 'gzip-1.4-GCC-4.9.3-2.26.eb'))
+        ec_file = find_full_path(os.path.join(TEST_ECS_DIR, 'g', 'gzip', 'gzip-1.4-GCC-4.9.3-2.26.eb'))
         ec = EasyConfig(ec_file, validate=False)
         tc = ec.toolchain
         self.assertIn('debug', tc.options)
@@ -860,8 +860,7 @@ class ToolchainTest(EnhancedTestCase):
 
     def test_easyconfig_optarch_flags(self):
         """Test whether specifying optarch flags in the easyconfigs works."""
-        topdir = os.path.dirname(os.path.abspath(__file__))
-        eb_file = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0-gompi-2018a.eb')
+        eb_file = os.path.join(TEST_ECS_DIR, 't', 'toy', 'toy-0.0-gompi-2018a.eb')
 
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         toy_txt = read_file(eb_file)
@@ -2424,11 +2423,8 @@ class ToolchainTest(EnhancedTestCase):
 
     def test_compiler_cache(self):
         """Test ccache"""
-        topdir = os.path.dirname(os.path.abspath(__file__))
-        eb_file = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
-
         args = [
-            eb_file,
+            TOY_EC,
             "--use-ccache=%s" % os.path.join(self.test_prefix, 'ccache'),
             "--force",
             "--debug",
@@ -3346,8 +3342,7 @@ class ToolchainTest(EnhancedTestCase):
         tmp_modules = os.path.join(self.test_prefix, 'modules')
         mkdir(tmp_modules)
 
-        test_dir = os.path.abspath(os.path.dirname(__file__))
-        copy_dir(os.path.join(test_dir, 'modules', 'OpenMPI'), os.path.join(tmp_modules, 'OpenMPI'))
+        copy_dir(os.path.join(TEST_MODULES_DIR, 'OpenMPI'), os.path.join(tmp_modules, 'OpenMPI'))
 
         openmpi_module = os.path.join(tmp_modules, 'OpenMPI', '2.1.2-GCC-6.4.0-2.28')
         ompi_mod_txt = read_file(openmpi_module)
@@ -3481,11 +3476,7 @@ class ToolchainTest(EnhancedTestCase):
         write_file(tc_ec, tc_ec_txt)
         self.eb_main([tc_ec], raise_error=True, do_build=True)
 
-        topdir = os.path.dirname(os.path.abspath(__file__))
-        toy_ec = os.path.join(topdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb')
-        toy_ec_txt = read_file(toy_ec)
-
-        test_ec_txt = re.sub('toolchain.*', "toolchain = {'name': 'GCC', 'version': 'external'}", toy_ec_txt)
+        test_ec_txt = re.sub('toolchain.*', "toolchain = {'name': 'GCC', 'version': 'external'}", TOY_EC_TXT)
 
         test_ec = os.path.join(self.test_prefix, 'test.eb')
         write_file(test_ec, test_ec_txt)

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -37,7 +37,7 @@ import tempfile
 import textwrap
 from itertools import product
 from unittest import TextTestRunner
-from test.framework import TEST_ECS_DIR, TEST_MODULES_DIR, TOY_EC, TOY_EC_TXT
+from test.framework import TOY_EC, TOY_EC_TXT, TEST_ECS_DIR, TEST_MODULES_DIR
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, find_full_path, init_config
 
 import easybuild.tools.modules as modules


### PR DESCRIPTION
Followup to:
- https://github.com/easybuilders/easybuild-framework/pull/5050

Split from:
- https://github.com/easybuilders/easybuild-framework/pull/5203