### PR TITLE
Accept Path argument in `filetools.copy`

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -2784,7 +2784,7 @@ def copy(paths, target_path, force_in_dry_run=False, **kwargs):
     :param force_in_dry_run: force running the command during dry run
     :param kwargs: additional named arguments to pass down to copy_dir
     """
-    if isinstance(paths, str):
+    if isinstance(paths, (str, Path)):
         paths = [paths]
 
     _log.info("Copying %d files & directories to %s", len(paths), target_path)

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -62,6 +62,7 @@ import zlib
 from functools import partial
 from html.parser import HTMLParser
 from pathlib import Path
+from typing import List, Union
 import urllib.request as std_urllib
 
 from easybuild.base import fancylogger
@@ -2538,7 +2539,7 @@ def find_flexlm_license(custom_env_vars=None, lic_specs=None):
     return (valid_lic_specs, lic_env_var)
 
 
-def copy_file(path, target_path, force_in_dry_run=False):
+def copy_file(path: Union[str, Path], target_path: Union[str, Path], force_in_dry_run: bool = False):
     """
     Copy a file from specified location to specified location
 
@@ -2622,7 +2623,8 @@ def copy_file(path, target_path, force_in_dry_run=False):
             raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
 
 
-def copy_files(paths, target_path, force_in_dry_run=False, target_single_file=False, allow_empty=True, verbose=False):
+def copy_files(paths: List[Union[str, Path]], target_path: Union[str, Path], force_in_dry_run: bool = False,
+               target_single_file: bool = False, allow_empty: bool = True, verbose: bool = False) -> None:
     """
     Copy list of files to specified target path.
     Target directory is created if it doesn't exist yet.
@@ -2694,8 +2696,8 @@ def has_recursive_symlinks(path):
     return False
 
 
-def copy_dir(path, target_path, force_in_dry_run=False, dirs_exist_ok=False, check_for_recursive_symlinks=True,
-             **kwargs):
+def copy_dir(path: Union[str, Path], target_path: Union[str, Path], force_in_dry_run: bool = False,
+             dirs_exist_ok: bool = False, check_for_recursive_symlinks: bool = True, **kwargs) -> None:
     """
     Copy a directory from specified location to specified location
 
@@ -2775,7 +2777,8 @@ def copy_dir(path, target_path, force_in_dry_run=False, dirs_exist_ok=False, che
             raise EasyBuildError("Failed to copy directory %s to %s: %s", path, target_path, err)
 
 
-def copy(paths, target_path, force_in_dry_run=False, **kwargs):
+def copy(paths: Union[Union[str, Path], List[Union[str, Path]]], target_path: Union[str, Path],
+         force_in_dry_run: bool = False, **kwargs) -> None:
     """
     Copy single file/directory or list of files and directories to specified location
 

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -82,6 +82,8 @@ try:
 except ImportError:
     HAVE_REQUESTS = False
 
+PathOrStr = Union[str, Path]
+
 _log = fancylogger.getLogger('filetools', fname=False)
 
 # easyblock class prefix
@@ -2539,7 +2541,7 @@ def find_flexlm_license(custom_env_vars=None, lic_specs=None):
     return (valid_lic_specs, lic_env_var)
 
 
-def copy_file(path: Union[str, Path], target_path: Union[str, Path], force_in_dry_run: bool = False):
+def copy_file(path: PathOrStr, target_path: PathOrStr, force_in_dry_run: bool = False):
     """
     Copy a file from specified location to specified location
 
@@ -2623,7 +2625,7 @@ def copy_file(path: Union[str, Path], target_path: Union[str, Path], force_in_dr
             raise EasyBuildError("Failed to copy file %s to %s: %s", path, target_path, err)
 
 
-def copy_files(paths: List[Union[str, Path]], target_path: Union[str, Path], force_in_dry_run: bool = False,
+def copy_files(paths: List[PathOrStr], target_path: PathOrStr, force_in_dry_run: bool = False,
                target_single_file: bool = False, allow_empty: bool = True, verbose: bool = False) -> None:
     """
     Copy list of files to specified target path.
@@ -2696,7 +2698,7 @@ def has_recursive_symlinks(path):
     return False
 
 
-def copy_dir(path: Union[str, Path], target_path: Union[str, Path], force_in_dry_run: bool = False,
+def copy_dir(path: PathOrStr, target_path: PathOrStr, force_in_dry_run: bool = False,
              dirs_exist_ok: bool = False, check_for_recursive_symlinks: bool = True, **kwargs) -> None:
     """
     Copy a directory from specified location to specified location
@@ -2777,7 +2779,7 @@ def copy_dir(path: Union[str, Path], target_path: Union[str, Path], force_in_dry
             raise EasyBuildError("Failed to copy directory %s to %s: %s", path, target_path, err)
 
 
-def copy(paths: Union[Union[str, Path], List[Union[str, Path]]], target_path: Union[str, Path],
+def copy(paths: Union[PathOrStr, List[PathOrStr]], target_path: PathOrStr,
          force_in_dry_run: bool = False, **kwargs) -> None:
     """
     Copy single file/directory or list of files and directories to specified location

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -2444,6 +2444,14 @@ class FileToolsTest(EnhancedTestCase):
         ft.copy(toy_file, os.path.join(self.test_prefix, 'foo'))
         self.assertTrue(os.path.isfile(os.path.join(self.test_prefix, 'foo', 'toy-0.0.eb')))
 
+        # Test using Path instance
+        toy_patch_path = Path(toy_patch)
+        ft.copy(toy_patch_path, os.path.join(self.test_prefix, 'foo'))
+        self.assertTrue(os.path.isfile(os.path.join(self.test_prefix, 'foo', toy_patch_path.name)))
+        # And as list
+        ft.copy([toy_patch_path], os.path.join(self.test_prefix, 'foo2'))
+        self.assertTrue(os.path.isfile(os.path.join(self.test_prefix, 'foo2', toy_patch_path.name)))
+
         # also test behaviour of copy under --dry-run
         build_options = {
             'extended_dry_run': True,


### PR DESCRIPTION
The check for `str` before converting to list fails when being passed a `pathlib.Path` instance.
Handle that.

To make this clear I added type hints.
I wanted to create a shortcut/alias for `Union[str, Path]` but lack a good name `PathLike` is already taken in the standard [`os` module](https://docs.python.org/3/library/os.html#os.PathLike) to mean something like `Path`
Maybe just `PathOrStr`?