### PR TITLE
[2/5] Use `skipTest` rather than faulty copy-paste of `return` conditions: Skip marker for GitHub tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -279,6 +279,7 @@ jobs:
             IGNORE_PATTERNS+="|Ignoring rate limit error"
             IGNORE_PATTERNS+="|skipping SvnRepository test"
             IGNORE_PATTERNS+="|requires Lmod as modules tool"
+            IGNORE_PATTERNS+="|^[s.]*$" # Only PASS (.) and SKIP (s) status on line
             IGNORE_PATTERNS+="|stty: 'standard input': Inappropriate ioctl for device"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 3.[78]"
             IGNORE_PATTERNS+="|from cryptography.* import "
@@ -286,9 +287,9 @@ jobs:
             IGNORE_PATTERNS+="|GC3Pie not available, skipping test"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: TripleDES has been moved"
             IGNORE_PATTERNS+="|algorithms.TripleDES"
-            # ignore lines with only successful ('.') and skipped ('s') tests
-            IGNORE_PATTERNS+="|^[\.s]+$"
+
+            TEST_OUTPUT=$(sed -n '/------------------------------/q;p' test_framework_suite.log)  # Everything up to the result divider
             # '|| true' is needed to avoid that GitHub Actions stops the job on non-zero exit of grep (i.e. when there are no matches)
-            PRINTED_MSG=$(egrep -v "${IGNORE_PATTERNS}" test_framework_suite.log | grep '\.\n*[A-Za-z]' || true)
-            test "x$PRINTED_MSG" = "x" || (echo "ERROR: Found printed messages in output of test suite" && echo "${PRINTED_MSG}" && exit 1)
+            PRINTED_MSG=$(echo "$TEST_OUTPUT" | egrep -v "${IGNORE_PATTERNS}" || true)
+            [[ -z $PRINTED_MSG ]] || (echo "ERROR: Found printed messages in output of test suite" && echo "${PRINTED_MSG}" && exit 1)
           done

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -261,6 +261,16 @@ jobs:
             # create file owned by root but writable by anyone (used by test_copy_file)
             sudo touch /tmp/file_to_overwrite_for_easybuild_test_copy_file.txt
             sudo chmod o+w /tmp/file_to_overwrite_for_easybuild_test_copy_file.txt
+
+            if [ "$GITHUB_REPOSITORY_OWNER" == 'easybuilders' ] || [ '${{github.event.pull_request.head.repo.owner}}' == 'easybuilders' ]; then
+              FORCE_EB_GITHUB_TESTS=1
+            else
+              echo "Not force-enabling Github tests"
+              echo "\$GITHUB_EVENT_NAME=GITHUB_EVENT_NAME"
+              echo "\$GITHUB_REPOSITORY_OWNER=$GITHUB_REPOSITORY_OWNER"
+              echo "PR HEAD repo owner=${{github.event.pull_request.head.repo.owner}}"
+            fi
+
             # run test suite
             python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
             # try and make sure output of running tests is clean (no printed messages/warnings)

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -274,7 +274,9 @@ jobs:
             # run test suite
             python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
             # try and make sure output of running tests is clean (no printed messages/warnings)
-            IGNORE_PATTERNS="no GitHub token available"
+            IGNORE_PATTERNS="=== Skipped tests ==="
+            IGNORE_PATTERNS+="|no GitHub token available"
+            IGNORE_PATTERNS+="|Ignoring rate limit error"
             IGNORE_PATTERNS+="|skipping SvnRepository test"
             IGNORE_PATTERNS+="|requires Lmod as modules tool"
             IGNORE_PATTERNS+="|stty: 'standard input': Inappropriate ioctl for device"

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -101,6 +101,25 @@ def ignore_rate_limit_in_pr(test_item):
     return skip_wrapper
 
 
