### PR TITLE
Add `extension_name` easyconfig parameter, to specify name of extension to use in generated module file

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -866,8 +866,7 @@ class EasyBlock:
                     exts_sources.append(ext_src)
 
             elif isinstance(ext, str):
-                exts_sources.append({'name': ext})
-
+                exts_sources.append({'name': resolve_template(ext, self.cfg.template_values)})
             else:
                 raise EasyBuildError("Extension specified in unknown format (not a string/list/tuple)")
 

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -695,7 +695,7 @@ class EasyBlock:
                         'github_account': ext_options.get('github_account', orig_github_account),
                         # if a particular easyblock is specified, make sure it's used
                         # (this is picked up by init_ext_instances)
-                        'easyblock': ext_options.get('easyblock', None),
+                        'easyblock': ext_options.get('easyblock'),
                     }
 
                     # construct dictionary with template values;

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -703,6 +703,10 @@ class EasyBlock:
                     template_values = copy.deepcopy(self.cfg.template_values)
                     template_values.update(template_constant_dict(ext_src))
 
+                    # Resolve this here where we have the template values available
+                    if 'extension_name' in ext_options:
+                        ext_options['extension_name'] = resolve_template(ext_options['extension_name'], template_values)
+
                     source_urls = resolve_template(ext_options.get('source_urls', []), template_values)
                     checksums = resolve_template(ext_options.get('checksums', []), template_values)
                     ext_src['checksums'] = checksums
@@ -1679,8 +1683,8 @@ class EasyBlock:
         """
         footer = [self.module_generator.comment("Built with EasyBuild version %s" % VERBOSE_VERSION)]
 
-        # add extra stuff for extensions (if any)
-        if self.cfg.get_ref('exts_list'):
+        # add extra stuff for extensions (if any), or if the 'extension_name' easyconfig parameter is used
+        if self.cfg.get_ref('exts_list') or self.cfg.get('extension_name'):
             footer.append(self.make_module_extra_extensions())
 
         # include modules footer if one is specified
@@ -2003,23 +2007,35 @@ class EasyBlock:
         Each entry should be a (name, version) tuple or just (name, ) if no version exists.
         Custom EasyBlocks may override this to add extensions that cannot be found automatically.
 
+        An 'extension_name' option for an extension in exts_list replaces its name.
+        The 'extension_name' easyconfig parameter, if set, is added as an extra extension.
+
         :param formatted: boolean indicating whether the extension name should be formatted. If True, format using
                           the function defined by the exts_formatter parameter.
         """
-        # Each extension in exts_list is either a string or a list/tuple with name, version as first entries
-        # As name can be a templated value we must resolve templates
         if hasattr(self, '_make_extension_list'):
             self.log.nosupport("self._make_extension_list is replaced by self.make_extension_list", '5.0')
         if type(self).make_extension_string != EasyBlock.make_extension_string:
             self.log.nosupport("self.make_extension_string should not be overridden", '5.0')
 
+        if self.cfg.get_ref('exts_list') and not self.exts:
+            self.exts = self.collect_exts_file_info(fetch_files=False, verify_checksums=False)
+
         exts_list = []
-        for ext in self.cfg.get_ref('exts_list'):
-            if isinstance(ext, str):
-                exts_list.append((resolve_template(ext, self.cfg.template_values), ))
+        for ext in self.exts:
+            ext_name = ext.get('options', {}).get('extension_name') or ext['name']
+            ext_version = ext.get('version')
+            if ext_version is not None:
+                exts_list.append((ext_name, ext_version))
             else:
