### PR TITLE
Remove superflous cleanup steps in tests

### DIFF
--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -164,7 +164,6 @@ class EasyBlockTest(EnhancedTestCase):
 
         # cleanup
         eb.close_log()
-        os.remove(eb.logfile)
 
     def test_load_module(self):
         """Test load_module method."""
@@ -218,7 +217,6 @@ class EasyBlockTest(EnhancedTestCase):
 
         # cleanup
         eb.close_log()
-        os.remove(eb.logfile)
 
         # test HMNS module load when conflicting dependencies are available in both Core and
         # toolchain-specific modulepaths
@@ -293,7 +291,6 @@ class EasyBlockTest(EnhancedTestCase):
 
         # cleanup
         eb.close_log()
-        os.remove(eb.logfile)
 
     def test_make_module_extend_modpath(self):
         """Test for make_module_extend_modpath"""
@@ -786,7 +783,6 @@ class EasyBlockTest(EnhancedTestCase):
 
         # cleanup
         eb.close_log()
-        os.remove(eb.logfile)
 
     def test_module_search_path_headers(self):
         """Test functionality of module-search-path-headers option"""
@@ -879,7 +875,6 @@ class EasyBlockTest(EnhancedTestCase):
 
         # cleanup
         eb.close_log()
-        os.remove(eb.logfile)
 
     def test_make_module_extra(self):
         """Test for make_module_extra."""
@@ -1465,7 +1460,6 @@ class EasyBlockTest(EnhancedTestCase):
 
         # cleanup
         eb.close_log()
-        os.remove(eb.logfile)
 
     def test_extensions_step_deprecations(self):
         """Test extension install with deprecated substeps."""
@@ -1645,7 +1639,6 @@ class EasyBlockTest(EnhancedTestCase):
 
         # cleanup
         eb.close_log()
-        os.remove(eb.logfile)
 
     def test_extension_fake_modules(self):
         """
@@ -1887,8 +1880,6 @@ class EasyBlockTest(EnhancedTestCase):
             "toolchain = SYSTEM",
         ])
         self.writeEC()
-        stdoutorig = sys.stdout
-        sys.stdout = open("/dev/null", 'w')
         eb = EasyBlock(EasyConfig(self.eb_file))
         resb = eb.gen_builddir()
         resi = eb.gen_installdir()
@@ -1920,8 +1911,6 @@ class EasyBlockTest(EnhancedTestCase):
             eb.make_builddir()
 
         # cleanup
-        sys.stdout.close()
-        sys.stdout = stdoutorig
         eb.close_log()
 
     def test_make_builddir(self):
@@ -2080,6 +2069,7 @@ class EasyBlockTest(EnhancedTestCase):
     @requires_github_access()
     def test_fetch_sources_git(self):
         """Test fetch_sources method from git repo."""
+        init_config(args=[f"--sourcepath={self.test_prefix}"])
 
         testdir = os.path.abspath(os.path.dirname(__file__))
         ec = process_easyconfig(os.path.join(testdir, 'easyconfigs', 'test_ecs', 't', 'toy', 'toy-0.0.eb'))[0]
@@ -2118,9 +2108,6 @@ class EasyBlockTest(EnhancedTestCase):
             reference_checksum = None
 
         self.assertEqual(eb.src[0]['checksum'], reference_checksum)
-
-        # cleanup
-        remove_file(eb.src[0]['path'])
 
     def test_download_instructions(self):
         """Test use of download_instructions easyconfig parameter."""
@@ -3863,8 +3850,6 @@ class EasyBlockTest(EnhancedTestCase):
         # Then close the log from creating EasyBlock. This should work as expected.
         eb.close_log()
         self.assertEqual(getattr(file_log, 'logtofile_%s' % eb.logfile), False)
-
-        os.remove(eb.logfile)
 
     def test_report_current_step_method(self):
         """

--- a/test/framework/easyconfig.py
+++ b/test/framework/easyconfig.py
@@ -785,9 +785,6 @@ class EasyConfigTest(EnhancedTestCase):
         eb = EasyConfig(tweaked_fn)
         self.assertEqual(eb['patches'], [new_patches[0]])
 
-        # cleanup
-        os.remove(tweaked_fn)
-
     def test_parse_easyconfig(self):
         """Test parse_easyconfig function"""
         self.contents = textwrap.dedent("""
@@ -4609,9 +4606,6 @@ class EasyConfigTest(EnhancedTestCase):
         ]
         for idx, pattern in enumerate(patterns):
             self.assertTrue(re.match(pattern, stdout[idx]), "Pattern '%s' matches '%s'" % (pattern, stdout[idx]))
-
-        # cleanup
-        remove_file(glob.glob(os.path.join(test_ec + '.orig*'))[0])
 
     def test_parse_list_comprehension_scope(self):
         """Test parsing of an easyconfig file that uses a local variable in list comprehension."""

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -1767,7 +1767,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
             os.remove(dummylogfn)
 
         # cleanup
-        shutil.rmtree(tmpdir)
         sys.path[:] = orig_sys_path
 
     def test_try_robot_force(self):
@@ -2433,10 +2432,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
         msg = "modules footer '%s' is present in '%s'" % (modules_footer_txt, toy_module_txt)
         self.assertRegex(toy_module_txt, regex, msg)
 
-        # cleanup
-        os.remove(modules_footer)
-        os.remove(modules_header)
-
     def test_recursive_module_unload(self):
         """Test generating recursively unloading modules."""
 
@@ -2497,11 +2492,8 @@ class CommandLineOptionsTest(EnhancedTestCase):
         tempfile_tmpdir = tempfile.mkdtemp()
         self.assertTrue(tempfile_tmpdir.startswith(os.path.join(tmpdir, 'eb-')))
         fd, tempfile_tmpfile = tempfile.mkstemp()
-        self.assertTrue(tempfile_tmpfile.startswith(os.path.join(tmpdir, 'eb-')))
-
-        # cleanup
         os.close(fd)
-        shutil.rmtree(tmpdir)
+        self.assertTrue(tempfile_tmpfile.startswith(os.path.join(tmpdir, 'eb-')))
 
     def test_ignore_osdeps(self):
         """Test ignoring of listed OS dependencies."""
@@ -3302,9 +3294,6 @@ class CommandLineOptionsTest(EnhancedTestCase):
         expected = [mentionhdr % (testdohdr), mentionfile % (testcmdfile), mentionfile % (testurlpatfile)]
         not_expected = [testdoval, testdonthdr, testdontval]
         run_and_assert(args, expected, not_expected)
-
-        # cleanup downloads
-        shutil.rmtree(tmpdir)
 
     def test_test_report_env_filter(self):
         """Test use of --test-report-env-filter."""

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -276,9 +276,6 @@ class ToyBuildTest(EnhancedTestCase):
         self.run_test_toy_build_with_output(ec_file=broken_toy_ec, tmpdir=tmpdir, verify=False, fails=True,
                                             verbose=False, raise_error=True, test_report=test_report_fp)
 
-        # cleanup
-        shutil.rmtree(tmpdir)
-
     def test_toy_broken_copy_log_build_dir(self):
         """
         Test whether log files and the build directory are copied to a permanent location
@@ -519,7 +516,6 @@ class ToyBuildTest(EnhancedTestCase):
                            versionprefix=toy_prefix, versionsuffix=toy_suffix)
 
         # cleanup
-        shutil.rmtree(tmpdir)
         sys.path[:] = orig_sys_path
 
     def test_toy_build_formatv2_sections(self):


### PR DESCRIPTION
The test tmp directory is removed by `EnhancedTestCase` so the manual cleanup can be removed to reduce the noise.