### PR TITLE
Properly escape single quotes in RPATH wrapper

### DIFF
--- a/easybuild/scripts/rpath_args.py
+++ b/easybuild/scripts/rpath_args.py
@@ -197,8 +197,10 @@ if add_rpath_args:
     # add -rpath flags in front
     cmd_args = cmd_args_rpath + cmd_args
 
-# wrap all arguments into single quotes to avoid further bash expansion
-cmd_args = ["'%s'" % a.replace("'", "''") for a in cmd_args]
+# wrap all arguments into single quotes to avoid further bash expansion.
+# a literal single quote must be escaped as '\'', since doubling it up ('')
+# just cancels out and drops the quote character entirely
+cmd_args = ["'%s'" % a.replace("'", "'\\''") for a in cmd_args]
 
 # output: statement to define $CMD_ARGS
 print("CMD_ARGS=(%s)" % ' '.join(cmd_args))

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -3073,6 +3073,18 @@ class ToolchainTest(EnhancedTestCase):
         cmd_args = pre_cmd_args_ld + ["'-rpath=%s'" % new_lib64] + post_cmd_args_ld
         self.assertEqual(res.output.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
 
+        # arguments containing single quotes must be preserved as-is
+        cmd = script + ''' gcc '' '%s' '-DFOO="'\\''"' -c foo.c''' % rpath_inc
+        with self.mocked_stdout_stderr():
+            res = run_shell_cmd(cmd)
+        self.assertEqual(res.exit_code, 0)
+        cmd_args = [
+            '''\'-DFOO="'\\''"\'''',
+            "'-c'",
+            "'foo.c'",
+        ]
+        self.assertEqual(res.output.strip(), "CMD_ARGS=(%s)" % ' '.join(cmd_args))
+
     def test_toolchain_prepare_rpath(self):
         """Test toolchain.prepare under --rpath"""
 


### PR DESCRIPTION
In rare cases, a tool might pass single quotes during the compile process. Due to the rpath wrappers however, these quotes got lost. Single quotes were replaced by double quotes, being evaluated as a start and end quote of a string, hence lead to being eliminated from the actual compile command.

To fix this, properly escape with backslashes instead. To verify that this resolves the issue, add a regression test, checking against the expected pattern.

Closes https://github.com/easybuilders/easybuild-framework/issues/5192

Assisted-by: Claude Sonnet 5

---

AI disclosure:

Claude Sonnet 5 was used for the initial draft of this PR. All validation was done by hand, as were further improvements upon the initial draft.