### PR TITLE
Remove `raise_systemexit` from tests

### DIFF
--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -50,7 +50,7 @@ from easybuild.framework.easyconfig import BUILD, CUSTOM, DEPENDENCIES, EXTENSIO
 from easybuild.framework.easyconfig import MANDATORY, MODULES, OTHER, TOOLCHAIN
 from easybuild.framework.easyconfig.easyconfig import EasyConfig, get_easyblock_class, robot_find_easyconfig
 from easybuild.framework.easyconfig.parser import EasyConfigParser
-from easybuild.tools.build_log import EasyBuildError, EasyBuildLog
+from easybuild.tools.build_log import EasyBuildError, EasyBuildExit, EasyBuildLog
 from easybuild.tools.config import DEFAULT_MODULECLASSES, BuildOptions, ConfigurationVariables
 from easybuild.tools.config import build_option, find_last_log, get_build_log_path, get_module_syntax, module_classes
 from easybuild.tools.filetools import adjust_permissions, change_dir, copy_dir, copy_file, download_file
@@ -1182,10 +1182,12 @@ class CommandLineOptionsTest(EnhancedTestCase):
             for pattern in ['netCDF-C++', 'foo|bar', '^foo', 'foo.*bar']:
                 args = [opt, pattern, '--robot', test_easyconfigs_dir]
                 with self.mocked_stdout_stderr(mock_stderr=False):
-                    self.eb_main(args, raise_error=True, verbose=True, testing=False)
+                    _log, err = self.eb_main(args, return_error=True, verbose=True, testing=False)
                     stdout = self.get_stdout()
                 # there shouldn't be any hits for any of these queries, so empty output...
                 self.assertEqual(stdout.strip(), '')
+                self.assertIsInstance(err, SystemExit)
+                self.assertEqual(err.code, EasyBuildExit.MISSING_EASYCONFIG)
 
         # some search patterns are simply invalid,
         # if they include allowed special characters like '*' but are used incorrectly...
