### PR TITLE
Initialize `name` and `version` in `EasyConfig` instance of `Extension`

### DIFF
--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -146,8 +146,8 @@ class Extension:
             self.cfg[opt_name] = get_easyconfig_parameter_default(opt_name)
 
         # Update name and version
-        self.cfg['name'] = self.ext.get('name', None)
-        self.cfg['version'] = self.ext.get('version', None)
+        self.cfg['name'] = name
+        self.cfg['version'] = version
         # construct dict with template values that can be used
         self.cfg.template_values.update(template_constant_dict({'name': name, 'version': version}))
 

--- a/easybuild/framework/extension.py
+++ b/easybuild/framework/extension.py
@@ -145,6 +145,9 @@ class Extension:
         for opt_name in restore_options:
             self.cfg[opt_name] = get_easyconfig_parameter_default(opt_name)
 
+        # Update name and version
+        self.cfg['name'] = self.ext.get('name', None)
+        self.cfg['version'] = self.ext.get('version', None)
         # construct dict with template values that can be used
         self.cfg.template_values.update(template_constant_dict({'name': name, 'version': version}))
 

--- a/easybuild/framework/extensioneasyblock.py
+++ b/easybuild/framework/extensioneasyblock.py
@@ -81,10 +81,6 @@ class ExtensionEasyBlock(EasyBlock, Extension):
 
             Extension.__init__(self, *args, **kwargs)
 
-            # name and version properties of EasyBlock are used, so make sure name and version are correct
-            self.cfg['name'] = self.ext.get('name', None)
-            self.cfg['version'] = self.ext.get('version', None)
-
             self.builddir = self.master.builddir
             self.installdir = self.master.installdir
             self.modules_tool = self.master.modules_tool


### PR DESCRIPTION
Do this early instead of in `ExtensionEasyBlock` as otherwise usage of `self.name` would yield the parent name due to Python MRO inside `__init__`

It also makes sense to keep those in sync with the updated template values.
I'm wondering if we could just call `self.cfg.generate_template_values()` after setting name and version