-                exts_list.append((resolve_template(ext[0], self.cfg.template_values),
-                                  resolve_template(ext[1], self.cfg.template_values)))
+                exts_list.append((ext_name,))
+
+        # 'extension_name' easyconfig parameter (if set) is added as an extra extension, as if in exts_list
+        extension_name = self.cfg.get('extension_name')
+        if extension_name and extension_name not in [ext[0] for ext in exts_list]:
+            self.log.debug(f"Adding '{extension_name}' to list of extensions, "
+                           f"as specified via the 'extension_name' easyconfig parameter")
+            exts_list.append((extension_name, self.version))
 
         if formatted:
             formatter = self.cfg.get('exts_formatter')

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -190,6 +190,9 @@ DEFAULT_CONFIG = {
     'license_server_port': [None, 'Port for license server', LICENSE],
 
     # EXTENSIONS easyconfig parameters
+    'extension_name': [None, "Name to add to the list of extensions in the module file (as if in exts_list); "
+                             "can also be used as an option for an extension in exts_list, "
+                             "in which case it is used in the module file instead of the extension name", EXTENSIONS],
     'exts_classmap': [{}, "Map of extension name to class for handling build and installation.", EXTENSIONS],
     'exts_defaultclass': [None, "Name of default easyblock for extensions", EXTENSIONS],
     'exts_default_options': [{}, "List of default options for extensions", EXTENSIONS],

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1587,6 +1587,91 @@ class EasyBlockTest(EnhancedTestCase):
         eb = EasyBlock(EasyConfig(self.eb_file))
         eb.fetch_step()
 
+    def test_make_extension_list(self):
+        """Test make_extension_list method, incl. 'extension_name' easyconfig parameter & option."""
+        self.contents = '\n'.join([
+            "easyblock = 'ConfigureMake'",
+            "name = 'toy'",
+            "version = '0.0'",
+            "homepage = 'https://example.com'",
+            "description = 'test'",
+            "toolchain = SYSTEM",
+            "exts_list = [",
+            "    'ulimit',",
+            "    ('bar', '0.0', {'extension_name': 'bar-alias'}),",
+            "    ('barbar', '1.2', {'extension_name': '%(name)s-ext_%(version)s'}),",
+            "    ('%(name)s', '%(version)s'),",
+            "]",
+        ])
+        self.writeEC()
+        eb = EasyBlock(EasyConfig(self.eb_file))
+
+        # 'extension_name' option for an extension is used instead of the extension name;
+        # templates used for name and version are resolved using parent templates,
+        # templates in options (including in extension_name) are resolved using the extension template values.
+        expected = [
+            ('ulimit',),
+            ('bar-alias', '0.0'),
+            ('barbar-ext_1.2', '1.2'),
+            ('toy', '0.0'),
+        ]
+        self.assertEqual(eb.make_extension_list(), expected)
+        self.assertEqual(eb.make_extension_string(), 'bar-alias-0.0, barbar-ext_1.2-1.2, toy-0.0, ulimit')
+
+        # top-level 'extension_name' is added as an extra extension, as if it was in exts_list
+        eb.cfg['extension_name'] = 'extra'
+        self.assertEqual(eb.make_extension_list(), expected + [('extra', '0.0')])
+        self.assertEqual(eb.make_extension_string(),
+                         'bar-alias-0.0, barbar-ext_1.2-1.2, extra-0.0, toy-0.0, ulimit')
+
+        # templates used in top-level 'extension_name' are resolved
+        eb.cfg['extension_name'] = '%(name)s-extra'
+        self.assertEqual(eb.make_extension_list(), expected + [('toy-extra', '0.0')])
+
+        # no duplicate if value of 'extension_name' matches an extension name already in the list
+        eb.cfg['extension_name'] = 'ulimit'
+        self.assertEqual(eb.make_extension_list(), expected)
+
+        # exts_formatter is applied to all extension names, incl. renamed/added ones
+        eb.cfg['extension_name'] = 'extra'
+        eb.cfg['exts_formatter'] = lambda name: name + '-fmt'
+        self.assertEqual(eb.make_extension_list(), [
+            ('ulimit-fmt',),
+            ('bar-alias-fmt', '0.0'),
+            ('barbar-ext_1.2-fmt', '1.2'),
+            ('toy-fmt', '0.0'),
+            ('extra-fmt', '0.0'),
+        ])
+
+        # top-level 'extension_name' works without any extensions in exts_list
+        self.contents = '\n'.join([
+            "easyblock = 'ConfigureMake'",
+            "name = 'toy'",
+            "version = '0.0'",
+            "homepage = 'https://example.com'",
+            "description = 'test'",
+            "toolchain = SYSTEM",
+            "extension_name = 'extra'",
+        ])
+        self.writeEC()
+        eb = EasyBlock(EasyConfig(self.eb_file))
+        self.assertEqual(eb.make_extension_list(), [('extra', '0.0')])
+        self.assertEqual(eb.make_extension_string(), 'extra-0.0')
+
+        # the generated module file includes 'extension_name' in the list of extensions,
+        # in whatis, and in the EBEXTSLIST* environment variable
+        with self.mocked_stdout_stderr():
+            modfile = os.path.join(eb.make_module_step(), 'toy',
+                                   '0.0' + eb.module_generator.MODULE_FILE_EXTENSION)
+        modtxt = read_file(modfile)
+        self.assert_multi_regex([
+            'Included extensions',
+            r'^\s*extra-0.0\s*$',
+            r'Extensions: extra',
+            r'EBEXTSLISTTOY.*extra',
+            ],
+            modtxt)
+
     def test_skip_extensions_step(self):
         """Test the skip_extensions_step"""
 

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -1601,6 +1601,7 @@ class EasyBlockTest(EnhancedTestCase):
             "    ('bar', '0.0', {'extension_name': 'bar-alias'}),",
             "    ('barbar', '1.2', {'extension_name': '%(name)s-ext_%(version)s'}),",
             "    ('%(name)s', '%(version)s'),",
+            "    '%(name)s-str',",
             "]",
         ])
         self.writeEC()
