### PR TITLE
[1/5] Use `skipTest` rather than faulty copy-paste of `return` conditions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -265,7 +265,6 @@ jobs:
             python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
             # try and make sure output of running tests is clean (no printed messages/warnings)
             IGNORE_PATTERNS="no GitHub token available"
-            IGNORE_PATTERNS+="|skipping SvnRepository test"
             IGNORE_PATTERNS+="|requires Lmod as modules tool"
             IGNORE_PATTERNS+="|stty: 'standard input': Inappropriate ioctl for device"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 3.[78]"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -264,13 +264,14 @@ jobs:
             # run test suite
             python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
             # try and make sure output of running tests is clean (no printed messages/warnings)
-            IGNORE_PATTERNS="no GitHub token available"
+            IGNORE_PATTERNS="=== Skipped tests ==="
+            IGNORE_PATTERNS+="|no GitHub token available"
+            IGNORE_PATTERNS+="|Ignoring rate limit error"
             IGNORE_PATTERNS+="|requires Lmod as modules tool"
             IGNORE_PATTERNS+="|stty: 'standard input': Inappropriate ioctl for device"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 3.[78]"
             IGNORE_PATTERNS+="|from cryptography.* import "
             IGNORE_PATTERNS+="|Blowfish"
-            IGNORE_PATTERNS+="|GC3Pie not available, skipping test"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: TripleDES has been moved"
             IGNORE_PATTERNS+="|algorithms.TripleDES"
             # ignore lines with only successful ('.') and skipped ('s') tests

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -268,15 +268,16 @@ jobs:
             IGNORE_PATTERNS+="|no GitHub token available"
             IGNORE_PATTERNS+="|Ignoring rate limit error"
             IGNORE_PATTERNS+="|requires Lmod as modules tool"
+            IGNORE_PATTERNS+="|^[s.]*$" # Only PASS (.) and SKIP (s) status on line
             IGNORE_PATTERNS+="|stty: 'standard input': Inappropriate ioctl for device"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 3.[78]"
             IGNORE_PATTERNS+="|from cryptography.* import "
             IGNORE_PATTERNS+="|Blowfish"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: TripleDES has been moved"
             IGNORE_PATTERNS+="|algorithms.TripleDES"
-            # ignore lines with only successful ('.') and skipped ('s') tests
-            IGNORE_PATTERNS+="|^[\.s]+$"
+
+            TEST_OUTPUT=$(sed -n '/------------------------------/q;p' test_framework_suite.log)  # Everything up to the result divider
             # '|| true' is needed to avoid that GitHub Actions stops the job on non-zero exit of grep (i.e. when there are no matches)
-            PRINTED_MSG=$(egrep -v "${IGNORE_PATTERNS}" test_framework_suite.log | grep '\.\n*[A-Za-z]' || true)
-            test "x$PRINTED_MSG" = "x" || (echo "ERROR: Found printed messages in output of test suite" && echo "${PRINTED_MSG}" && exit 1)
+            PRINTED_MSG=$(echo "$TEST_OUTPUT" | egrep -v "${IGNORE_PATTERNS}" || true)
+            [[ -z $PRINTED_MSG ]] || (echo "ERROR: Found printed messages in output of test suite" && echo "${PRINTED_MSG}" && exit 1)
           done

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ requires = environment-modules, bash, python >= 2.6, python < 3
 
 [flake8]
 # Ignore vendored copy
-exclude = easybuild/tools/tomllib/tomli
+extend-exclude = easybuild/tools/tomllib/tomli
 
 max-line-length = 120
 # C4: Comprehensions

--- a/test/framework/github.py
+++ b/test/framework/github.py
@@ -35,10 +35,10 @@ import random
 import re
 import sys
 import textwrap
-import unittest
 from string import ascii_letters
 from test.framework import TEST_DIR, TEST_ECS_DIR
-from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, init_config
+from test.framework.utilities import (EnhancedTestCase, TestLoaderFiltered, init_config,
+                                      skip_never, skip_silentCI_unless)
 from time import gmtime
 from unittest import TextTestRunner
 from urllib.request import HTTPError, URLError
@@ -75,14 +75,13 @@ GITHUB_BRANCH = 'main'
 
 
 def requires_github_access():
