### PR TITLE
Show proper error message for issues in easyblocks (syntax errors, etc.)

### DIFF
--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -3107,9 +3107,9 @@ def install_fake_vsc():
     return fake_vsc_path
 
 
-def get_easyblock_class_name(path):
-    """Make sure file is an easyblock and get easyblock class name"""
-    fn = os.path.basename(path).split('.')[0]
+def get_easyblock_class_name(path: PathOrStr):
+    """Check that file is an easyblock and get easyblock class name"""
+    fn = Path(path).stem
     try:
         mod = load_source(fn, path)
     except SyntaxError as err:

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -3113,15 +3113,9 @@ def get_easyblock_class_name(path):
     try:
         mod = load_source(fn, path)
     except SyntaxError as err:
-        raise EasyBuildError(
-            "Failed to load easyblock file '%s': %s (line %d)",
-            os.path.basename(path), err.msg, err.lineno,
-        )
+        raise EasyBuildError("Failed to load easyblock file '%s': %s (line %d)", path, err.msg, err.lineno)
     except ImportError as err:
-        raise EasyBuildError(
-            "Failed to load easyblock file '%s': %s",
-            os.path.basename(path), err,
-        )
+        raise EasyBuildError("Failed to load easyblock file '%s': %s", path, err)
     clsmembers = inspect.getmembers(mod, inspect.isclass)
     for cn, co in clsmembers:
         if co.__module__ == mod.__name__:

--- a/easybuild/tools/filetools.py
+++ b/easybuild/tools/filetools.py
@@ -3110,7 +3110,18 @@ def install_fake_vsc():
 def get_easyblock_class_name(path):
     """Make sure file is an easyblock and get easyblock class name"""
     fn = os.path.basename(path).split('.')[0]
-    mod = load_source(fn, path)
+    try:
+        mod = load_source(fn, path)
+    except SyntaxError as err:
+        raise EasyBuildError(
+            "Failed to load easyblock file '%s': %s (line %d)",
+            os.path.basename(path), err.msg, err.lineno,
+        )
+    except ImportError as err:
+        raise EasyBuildError(
+            "Failed to load easyblock file '%s': %s",
+            os.path.basename(path), err,
+        )
     clsmembers = inspect.getmembers(mod, inspect.isclass)
     for cn, co in clsmembers:
         if co.__module__ == mod.__name__:

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -3632,17 +3632,17 @@ class FileToolsTest(EnhancedTestCase):
 
         # test with syntax error in easyblock file
         ft.write_file(bad_py, "def foo(:\n    pass\n")
-        err = r"^Failed to load easyblock file 'bad_easyblock\.py': .* \(line 1\)$"
+        err = r"^Failed to load easyblock file '/.*/bad_easyblock\.py': .* \(line 1\)$"
         self.assertRaisesRegex(EasyBuildError, err, ft.get_easyblock_class_name, bad_py)
 
         # test with import error in easyblock file
         ft.write_file(bad_py, "import non_existent_module_xyz\n")
-        err = r"^Failed to load easyblock file 'bad_easyblock\.py': No module named 'non_existent_module_xyz'$"
+        err = r"^Failed to load easyblock file '/.*/bad_easyblock\.py': No module named 'non_existent_module_xyz'$"
         self.assertRaisesRegex(EasyBuildError, err, ft.get_easyblock_class_name, bad_py)
 
         # Both
         ft.write_file(bad_py, "def foo(:\n    pass\n", append=True)
-        err = r"^Failed to load easyblock file 'bad_easyblock\.py': .* \(line 2\)$"
+        err = r"^Failed to load easyblock file '/.*/bad_easyblock\.py': .* \(line 2\)$"
         self.assertRaisesRegex(EasyBuildError, err, ft.get_easyblock_class_name, bad_py)
 
     def test_copy_easyblocks(self):

--- a/test/framework/filetools.py
+++ b/test/framework/filetools.py
@@ -3628,6 +3628,23 @@ class FileToolsTest(EnhancedTestCase):
         toy_eb = os.path.join(test_ebs, 't', 'toy.py')
         self.assertEqual(ft.get_easyblock_class_name(toy_eb), 'EB_toy')
 
+        bad_py = os.path.join(self.test_prefix, 'bad_easyblock.py')
+
+        # test with syntax error in easyblock file
+        ft.write_file(bad_py, "def foo(:\n    pass\n")
+        err = r"^Failed to load easyblock file 'bad_easyblock\.py': .* \(line 1\)$"
+        self.assertRaisesRegex(EasyBuildError, err, ft.get_easyblock_class_name, bad_py)
+
+        # test with import error in easyblock file
+        ft.write_file(bad_py, "import non_existent_module_xyz\n")
+        err = r"^Failed to load easyblock file 'bad_easyblock\.py': No module named 'non_existent_module_xyz'$"
+        self.assertRaisesRegex(EasyBuildError, err, ft.get_easyblock_class_name, bad_py)
+
+        # Both
+        ft.write_file(bad_py, "def foo(:\n    pass\n", append=True)
+        err = r"^Failed to load easyblock file 'bad_easyblock\.py': .* \(line 2\)$"
+        self.assertRaisesRegex(EasyBuildError, err, ft.get_easyblock_class_name, bad_py)
+
     def test_copy_easyblocks(self):
         """Test for copy_easyblocks function."""
 


### PR DESCRIPTION
```
EasyBuild crashed! Please consider reporting a bug, this should not happen...

Traceback (most recent call last):
  File "/usr/lib64/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib64/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File " /eb/easybuild-framework/easybuild/main.py", line 891, in <module>
    main_with_hooks()
  File " /eb/easybuild-framework/easybuild/main.py", line 872, in main_with_hooks
    exit_code: EasyBuildExit = main(args=args, prepared_cfg_data=(init_session_state, eb_go, cfg_settings))
  File " /eb/easybuild-framework/easybuild/main.py", line 814, in main
    is_successful = process_eb_args(orig_paths, eb_go, cfg_settings, modtool, testing, init_session_state,
  File " /eb/easybuild-framework/easybuild/main.py", line 559, in process_eb_args
    update_pr(options.update_pr, categorized_paths, ordered_ecs)
  File " /eb/easybuild-framework/easybuild/tools/github.py", line 2319, in update_pr
    pr_target_repo = det_pr_target_repo(paths)
  File " /eb/easybuild-framework/easybuild/tools/github.py", line 2254, in det_pr_target_repo
    if all(get_easyblock_class_name(path) for path in py_files):
  File " /eb/easybuild-framework/easybuild/tools/github.py", line 2254, in <genexpr>
    if all(get_easyblock_class_name(path) for path in py_files):
  File " /eb/easybuild-framework/easybuild/tools/filetools.py", line 3128, in get_easyblock_class_name
    mod = load_source(fn, path)
  File " /eb/easybuild-framework/easybuild/tools/hooks.py", line 132, in load_source
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 846, in exec_module
  File "<frozen importlib._bootstrap_external>", line 983, in get_code
  File "<frozen importlib._bootstrap_external>", line 913, in source_to_code
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "easybuild-easyblocks/easybuild/easyblocks/p/pmix.py", line 66
    return re.search(rf'({'|'.join(prefixes)}){opt_name}\b', configopts)
                           ^
SyntaxError: f-string: expecting '}'
```


This shortens it down to the error and line:
`ERROR: Failed to load easyblock file 'easybuild-easyblocks/easybuild/easyblocks/p/pmix.py': f-string: expecting '}' (line 66)`
