### PR TITLE
Add support for specifying dependencies required to obtain source files via `source_deps` easyconfig parameter

### DIFF
--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -5437,7 +5437,7 @@ def build_and_install_one(ecdict, init_env):
                     adjust_permissions(log_dir, stat.S_IWUSR, add=True, recursive=True)
                 else:
                     parent_dir = os.path.dirname(log_dir)
-                    if os.path.exists(parent_dir):
+                    if os.path.exists(parent_dir) and not (os.stat(parent_dir).st_mode & stat.S_IWUSR):
                         adjust_permissions(parent_dir, stat.S_IWUSR, add=True, recursive=False)
                         mkdir(log_dir, parents=True)
                         adjust_permissions(parent_dir, stat.S_IWUSR, add=False, recursive=False)
@@ -5530,7 +5530,7 @@ def build_and_install_one(ecdict, init_env):
                     copy_file(patch_path, target)
                     _log.debug("Copied patch %s to %s", patch_path, target)
 
-                if build_option('read_only_installdir'):
+                if build_option('read_only_installdir') and not app.cfg['stop']:
                     # take away user write permissions (again)
                     perms = stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH
                     adjust_permissions(new_log_dir, perms, add=False, recursive=True)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -2862,6 +2862,14 @@ class EasyBlock:
                 raise EasyBuildError("EasyBuild-version %s is newer than the currently running one. Aborting!",
                                      easybuild_version)
 
+        source_deps = self.cfg['source_deps']
+        pre_fetch_env = None
+        # load modules for source dependencies (if any)
+        if source_deps:
+            pre_fetch_env = copy.deepcopy(os.environ)
+            source_deps_mod_names = [d['short_mod_name'] for d in source_deps]
+            self.modules_tool.load(source_deps_mod_names)
+
         start_progress_bar(PROGRESS_BAR_DOWNLOAD_ALL, self.cfg.count_files())
 
         if self.dry_run:
@@ -2948,6 +2956,9 @@ class EasyBlock:
             self.log.info("Skipped installation dirs check per user request")
 
         stop_progress_bar(PROGRESS_BAR_DOWNLOAD_ALL)
+
+        if pre_fetch_env:
+            restore_env(pre_fetch_env)
 
     def checksum_step(self):
         """Verify checksum of sources and patches, if a checksum is available."""
@@ -5426,7 +5437,7 @@ def build_and_install_one(ecdict, init_env):
                     adjust_permissions(log_dir, stat.S_IWUSR, add=True, recursive=True)
                 else:
                     parent_dir = os.path.dirname(log_dir)
-                    if os.path.exists(parent_dir) and not (os.stat(parent_dir).st_mode & stat.S_IWUSR):
+                    if os.path.exists(parent_dir):
                         adjust_permissions(parent_dir, stat.S_IWUSR, add=True, recursive=False)
                         mkdir(log_dir, parents=True)
                         adjust_permissions(parent_dir, stat.S_IWUSR, add=False, recursive=False)
@@ -5519,7 +5530,7 @@ def build_and_install_one(ecdict, init_env):
                     copy_file(patch_path, target)
                     _log.debug("Copied patch %s to %s", patch_path, target)
 
-                if build_option('read_only_installdir') and not app.cfg['stop']:
+                if build_option('read_only_installdir'):
                     # take away user write permissions (again)
                     perms = stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH
                     adjust_permissions(new_log_dir, perms, add=False, recursive=True)

--- a/easybuild/framework/easyblock.py
+++ b/easybuild/framework/easyblock.py
@@ -116,6 +116,7 @@ from easybuild.tools.modules import ROOT_ENV_VAR_NAME_PREFIX, VERSION_ENV_VAR_NA
 from easybuild.tools.modules import Lmod, ModEnvVarType, ModuleLoadEnvironment, MODULE_LOAD_ENV_HEADERS
 from easybuild.tools.modules import curr_module_paths, invalidate_module_caches_for, get_software_root
 from easybuild.tools.modules import get_software_root_env_var_name, get_software_version_env_var_name
