### PR TITLE
[3/5] Use `skipTest` rather than faulty copy-paste of `return` conditions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -264,7 +264,9 @@ jobs:
             # run test suite
             python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
             # try and make sure output of running tests is clean (no printed messages/warnings)
-            IGNORE_PATTERNS="no GitHub token available"
+            IGNORE_PATTERNS="=== Skipped tests ==="
+            IGNORE_PATTERNS+="|no GitHub token available"
+            IGNORE_PATTERNS+="|Ignoring rate limit error"
             IGNORE_PATTERNS+="|skipping SvnRepository test"
             IGNORE_PATTERNS+="|requires Lmod as modules tool"
             IGNORE_PATTERNS+="|stty: 'standard input': Inappropriate ioctl for device"

--- a/.github/workflows/unit_tests.yml.orig
+++ b/.github/workflows/unit_tests.yml.orig
@@ -265,16 +265,15 @@ jobs:
             python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
             # try and make sure output of running tests is clean (no printed messages/warnings)
             IGNORE_PATTERNS="=== Skipped tests ==="
-            IGNORE_PATTERNS+="|no GitHub token available"
-            IGNORE_PATTERNS+="|Ignoring rate limit error"
+            IGNORE_PATTERNS+="no GitHub token available"
+            IGNORE_PATTERNS+="Ignoring rate limit error"
             IGNORE_PATTERNS+="|skipping SvnRepository test"
             IGNORE_PATTERNS+="|requires Lmod as modules tool"
-            IGNORE_PATTERNS+="|^[s.]*$" # Only PASS (.) and SKIP (s) status on line
+            IGNORE_PATTERNS="^[s.]*$" # Only PASS (.) and SKIP (s) status on line
             IGNORE_PATTERNS+="|stty: 'standard input': Inappropriate ioctl for device"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 3.[78]"
             IGNORE_PATTERNS+="|from cryptography.* import "
             IGNORE_PATTERNS+="|Blowfish"
-            IGNORE_PATTERNS+="|GC3Pie not available, skipping test"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: TripleDES has been moved"
             IGNORE_PATTERNS+="|algorithms.TripleDES"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ requires = environment-modules, bash, python >= 2.6, python < 3
 
 [flake8]
 # Ignore vendored copy
-exclude = easybuild/tools/tomllib/tomli
+extend-exclude = easybuild/tools/tomllib/tomli
 
 max-line-length = 120
 # C4: Comprehensions

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -80,12 +80,7 @@ from easybuild.tools.systemtools import get_cpu_architecture, get_shared_lib_ext
 from easybuild.tools.toolchain.utilities import search_toolchain
 from easybuild.tools.utilities import quote_str, quote_py_str
 from test.framework.github import GITHUB_TEST_ACCOUNT
-from test.framework.utilities import find_full_path
-
-try:
-    import pycodestyle  # noqa # pylint:disable=unused-import
-except ImportError:
-    pass
+from test.framework.utilities import find_full_path, requires_autopep8, requires_pycodestyle, requires_graphviz
 
 
 class EasyConfigTest(EnhancedTestCase):
@@ -2776,24 +2771,17 @@ class EasyConfigTest(EnhancedTestCase):
                     'foo_extra1', '', 'moduleclass', '']
         self.assertEqual(param_regex.findall(ectxt), expected)
 
+    @requires_autopep8()
     def test_dump_autopep8(self):
         """Test dump() with autopep8 usage enabled (only if autopep8 is available)."""
-        try:
-            import autopep8 # noqa # pylint:disable=unused-import
-        except ImportError:
-            print("Skipping test_dump_autopep8, since autopep8 is not available")
-            return
         os.environ['EASYBUILD_DUMP_AUTOPEP8'] = '1'
         init_config()
         self.test_dump()
         del os.environ['EASYBUILD_DUMP_AUTOPEP8']
 
+    @requires_pycodestyle()
     def test_dump_extra(self):
         """Test EasyConfig's dump() method for files containing extra values"""