-    """Silently skip for pull requests unless $FORCE_EB_GITHUB_TESTS is set
+    """Skip for pull requests unless $FORCE_EB_GITHUB_TESTS is set
 
     Useful when the test uses e.g. `git` commands to download from Github and would run into rate limits
     """
-    return unittest.skipUnless(
-        os.environ.get('FORCE_EB_GITHUB_TESTS', '0') != '0' or os.getenv('GITHUB_EVENT_NAME') != 'pull_request',
-        "Skipping test requiring GitHub access"
-    )
+    if 'FORCE_EB_GITHUB_TESTS' in os.environ:
+        return skip_never
+    return skip_silentCI_unless(os.getenv('GITHUB_EVENT_NAME') != 'pull_request', "Requires GitHub access")
 
 
 def ignore_rate_limit_in_pr(test_item):

--- a/test/framework/parallelbuild.py
+++ b/test/framework/parallelbuild.py
@@ -44,7 +44,7 @@ from easybuild.tools.job.pbs_python import PbsPython
 from easybuild.tools.options import parse_options
 from easybuild.tools.parallelbuild import build_easyconfigs_in_parallel, submit_jobs
 from easybuild.tools.robot import resolve_dependencies
-
+from test.framework.utilities import requires_GC3Pie
 
 # test GC3Pie configuration with large resource specs
 GC3PIE_LOCAL_CONFIGURATION = """[resource/ebtestlocalhost]
@@ -214,14 +214,9 @@ class ParallelBuildTest(EnhancedTestCase):
         PbsPython.ppn = PbsPython_ppn
         pbs_python.PbsJob = pbs_python_PbsJob
 
+    @requires_GC3Pie()
     def test_build_easyconfigs_in_parallel_gc3pie(self):
         """Test build_easyconfigs_in_parallel(), using GC3Pie with local config as backend for --job."""
-        try:
-            import gc3libs  # noqa (ignore unused import)
-        except ImportError:
-            print("GC3Pie not available, skipping test")
-            return
-
         self.allow_deprecated_behaviour()
 
         # put GC3Pie config in place to use local host and fork/exec

--- a/test/framework/repository.py
+++ b/test/framework/repository.py
@@ -44,6 +44,7 @@ from easybuild.tools.repository.svnrepo import SvnRepository
 from easybuild.tools.repository.repository import init_repository
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.version import VERSION
+from test.framework.utilities import requires_pysvn
 
 
 class RepositoryTest(EnhancedTestCase):
@@ -113,15 +114,9 @@ class RepositoryTest(EnhancedTestCase):
             shutil.rmtree(repo.wc)
             shutil.rmtree(tmpdir)
 
+    @requires_pysvn()
     def test_svnrepo(self):
         """Test using SvnRepository."""
-        # only run this test if pysvn Python module is available
-        try:
-            from pysvn import ClientError  # noqa
-        except ImportError:
-            print("(skipping SvnRepository test)")
-            return
-
         # GitHub also supports SVN
         test_repo_url = 'https://github.com/easybuilders/testrepository'
 

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -138,12 +138,29 @@ class EasyBuildFrameworkTestSuite(unittest.TestSuite):
         return res
 
 
-def load_tests(loader, tests, pattern):
+class SkipSummaryResult(unittest.TextTestResult):
+    """Decorator that prints skipped tests at the end of the run if in CI environment."""
+    def __init__(self, stream, descriptions, verbosity, *args, **kwargs):
+        super().__init__(stream, descriptions, verbosity, *args, **kwargs)
+        self._verbosity = verbosity
+
+    def stopTestRun(self):
+        super().stopTestRun()
+        if 'CI' in os.environ and self.skipped:
+            print('\n=== Skipped tests ===')
+            print('\n'.join(f'\t{test}: {reason}' for test, reason in self.skipped))
+
+
+class SkipSummaryRunner(unittest.TextTestRunner):
+    resultclass = SkipSummaryResult
+
+
+def load_tests(loader, _tests, _pattern):
     return EasyBuildFrameworkTestSuite(loader)
 
 
 if __name__ == '__main__':
     if len(sys.argv) > 1 and sys.argv[1].startswith('-'):
-        unittest.main()
+        unittest.main(testRunner=SkipSummaryRunner())
     else:
-        unittest.TextTestRunner().run(EasyBuildFrameworkTestSuite(None))
+        SkipSummaryRunner().run(EasyBuildFrameworkTestSuite(None))

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -51,7 +51,7 @@ import easybuild.tools.module_naming_scheme.toolchain as mns_toolchain
 from easybuild.framework.easyconfig import easyconfig
 from easybuild.framework.easyblock import EasyBlock
 from easybuild.main import main
-from easybuild.tools import config
+from easybuild.tools import config, LooseVersion
 from easybuild.tools.config import GENERAL_CLASS, Singleton, module_classes
 from easybuild.tools.configobj import ConfigObj
 from easybuild.tools.environment import modify_env
@@ -607,7 +607,12 @@ def requires_GC3Pie():
         ok = True
     except ImportError:
         ok = False