+from easybuild.tools.modules import NoModulesTool, modules_tool
 from easybuild.tools.output import PROGRESS_BAR_DOWNLOAD_ALL, PROGRESS_BAR_EASYCONFIG, PROGRESS_BAR_EXTENSIONS
 from easybuild.tools.output import show_progress_bars, start_progress_bar, stop_progress_bar, update_progress_bar
 from easybuild.tools.package.utilities import package
@@ -2867,6 +2868,10 @@ class EasyBlock:
         # load modules for source dependencies (if any)
         if source_deps:
             pre_fetch_env = copy.deepcopy(os.environ)
+
+            if isinstance(self.modules_tool, NoModulesTool):
+                self.modules_tool = modules_tool(modules_tool_name=build_option('original_modules_tool'))
+
             source_deps_mod_names = [d['short_mod_name'] for d in source_deps]
             self.modules_tool.load(source_deps_mod_names)
 

--- a/easybuild/framework/easyconfig/default.py
+++ b/easybuild/framework/easyconfig/default.py
@@ -179,6 +179,7 @@ DEFAULT_CONFIG = {
     'multi_deps_load_default': [True, "Load module for first version listed in multi_deps by default", DEPENDENCIES],
     'osdependencies': [[], "OS dependencies that should be present on the system", DEPENDENCIES],
     'moddependpaths': [None, "Absolute path(s) to prepend to MODULEPATH before loading dependencies", DEPENDENCIES],
+    'source_deps': [[], "source dependencies that should be present befory getting the sources", DEPENDENCIES],
 
     # LICENSE easyconfig parameters
     'accept_eula': [False, "Accepted End User License Agreement (EULA) for this software", LICENSE],

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -831,6 +831,14 @@ class EasyConfig:
                 builddeps = [self._parse_dependency(dep, build_only=True) for dep in builddeps]
             self['builddependencies'] = remove_false_versions(builddeps)
 
+            sourcedeps = self['source_deps']
+            if sourcedeps and all(isinstance(x, (list, tuple)) for b in sourcedeps for x in b):
+                self.iterate_options.append('source_deps')
+                sourcedeps = [[self._parse_dependency(dep, build_only=True) for dep in x] for x in sourcedeps]
+            else:
+                sourcedeps = [self._parse_dependency(dep, build_only=True) for dep in sourcedeps]
+            self['source_deps'] = remove_false_versions(sourcedeps)
+
             # keep track of parsed multi deps, they'll come in handy during sanity check & module steps...
             self.multi_deps = self.get_parsed_multi_deps()
 

--- a/easybuild/framework/easyconfig/easyconfig.py
+++ b/easybuild/framework/easyconfig/easyconfig.py
@@ -831,13 +831,12 @@ class EasyConfig:
                 builddeps = [self._parse_dependency(dep, build_only=True) for dep in builddeps]
             self['builddependencies'] = remove_false_versions(builddeps)
 
-            sourcedeps = self['source_deps']
-            if sourcedeps and all(isinstance(x, (list, tuple)) for b in sourcedeps for x in b):
-                self.iterate_options.append('source_deps')
-                sourcedeps = [[self._parse_dependency(dep, build_only=True) for dep in x] for x in sourcedeps]
+            source_deps = self['source_deps']
+            if source_deps and all(isinstance(x, (list, tuple)) for b in source_deps for x in b):
+                source_deps = [[self._parse_dependency(dep, build_only=True) for dep in x] for x in source_deps]
             else:
-                sourcedeps = [self._parse_dependency(dep, build_only=True) for dep in sourcedeps]
-            self['source_deps'] = remove_false_versions(sourcedeps)
+                source_deps = [self._parse_dependency(dep, build_only=True) for dep in source_deps]
+            self['source_deps'] = remove_false_versions(source_deps)
 
             # keep track of parsed multi deps, they'll come in handy during sanity check & module steps...
             self.multi_deps = self.get_parsed_multi_deps()

--- a/easybuild/framework/easyconfig/format/format.py
+++ b/easybuild/framework/easyconfig/format/format.py
@@ -50,7 +50,7 @@ FORMAT_VERSION_HEADER_TEMPLATE = "# %s %s\n" % (FORMAT_VERSION_KEYWORD, FORMAT_V
 FORMAT_VERSION_REGEXP = re.compile(r'^#\s+%s\s*(?P<major>\d+)\.(?P<minor>\d+)\s*$' % FORMAT_VERSION_KEYWORD, re.M)
 FORMAT_DEFAULT_VERSION = EasyVersion('1.0')
 
-DEPENDENCY_PARAMETERS = ['builddependencies', 'dependencies', 'hiddendependencies']
+DEPENDENCY_PARAMETERS = ['builddependencies', 'dependencies', 'hiddendependencies', 'source_deps']
 
 # values for these keys will not be templated in dump()
 EXCLUDED_KEYS_REPLACE_TEMPLATES = ['description', 'easyblock', 'exts_default_options', 'exts_list',

--- a/easybuild/tools/config.py
+++ b/easybuild/tools/config.py
@@ -467,6 +467,7 @@ BUILD_OPTIONS_OTHER = {
         'external_modules_metadata',
         'extra_ec_paths',
         'mod_depends_on',  # deprecated
+        'original_modules_tool',
         'robot_path',
         'valid_module_classes',
         'valid_stops',

--- a/easybuild/tools/modules.py
+++ b/easybuild/tools/modules.py
@@ -2280,13 +2280,15 @@ def avail_modules_tools():
     return class_dict
 
 
-def modules_tool(mod_paths=None, testing=False) -> ModulesTool:
+def modules_tool(mod_paths=None, testing=False, modules_tool_name=None) -> ModulesTool:
     """
     Return interface to modules tool (EnvironmentModules, Lmod, ...)
     """
     # get_modules_tool might return none (e.g. if config was not initialized yet)
-    modules_tool = get_modules_tool()
-    modules_tool_class = avail_modules_tools().get(modules_tool, NoModulesTool)
+    if modules_tool_name is None:
+        modules_tool_name = get_modules_tool()
+
+    modules_tool_class = avail_modules_tools().get(modules_tool_name, NoModulesTool)
     return modules_tool_class(mod_paths=mod_paths, testing=testing)
 
 

--- a/easybuild/tools/options.py
+++ b/easybuild/tools/options.py
@@ -1398,6 +1398,7 @@ class EasyBuildOptions(GeneralOption):
             self.options.stop = FETCH_STEP
             self.options.ignore_locks = True
             self.options.ignore_osdeps = True
+            self.original_modules_tool = self.options.modules_tool
             self.options.modules_tool = None
 
         # imply --disable-pre-create-installdir with --inject-checksums or --inject-checksums-to-json
@@ -1941,6 +1942,7 @@ def set_up_configuration(args=None, logfile=None, testing=False, silent=False, r
         'command_line': eb_cmd_line,
         'external_modules_metadata': parse_external_modules_metadata(options.external_modules_metadata),
         'extra_ec_paths': extra_ec_paths,
+        'original_modules_tool': getattr(eb_go, 'original_modules_tool', None),
         'robot_path': robot_path,
         'silent': testing or new_update_opt,
         'try_to_generate': try_to_generate,

--- a/test/framework/easyblock.py
+++ b/test/framework/easyblock.py
@@ -59,7 +59,7 @@ from easybuild.tools.config import get_module_syntax, update_build_option
 from easybuild.tools.filetools import adjust_permissions, change_dir, copy_dir, copy_file, mkdir, read_file
 from easybuild.tools.filetools import remove_dir, remove_file, symlink, verify_checksum, write_file
 from easybuild.tools.module_generator import module_generator
-from easybuild.tools.modules import EnvironmentModules, Lmod, reset_module_caches
+from easybuild.tools.modules import EnvironmentModules, Lmod, NoModulesTool, reset_module_caches
 from easybuild.tools.output import PROGRESS_BAR_DOWNLOAD_ALL
 from easybuild.tools.run import RunShellCmdError
 from easybuild.tools.version import get_git_revision, this_is_easybuild
@@ -1316,6 +1316,49 @@ class EasyBlockTest(EnhancedTestCase):
             ])
         self.assertTrue(os.path.samefile(eb.src[0]['path'], expected_path_src))
         self.assertTrue(os.path.samefile(eb.patches[0]['path'], expected_path_patch))
+
+    def test_fetch_step_source_deps(self):
+        """Test fetching sources with source dependencies."""
+        init_config(
+            [f'--sourcepath={self.test_prefix}'],
+            build_options={'original_modules_tool': 'Lmod'},
+        )
+
+        url = 'https://dummy-url-for-testing'
+        source_fn = 'mysource.tar.gz'
+        self.contents = textwrap.dedent(f"""
+            easyblock = "ConfigureMake"
+            name = "Uniq_1"
+            version = "3.14"
+            homepage = "http://example.com"
+            description = "test"
+            toolchain = SYSTEM
+            source_urls = ['{url}']
+            sources = ['{source_fn}']
+            source_deps = [('foo', '1.2.3')]
+        """)
+        self.writeEC()
+
+        eb = EasyBlock(EasyConfig(self.eb_file))
+        eb.modules_tool = NoModulesTool(testing=True)
+
+        def create_file(_filename, _url, path, *_args, **_kwargs):
+            write_file(path, 'content')
+            return True
+
+        mocked_modtool = unittest.mock.MagicMock()
+
+        with unittest.mock.patch(
+            'easybuild.framework.easyblock.modules_tool',
+            return_value=mocked_modtool,
+        ) as mocked_modules_tool, unittest.mock.patch(
+            'easybuild.framework.easyblock.download_file',
+            side_effect=create_file,
+        ):
+            eb.fetch_step()
+
+        mocked_modules_tool.assert_called_once_with(modules_tool_name='Lmod')
+        mocked_modtool.load.assert_called_once_with(['foo/1.2.3'])
 
     def test_test_cases_step(self):
         """Test test_cases_step"""

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -5557,11 +5557,12 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
     def test_fetch(self):
         """Test use of --fetch"""
-        options = EasyBuildOptions(go_args=['--fetch'])
+        options = EasyBuildOptions(go_args=['--fetch', '--modules-tool=Lmod'])
 
         self.assertTrue(options.options.fetch)
         self.assertEqual(options.options.stop, 'fetch')
         self.assertEqual(options.options.modules_tool, None)
+        self.assertEqual(options.original_modules_tool, 'Lmod')
         self.assertTrue(options.options.ignore_locks)
         self.assertTrue(options.options.ignore_osdeps)
 
@@ -5644,6 +5645,17 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
             pattern = r"WARNING: FAILED: File toy-1.2.3.4.5.6.tar.gz not found from NO_SOURCE_URLS_PROVIDED."
             self.assertRegex(stderr, pattern)
+
+    def test_fetch_original_modules_tool(self):
+        """Test preserving the original modules tool with --fetch."""
+        set_up_configuration(
+            args=['--fetch', '--modules-tool=Lmod'],
+            silent=True,
+            reconfigure=True,
+        )
+
+        self.assertEqual(build_option('original_modules_tool'), 'Lmod')
+        self.assertEqual(ConfigurationVariables()['modules_tool'], None)
 
     def test_parse_external_modules_metadata(self):
         """Test parse_external_modules_metadata function."""


### PR DESCRIPTION
This PR replaces https://github.com/easybuilders/easybuild-framework/pull/4766.

It adds support for the `source_deps` easyconfig parameter, which can be used to specify dependencies that are required to obtain source files.

This is useful for sources that require additional tools during the fetch step, such as `git-lfs`. Source dependencies are loaded before fetching the sources and the original environment is restored afterwards.

It also supports using `source_deps` together with `eb --fetch`, where EasyBuild normally disables the modules tool.

Created with help of ChatGPT5.6