-
-        if 'pycodestyle' not in sys.modules:
-            print("Skipping test_dump_extra pycodestyle is not available")
-            return
 
         rawtxt = '\n'.join([
             "easyblock = 'EB_foo'",
@@ -2831,12 +2819,9 @@ class EasyConfigTest(EnhancedTestCase):
 
         check_easyconfigs_style([testec])
 
+    @requires_pycodestyle()
     def test_dump_template(self):
         """ Test EasyConfig's dump() method for files containing templates"""
-
-        if 'pycodestyle' not in sys.modules:
-            print("Skipping test_dump_template pycodestyle is not available")
-            return
 
         rawtxt = '\n'.join([
             "easyblock = 'EB_foo'",
@@ -2920,12 +2905,9 @@ class EasyConfigTest(EnhancedTestCase):
 
         check_easyconfigs_style([testec])
 
+    @requires_pycodestyle()
     def test_dump_comments(self):
         """ Test dump() method for files containing comments """
-
-        if 'pycodestyle' not in sys.modules:
-            print("Skipping test_dump_comments pycodestyle is not available")
-            return
 
         rawtxt = '\n'.join([
             "# #",
@@ -3275,13 +3257,9 @@ class EasyConfigTest(EnhancedTestCase):
         res = "sanity_check_paths = {\n    'files': [],\n    'dirs': ['lib/python%(pyshortver)s/site-packages'],\n}"
         self.assertEqual(to_template_str('sanity_check_paths', test_input, templ_const, templ_val), res)
 
+    @requires_graphviz()
     def test_dep_graph(self):
         """Test for dep_graph."""
-        try:
-            import graphviz  # noqa # pylint:disable=unused-import
-        except ImportError:
-            print("Skipping test_dep_graph, since graphviz is not available")
-            return
 
         test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         build_options = {
@@ -3316,15 +3294,11 @@ class EasyConfigTest(EnhancedTestCase):
         ]
         self.assert_multi_regex(patterns, dottxt)
 
+    @requires_graphviz()
     def test_dep_graph_multi_deps(self):
         """
         Test for dep_graph using easyconfig that uses multi_deps.
         """
-        try:
-            import graphviz  # noqa # pylint:disable=unused-import
-        except ImportError:
-            print("Skipping test_dep_graph_multi_deps, since graphviz is not available")
-            return
 
         test_easyconfigs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         build_options = {
@@ -4915,10 +4889,13 @@ class EasyConfigTest(EnhancedTestCase):
             self.assertEqual(paths, args[:-1])
             self.assertEqual(target_path, args[-1])
 
-        if self.skip_github_tests:
-            print("Skipping test_det_copy_ec_specs using --from-pr, no GitHub token available?")
-            return
+    def test_det_copy_ec_specs_from_pr(self):
+        """Test det_copy_ec_specs function with --from-pr."""
 
+        if self.skip_github_tests:
+            self.skipTest("No GitHub token available?")
+
+        cwd = os.getcwd()
         # use fixed PR (speeds up the test due to caching in fetch_files_from_pr;
         # see https://github.com/easybuilders/easybuild-easyconfigs/pull/22345
         from_pr = 22345

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -35,10 +35,10 @@ import random
 import re
 import sys
 import textwrap
-import unittest
 from string import ascii_letters
 from test.framework import TEST_DIR, TEST_ECS_DIR
-from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
+from test.framework.utilities import (EnhancedTestCase, TestLoaderFiltered, init_config,
+                                      skip_never, skip_silentCI_unless)
 from time import gmtime
 from unittest import TextTestRunner
 from urllib.request import HTTPError, URLError
@@ -75,14 +75,13 @@ GITHUB_BRANCH = 'main'
 
 
 def requires_github_access():
-    """Silently skip for pull requests unless $FORCE_EB_GITHUB_TESTS is set
+    """Skip for pull requests unless $FORCE_EB_GITHUB_TESTS is set
 
     Useful when the test uses e.g. `git` commands to download from Github and would run into rate limits
     """
-    return unittest.skipUnless(
-        os.environ.get('FORCE_EB_GITHUB_TESTS', '0') != '0' or os.getenv('GITHUB_EVENT_NAME') != 'pull_request',
-        "Skipping test requiring GitHub access"
-    )
+    if 'FORCE_EB_GITHUB_TESTS' in os.environ:
+        return skip_never
+    return skip_silentCI_unless(os.getenv('GITHUB_EVENT_NAME') != 'pull_request', "Requires GitHub access")
 
 
 def ignore_rate_limit_in_pr(test_item):

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -754,8 +754,7 @@ class RobotTest(EnhancedTestCase):
     def test_github_det_easyconfig_paths_from_pr(self):
         """Test det_easyconfig_paths function, with --from-pr enabled as well."""
         if self.github_token is None:
-            print("Skipping test_from_pr, no GitHub token available?")
-            return
+            self.skipTest("No GitHub token available?")
 
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)

--- a/test/framework/style.py
+++ b/test/framework/style.py
@@ -31,26 +31,19 @@ Style tests for easyconfig files.
 import glob
 import os
 import sys
-from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
+from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, requires_pycodestyle
 from unittest import TextTestRunner
 
 from easybuild.base import fancylogger
 from easybuild.framework.easyconfig.style import _eb_check_trailing_whitespace, check_easyconfigs_style
 
-try:
-    import pycodestyle  # noqa
-except ImportError:
-    pass
-
 
 class StyleTest(EnhancedTestCase):
     log = fancylogger.getLogger("StyleTest", fname=False)
 
+    @requires_pycodestyle()
     def test_style_conformance(self):
         """Check the easyconfigs for style"""
-        if 'pycodestyle' not in sys.modules:
-            print("Skipping test_style_conformance pycodestyle is not available")
-            return
 
         # all available easyconfig files
         test_easyconfigs_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
@@ -61,11 +54,9 @@ class StyleTest(EnhancedTestCase):
 
         self.assertEqual(result, 0, "No code style errors (and/or warnings) found.")
 
+    @requires_pycodestyle()
     def test_check_trailing_whitespace(self):
         """Test for trailing whitespace check."""
-        if 'pycodestyle' not in sys.modules:
-            print("Skipping test_check_trailing_whitespace pycodestyle is not available")
-            return
 
         lines = [
             "name = 'foo'",  # no trailing whitespace

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -138,12 +138,29 @@ class EasyBuildFrameworkTestSuite(unittest.TestSuite):
         return res
 
 
-def load_tests(loader, tests, pattern):
+class SkipSummaryResult(unittest.TextTestResult):
+    """Decorator that prints skipped tests at the end of the run if in CI environment."""
+    def __init__(self, stream, descriptions, verbosity, *args, **kwargs):
+        super().__init__(stream, descriptions, verbosity, *args, **kwargs)
+        self._verbosity = verbosity
+
+    def stopTestRun(self):
+        super().stopTestRun()
+        if 'CI' in os.environ and self.skipped:
+            print('\n=== Skipped tests ===')
+            print('\n'.join(f'\t{test}: {reason}' for test, reason in self.skipped))
+
+
+class SkipSummaryRunner(unittest.TextTestRunner):
+    resultclass = SkipSummaryResult
+
+
+def load_tests(loader, _tests, _pattern):
     return EasyBuildFrameworkTestSuite(loader)
 
 
 if __name__ == '__main__':
     if len(sys.argv) > 1 and sys.argv[1].startswith('-'):
-        unittest.main()
+        unittest.main(testRunner=SkipSummaryRunner())
     else:
-        unittest.TextTestRunner().run(EasyBuildFrameworkTestSuite(None))
+        SkipSummaryRunner().run(EasyBuildFrameworkTestSuite(None))

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -557,3 +557,39 @@ def find_full_path(base_path, trim=(lambda x: x)):
             break
 
     return full_path
+
+
+def requires_pycodestyle():
+    try:
+        import pycodestyle  # noqa # pylint:disable=unused-import
+        ok = True
+    except ImportError:
+        ok = False
+    return unittest.skipUnless(ok, "no pycodestyle available")
+
+
+def requires_autopep8():
+    try:
+        import autopep8  # noqa # pylint:disable=unused-import
+        ok = True
+    except ImportError:
+        ok = False
+    return unittest.skipUnless(ok, "autopep8 is not available")
+
+
+def requires_graphviz():
+    try:
+        import graphwiz  # noqa # pylint:disable=unused-import
+        ok = True
+    except ImportError:
+        ok = False
+    return unittest.skipUnless(ok, "graphviz is not available")
+
+
+def requires_PyYAML():
+    try:
+        import yaml  # noqa # pylint:disable=unused-import
+        ok = True
+    except ImportError:
+        ok = False
+    return unittest.skipUnless(ok, "PyYAML is not available")

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -30,6 +30,7 @@ Various test utility functions.
 """
 import copy
 import fileinput
+import functools
 import os
 import re
 import shutil
@@ -559,6 +560,29 @@ def find_full_path(base_path, trim=(lambda x: x)):
     return full_path
 
 
+def skip_silently(test_item):
+    """Decorator to turn a test into a no-op"""
+    @functools.wraps(test_item)
+    def skip_wrapper(*args, **kwargs):
+        return
+    return skip_wrapper
+
+
+def skip_never(test_item):
+    """Decorator to not skip a test"""
+    return test_item
+
+
+def skip_silentCI_unless(condition, reason):
+    """Decorator to skip a test if the condition is met.
+
+    On CI the test is turned into a no-op to avoid any output."""
+    if 'CI' in os.environ:
+        return skip_never if condition else skip_silently
+    else:
+        return unittest.skipUnless(condition, reason)
+
+
 def requires_pycodestyle():
     try:
         import pycodestyle  # noqa # pylint:disable=unused-import
@@ -584,6 +608,17 @@ def requires_graphviz():
     except ImportError:
         ok = False
     return unittest.skipUnless(ok, "graphviz is not available")
+
+
+def requires_pysvn():
+    try:
+        from pysvn import ClientError  # noqa
+        ok = True
+    except ImportError:
+        ok = False
+    # For CI skip silently, not easy enough to install,
+    # see https://github.com/leafvmaple/pysvn/issues/1
+    return skip_silentCI_unless(ok, "PySVN is not available, use e.g. apt-get install python3-svn")
 
 
 def requires_PyYAML():


### PR DESCRIPTION
Extracted from  #4188