@@ -1614,15 +1615,16 @@ class EasyBlockTest(EnhancedTestCase):
             ('bar-alias', '0.0'),
             ('barbar-ext_1.2', '1.2'),
             ('toy', '0.0'),
+            ('toy-str',),
         ]
         self.assertEqual(eb.make_extension_list(), expected)
-        self.assertEqual(eb.make_extension_string(), 'bar-alias-0.0, barbar-ext_1.2-1.2, toy-0.0, ulimit')
+        self.assertEqual(eb.make_extension_string(), 'bar-alias-0.0, barbar-ext_1.2-1.2, toy-0.0, toy-str, ulimit')
 
         # top-level 'extension_name' is added as an extra extension, as if it was in exts_list
         eb.cfg['extension_name'] = 'extra'
         self.assertEqual(eb.make_extension_list(), expected + [('extra', '0.0')])
         self.assertEqual(eb.make_extension_string(),
-                         'bar-alias-0.0, barbar-ext_1.2-1.2, extra-0.0, toy-0.0, ulimit')
+                         'bar-alias-0.0, barbar-ext_1.2-1.2, extra-0.0, toy-0.0, toy-str, ulimit')
 
         # templates used in top-level 'extension_name' are resolved
         eb.cfg['extension_name'] = '%(name)s-extra'
@@ -1640,6 +1642,7 @@ class EasyBlockTest(EnhancedTestCase):
             ('bar-alias-fmt', '0.0'),
             ('barbar-ext_1.2-fmt', '1.2'),
             ('toy-fmt', '0.0'),
