### PR TITLE
[4/5] Use `skipTest` rather than faulty copy-paste of `return` conditions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -268,6 +268,7 @@ jobs:
             IGNORE_PATTERNS+="|no GitHub token available"
             IGNORE_PATTERNS+="|Ignoring rate limit error"
             IGNORE_PATTERNS+="|requires Lmod as modules tool"
+            IGNORE_PATTERNS+="|^[s.]*$" # Only PASS (.) and SKIP (s) status on line
             IGNORE_PATTERNS+="|stty: 'standard input': Inappropriate ioctl for device"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 3.[78]"
             IGNORE_PATTERNS+="|from cryptography.* import "
@@ -275,9 +276,9 @@ jobs:
             IGNORE_PATTERNS+="|GC3Pie not available, skipping test"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: TripleDES has been moved"
             IGNORE_PATTERNS+="|algorithms.TripleDES"
-            # ignore lines with only successful ('.') and skipped ('s') tests
-            IGNORE_PATTERNS+="|^[\.s]+$"
+
+            TEST_OUTPUT=$(sed -n '/------------------------------/q;p' test_framework_suite.log)  # Everything up to the result divider
             # '|| true' is needed to avoid that GitHub Actions stops the job on non-zero exit of grep (i.e. when there are no matches)
-            PRINTED_MSG=$(egrep -v "${IGNORE_PATTERNS}" test_framework_suite.log | grep '\.\n*[A-Za-z]' || true)
-            test "x$PRINTED_MSG" = "x" || (echo "ERROR: Found printed messages in output of test suite" && echo "${PRINTED_MSG}" && exit 1)
+            PRINTED_MSG=$(echo "$TEST_OUTPUT" | egrep -v "${IGNORE_PATTERNS}" || true)
+            [[ -z $PRINTED_MSG ]] || (echo "ERROR: Found printed messages in output of test suite" && echo "${PRINTED_MSG}" && exit 1)
           done

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -264,7 +264,9 @@ jobs:
             # run test suite
             python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
             # try and make sure output of running tests is clean (no printed messages/warnings)
-            IGNORE_PATTERNS="no GitHub token available"
+            IGNORE_PATTERNS="=== Skipped tests ==="
+            IGNORE_PATTERNS+="|no GitHub token available"
+            IGNORE_PATTERNS+="|Ignoring rate limit error"
             IGNORE_PATTERNS+="|requires Lmod as modules tool"
             IGNORE_PATTERNS+="|stty: 'standard input': Inappropriate ioctl for device"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 3.[78]"

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -265,7 +265,6 @@ jobs:
             python -O -m test.framework.suite 2>&1 | tee test_framework_suite.log
             # try and make sure output of running tests is clean (no printed messages/warnings)
             IGNORE_PATTERNS="no GitHub token available"
-            IGNORE_PATTERNS+="|skipping SvnRepository test"
             IGNORE_PATTERNS+="|requires Lmod as modules tool"
             IGNORE_PATTERNS+="|stty: 'standard input': Inappropriate ioctl for device"
             IGNORE_PATTERNS+="|CryptographyDeprecationWarning: Python 3.[78]"

--- a/test/framework/repository.py
+++ b/test/framework/repository.py
@@ -44,6 +44,7 @@ from easybuild.tools.repository.svnrepo import SvnRepository
 from easybuild.tools.repository.repository import init_repository
 from easybuild.tools.run import run_shell_cmd
 from easybuild.tools.version import VERSION
+from test.framework.utilities import requires_pysvn
 
 
 class RepositoryTest(EnhancedTestCase):
@@ -113,15 +114,9 @@ class RepositoryTest(EnhancedTestCase):
             shutil.rmtree(repo.wc)
             shutil.rmtree(tmpdir)
 
+    @requires_pysvn()
     def test_svnrepo(self):
         """Test using SvnRepository."""
-        # only run this test if pysvn Python module is available
-        try:
-            from pysvn import ClientError  # noqa
-        except ImportError:
-            print("(skipping SvnRepository test)")
-            return
-
         # GitHub also supports SVN
         test_repo_url = 'https://github.com/easybuilders/testrepository'
 

--- a/test/framework/robot.py
+++ b/test/framework/robot.py
@@ -754,8 +754,7 @@ class RobotTest(EnhancedTestCase):
     def test_github_det_easyconfig_paths_from_pr(self):
         """Test det_easyconfig_paths function, with --from-pr enabled as well."""
         if self.github_token is None:
-            print("Skipping test_from_pr, no GitHub token available?")
-            return
+            self.skipTest("No GitHub token available?")
 
         fd, dummylogfn = tempfile.mkstemp(prefix='easybuild-dummy', suffix='.log')
         os.close(fd)

--- a/test/framework/style.py
+++ b/test/framework/style.py
@@ -31,26 +31,19 @@ Style tests for easyconfig files.
 import glob
 import os
 import sys