+def requires_github_token():
+    """Require a github token to be available unless $FORCE_EB_GITHUB_TESTS is set"""
+    if 'FORCE_EB_GITHUB_TESTS' in os.environ:
+        return unittest.skipIf(False, None)
+    github_token = gh.fetch_github_token(GITHUB_TEST_ACCOUNT)
+    if os.getenv('GITHUB_EVENT_NAME') != 'pull_request':
+        return unittest.skipUnless(github_token, "No GitHub token available")
+    elif github_token:
+        return unittest.skipIf(False, None)
+    else:
+        # For pull requests silently skip if no token is available as that is expected
+        def decorator(test_item):
+            @functools.wraps(test_item)
+            def skip_wrapper(*args, **kwargs):
+                return
+            return skip_wrapper
+        return decorator
+
+
 class GithubTest(EnhancedTestCase):
     """ small test for The github package
     This should not be to much, since there is an hourly limit of request

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -66,14 +66,13 @@ from easybuild.tools.toolchain.utilities import TC_CONST_PREFIX
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.systemtools import DARWIN, HAVE_ARCHSPEC, get_os_type
 from easybuild.tools.version import VERSION
+from test.framework.github import ignore_rate_limit_in_pr, requires_github_token
 from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, cleanup, init_config
-from test.framework.github import ignore_rate_limit_in_pr
 
 try:
     import pycodestyle  # noqa
 except ImportError:
     pass
-
 
 EXTERNAL_MODULES_METADATA = """[foobar/1.2.3]
 name = foo, bar
@@ -106,7 +105,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
     def setUp(self):
         """Set up test."""
         super().setUp()
-        self.github_token = fetch_github_token(GITHUB_TEST_ACCOUNT)
 
         self.orig_terminal_supports_colors = easybuild.tools.options.terminal_supports_colors
         self.orig_os_getuid = easybuild.main.os.getuid
@@ -1404,12 +1402,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, error_pattern, self.eb_main, args, raise_error=True)
 
+    @requires_github_token()
     def test_github_copy_ec_from_pr(self):
         """Test combination of --copy-ec with --from-pr."""
-        if self.github_token is None:
-            print("Skipping test_copy_ec_from_pr, no GitHub token available?")
-            return
-
         test_working_dir = os.path.join(self.test_prefix, 'test_working_dir')
         mkdir(test_working_dir)
         test_target_dir = os.path.join(self.test_prefix, 'test_target_dir')
@@ -2028,12 +2023,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         if os.path.exists(dummylogfn):
             os.remove(dummylogfn)
 
+    @requires_github_token()
     def test_github_from_pr(self):
         """Test fetching easyconfigs from a PR."""
-        if self.github_token is None:
-            print("Skipping test_from_pr, no GitHub token available?")
-            return
-
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 
@@ -2097,12 +2089,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         except URLError as err:
             print("Ignoring URLError '%s' in test_from_pr" % err)
 
+    @requires_github_token()
     def test_github_from_pr_token_log(self):
         """Check that --from-pr doesn't leak GitHub token in log."""
-        if self.github_token is None:
-            print("Skipping test_from_pr_token_log, no GitHub token available?")
-            return
-
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 
@@ -2115,24 +2104,22 @@ class CommandLineOptionsTest(EnhancedTestCase):
             '--robot=%s' % os.path.join(os.path.dirname(__file__), 'easyconfigs'),
             '--github-user=%s' % GITHUB_TEST_ACCOUNT,  # a GitHub token should be available for this user
         ]
+        github_token = fetch_github_token(GITHUB_TEST_ACCOUNT)
         try:
             with self.mocked_stdout_stderr():
                 outtxt = self.eb_main(args, logfile=dummylogfn, raise_error=True)
                 stdout = self.get_stdout()
                 stderr = self.get_stderr()
-            self.assertNotIn(self.github_token, outtxt)
-            self.assertNotIn(self.github_token, stdout)
-            self.assertNotIn(self.github_token, stderr)
+            self.assertNotIn(github_token, outtxt)
+            self.assertNotIn(github_token, stdout)
+            self.assertNotIn(github_token, stderr)
 
         except URLError as err:
             print("Ignoring URLError '%s' in test_from_pr" % err)
 
+    @requires_github_token()
     def test_github_from_pr_listed_ecs(self):
         """Test --from-pr in combination with specifying easyconfigs on the command line."""
-        if self.github_token is None:
-            print("Skipping test_from_pr, no GitHub token available?")
-            return
-
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 
@@ -2180,12 +2167,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         except URLError as err:
             print("Ignoring URLError '%s' in test_from_pr" % err)
 
+    @requires_github_token()
     def test_github_from_pr_x(self):
         """Test combination of --from-pr with --extended-dry-run."""
-        if self.github_token is None:
-            print("Skipping test_from_pr_x, no GitHub token available?")
-            return
-
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 
@@ -2216,6 +2200,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         except URLError as err:
             print("Ignoring URLError '%s' in test_from_pr_x" % err)
 
+    @requires_github_token()
     def test_from_commit(self):
         """Test for --from-commit."""
         # --from-commit does not involve using GitHub API, so no GitHub token required;