+            ('toy-str-fmt',),
             ('extra-fmt', '0.0'),
         ])
 

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -482,6 +482,7 @@ class EasyConfigTest(EnhancedTestCase):
                ("ext2", "2.0", {
                    "source_urls": [("http://example.com", "suffix")],
                    "patches": [("toy-0.0.eb", ".")], # dummy patch to avoid download fail
+                   "extension_name": "ext2-renamed",
                    "checksums": [
                        # SHA256 checksum for source (gzip-1.4.eb)
                        "6a5abcab719cefa95dca4af0db0d2a9d205d68f775a33b452ec0f2b75b6a3a45",
@@ -496,6 +497,7 @@ class EasyConfigTest(EnhancedTestCase):
                ("ext-%(name)s", "%(version)s"),
                ("ext-%(namelower)s", "%(version_major)s.0"),
             ]
+            extension_name = "ext-extra"
         """)
         self.prep()
         ec = EasyConfig(self.eb_file)
@@ -516,6 +518,7 @@ class EasyConfigTest(EnhancedTestCase):
                           {'toy-0.%(version_minor)s.eb':
                            '177b34bcdfa1abde96f30354848a01894ebc9c24913bc5145306cd30f78fc8ad'}],
             'patches': [('toy-0.0.eb', '.')],
+            'extension_name': 'ext2-renamed',
             'source_tmpl': 'gzip-1.4.eb',
             'source_urls': [('http://example.com', 'suffix')],
         })
@@ -527,9 +530,9 @@ class EasyConfigTest(EnhancedTestCase):
         with self.mocked_stdout_stderr():
             modfile = os.path.join(eb.make_module_step(), 'PI', '3.14' + eb.module_generator.MODULE_FILE_EXTENSION)
         modtxt = read_file(modfile)
-        # verify that templates used for extensions are resolved as they should
-        regex = re.compile('EBEXTSLISTPI.*"ext1-1.0,ext2-2.0,ext-PI-3.14,ext-pi-3.0')
-        self.assertTrue(regex.search(modtxt), "Pattern '%s' found in: %s" % (regex.pattern, modtxt))
+        # verify that templates used for extensions are resolved as they should,
+        # and that 'extension_name' option & easyconfig parameter are honored
+        self.assertRegex(modtxt, 'EBEXTSLISTPI.*"ext1-1.0,ext2-renamed-2.0,ext-PI-3.14,ext-pi-3.0,ext-extra-3.14"')
 
     def test_extensions_default_class(self):
         """Test that exts_defaultclass doesn't need to be specified if explicit one is present."""

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -34,11 +34,13 @@ import re
 import sys
 import tempfile
 from unittest import TextTestRunner, TestSuite
+from typing import Optional, Type
 
 from easybuild.framework.easyconfig.tools import process_easyconfig
 from easybuild.tools import LooseVersion, config
 from easybuild.tools.filetools import mkdir, read_file, remove_file, write_file
-from easybuild.tools.module_generator import ModuleGeneratorLua, ModuleGeneratorTcl, dependencies_for, wrap_shell_vars
+from easybuild.tools.module_generator import ModuleGenerator, ModuleGeneratorLua, ModuleGeneratorTcl
+from easybuild.tools.module_generator import dependencies_for, wrap_shell_vars
 from easybuild.tools.module_naming_scheme.utilities import is_valid_module_name
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, ActiveMNS
@@ -51,7 +53,7 @@ from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, find_
 class ModuleGeneratorTest(EnhancedTestCase):
     """Tests for module_generator module."""
 
-    MODULE_GENERATOR_CLASS = None
+    MODULE_GENERATOR_CLASS: Optional[Type[ModuleGenerator]] = None
 
     def setUp(self):
         """Test setup."""
@@ -1012,6 +1014,7 @@ class ModuleGeneratorTest(EnhancedTestCase):
     def test_env(self):
         """Test setting of environment variables."""
         collection = (
+            # pylint: disable=line-too-long
             # value,               relpath, Tcl reference,                                    Lua reference
             ("value",              False,   'setenv\tkey\t\t"value"\n',                       'setenv("key", "value")\n'),  # noqa
             ('va"lue',             False,   'setenv\tkey\t\t"va\\"lue"\n',                    'setenv("key", \'va"lue\')\n'),  # noqa

--- a/test/framework/module_generator.py
+++ b/test/framework/module_generator.py
@@ -862,6 +862,41 @@ class ModuleGeneratorTest(EnhancedTestCase):
             regex = re.compile(pattern, re.M)
             self.assertFalse(regex.search(desc), "Pattern '%s' not found in: %s" % (regex.pattern, desc))
 
+    def test_module_extensions_extension_name(self):
+        """Test that the 'extension_name' easyconfig parameter is included in the 'extensions' statement."""
+        # not supported by Environment Modules for the moment
+        if isinstance(self.modtool, EnvironmentModules):
+            return
+
+        init_config(build_options={'module_extensions': True})
+
+        test_dir = os.path.abspath(os.path.dirname(__file__))
+        os.environ['MODULEPATH'] = os.path.join(test_dir, 'modules')
+        # toy easyconfig without extensions in exts_list
+        test_ec_txt = read_file(os.path.join(test_dir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0-test.eb'))
+        test_ec = os.path.join(self.test_prefix, 'test.eb')
+        for with_ext in (True, False):
+            with self.subTest(add_extension=with_ext):
+                if with_ext:
+                    ec_txt = test_ec_txt + "\nextension_name = 'extra'\n"
+                else:
+                    ec_txt = test_ec_txt
+                write_file(test_ec, ec_txt)
+
+                eb = EasyBlock(EasyConfig(test_ec))
+                modgen = self.MODULE_GENERATOR_CLASS(eb)
+                desc = modgen.get_description()
+
+                if self.MODULE_GENERATOR_CLASS == ModuleGeneratorTcl:
+                    pattern = r'\s*extensions extra/0.0\n'
+                else:
+                    pattern = r'\s*extensions\("extra/0\.0"\)'
+
+                if with_ext:
+                    self.assertRegex(desc, pattern)
+                else:
+                    self.assertNotRegex(desc, pattern)
+
     def test_prepend_paths(self):
         """Test generating prepend-paths statements."""
         # test prepend_paths


### PR DESCRIPTION
When set for an extension it is used instead of its name in the extension list of the module.
When set for a (root) easyconfig it will add an extension entry for it.

This can then be used by easyblocks e.g. to check for Python package name in `pip list`.

I would also combine it with #5257 : When `extension_name` is set it is used as the default for `load_name`. I expect that this applies to many packages. E.g. `PyTorch` is listed and loaded as `torch`

I also found and fixed a bug/inconsistency: For string-extensions templates were only resolved in `make_extension_list` but not in `collect_exts_file_info`

As for templating: `extension_name` templates are resolved using the extension templates, i.e. `%(name)s` is that of the extension, not the parent EC. That is consistent with the other options.

Initial draft done by AI, manually verified and adjusted afterwards