-    return unittest.skipUnless(ok, "GC3Pie not available")
+    if LooseVersion(sys.version) < '3.11':
+        return unittest.skipUnless(ok, "GC3Pie not available")
+    else:
+        # GC3Pie not available for Python 3.11 so silently skip:
+        # https://github.com/gc3pie/gc3pie/issues/674
+        return skip_silentCI_unless(ok, "GC3Pie not available")
 
 
 def requires_graphviz():

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -560,6 +560,29 @@ def find_full_path(base_path, trim=(lambda x: x)):
     return full_path
 
 
+def skip_silently(test_item):
+    """Decorator to turn a test into a no-op"""
+    @functools.wraps(test_item)
+    def skip_wrapper(*args, **kwargs):
+        return
+    return skip_wrapper
+
+
+def skip_never(test_item):
+    """Decorator to not skip a test"""
+    return test_item
+
+
+def skip_silentCI_unless(condition, reason):
+    """Decorator to skip a test if the condition is met.
+
+    On CI the test is turned into a no-op to avoid any output."""
+    if 'CI' in os.environ:
+        return skip_never if condition else skip_silently
+    else:
+        return unittest.skipUnless(condition, reason)
+
+
 def requires_pycodestyle():
     try:
         import pycodestyle  # noqa # pylint:disable=unused-import
@@ -598,21 +621,13 @@ def requires_graphviz():
 
 def requires_pysvn():
     try:
-        from pysvn import ClientError # noqa
+        from pysvn import ClientError  # noqa
         ok = True
     except ImportError:
         ok = False
-    if 'CI' in os.environ:
-        # For CI skip silently, not easy enough to install,
-        # see https://github.com/leafvmaple/pysvn/issues/1
-        def decorator(test_item):
-            @functools.wraps(test_item)
-            def skip_wrapper(*args, **kwargs):
-                return
-            return skip_wrapper
-        return decorator
-    else:
-        return unittest.skipUnless(ok, "PySVN is not available, use e.g. apt-get install python3-svn")
+    # For CI skip silently, not easy enough to install,
+    # see https://github.com/leafvmaple/pysvn/issues/1
+    return skip_silentCI_unless(ok, "PySVN is not available, use e.g. apt-get install python3-svn")
 
 
 def requires_PyYAML():

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -563,7 +563,7 @@ def find_full_path(base_path, trim=(lambda x: x)):
 def skip_silently(test_item):
     """Decorator to turn a test into a no-op"""
     @functools.wraps(test_item)
-    def skip_wrapper(*args, **kwargs):
+    def skip_wrapper(*_args, **_kwargs):
         return
     return skip_wrapper
 
@@ -584,6 +584,7 @@ def skip_silentCI_unless(condition, reason):
 
 
 def requires_pycodestyle():
+    """Decorator to skip a test if pycodestyle is not available."""
     try:
         import pycodestyle  # noqa # pylint:disable=unused-import
         ok = True
@@ -593,6 +594,7 @@ def requires_pycodestyle():
 
 
 def requires_autopep8():
+    """Decorator to skip a test if autopep8 is not available."""
     try:
         import autopep8  # noqa # pylint:disable=unused-import
         ok = True
@@ -602,8 +604,9 @@ def requires_autopep8():
 
 
 def requires_GC3Pie():
+    """Decorator to skip a test if GC3Pie is not available."""
     try:
-        import gc3libs  # noqa
+        import gc3libs  # noqa # pylint:disable=unused-import
         ok = True
     except ImportError:
         ok = False
@@ -617,7 +620,7 @@ def requires_GC3Pie():
 
 def requires_graphviz():
     try:
-        import graphwiz  # noqa # pylint:disable=unused-import
+        import graphviz  # noqa # pylint:disable=unused-import
         ok = True
     except ImportError:
         ok = False
@@ -625,6 +628,7 @@ def requires_graphviz():
 
 
 def requires_pysvn():