@@ -2223,9 +2208,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # (see also https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/),
         # we only run this test when a GitHub token is available,
         # which is only the case for a limited number of test configurations (see .github/workflows/unit_tests.yml)
-        if self.github_token is None:
-            print("Skipping test_from_commit (no GitHub token available)")
-            return
 
         # easyconfigs commit to add EasyBuild-4.8.2.eb
         test_commit = '7c83a553950c233943c7b0189762f8c05cfea852'
@@ -2305,6 +2287,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     # must be run after test for --list-easyblocks, hence the '_xxx_'
     # cleaning up the imported easyblocks is quite difficult...
+    @requires_github_token()
     def test_xxx_include_easyblocks_from_commit(self):
         """Test for --include-easyblocks-from-commit."""
         # --from-commit does not involve using GitHub API, so no GitHub token required;
@@ -2312,9 +2295,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # (see also https://github.blog/changelog/2025-05-08-updated-rate-limits-for-unauthenticated-requests/),
         # we only run this test when a GitHub token is available,
         # which is only the case for a limited number of test configurations (see .github/workflows/unit_tests.yml)
-        if self.github_token is None:
-            print("Skipping test_xxx_include_easyblocks_from_commit (no GitHub token available)")
-            return
 
         orig_local_sys_path = sys.path[:]
         # easyblocks commit only touching Binary easyblock
@@ -3867,12 +3847,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     # must be run after test for --list-easyblocks, hence the '_xxx_'
     # cleaning up the imported easyblocks is quite difficult...
+    @requires_github_token()
     def test_github_xxx_include_easyblocks_from_pr(self):
         """Test --include-easyblocks-from-pr."""
-        if self.github_token is None:
-            print("Skipping test_preview_pr, no GitHub token available?")
-            return
-
         orig_local_sys_path = sys.path[:]
 
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
@@ -4266,12 +4243,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
             tweaked_dir = os.path.join(tmpdir, tmpdir_files[0], 'tweaked_easyconfigs')
             self.assertExists(os.path.join(tweaked_dir, 'toy-1.0.eb'))
 
+    @requires_github_token()
     def test_github_preview_pr(self):
         """Test --preview-pr."""
-        if self.github_token is None:
-            print("Skipping test_preview_pr, no GitHub token available?")
-            return
-
         test_ecs_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         eb_file = os.path.join(test_ecs_path, 'b', 'bzip2', 'bzip2-1.0.6-GCC-4.9.2.eb')
         args = [
@@ -4285,12 +4259,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
             txt = self.get_stdout()
         self.assertRegex(txt, r"^Comparing bzip2-1.0.6\S* with bzip2-1.0.8")
 
+    @requires_github_token()
     def test_github_review_pr(self):
         """Test --review-pr."""
-        if self.github_token is None:
-            print("Skipping test_review_pr, no GitHub token available?")
-            return
-
         # PR for bwidget 1.10.1 easyconfig, see https://github.com/easybuilders/easybuild-easyconfigs/pull/22227
         args = [
             '--color=never',
@@ -4537,12 +4508,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
             stderr_txt = stderr_txt.strip()
         return stdout_txt, stderr_txt
 
+    @requires_github_token()
     def test_new_branch_github(self):
         """Test for --new-branch-github."""
-        if self.github_token is None:
-            print("Skipping test_create_branch_github, no GitHub token available?")
-            return
-
         topdir = os.path.dirname(os.path.abspath(__file__))
 
         # test easyconfigs
@@ -4613,12 +4581,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         self.assert_multi_regex(regexs, txt)
 
+    @requires_github_token()
     def test_github_new_pr_from_branch(self):
         """Test --new-pr-from-branch."""
-        if self.github_token is None:
-            print("Skipping test_github_new_pr_from_branch, no GitHub token available?")
-            return
-
         # see https://github.com/boegel/easybuild-easyconfigs/tree/test_new_pr_from_branch_DO_NOT_REMOVE
         # branch created specifically for this test,
         # only adds toy-0.0.eb test easyconfig compared to central develop branch
@@ -4653,12 +4618,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         self.assert_multi_regex(regexs, txt)
 
+    @requires_github_token()
     def test_update_branch_github(self):
         """Test --update-branch-github."""
-        if self.github_token is None:
-            print("Skipping test_update_branch_github, no GitHub token available?")
-            return
-
         topdir = os.path.dirname(os.path.abspath(__file__))
         test_ecs = os.path.join(topdir, 'easyconfigs', 'test_ecs')
         toy_ec = os.path.join(test_ecs, 't', 'toy', 'toy-0.0.eb')
@@ -4683,12 +4645,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         self.assert_multi_regex(regexs, txt)
 
+    @requires_github_token()
     def test_github_new_update_pr(self):
         """Test use of --new-pr (dry run only)."""
-        if self.github_token is None:
-            print("Skipping test_new_update_pr, no GitHub token available?")
-            return
-
         # copy toy test easyconfig
         topdir = os.path.dirname(os.path.abspath(__file__))
         test_ecs = os.path.join(topdir, 'easyconfigs', 'test_ecs')
@@ -4910,13 +4869,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         self.assert_multi_regex(regexs, txt, assert_true=False)
 
+    @requires_github_token()
     def test_github_new_pr_warning_missing_patch(self):
         """Test warning printed by --new-pr (dry run only) when a specified patch file could not be found."""
-
-        if self.github_token is None:
-            print("Skipping test_new_pr_warning_missing_patch, no GitHub token available?")
-            return
-
         topdir = os.path.dirname(os.path.abspath(__file__))
         test_ecs = os.path.join(topdir, 'easyconfigs', 'test_ecs')
         test_ec = os.path.join(self.test_prefix, 'test.eb')
@@ -4952,12 +4907,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         self.assertRegex(stdout, new_pr_out_regex)
         self.assertRegex(stderr, warning_regex)
 
+    @requires_github_token()
     def test_github_sync_pr_with_develop(self):
         """Test use of --sync-pr-with-develop (dry run only)."""
-        if self.github_token is None:
-            print("Skipping test_sync_pr_with_develop, no GitHub token available?")
-            return
-
         # use https://github.com/easybuilders/easybuild-easyconfigs/pull/9150,
         # which is a PR from boegel:develop to easybuilders:develop
         # (to sync 'develop' branch in boegel's fork with central develop branch);
@@ -4981,12 +4933,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ])
         self.assertTrue(re.match(pattern, txt), "Pattern '%s' doesn't match: %s" % (pattern, txt))
 
