### PR TITLE
Make network ops on CI more reliable

### DIFF
--- a/.github/workflows/container_tests.yml
+++ b/.github/workflows/container_tests.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
   cancel-in-progress: true
 
+env:
+  EASYBUILD_DOWNLOAD_TIMEOUT: 100
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/container_tests.yml
+++ b/.github/workflows/container_tests.yml
@@ -37,10 +37,10 @@ jobs:
 
         # Avoid apt-get update, as we don't really need it,
         # and it does more harm than good (it's fairly expensive, and it results in flaky test runs)
-        if ! sudo apt-get install $APT_PKGS; then
+        if ! sudo apt-get install -o Acquire::Retries=3 -y --no-install-suggests --no-install-recommends $APT_PKGS; then
           # Try to update cache, then try again to resolve 404s of old packages
           sudo apt-get update -yqq || true
-          sudo apt-get install $APT_PKGS
+          sudo apt-get install -o Acquire::Retries=3 -y --no-install-suggests --no-install-recommends $APT_PKGS
         fi
 
     - name: install Lmod
@@ -60,14 +60,14 @@ jobs:
       run: |
         sudo apt-get update
         # install alien, which can be used to convert RPMs to Debian packages
-        sudo apt-get install alien
+        sudo apt-get install -o Acquire::Retries=3 -y --no-install-suggests --no-install-recommends alien
         alien --version
         # determine latest version of Singularity available in EPEL, and download RPM
         singularity_rpm=$(curl -sL https://dl.fedoraproject.org/pub/archive/epel/8.5/Everything/x86_64/Packages/s/ | grep singularity | sed 's/.*singularity/singularity/g' | sed 's/rpm.*/rpm/g')
         curl -OL https://dl.fedoraproject.org/pub/archive/epel/8.5/Everything/x86_64/Packages/s/${singularity_rpm}
         # convert Singularity RPM to Debian package, and install it
         sudo alien -d ${singularity_rpm}
-        sudo apt-get install ./singularity*.deb
+        sudo apt-get install -o Acquire::Retries=3 -y --no-install-suggests --no-install-recommends ./singularity*.deb
         singularity --version
 
     - name: install sources

--- a/.github/workflows/container_tests_apptainer.yml
+++ b/.github/workflows/container_tests_apptainer.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{format('{0}:{1}:{2}', github.repository, github.ref, github.workflow)}}
   cancel-in-progress: true
 
+env:
+  EASYBUILD_DOWNLOAD_TIMEOUT: 100
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/container_tests_apptainer.yml
+++ b/.github/workflows/container_tests_apptainer.yml
@@ -38,10 +38,10 @@ jobs:
 
         # Avoid apt-get update, as we don't really need it,
         # and it does more harm than good (it's fairly expensive, and it results in flaky test runs)
-        if ! sudo apt-get install $APT_PKGS; then
+        if ! sudo apt-get install -o Acquire::Retries=3 -y --no-install-suggests --no-install-recommends $APT_PKGS; then
           # Try to update cache, then try again to resolve 404s of old packages
-          sudo apt-get update -yqq || true
-          sudo apt-get install $APT_PKGS
+          sudo apt-get update -yqq -o Acquire::Retries=3 || true
+          sudo apt-get install -o Acquire::Retries=3 -y --no-install-suggests --no-install-recommends $APT_PKGS
         fi
 
     - name: install Lmod

--- a/.github/workflows/eb_command.yml
+++ b/.github/workflows/eb_command.yml
@@ -45,10 +45,10 @@ jobs:
 
         # Avoid apt-get update, as we don't really need it,
         # and it does more harm than good (it's fairly expensive, and it results in flaky test runs)
-        if ! sudo apt-get install $APT_PKGS; then
+        if ! sudo apt-get install -o Acquire::Retries=3 -y --no-install-suggests --no-install-recommends $APT_PKGS; then
           # Try to update cache, then try again to resolve 404s of old packages
           sudo apt-get update -yqq || true
-          sudo apt-get install $APT_PKGS
+          sudo apt-get install -o Acquire::Retries=3 -y --no-install-suggests --no-install-recommends $APT_PKGS
         fi
 
     - name: install modules tool

--- a/.github/workflows/end2end.yml
+++ b/.github/workflows/end2end.yml
@@ -1,5 +1,8 @@
 name: End-to-end test of EasyBuild in different distros
 on: [push, pull_request]
+env:
+  EASYBUILD_DOWNLOAD_TIMEOUT: 100
+
 jobs:
   build_publish:
     name: End-to-end test

--- a/.github/workflows/end2end_bwrap.yml
+++ b/.github/workflows/end2end_bwrap.yml
@@ -2,6 +2,9 @@ name: End-to-end test of EasyBuild with bwrap
 
 on: [push, pull_request]
 
+env:
+  EASYBUILD_DOWNLOAD_TIMEOUT: 100
+
 jobs:
   end2end:
     name: End-to-end test (runner VM)

--- a/.github/workflows/end2end_bwrap.yml
+++ b/.github/workflows/end2end_bwrap.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # 7.0.0
 
       - name: Install system packages
-        run: sudo apt-get install -y lmod bubblewrap
+        run: sudo apt-get install -o Acquire::Retries=3 -y --no-install-suggests --no-install-recommends lmod bubblewrap
 
       - name: Allow unprivileged user namespaces (Ubuntu 26.04)
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -95,10 +95,10 @@ jobs:
         APT_PKGS+=" graphviz"
         # Avoid apt-get update, as we don't really need it,
         # and it does more harm than good (it's fairly expensive, and it results in flaky test runs)
-        if ! sudo apt-get install $APT_PKGS; then
+        if ! sudo apt-get install -o Acquire::Retries=3 -y --no-install-suggests --no-install-recommends $APT_PKGS; then
           # Try to update cache, then try again to resolve 404s of old packages
           sudo apt-get update -yqq || true
-          sudo apt-get install $APT_PKGS
+          sudo apt-get install -o Acquire::Retries=3 -y --no-install-suggests --no-install-recommends $APT_PKGS
         fi
 
     - name: set up Python

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -627,8 +627,8 @@ class FileToolsTest(EnhancedTestCase):
         # make sure specified timeout is parsed correctly (as a float, not a string)
         opts = init_config(args=['--download-timeout=5.3'])
         init_config(build_options={'download_timeout': opts.download_timeout})
-        target_location = os.path.join(self.test_prefix, 'jenkins_robots.txt')
-        url = 'https://raw.githubusercontent.com/easybuilders/easybuild-framework/master/README.rst'
+        url = 'https://sources.easybuild.io/icons/blank.gif'
+        target_location = os.path.join(self.test_prefix, os.path.basename(url))
         try:
             request.urlopen(url)
             with self.mocked_stdout_stderr():


### PR DESCRIPTION
1. Use smaller file for download timeout test
	The test sometimes fails, so try a smaller file (~500B instead of some kB) and not from github.com.
1. Increase download timeout for end2end tests to 100s
2. Make apt-get more reliable
	- Do not install additional packages
	- Do not ask questions
	- Retry 3 times