+    """Decorator to skip a test if PySVN is not available."""
     try:
         from pysvn import ClientError  # noqa
         ok = True

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -30,6 +30,7 @@ Various test utility functions.
 """
 import copy
 import fileinput
+import functools
 import os
 import re
 import shutil
@@ -557,3 +558,58 @@ def find_full_path(base_path, trim=(lambda x: x)):
             break
 
     return full_path
+
+
+def requires_pycodestyle():
+    try:
+        import pycodestyle  # noqa # pylint:disable=unused-import
+        ok = True
+    except ImportError:
+        ok = False
+    return unittest.skipUnless(ok, "no pycodestyle available")
+
+
+def requires_autopep8():
+    try:
+        import autopep8  # noqa # pylint:disable=unused-import
+        ok = True
+    except ImportError:
+        ok = False
+    return unittest.skipUnless(ok, "autopep8 is not available")
+
+
+def requires_graphviz():
+    try:
+        import graphwiz  # noqa # pylint:disable=unused-import
+        ok = True
+    except ImportError:
+        ok = False
+    return unittest.skipUnless(ok, "graphviz is not available")
+
+
+def requires_pysvn():
+    try:
+        from pysvn import ClientError # noqa
+        ok = True
+    except ImportError:
+        ok = False
+    if 'CI' in os.environ:
+        # For CI skip silently, not easy enough to install,
+        # see https://github.com/leafvmaple/pysvn/issues/1
+        def decorator(test_item):
+            @functools.wraps(test_item)
+            def skip_wrapper(*args, **kwargs):
+                return
+            return skip_wrapper
+        return decorator
+    else:
+        return unittest.skipUnless(ok, "PySVN is not available, use e.g. apt-get install python3-svn")
+
+
+def requires_PyYAML():
+    try:
+        import yaml  # noqa # pylint:disable=unused-import
+        ok = True
+    except ImportError:
+        ok = False
+    return unittest.skipUnless(ok, "PyYAML is not available")

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -578,6 +578,15 @@ def requires_autopep8():
     return unittest.skipUnless(ok, "autopep8 is not available")
 
 
+def requires_GC3Pie():
+    try:
+        import gc3libs  # noqa
+        ok = True
+    except ImportError:
+        ok = False
+    return unittest.skipUnless(ok, "GC3Pie not available")
+
+
 def requires_graphviz():
     try:
         import graphwiz  # noqa # pylint:disable=unused-import

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -579,28 +579,27 @@ def skip_silentCI_unless(condition, reason):
     On CI the test is turned into a no-op to avoid any output."""
     if 'CI' in os.environ:
         return skip_never if condition else skip_silently
-    else:
-        return unittest.skipUnless(condition, reason)
+    return unittest.skipUnless(condition, reason)
 
 
-def requires_pycodestyle():
-    """Decorator to skip a test if pycodestyle is not available."""
+def requires_package(package):
+    """Skip a test if *package* cannot be imported"""
     try:
-        import pycodestyle  # noqa # pylint:disable=unused-import
+        __import__(package)
         ok = True
     except ImportError:
         ok = False
-    return unittest.skipUnless(ok, "no pycodestyle available")
+    return unittest.skipUnless(ok, f"{package} is not available")
 
 
-def requires_autopep8():
-    """Decorator to skip a test if autopep8 is not available."""
-    try:
-        import autopep8  # noqa # pylint:disable=unused-import
-        ok = True
-    except ImportError:
-        ok = False
-    return unittest.skipUnless(ok, "autopep8 is not available")
+# Decorator to skip a test if pycodestyle is not available
+requires_pycodestyle = requires_package('pycodestyle')
+# Decorator to skip a test if autopep8 is not available
+requires_autopep8 = requires_package('autopep8')
+# Decorator to skip a test if graphviz is not available
+requires_graphviz = requires_package('graphviz')
+# Decorator to skip a test if PyYAML is not available
+requires_PyYAML = requires_package('yaml')
 
 
 def requires_GC3Pie():
@@ -610,39 +609,20 @@ def requires_GC3Pie():
         ok = True
     except ImportError:
         ok = False
-    if LooseVersion(sys.version) < '3.11':
-        return unittest.skipUnless(ok, "GC3Pie not available")
-    else:
+    if LooseVersion(sys.version) >= '3.11':
         # GC3Pie not available for Python 3.11 so silently skip:
         # https://github.com/gc3pie/gc3pie/issues/674
         return skip_silentCI_unless(ok, "GC3Pie not available")
-
-
-def requires_graphviz():
-    try:
-        import graphviz  # noqa # pylint:disable=unused-import
-        ok = True
-    except ImportError:
-        ok = False
-    return unittest.skipUnless(ok, "graphviz is not available")
+    return unittest.skipUnless(ok, "GC3Pie not available")
 
 
 def requires_pysvn():
     """Decorator to skip a test if PySVN is not available."""
     try:
-        from pysvn import ClientError  # noqa
+        from pysvn import ClientError  # noqa # pylint:disable=unused-import
         ok = True
     except ImportError:
         ok = False
     # For CI skip silently, not easy enough to install,
     # see https://github.com/leafvmaple/pysvn/issues/1
     return skip_silentCI_unless(ok, "PySVN is not available, use e.g. apt-get install python3-svn")
-
-
-def requires_PyYAML():
-    try:
-        import yaml  # noqa # pylint:disable=unused-import
-        ok = True
-    except ImportError:
-        ok = False
-    return unittest.skipUnless(ok, "PyYAML is not available")


### PR DESCRIPTION
Mostly preparation for use of skip markers: Contains the `requires_foo` decorators used by other PRs and related machinery

Example use for pysvn and GC3Pie

Extracted from https://github.com/easybuilders/easybuild-framework/pull/4188