-from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered
+from test.framework.utilities import EnhancedTestCase, TestLoaderFiltered, requires_pycodestyle
 from unittest import TextTestRunner
 
 from easybuild.base import fancylogger
 from easybuild.framework.easyconfig.style import _eb_check_trailing_whitespace, check_easyconfigs_style
 
-try:
-    import pycodestyle  # noqa
-except ImportError:
-    pass
-
 
 class StyleTest(EnhancedTestCase):
     log = fancylogger.getLogger("StyleTest", fname=False)
 
+    @requires_pycodestyle()
     def test_style_conformance(self):
         """Check the easyconfigs for style"""
-        if 'pycodestyle' not in sys.modules:
-            print("Skipping test_style_conformance pycodestyle is not available")
-            return
 
         # all available easyconfig files
         test_easyconfigs_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'easyconfigs', 'test_ecs')
@@ -61,11 +54,9 @@ class StyleTest(EnhancedTestCase):
 
         self.assertEqual(result, 0, "No code style errors (and/or warnings) found.")
 
+    @requires_pycodestyle()
     def test_check_trailing_whitespace(self):
         """Test for trailing whitespace check."""
-        if 'pycodestyle' not in sys.modules:
-            print("Skipping test_check_trailing_whitespace pycodestyle is not available")
-            return
 
         lines = [
             "name = 'foo'",  # no trailing whitespace

--- a/test/framework/suite.py
+++ b/test/framework/suite.py
@@ -138,12 +138,29 @@ class EasyBuildFrameworkTestSuite(unittest.TestSuite):
         return res
 
 
-def load_tests(loader, tests, pattern):
+class SkipSummaryResult(unittest.TextTestResult):
+    """Decorator that prints skipped tests at the end of the run if in CI environment."""
+    def __init__(self, stream, descriptions, verbosity, *args, **kwargs):
+        super().__init__(stream, descriptions, verbosity, *args, **kwargs)
+        self._verbosity = verbosity
+
+    def stopTestRun(self):
+        super().stopTestRun()
+        if 'CI' in os.environ and self.skipped:
+            print('\n=== Skipped tests ===')
+            print('\n'.join(f'\t{test}: {reason}' for test, reason in self.skipped))
+
+
+class SkipSummaryRunner(unittest.TextTestRunner):
+    resultclass = SkipSummaryResult
+
+
+def load_tests(loader, _tests, _pattern):
     return EasyBuildFrameworkTestSuite(loader)
 
 
 if __name__ == '__main__':
     if len(sys.argv) > 1 and sys.argv[1].startswith('-'):
-        unittest.main()
+        unittest.main(testRunner=SkipSummaryRunner())
     else:
-        unittest.TextTestRunner().run(EasyBuildFrameworkTestSuite(None))
+        SkipSummaryRunner().run(EasyBuildFrameworkTestSuite(None))

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -557,3 +557,39 @@ def find_full_path(base_path, trim=(lambda x: x)):
             break
 
     return full_path
+
+
+def requires_pycodestyle():
+    try:
+        import pycodestyle  # noqa # pylint:disable=unused-import
+        ok = True
+    except ImportError:
+        ok = False
+    return unittest.skipUnless(ok, "no pycodestyle available")
+
+
+def requires_autopep8():
+    try:
+        import autopep8  # noqa # pylint:disable=unused-import
+        ok = True
+    except ImportError:
+        ok = False
+    return unittest.skipUnless(ok, "autopep8 is not available")
+
+
+def requires_graphviz():
+    try:
+        import graphwiz  # noqa # pylint:disable=unused-import
+        ok = True
+    except ImportError:
+        ok = False
+    return unittest.skipUnless(ok, "graphviz is not available")
+
+
+def requires_PyYAML():
+    try:
+        import yaml  # noqa # pylint:disable=unused-import
+        ok = True
+    except ImportError:
+        ok = False
+    return unittest.skipUnless(ok, "PyYAML is not available")

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -30,6 +30,7 @@ Various test utility functions.
 """
 import copy
 import fileinput
+import functools
 import os
 import re
 import shutil
@@ -584,6 +585,25 @@ def requires_graphviz():
     except ImportError:
         ok = False
     return unittest.skipUnless(ok, "graphviz is not available")
+
+
+def requires_pysvn():
+    try:
+        from pysvn import ClientError # noqa
+        ok = True
+    except ImportError:
+        ok = False
+    if 'CI' in os.environ:
+        # For CI skip silently, not easy enough to install,
+        # see https://github.com/leafvmaple/pysvn/issues/1
+        def decorator(test_item):
+            @functools.wraps(test_item)
+            def skip_wrapper(*args, **kwargs):
+                return
+            return skip_wrapper
+        return decorator
+    else:
+        return unittest.skipUnless(ok, "PySVN is not available, use e.g. apt-get install python3-svn")
 
 
 def requires_PyYAML():


### PR DESCRIPTION
Extracted from https://github.com/easybuilders/easybuild-framework/pull/4188