@@ -1200,7 +1202,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # 4 corresponds with MISSING_EASYCONFIG in EasyBuildExit (see easybuild/tools/build_log.py)
         args = ['--search', 'nosuchsoftware-1.2.3.4.5']
         self.assertErrorRegex(SystemExit, 'MISSING_EASYCONFIG|4', self.eb_main, args,
-                              testing=False, raise_error=True, raise_systemexit=True)
+                              testing=False, raise_error=True)
 
     def test_ignore_index(self):
         """
@@ -3492,7 +3494,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         for arg in ['-DX', '-DrX', '-DXr', '-frkDX', '-XfrD']:
             args = ['toy-0.0.eb', arg]
             with self.mocked_stdout_stderr():
-                self.assertErrorRegex(SystemExit, '.*', self.eb_main, args, raise_error=True, raise_systemexit=True)
+                self.assertErrorRegex(SystemExit, '.*', self.eb_main, args, raise_error=True)
                 stderr = self.get_stderr()
             self.assertIn("error: no such option: -X", stderr)
 
@@ -4114,11 +4116,11 @@ class CommandLineOptionsTest(EnhancedTestCase):
         error_regex = "Selected module naming scheme \'AnotherTestIncludedMNS\' is unknown"
         with self.mocked_stdout_stderr():
             self.assertErrorRegex(EasyBuildError, error_regex, self.eb_main, args, logfile=dummylogfn,
-                                  raise_error=True, raise_systemexit=True)
+                                  raise_error=True)
 
         args.append('--include-module-naming-schemes=%s/*.py' % self.test_prefix)
         with self.mocked_stdout_stderr():
-            self.eb_main(args, logfile=dummylogfn, do_build=True, raise_error=True, raise_systemexit=True, verbose=True)
+            self.eb_main(args, logfile=dummylogfn, do_build=True, raise_error=True, verbose=True)
         toy_mod = os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0')
         if get_module_syntax() == 'Lua':
             toy_mod += '.lua'
@@ -5552,8 +5554,10 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # 'source' step was renamed to 'extract' in EasyBuild 5.0,
         # see https://github.com/easybuilders/easybuild-framework/pull/4629
         args = ['toy-0.0.eb', '--force', '--stop=source']
-        _, stderr = self._run_mock_eb(args, do_build=True, raise_error=True, testing=False, strip=True)
-        self.assertIn("option --stop: invalid choice: 'source' (choose from", stderr)
+        with self.mocked_stderr() as stderr:
+            with self.assertRaises(SystemExit):
+                self.eb_main(args, do_build=True, raise_error=True, testing=False)
+            self.assertIn("option --stop: invalid choice: 'source' (choose from", stderr.getvalue())
 
     def test_fetch(self):
         """Test use of --fetch"""
@@ -6557,7 +6561,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
         # because it's not a valid type of checksum
         args = ['--inject-checksums', test_ec]
         with self.mocked_stdout_stderr():
-            self.assertErrorRegex(SystemExit, '.*', self.eb_main, args, raise_error=True, raise_systemexit=True)
+            self.assertErrorRegex(SystemExit, '.*', self.eb_main, args, raise_error=True)
             stdout = self.get_stdout().strip()
             stderr = self.get_stderr().strip()
 

--- a/test/framework/options.py
+++ b/test/framework/options.py
@@ -261,7 +261,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
             outtxt, error_thrown = self.eb_main(args, return_error=True)
 
         error_msg = "No error is thrown if software is already installed (error_thrown: %s)" % error_thrown
-        self.assertTrue(not error_thrown, error_msg)
+        self.assertIsNone(error_thrown, error_msg)
 
         already_msg = "GCC/4.6.3 is already installed"
         error_msg = "Already installed message without --force, outtxt: %s" % outtxt
@@ -6958,7 +6958,7 @@ class CommandLineOptionsTest(EnhancedTestCase):
 
         args = [test_ec, '--force', '--skip-extensions']
         with self.mocked_stdout_stderr():
-            self.eb_main(args, do_build=True, return_error=True)
+            self.eb_main(args, do_build=True)
 
         toy_mod = os.path.join(self.test_installpath, 'modules', 'all', 'toy', '0.0')
         if get_module_syntax() == 'Lua':

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -160,7 +160,7 @@ class ToyBuildTest(EnhancedTestCase):
 
     def _test_toy_build(self, extra_args=None, ec_file=None, tmpdir=None, verify=True, fails=False, verbose=True,
                         raise_error=False, test_report=None, name='toy', versionsuffix='', testing=True,
-                        raise_systemexit=False, force=True, test_report_regexs=None, debug=True, trace=True):
+                        force=True, test_report_regexs=None, debug=True, trace=True):
         """Perform a toy build."""
         if extra_args is None:
             extra_args = []
@@ -188,7 +188,7 @@ class ToyBuildTest(EnhancedTestCase):
         myerr = None
         try:
             outtxt = self.eb_main(args, logfile=self.dummylogfn, do_build=True, verbose=verbose,
-                                  raise_error=raise_error, testing=testing, raise_systemexit=raise_systemexit)
+                                  raise_error=raise_error, testing=testing)
         except Exception as err:
             myerr = err
             if raise_error:
@@ -832,7 +832,7 @@ class ToyBuildTest(EnhancedTestCase):
                 write_file(test_ec, TOY_EC_TXT + "\ngroup = %s\n" % str(group))
 
             with self.mocked_stdout():
-                outtxt = self.eb_main(args, logfile=dummylogfn, do_build=True, raise_error=True, raise_systemexit=True)
+                outtxt = self.eb_main(args, logfile=dummylogfn, do_build=True, raise_error=True)
 
             if get_module_syntax() == 'Tcl':
                 module_version = LooseVersion(self.modtool.version)
@@ -881,8 +881,7 @@ class ToyBuildTest(EnhancedTestCase):
                 self.fail("Unknown module syntax: %s" % get_module_syntax())
 
         write_file(test_ec, TOY_EC_TXT + "\ngroup = ('%s', 'custom message', 'extra item')\n" % group_name)
-        self.assertErrorRegex(SystemExit, '.*', self.eb_main, args, do_build=True,
-                              raise_error=True, raise_systemexit=True)
+        self.assertErrorRegex(SystemExit, '.*', self.eb_main, args, do_build=True, raise_error=True)
 
     def test_allow_system_deps(self):
         """Test allow_system_deps easyconfig parameter."""
@@ -4404,7 +4403,7 @@ class ToyBuildTest(EnhancedTestCase):
 
                 with self.mocked_stdout_stderr():
                     self.assertErrorRegex(exc, '.*', self._test_toy_build, ec_file=test_ec, verify=False,
-                                          extra_args=extra_args, raise_error=True, testing=False, raise_systemexit=True)
+                                          extra_args=extra_args, raise_error=True, testing=False)
 
                     stderr = self.get_stderr().strip()
 

--- a/test/framework/toy_build.py
+++ b/test/framework/toy_build.py
@@ -602,8 +602,7 @@ class ToyBuildTest(EnhancedTestCase):
 
         # test specifying a non-existing group
         allargs = [test_ec] + args + ['--group=thisgroupdoesnotexist']
-        outtxt, _err = self.run_eb_main_capture_output(allargs, logfile=self.dummylogfn, do_build=True,
-                                                       return_error=True)
+        outtxt = self.run_eb_main_capture_output(allargs, logfile=self.dummylogfn, do_build=True)
         err_regex = re.compile("Failed to get group ID .* group does not exist")
         self.assertTrue(err_regex.search(outtxt), "Pattern '%s' found in '%s'" % (err_regex.pattern, outtxt))
 

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -318,7 +318,7 @@ class EnhancedTestCase(TestCase):
         # note: don't change 'args' value, which is passed by reference!
         main_args = [str(arg) if isinstance(arg, Path) else arg for arg in args] + ['--unit-testing-mode']
 
-        myerr = False
+        myerr = None
         if logfile is None:
             logfile = self.logfile
         # clear log file
@@ -336,7 +336,14 @@ class EnhancedTestCase(TestCase):
                 modtool = None
             else:
                 modtool = self.modtool
-            exit_code = main(args=main_args, logfile=logfile, do_build=do_build, testing=testing, modtool=modtool)
+            try:
+                exit_code = main(args=main_args, logfile=logfile, do_build=do_build, testing=testing, modtool=modtool)
+            except SystemExit as err:
+                # Ignore successful exits, i.e. `sys.exit(0)` on e.g. --help
+                if err.code != 0:
+                    myerr = err
+                    exit_code = err.code
+
         except Exception as err:
             myerr = err
             if verbose:

--- a/test/framework/utilities.py
+++ b/test/framework/utilities.py
@@ -308,7 +308,7 @@ class EnhancedTestCase(TestCase):
         self.modtool.set_mod_paths()
 
     def eb_main(self, args, do_build=False, return_error=False, return_exit_code=False, logfile=None, verbose=False,
-                raise_error=False, reset_env=True, raise_systemexit=False, testing=True, redo_init_config=True,
+                raise_error=False, reset_env=True, testing=True, redo_init_config=True,
                 clear_caches=True):
         """Helper method to call EasyBuild main function."""
 
@@ -337,9 +337,6 @@ class EnhancedTestCase(TestCase):
             else:
                 modtool = self.modtool
             exit_code = main(args=main_args, logfile=logfile, do_build=do_build, testing=testing, modtool=modtool)
-        except SystemExit as err:
-            if raise_systemexit:
-                raise err
         except Exception as err:
             myerr = err
             if verbose:


### PR DESCRIPTION
Swallowing this error by default hides issues in the test code causing later failures (or unexpected success) which are hard to diagnose.

Currently when `raise_systemexit=True` is passed `raise_error=True` is also passed. So it seems like it is often simply forgotten to pass the former when the latter is passed.

Just remove this parameter.

I got bitten by this in https://github.com/easybuilders/easybuild-framework/pull/5257
See log at https://github.com/easybuilders/easybuild-framework/actions/runs/34577844114/job/103194325892?pr=5257
which simply shows
> FileNotFoundError: [Errno 2] No such file or directory: '/tmp/eb-zxeprflh/eb-g9irio0z/eb-bf_ydfey/tmpl2r5loz1/modules/all/toy/0.0.lua'

The actual error was a misspelled CLI argument