+    @requires_github_token()
     def test_github_sync_branch_with_develop(self):
         """Test use of --sync-branch-with-develop (dry run only)."""
-        if self.github_token is None:
-            print("Skipping test_sync_pr_with_develop, no GitHub token available?")
-            return
-
         # see https://github.com/boegel/easybuild-easyconfigs/tree/test_new_pr_from_branch_DO_NOT_REMOVE
         test_branch = 'test_new_pr_from_branch_DO_NOT_REMOVE'
 
@@ -5010,12 +4959,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ])
         self.assertTrue(re.match(pattern, stdout), "Pattern '%s' doesn't match: %s" % (pattern, stdout))
 
+    @requires_github_token()
     def test_github_new_pr_python(self):
         """Check generated PR title for --new-pr on easyconfig that includes Python dependency."""
-        if self.github_token is None:
-            print("Skipping test_new_pr_python, no GitHub token available?")
-            return
-
         # copy toy test easyconfig
         test_ecs = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
         toy_ec = os.path.join(self.test_prefix, 'toy.eb')
@@ -5055,13 +5001,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         regex = re.compile(r"^\* title: \"\{tools\}\[system/system\] toy v0.0\"$", re.M)
         self.assertRegex(txt, regex)
 
+    @requires_github_token()
     def test_github_new_pr_delete(self):
         """Test use of --new-pr to delete easyconfigs."""
