### PR TITLE
Fix unsetting `$MODULEPATH` when removing last path in `Lmod.unuse`

### DIFF
--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -2081,16 +2081,15 @@ class Lmod(ModulesTool):
         # We can simply remove the path from MODULEPATH to avoid the costly module call
         cur_mod_path = os.environ.get('MODULEPATH')
         if cur_mod_path is not None:
+            path = normalize_path(path)
+            new_mod_path = ':'.join(p for p in cur_mod_path.split(':') if normalize_path(p) != path)
             # Removing the last entry unsets the variable
-            if cur_mod_path == path:
+            if not new_mod_path:
                 self.log.debug('Changing MODULEPATH from %s to <unset>' % cur_mod_path)
                 del os.environ['MODULEPATH']
-            else:
-                path = normalize_path(path)
-                new_mod_path = ':'.join(p for p in cur_mod_path.split(':') if normalize_path(p) != path)
-                if new_mod_path != cur_mod_path:
-                    self.log.debug('Changing MODULEPATH from %s to %s' % (cur_mod_path, new_mod_path))
-                    os.environ['MODULEPATH'] = new_mod_path
+            elif new_mod_path != cur_mod_path:
+                self.log.debug('Changing MODULEPATH from %s to %s' % (cur_mod_path, new_mod_path))
+                os.environ['MODULEPATH'] = new_mod_path
 
     def prepend_module_path(self, path, set_mod_paths=True, priority=None):
         """

--- a/test/framework/modules.py
+++ b/test/framework/modules.py
@@ -1282,11 +1282,22 @@ class ModulesTest(EnhancedTestCase):
             # Check load and unload for a single path when it is the only one
             # Only for Lmod as we have some shortcuts for avoiding the module call there
             old_module_path = os.environ['MODULEPATH']
+
             del os.environ['MODULEPATH']
             self.modtool.use(test_dir1)
             self.assertEqual(os.environ['MODULEPATH'], test_dir1)
             self.modtool.unuse(test_dir1)
             self.assertNotIn('MODULEPATH', os.environ)
+
+            test_dir4 = os.path.join(self.test_prefix, 'four')
+            os.mkdir(test_dir4)
+            # Same but not normalized
+            test_dir4_2 = os.path.join(self.test_prefix, '.', 'four')
+            self.modtool.use(test_dir4)
+            self.assertEqual(os.environ['MODULEPATH'], test_dir4)
+            self.modtool.unuse(test_dir4_2)
+            self.assertNotIn('MODULEPATH', os.environ)
+
             os.environ['MODULEPATH'] = old_module_path  # Restore
 
     def test_add_and_remove_module_path(self):


### PR DESCRIPTION
The check needs to be done for the new string using normalized paths
or the variable may be set to the empty string instead of being unset.