-
-        if self.github_token is None:
-            print("Skipping test_new_pr_delete, no GitHub token available?")
-            return
-
         ec_name = 'bzip2-1.0.8.eb'
         args = [
             '--new-pr',
@@ -5081,13 +5023,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         self.assert_multi_regex(regexs, txt)
 
+    @requires_github_token()
     def test_github_new_pr_dependencies(self):
         """Test use of --new-pr with automatic dependency lookup."""
-
-        if self.github_token is None:
-            print("Skipping test_new_pr_dependencies, no GitHub token available?")
-            return
-
         foo_eb = '\n'.join([
             'easyblock = "ConfigureMake"',
             'name = "foo"',
@@ -5129,15 +5067,11 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         self.assert_multi_regex(regexs, txt)
 
+    @requires_github_token()
     def test_github_new_pr_easyblock(self):
         """
         Test using --new-pr to open an easyblocks PR
         """
-
-        if self.github_token is None:
-            print("Skipping test_new_pr_easyblock, no GitHub token available?")
-            return
-
         topdir = os.path.dirname(os.path.abspath(__file__))
         toy_eb = os.path.join(topdir, 'sandbox', 'easybuild', 'easyblocks', 't', 'toy.py')
         self.assertExists(toy_eb)
@@ -5158,13 +5092,10 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ]
         self.assert_multi_regex(patterns, txt)
 
+    @requires_github_token()
     def test_github_merge_pr(self):
         """
         Test use of --merge-pr (dry run)"""
-        if self.github_token is None:
-            print("Skipping test_merge_pr, no GitHub token available?")
-            return
-
         # start by making sure --merge-pr without dry-run errors out for a closed PR
         args = [
             '--merge-pr',
@@ -5265,12 +5196,9 @@ class CommandLineOptionsTest(EnhancedTestCase):
         ])
         self.assertIn(expected_stdout, stdout)
 
+    @requires_github_token()
     def test_github_empty_pr(self):
         """Test use of --new-pr (dry run only) with no changes"""
-        if self.github_token is None:
-            print("Skipping test_empty_pr, no GitHub token available?")
-            return
-
         # get file from develop branch
         full_url = URL_SEPARATOR.join([GITHUB_RAW, GITHUB_EB_MAIN, GITHUB_EASYCONFIGS_REPO,
                                        'develop/easybuild/easyconfigs/z/zlib/zlib-1.3.1-GCCcore-14.2.0.eb'])

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -51,10 +51,10 @@ from easybuild.tools.build_log import EasyBuildError
 from easybuild.tools.config import module_classes
 from easybuild.tools.configobj import ConfigObj
 from easybuild.tools.filetools import copy_file, mkdir, read_file, write_file
-from easybuild.tools.github import fetch_github_token
 from easybuild.tools.module_naming_scheme.utilities import det_full_ec_version
 from easybuild.tools.modules import invalidate_module_caches_for, reset_module_caches
 from easybuild.tools.robot import check_conflicts, det_robot_path, resolve_dependencies, search_easyconfigs
+from test.framework.github import requires_github_token
 from test.framework.utilities import find_full_path
 
 
@@ -113,7 +113,6 @@ class RobotTest(EnhancedTestCase):
     def setUp(self):
         """Set up test."""
         super().setUp()
-        self.github_token = fetch_github_token(GITHUB_TEST_ACCOUNT)
         self.orig_experimental = easybuild.framework.easyconfig.tools._log.experimental
         self.orig_modtool = self.modtool
 
@@ -751,12 +750,9 @@ class RobotTest(EnhancedTestCase):
             regex = re.compile(r"^ \* \[.\] %s.*%s \(module: %s\)$" % (path_prefix, ec_fn, module), re.M)
             self.assertTrue(regex.search(outtxt), "Found pattern %s in %s" % (regex.pattern, outtxt))
 
+    @requires_github_token()
     def test_github_det_easyconfig_paths_from_pr(self):
         """Test det_easyconfig_paths function, with --from-pr enabled as well."""
-        if self.github_token is None:
-            print("Skipping test_from_pr, no GitHub token available?")
-            return
-
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)
 

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -138,12 +138,29 @@ class EasyBuildFrameworkTestSuite(unittest.TestSuite):
         return res
 
 
-def load_tests(loader, tests, pattern):
+class SkipSummaryResult(unittest.TextTestResult):
+    """Decorator that prints skipped tests at the end of the run if in CI environment."""
+    def __init__(self, stream, descriptions, verbosity, *args, **kwargs):
+        super().__init__(stream, descriptions, verbosity, *args, **kwargs)
+        self._verbosity = verbosity
+
+    def stopTestRun(self):
+        super().stopTestRun()
+        if 'CI' in os.environ and self.skipped:
+            print('\n=== Skipped tests ===')
+            print('\n'.join(f'\t{test}: {reason}' for test, reason in self.skipped))
+
+
+class SkipSummaryRunner(unittest.TextTestRunner):
+    resultclass = SkipSummaryResult
+
+
+def load_tests(loader, _tests, _pattern):
     return EasyBuildFrameworkTestSuite(loader)
 
 
 if __name__ == '__main__':
     if len(sys.argv) > 1 and sys.argv[1].startswith('-'):
-        unittest.main()
+        unittest.main(testRunner=SkipSummaryRunner())
     else:
-        unittest.TextTestRunner().run(EasyBuildFrameworkTestSuite(None))
+        SkipSummaryRunner().run(EasyBuildFrameworkTestSuite(None))


### PR DESCRIPTION
Extracted from https://github.com/easybuilders/easybuild-framework/pull/4188